### PR TITLE
feat(ui): toolkit-free VSS chat surface

### DIFF
--- a/deploy/docker/services/infra/haproxy/haproxy.cfg.template
+++ b/deploy/docker/services/infra/haproxy/haproxy.cfg.template
@@ -127,6 +127,12 @@ frontend fe_http
     acl known_host hdr(host) -i "${HOST_IP}"
     acl known_host hdr(host) -i "${HOST_IP}:${HAPROXY_PORT}"
     acl known_host hdr(host) -i localhost
+    # The UI's media proxy reaches the ingress container-to-container, so the
+    # Host it sends is the compose service name. Node's fetch will not let the
+    # proxy override Host, so the ingress has to accept it or every proxied
+    # thumbnail is denied 404 by the known_host guard.
+    acl known_host hdr(host) -i vss-haproxy-ingress
+    acl known_host hdr(host) -i "vss-haproxy-ingress:${HAPROXY_PORT}"
     acl known_host hdr(host) -i "localhost:${HAPROXY_PORT}"
     acl known_host hdr(host) -i 127.0.0.1
     acl known_host hdr(host) -i "127.0.0.1:${HAPROXY_PORT}"
@@ -138,6 +144,12 @@ frontend fe_http
     acl h_main hdr(host) -i "${EXTERNAL_IP}:${HAPROXY_PORT}"
     acl h_main hdr(host) -i "${HOST_IP}"
     acl h_main hdr(host) -i "${HOST_IP}:${HAPROXY_PORT}"
+    # Same reason as the known_host entry: the UI's media proxy calls the
+    # ingress by compose service name, and backend selection keys off h_main,
+    # so without this every proxied request passes the host guard and then
+    # falls through to no backend (503).
+    acl h_main hdr(host) -i vss-haproxy-ingress
+    acl h_main hdr(host) -i "vss-haproxy-ingress:${HAPROXY_PORT}"
     acl h_main hdr(host) -i localhost
     acl h_main hdr(host) -i "localhost:${HAPROXY_PORT}"
     acl h_main hdr(host) -i 127.0.0.1
@@ -239,6 +251,9 @@ frontend fe_http
     acl p_api_vss_chat path /api/vss-chat
     acl p_api_vss_chat path_beg /api/vss-chat/
     use_backend bk_vss_ui if h_main p_api_vss_chat
+
+    acl p_api_proxy path_beg /api/proxy/
+    use_backend bk_vss_ui if h_main p_api_proxy
 
     acl p_api path /api
     acl p_api path_beg /api/

--- a/deploy/docker/services/infra/haproxy/haproxy.cfg.template
+++ b/deploy/docker/services/infra/haproxy/haproxy.cfg.template
@@ -236,6 +236,10 @@ frontend fe_http
     acl p_api_chat path_beg /api/chat/
     use_backend bk_vss_ui if h_main p_api_chat
 
+    acl p_api_vss_chat path /api/vss-chat
+    acl p_api_vss_chat path_beg /api/vss-chat/
+    use_backend bk_vss_ui if h_main p_api_vss_chat
+
     acl p_api path /api
     acl p_api path_beg /api/
     use_backend bk_vss_agent if h_main p_api

--- a/deploy/docker/services/ui/compose.yml
+++ b/deploy/docker/services/ui/compose.yml
@@ -27,6 +27,12 @@ services:
         condition: service_healthy
     environment:
       RUN_APP_NAME: nv-metropolis-bp-vss-ui
+      # Where the UI's server-side media proxy reaches the ingress. Not the
+      # public origin: that would send internal fetches out and back through
+      # whatever fronts the deployment, which haproxy then challenges for
+      # credentials the server does not have. Same compose network, fixed
+      # service name, so only the port can vary.
+      HAPROXY_PORT: ${HAPROXY_PORT:-7777}
       NEXT_PUBLIC_APP_TITLE: '${NEXT_PUBLIC_APP_TITLE:-VSS BLUEPRINT}'
       NEXT_PUBLIC_APP_SUBTITLE: '${NEXT_PUBLIC_APP_SUBTITLE:-VISION}'
       # === App wide chat sidebar ===

--- a/services/ui/apps/nv-metropolis-bp-vss-ui/components/Home.tsx
+++ b/services/ui/apps/nv-metropolis-bp-vss-ui/components/Home.tsx
@@ -100,6 +100,35 @@ const VssChatPanel = dynamic(
   { ssr: false },
 );
 
+/**
+ * Point a VSS media URL at this app's proxy.
+ *
+ * The search CLI stamps every hit's media URL with the origin it was configured
+ * with (`vss configure --base-url`), which here is the host-local ingress. A
+ * browser resolving `http://localhost:7777/...` hits the user's own machine, so
+ * thumbnails and clips silently fail to load. Only the path matters — the proxy
+ * knows where the ingress actually is.
+ */
+const proxyMediaUrl = (value: unknown): unknown => {
+  if (typeof value !== 'string' || !/^https?:\/\//.test(value)) return value;
+  try {
+    const { pathname, search } = new URL(value);
+    return `/api/proxy${pathname}${search}`;
+  } catch {
+    return value;
+  }
+};
+
+/** Rewrite every *_url field on each search hit. */
+const withProxiedMedia = (hits: Array<Record<string, unknown>>) =>
+  hits.map((hit) => {
+    const next: Record<string, unknown> = { ...hit };
+    for (const key of Object.keys(next)) {
+      if (key.endsWith('_url')) next[key] = proxyMediaUrl(next[key]);
+    }
+    return next;
+  });
+
 const readEnv = (key: string) => env(key) || process.env[key] || '';
 
 const vssChatEnabled = () => readEnv('NEXT_PUBLIC_USE_VSS_CHAT') === 'true';
@@ -554,7 +583,7 @@ export default function Home({ alertsData, searchData, dashboardData, mapData, v
                 const last = await r.json();
                 if (!last?.data?.length) return;
                 handleSidebarAnswerCompleteWithContent(
-                  JSON.stringify({ data: last.data }),
+                  JSON.stringify({ data: withProxiedMedia(last.data) }),
                 );
               } catch {
                 // Non-fatal: the chat answer has already been delivered.

--- a/services/ui/apps/nv-metropolis-bp-vss-ui/components/Home.tsx
+++ b/services/ui/apps/nv-metropolis-bp-vss-ui/components/Home.tsx
@@ -92,6 +92,34 @@ interface TabConfig {
 
 // Dynamic component imports based on configuration
 // These are loaded at runtime only if the corresponding tab is enabled
+// Replacement chat surface. Rendered instead of the toolkit's chat when
+// NEXT_PUBLIC_USE_VSS_CHAT is 'true', so the two can be compared in place
+// before the toolkit dependency is dropped for licensing reasons.
+const VssChatPanel = dynamic(
+  () => import('@nv-metropolis-bp-vss-ui/chat').then((mod) => mod.ChatPanel),
+  { ssr: false },
+);
+
+const readEnv = (key: string) => env(key) || process.env[key] || '';
+
+const vssChatEnabled = () => readEnv('NEXT_PUBLIC_USE_VSS_CHAT') === 'true';
+
+/**
+ * Chat endpoint + title for a surface.
+ *
+ * The URL is this app's own proxy rather than the configured backend: the panel
+ * fetches from the browser, and the agent adapter listens on a host-private
+ * port a browser cannot reach. pages/api/vss-chat.ts resolves the real target
+ * server-side from the same NEXT_PUBLIC_* values as before.
+ */
+const vssChatConfig = (surface: 'main' | 'sidebar') => {
+  const prefix = surface === 'sidebar' ? 'NEXT_PUBLIC_SIDEBAR_CHAT_' : 'NEXT_PUBLIC_';
+  return {
+    url: `/api/vss-chat?surface=${surface}`,
+    title: readEnv(`${prefix}WORKFLOW`) || readEnv('NEXT_PUBLIC_WORKFLOW') || 'Chat',
+  };
+};
+
 const dynamicComponents = {
   NemoAgentToolkitApp: dynamic(() => 
     import('@nemo-agent-toolkit/ui').then(mod => mod.NemoAgentToolkitApp).catch((error) => {
@@ -502,7 +530,20 @@ export default function Home({ alertsData, searchData, dashboardData, mapData, v
   }, [visibleTabs, setActiveTab]);
 
   const renderAppSidebarChat = React.useCallback(
-    () => (
+    () =>
+      vssChatEnabled() ? (
+        // The bridge callbacks are what feed answers to the search/alerts tabs
+        // and clear stale results on submit, so they are preserved verbatim.
+        <VssChatPanel
+          endpoint={{ url: vssChatConfig('sidebar').url }}
+          title={vssChatConfig('sidebar').title}
+          theme={theme === 'dark' ? 'dark' : 'light'}
+          onAnswer={(answer: string) => {
+            handleSidebarAnswerCompleteWithContent(answer);
+          }}
+          onSubmit={() => handleSidebarMessageSubmitted()}
+        />
+      ) : (
       <RuntimeConfigProvider value={sidebarRuntimeConfig}>
         <SidebarNemoAgentToolkitApp
           theme={theme}
@@ -522,7 +563,7 @@ export default function Home({ alertsData, searchData, dashboardData, mapData, v
           onChatVideoUploadComplete={handleSidebarChatVideoUploadComplete}
         />
       </RuntimeConfigProvider>
-    ),
+      ),
     [
       theme,
       handleThemeChange,
@@ -634,6 +675,22 @@ export default function Home({ alertsData, searchData, dashboardData, mapData, v
     }
 
     // Main Chat tab: use default env (no RuntimeConfigProvider = getWorkflowName() reads NEXT_PUBLIC_WORKFLOW)
+    if (componentName === 'NemoAgentToolkitApp' && vssChatEnabled()) {
+      return (
+        <div
+          key={tabConfig.id}
+          className="absolute inset-0 flex flex-col overflow-hidden"
+          style={{ display: isActive ? 'flex' : 'none' }}
+        >
+          <VssChatPanel
+            endpoint={{ url: vssChatConfig('main').url }}
+            title={vssChatConfig('main').title}
+            theme={theme === 'dark' ? 'dark' : 'light'}
+          />
+        </div>
+      );
+    }
+
     if (componentName === 'NemoAgentToolkitApp') {
       return (
         <div 

--- a/services/ui/apps/nv-metropolis-bp-vss-ui/components/Home.tsx
+++ b/services/ui/apps/nv-metropolis-bp-vss-ui/components/Home.tsx
@@ -539,7 +539,27 @@ export default function Home({ alertsData, searchData, dashboardData, mapData, v
           title={vssChatConfig('sidebar').title}
           theme={theme === 'dark' ? 'dark' : 'light'}
           onAnswer={(answer: string) => {
+            // Feature tabs still receive the prose answer.
             handleSidebarAnswerCompleteWithContent(answer);
+            // Search results reach the Search tab out of band. The existing
+            // pipeline expects the whole Search API payload embedded in the
+            // reply text, which would mean the model transcribing every hit
+            // (DECISIONS.md 2.5). Instead the adapter keeps the last result and
+            // the payload is handed over directly, in the shape the tab's
+            // parser already understands.
+            void (async () => {
+              try {
+                const r = await fetch('/api/vss-chat?surface=sidebar');
+                if (!r.ok) return;
+                const last = await r.json();
+                if (!last?.data?.length) return;
+                handleSidebarAnswerCompleteWithContent(
+                  JSON.stringify({ data: last.data }),
+                );
+              } catch {
+                // Non-fatal: the chat answer has already been delivered.
+              }
+            })();
           }}
           onSubmit={() => handleSidebarMessageSubmitted()}
         />

--- a/services/ui/apps/nv-metropolis-bp-vss-ui/components/Home.tsx
+++ b/services/ui/apps/nv-metropolis-bp-vss-ui/components/Home.tsx
@@ -567,7 +567,7 @@ export default function Home({ alertsData, searchData, dashboardData, mapData, v
           endpoint={{ url: vssChatConfig('sidebar').url }}
           title={vssChatConfig('sidebar').title}
           theme={theme === 'dark' ? 'dark' : 'light'}
-          onAnswer={(answer: string) => {
+          onAnswer={(answer: string, conversationId: string) => {
             // Feature tabs still receive the prose answer.
             handleSidebarAnswerCompleteWithContent(answer);
             // Search results reach the Search tab out of band. The existing
@@ -578,7 +578,12 @@ export default function Home({ alertsData, searchData, dashboardData, mapData, v
             // parser already understands.
             void (async () => {
               try {
-                const r = await fetch('/api/vss-chat?surface=sidebar');
+                // Scoped to this conversation: the adapter's store is
+                // process-wide, so an unscoped read can return another
+                // conversation's media.
+                const r = await fetch(
+                  `/api/vss-chat?surface=sidebar&conversation=${encodeURIComponent(conversationId)}`,
+                );
                 if (!r.ok) return;
                 const last = await r.json();
                 if (!last?.data?.length) return;

--- a/services/ui/apps/nv-metropolis-bp-vss-ui/components/Home.tsx
+++ b/services/ui/apps/nv-metropolis-bp-vss-ui/components/Home.tsx
@@ -3,6 +3,7 @@ import React, { useState, useMemo, useEffect } from 'react';
 import dynamic from 'next/dynamic';
 import { env } from 'next-runtime-env';
 import type { ChatSidebarControlHandlers } from '@nemo-agent-toolkit/ui';
+import type { ChatSidebarControlHandlers as VssChatSidebarControlHandlers } from '@nv-metropolis-bp-vss-ui/chat';
 import { RuntimeConfigProvider } from '@nemo-agent-toolkit/ui';
 import type { 
   AlertsSidebarControlHandlers,
@@ -141,13 +142,72 @@ const vssChatEnabled = () => readEnv('NEXT_PUBLIC_USE_VSS_CHAT') === 'true';
  * port a browser cannot reach. pages/api/vss-chat.ts resolves the real target
  * server-side from the same NEXT_PUBLIC_* values as before.
  */
-const vssChatConfig = (surface: 'main' | 'sidebar') => {
-  const prefix = surface === 'sidebar' ? 'NEXT_PUBLIC_SIDEBAR_CHAT_' : 'NEXT_PUBLIC_';
-  return {
-    url: `/api/vss-chat?surface=${surface}`,
-    title: readEnv(`${prefix}WORKFLOW`) || readEnv('NEXT_PUBLIC_WORKFLOW') || 'Chat',
-  };
+type ChatSurface = 'main' | 'sidebar';
+
+/**
+ * Read a chat setting for one surface.
+ *
+ * The two surfaces are configured independently: the sidebar overrides a main
+ * variable by re-declaring it under `NEXT_PUBLIC_SIDEBAR_CHAT_`, falling back
+ * to the main value when it does not. This deployment relies on it — the
+ * sidebar chat has its own agent-parameter fields (search source type, critic
+ * toggle) that the chat tab does not, and reading only the main variables
+ * silently drops them.
+ *
+ * Same resolution order as `utils/tabChatEnv.ts`, which the toolkit path uses.
+ */
+const surfaceEnv = (surface: ChatSurface, mainKey: string): string => {
+  const suffix = mainKey.replace(/^NEXT_PUBLIC_/, '');
+  if (surface === 'sidebar') {
+    const scoped = readEnv(`NEXT_PUBLIC_SIDEBAR_CHAT_${suffix}`);
+    if (scoped) return scoped;
+  }
+  return readEnv(mainKey);
 };
+
+const surfaceFlag = (surface: ChatSurface, mainKey: string, fallback: boolean) => {
+  const value = surfaceEnv(surface, mainKey);
+  return value === '' ? fallback : value === 'true';
+};
+
+const vssChatConfig = (surface: ChatSurface) => ({
+  url: `/api/vss-chat?surface=${surface}`,
+  title: surfaceEnv(surface, 'NEXT_PUBLIC_WORKFLOW') || 'Chat',
+  // Upload talks to the agent API directly rather than through /api/vss-chat:
+  // it is a chunked, multi-minute transfer to VST, not a chat turn.
+  uploadUrlBase: surfaceEnv(surface, 'NEXT_PUBLIC_AGENT_API_URL_BASE'),
+});
+
+/**
+ * Feature switches for the replacement chat, read from the same
+ * NEXT_PUBLIC_CHAT_* variables the toolkit chat bar used.
+ *
+ * Reading the toolkit's own variables is the point: a deployment that already
+ * turned message copy off keeps it off after the swap, with nothing to migrate.
+ */
+const vssChatFeatures = (surface: ChatSurface) => ({
+  chatHistory: surfaceFlag(surface, 'NEXT_PUBLIC_CHAT_HISTORY_DEFAULT_ON', true),
+  intermediateSteps: surfaceFlag(surface, 'NEXT_PUBLIC_ENABLE_INTERMEDIATE_STEPS', true),
+  messageCopy: surfaceFlag(surface, 'NEXT_PUBLIC_CHAT_MESSAGE_COPY_ENABLED', false),
+  messageEdit: surfaceFlag(surface, 'NEXT_PUBLIC_CHAT_MESSAGE_EDIT_ENABLED', false),
+  messageSpeaker: surfaceFlag(surface, 'NEXT_PUBLIC_CHAT_MESSAGE_SPEAKER_ENABLED', false),
+  inputMic: surfaceFlag(surface, 'NEXT_PUBLIC_CHAT_INPUT_MIC_ENABLED', false),
+  uploadFile: surfaceFlag(surface, 'NEXT_PUBLIC_CHAT_UPLOAD_FILE_ENABLE', true),
+  uploadFileMetadata: surfaceFlag(surface, 'NEXT_PUBLIC_CHAT_UPLOAD_FILE_METADATA_ENABLED', false),
+  themeToggle: surfaceFlag(surface, 'NEXT_PUBLIC_SHOW_THEME_TOGGLE_BUTTON', false),
+});
+
+const vssChatUploadConfig = (surface: ChatSurface) => ({
+  customAgentParamsJson: surfaceEnv(surface, 'NEXT_PUBLIC_CHAT_API_CUSTOM_AGENT_PARAMS_JSON'),
+  uploadConfigTemplateJson: surfaceEnv(
+    surface,
+    'NEXT_PUBLIC_CHAT_UPLOAD_FILE_CONFIG_TEMPLATE_JSON',
+  ),
+  uploadHiddenMessageTemplate: surfaceEnv(
+    surface,
+    'NEXT_PUBLIC_CHAT_UPLOAD_FILE_HIDDEN_MESSAGE_TEMPLATE',
+  ),
+});
 
 const dynamicComponents = {
   NemoAgentToolkitApp: dynamic(() => 
@@ -378,6 +438,10 @@ export default function Home({ alertsData, searchData, dashboardData, mapData, v
 
   // State for holding mode-specific control handlers
   const [chatControlHandlers, setChatControlHandlers] = useState<ChatSidebarControlHandlers | null>(null);
+  // The replacement chat's controls have their own shape; kept separate so the
+  // toolkit path is untouched when NEXT_PUBLIC_USE_VSS_CHAT is unset.
+  const [vssChatControlHandlers, setVssChatControlHandlers] =
+    useState<VssChatSidebarControlHandlers | null>(null);
   const [alertsControlHandlers, setAlertsControlHandlers] = useState<AlertsSidebarControlHandlers | null>(null);
   const [searchControlHandlers, setSearchControlHandlers] = useState<SearchSidebarControlHandlers | null>(null);
   const [dashboardControlHandlers, setDashboardControlHandlers] = useState<DashboardSidebarControlHandlers | null>(null);
@@ -396,6 +460,25 @@ export default function Home({ alertsData, searchData, dashboardData, mapData, v
   const [hasLoadedFromStorage, setHasLoadedFromStorage] = React.useState(false);
 
   const sidebarApi = useAppChatSidebar();
+
+  // Read once. These come from env, which cannot change at runtime, and a fresh
+  // object each render would give ChatPanel a new `features` identity — which
+  // is the prop its per-message memo compares on, so every message in the
+  // thread would re-render on every Home render.
+  const vssMainChatFeatures = useMemo(() => vssChatFeatures('main'), []);
+  const vssSidebarChatFeatures = useMemo(() => vssChatFeatures('sidebar'), []);
+  const vssMainChatExtraConfig = useMemo(() => vssChatUploadConfig('main'), []);
+  const vssSidebarChatExtraConfig = useMemo(() => vssChatUploadConfig('sidebar'), []);
+  const vssMainChatEndpoint = useMemo(() => {
+    const { url, uploadUrlBase } = vssChatConfig('main');
+    return { url, uploadUrlBase };
+  }, []);
+  const vssMainChatTitle = useMemo(() => vssChatConfig('main').title, []);
+  const vssSidebarChatEndpoint = useMemo(() => {
+    const { url, uploadUrlBase } = vssChatConfig('sidebar');
+    return { url, uploadUrlBase };
+  }, []);
+  const vssSidebarChatTitle = useMemo(() => vssChatConfig('sidebar').title, []);
 
   const sidebarRuntimeConfig = useMemo(
     () => ({
@@ -564,9 +647,23 @@ export default function Home({ alertsData, searchData, dashboardData, mapData, v
         // The bridge callbacks are what feed answers to the search/alerts tabs
         // and clear stale results on submit, so they are preserved verbatim.
         <VssChatPanel
-          endpoint={{ url: vssChatConfig('sidebar').url }}
-          title={vssChatConfig('sidebar').title}
+          endpoint={vssSidebarChatEndpoint}
+          title={vssSidebarChatTitle}
           theme={theme === 'dark' ? 'dark' : 'light'}
+          onThemeChange={handleThemeChange}
+          isActive={activeTab !== 'chat'}
+          features={vssSidebarChatFeatures}
+          {...vssSidebarChatExtraConfig}
+          // Separates this panel's conversations from the chat tab's, the same
+          // job the toolkit's storageKeyPrefix did.
+          storageKeyPrefix={CHAT_SIDEBAR_INSTANCE_STORAGE_PREFIX}
+          onAnswerComplete={handleSidebarAnswerComplete}
+          onSubmitMessageReady={handleSidebarSubmitMessageReady}
+          onMessageSubmitted={handleSidebarMessageSubmitted}
+          onAddQueryContextReady={(addItem: (item: QueryDataContext) => void) => {
+            appSidebarAddQueryContextRef.current = addItem;
+          }}
+          onChatVideoUploadComplete={handleSidebarChatVideoUploadComplete}
           onAnswer={(answer: string, conversationId: string) => {
             // Feature tabs still receive the prose answer.
             handleSidebarAnswerCompleteWithContent(answer);
@@ -629,6 +726,10 @@ export default function Home({ alertsData, searchData, dashboardData, mapData, v
       handleSidebarSubmitMessageReady,
       handleSidebarMessageSubmitted,
       handleSidebarChatVideoUploadComplete,
+      vssSidebarChatFeatures,
+      vssSidebarChatExtraConfig,
+      vssSidebarChatEndpoint,
+      vssSidebarChatTitle,
     ],
   );
 
@@ -637,6 +738,11 @@ export default function Home({ alertsData, searchData, dashboardData, mapData, v
     chatHandlersSetRef.current = true;
     setChatControlHandlers(handlers);
   }, []);
+
+  const vssChatControlsReadyCallback = React.useCallback(
+    (handlers: VssChatSidebarControlHandlers) => setVssChatControlHandlers(handlers),
+    [],
+  );
 
   const alertsControlsReadyCallback = React.useCallback((handlers: AlertsSidebarControlHandlers) => {
     alertsHandlersSetRef.current = true;
@@ -684,6 +790,11 @@ export default function Home({ alertsData, searchData, dashboardData, mapData, v
     if (activeTab !== 'chat') {
       setChatControlHandlers(null);
       chatHandlersSetRef.current = false;
+      // The replacement chat's controls need clearing on the same edge; the
+      // panel stays mounted when the tab is hidden, so it never stops
+      // reporting them on its own and they would leak into the next tab's
+      // MODE CONTROLS section.
+      setVssChatControlHandlers(null);
     }
     if (activeTab !== 'alerts') {
       setAlertsControlHandlers(null);
@@ -737,9 +848,16 @@ export default function Home({ alertsData, searchData, dashboardData, mapData, v
           style={{ display: isActive ? 'flex' : 'none' }}
         >
           <VssChatPanel
-            endpoint={{ url: vssChatConfig('main').url }}
-            title={vssChatConfig('main').title}
+            endpoint={vssMainChatEndpoint}
+            title={vssMainChatTitle}
             theme={theme === 'dark' ? 'dark' : 'light'}
+            onThemeChange={handleThemeChange}
+            isActive={isActive}
+            features={vssMainChatFeatures}
+            {...vssMainChatExtraConfig}
+            // The chat tab renders its conversation list in the app's left
+            // sidebar, which is what renderControlsInLeftSidebar did before.
+            onControlsReady={isActive ? vssChatControlsReadyCallback : undefined}
           />
         </div>
       );
@@ -987,6 +1105,7 @@ export default function Home({ alertsData, searchData, dashboardData, mapData, v
             {/* Mode-Specific Controls Section */}
             <ModeControlsSection 
               chatHandlers={chatControlHandlers}
+              vssChatHandlers={vssChatControlHandlers}
               alertsHandlers={alertsControlHandlers}
               searchHandlers={searchControlHandlers}
               dashboardHandlers={dashboardControlHandlers}

--- a/services/ui/apps/nv-metropolis-bp-vss-ui/components/ModeControlsSection.tsx
+++ b/services/ui/apps/nv-metropolis-bp-vss-ui/components/ModeControlsSection.tsx
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: MIT
 import React from 'react';
 import { ChatSidebarContent, type ChatSidebarControlHandlers } from '@nemo-agent-toolkit/ui';
+import {
+  ConversationList,
+  type ChatSidebarControlHandlers as VssChatSidebarControlHandlers,
+} from '@nv-metropolis-bp-vss-ui/chat';
 import type { 
   AlertsSidebarControlHandlers,
   SearchSidebarControlHandlers,
@@ -13,6 +17,14 @@ import { hasComponentContentArray } from '../utils';
 
 interface ModeControlsSectionProps {
   chatHandlers: ChatSidebarControlHandlers | null;
+  /**
+   * Conversation controls from the replacement chat panel.
+   *
+   * Kept as its own prop rather than folded into `chatHandlers`: only one is
+   * ever non-null, and keeping the toolkit's path untouched is what makes
+   * NEXT_PUBLIC_USE_VSS_CHAT a true no-op when unset.
+   */
+  vssChatHandlers: VssChatSidebarControlHandlers | null;
   alertsHandlers: AlertsSidebarControlHandlers | null;
   searchHandlers: SearchSidebarControlHandlers | null;
   dashboardHandlers: DashboardSidebarControlHandlers | null;
@@ -31,6 +43,7 @@ interface ModeControlsSectionProps {
  */
 export const ModeControlsSection: React.FC<ModeControlsSectionProps> = ({ 
   chatHandlers, 
+  vssChatHandlers,
   alertsHandlers,
   searchHandlers,
   dashboardHandlers,
@@ -43,6 +56,7 @@ export const ModeControlsSection: React.FC<ModeControlsSectionProps> = ({
   // Determine if we have actual controls content to render
   const hasActualControlsContent = (
     chatHandlers ||
+    vssChatHandlers ||
     (alertsHandlers && hasAlertsModeControls) ||
     (searchHandlers && hasSearchModeControls) ||
     (dashboardHandlers && hasDashboardModeControls) ||
@@ -65,6 +79,7 @@ export const ModeControlsSection: React.FC<ModeControlsSectionProps> = ({
       {hasActualControlsContent ? (
         <div className="flex-1 overflow-y-auto overflow-x-auto flex flex-col bg-white dark:bg-neutral-900">
           {chatHandlers && <ChatSidebarContent {...chatHandlers} />}
+          {vssChatHandlers && <ConversationList {...vssChatHandlers} />}
           {alertsHandlers && alertsHandlers.controlsComponent}
           {searchHandlers && searchHandlers.controlsComponent}
           {dashboardHandlers && dashboardHandlers.controlsComponent}

--- a/services/ui/apps/nv-metropolis-bp-vss-ui/package.json
+++ b/services/ui/apps/nv-metropolis-bp-vss-ui/package.json
@@ -26,7 +26,8 @@
     "next-runtime-env": "^1.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "rsuite": "^6.0.0"
+    "rsuite": "^6.0.0",
+    "@nv-metropolis-bp-vss-ui/chat": "*"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.4",

--- a/services/ui/apps/nv-metropolis-bp-vss-ui/pages/_app.tsx
+++ b/services/ui/apps/nv-metropolis-bp-vss-ui/pages/_app.tsx
@@ -5,6 +5,7 @@ import { appWithTranslation } from 'next-i18next';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import { APPLICATION_TITLE } from '../constants/constants';
+import '@nv-metropolis-bp-vss-ui/chat/styles';
 import '../styles/globals.css';
 import 'rsuite/dist/rsuite.min.css';
 import '../styles/rsuite-custom.css';

--- a/services/ui/apps/nv-metropolis-bp-vss-ui/pages/api/proxy/[...path].ts
+++ b/services/ui/apps/nv-metropolis-bp-vss-ui/pages/api/proxy/[...path].ts
@@ -36,6 +36,21 @@ const HOP_BY_HOP = new Set([
   'content-length',
 ]);
 
+/**
+ * Headers that must not be forwarded to the ingress.
+ *
+ * This is the whole point of the proxy: haproxy challenges any request carrying
+ * CF-Connecting-IP, since that marks traffic arriving via Cloudflare. When the
+ * UI is reached through a tunnel the browser's request has those headers, and
+ * blindly forwarding them makes this server-to-server call look like public
+ * traffic and get a 401 -- which surfaces in the browser as a basic-auth prompt
+ * and "Failed to fetch streams: 401".
+ *
+ * Forwarded/X-Forwarded-* go too, for the same reason.
+ */
+const isProxyOnlyHeader = (name: string) =>
+  name.startsWith('cf-') || name.startsWith('x-forwarded-') || name === 'forwarded';
+
 async function readBody(req: NextApiRequest): Promise<Buffer | undefined> {
   if (req.method === 'GET' || req.method === 'HEAD') return undefined;
   const chunks: Buffer[] = [];
@@ -50,7 +65,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   const headers: Record<string, string> = {};
   for (const [k, v] of Object.entries(req.headers)) {
-    if (!HOP_BY_HOP.has(k.toLowerCase()) && typeof v === 'string') headers[k] = v;
+    const key = k.toLowerCase();
+    if (!HOP_BY_HOP.has(key) && !isProxyOnlyHeader(key) && typeof v === 'string') {
+      headers[k] = v;
+    }
   }
 
   let upstream: Response;

--- a/services/ui/apps/nv-metropolis-bp-vss-ui/pages/api/proxy/[...path].ts
+++ b/services/ui/apps/nv-metropolis-bp-vss-ui/pages/api/proxy/[...path].ts
@@ -15,6 +15,13 @@
  * via Cloudflare).
  *
  * Set VSS_INGRESS_ORIGIN to point at the ingress; defaults to the local one.
+ *
+ * SCOPE: deliberately narrow. This route is reachable from the public internet
+ * and reaches the ingress by its internal address, which haproxy leaves
+ * unauthenticated -- so an unrestricted catch-all would let anyone relay
+ * arbitrary methods and paths to internal APIs (Elasticsearch writes, for one)
+ * with the public auth stripped off. It therefore forwards only safe methods to
+ * an allowlisted path prefix: the search-hit media it exists to serve.
  */
 import type { NextApiRequest, NextApiResponse } from 'next';
 
@@ -26,6 +33,19 @@ export const config = {
     responseLimit: false,
   },
 };
+
+/** Only these reach the ingress; everything else is refused. */
+const ALLOWED_METHODS = new Set(['GET', 'HEAD']);
+
+/**
+ * Path prefixes this proxy will relay. The sole caller is `proxyMediaUrl` in
+ * Home.tsx, rewriting `*_url` fields on search hits -- VST replay media. Widen
+ * only with a matching reason; every addition is publicly reachable.
+ */
+const ALLOWED_PREFIXES = (process.env.VSS_PROXY_ALLOWED_PREFIXES || '/vst/')
+  .split(',')
+  .map((p) => p.trim())
+  .filter(Boolean);
 
 const HOP_BY_HOP = new Set([
   'connection',
@@ -59,9 +79,23 @@ async function readBody(req: NextApiRequest): Promise<Buffer | undefined> {
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (!ALLOWED_METHODS.has((req.method || '').toUpperCase())) {
+    res.status(405).json({ error: 'method not allowed' });
+    return;
+  }
+
   const segments = Array.isArray(req.query.path) ? req.query.path : [req.query.path ?? ''];
   const search = req.url?.includes('?') ? req.url.slice(req.url.indexOf('?')) : '';
-  const target = `${INGRESS}/${segments.join('/')}${search}`;
+  const path = `/${segments.join('/')}`;
+
+  // Resolve before checking so `..` cannot walk out of an allowed prefix.
+  const normalised = new URL(path, 'http://placeholder').pathname;
+  if (!ALLOWED_PREFIXES.some((prefix) => normalised.startsWith(prefix))) {
+    res.status(403).json({ error: 'path not permitted by proxy allowlist' });
+    return;
+  }
+
+  const target = `${INGRESS}${normalised}${search}`;
 
   const headers: Record<string, string> = {};
   for (const [k, v] of Object.entries(req.headers)) {

--- a/services/ui/apps/nv-metropolis-bp-vss-ui/pages/api/proxy/[...path].ts
+++ b/services/ui/apps/nv-metropolis-bp-vss-ui/pages/api/proxy/[...path].ts
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Same-origin proxy to the VSS ingress, for running the UI outside its normal
+ * deployment origin.
+ *
+ * In the deployed container the UI and every VSS API share one origin behind
+ * haproxy, so browser fetches work directly. Served from anywhere else — a dev
+ * server, a different tunnel — those same absolute URLs become cross-origin
+ * *and* hit haproxy's basic auth, which the browser has no credentials for, and
+ * every tab fails with "Failed to fetch".
+ *
+ * Forwarding through the server fixes both: the request is same-origin from the
+ * browser's point of view, and it reaches the ingress by its internal address,
+ * which haproxy leaves unauthenticated (auth only fires for traffic arriving
+ * via Cloudflare).
+ *
+ * Set VSS_INGRESS_ORIGIN to point at the ingress; defaults to the local one.
+ */
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const INGRESS = (process.env.VSS_INGRESS_ORIGIN || 'http://127.0.0.1:7777').replace(/\/$/, '');
+
+export const config = {
+  api: {
+    bodyParser: false, // stream bodies through untouched (uploads included)
+    responseLimit: false,
+  },
+};
+
+const HOP_BY_HOP = new Set([
+  'connection',
+  'keep-alive',
+  'transfer-encoding',
+  'upgrade',
+  'host',
+  'content-length',
+]);
+
+async function readBody(req: NextApiRequest): Promise<Buffer | undefined> {
+  if (req.method === 'GET' || req.method === 'HEAD') return undefined;
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(Buffer.from(chunk));
+  return chunks.length ? Buffer.concat(chunks) : undefined;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const segments = Array.isArray(req.query.path) ? req.query.path : [req.query.path ?? ''];
+  const search = req.url?.includes('?') ? req.url.slice(req.url.indexOf('?')) : '';
+  const target = `${INGRESS}/${segments.join('/')}${search}`;
+
+  const headers: Record<string, string> = {};
+  for (const [k, v] of Object.entries(req.headers)) {
+    if (!HOP_BY_HOP.has(k.toLowerCase()) && typeof v === 'string') headers[k] = v;
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(target, {
+      method: req.method,
+      headers,
+      body: await readBody(req),
+      redirect: 'manual',
+    });
+  } catch (err) {
+    res.status(502).json({
+      error: `VSS ingress unreachable at ${target}`,
+      detail: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+
+  upstream.headers.forEach((value, key) => {
+    if (!HOP_BY_HOP.has(key.toLowerCase())) res.setHeader(key, value);
+  });
+  res.status(upstream.status);
+
+  if (!upstream.body) {
+    res.end();
+    return;
+  }
+
+  const reader = upstream.body.getReader();
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      res.write(Buffer.from(value));
+    }
+  } catch {
+    // Client disconnected or upstream failed mid-response.
+  } finally {
+    reader.releaseLock();
+    res.end();
+  }
+}

--- a/services/ui/apps/nv-metropolis-bp-vss-ui/pages/api/proxy/[...path].ts
+++ b/services/ui/apps/nv-metropolis-bp-vss-ui/pages/api/proxy/[...path].ts
@@ -14,7 +14,10 @@
  * which haproxy leaves unauthenticated (auth only fires for traffic arriving
  * via Cloudflare).
  *
- * Set VSS_INGRESS_ORIGIN to point at the ingress; defaults to the local one.
+ * The ingress address is derived, not configured. It is a fixed service on the
+ * same compose network, so only its port can vary -- and deriving it avoids a
+ * second "where is the ingress" setting alongside the public origin, which is
+ * the same haproxy seen from outside.
  *
  * SCOPE: deliberately narrow. This route is reachable from the public internet
  * and reaches the ingress by its internal address, which haproxy leaves
@@ -25,7 +28,7 @@
  */
 import type { NextApiRequest, NextApiResponse } from 'next';
 
-const INGRESS = (process.env.VSS_INGRESS_ORIGIN || 'http://127.0.0.1:7777').replace(/\/$/, '');
+const INGRESS = `http://vss-haproxy-ingress:${process.env.HAPROXY_PORT || '7777'}`;
 
 export const config = {
   api: {

--- a/services/ui/apps/nv-metropolis-bp-vss-ui/pages/api/vss-chat.ts
+++ b/services/ui/apps/nv-metropolis-bp-vss-ui/pages/api/vss-chat.ts
@@ -40,8 +40,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       /\/chat\/stream$/,
       '',
     );
+    // Forward the conversation so the adapter serves only that conversation's
+    // result rather than whatever ran last, process-wide.
+    const conversation = String(req.query.conversation ?? '');
+    const qs = conversation ? `?conversation=${encodeURIComponent(conversation)}` : '';
     try {
-      const upstream = await fetch(`${base}/v1/search/last`);
+      const upstream = await fetch(`${base}/v1/search/last${qs}`);
       res.status(upstream.status).json(await upstream.json());
     } catch (err) {
       res.status(502).json({

--- a/services/ui/apps/nv-metropolis-bp-vss-ui/pages/api/vss-chat.ts
+++ b/services/ui/apps/nv-metropolis-bp-vss-ui/pages/api/vss-chat.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Server-side proxy from the VSS chat surfaces to the agent backend.
+ *
+ * Needed because the replacement ChatPanel fetches from the browser, while the
+ * configured backends (the agent adapter) sit on host-private ports that a
+ * browser cannot reach. Proxying server-side also keeps the adapter's address
+ * out of the client bundle.
+ *
+ * The SSE stream is piped through untouched; all parsing happens in
+ * @nv-metropolis-bp-vss-ui/chat.
+ *
+ * Targets resolve from server-only vars first, then fall back to the existing
+ * NEXT_PUBLIC_* chat completion URLs so an existing deployment needs no new
+ * configuration.
+ */
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const backendFor = (surface: string): string | undefined => {
+  if (surface === 'sidebar') {
+    return (
+      process.env.VSS_CHAT_BACKEND_SIDEBAR ||
+      process.env.NEXT_PUBLIC_SIDEBAR_CHAT_HTTP_CHAT_COMPLETION_URL ||
+      process.env.NEXT_PUBLIC_HTTP_CHAT_COMPLETION_URL
+    );
+  }
+  if (surface === 'main') {
+    return process.env.VSS_CHAT_BACKEND_MAIN || process.env.NEXT_PUBLIC_HTTP_CHAT_COMPLETION_URL;
+  }
+  return undefined;
+};
+
+export const config = { api: { bodyParser: { sizeLimit: '5mb' } } };
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'method not allowed' });
+    return;
+  }
+
+  const surface = String(req.query.surface ?? 'main');
+  const target = backendFor(surface);
+  if (!target) {
+    res.status(400).json({ error: `no backend configured for surface: ${surface}` });
+    return;
+  }
+
+  const controller = new AbortController();
+  // Navigating away or pressing Stop should drop the upstream turn too.
+  req.on('close', () => controller.abort());
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(target, {
+      method: 'POST',
+      signal: controller.signal,
+      headers: {
+        'Content-Type': 'application/json',
+        'Conversation-Id': String(req.headers['conversation-id'] ?? ''),
+      },
+      body: JSON.stringify(req.body ?? {}),
+    });
+  } catch (err) {
+    res.status(502).json({
+      error: `agent backend unreachable at ${target}`,
+      detail: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+
+  if (!upstream.ok || !upstream.body) {
+    res.status(502).json({ error: `agent backend returned HTTP ${upstream.status}` });
+    return;
+  }
+
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache, no-transform',
+    Connection: 'close',
+    'X-Accel-Buffering': 'no',
+  });
+
+  const reader = upstream.body.getReader();
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      res.write(Buffer.from(value));
+      // Next buffers by default; without flushing, SSE arrives all at once.
+      (res as unknown as { flush?: () => void }).flush?.();
+    }
+  } catch {
+    // Client hung up or upstream died mid-turn.
+  } finally {
+    reader.releaseLock();
+    res.end();
+  }
+}

--- a/services/ui/apps/nv-metropolis-bp-vss-ui/pages/api/vss-chat.ts
+++ b/services/ui/apps/nv-metropolis-bp-vss-ui/pages/api/vss-chat.ts
@@ -33,6 +33,25 @@ const backendFor = (surface: string): string | undefined => {
 export const config = { api: { bodyParser: { sizeLimit: '5mb' } } };
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  // GET returns the most recent search result from the adapter, so the Search
+  // tab can render hits that never passed through the model's reply text.
+  if (req.method === 'GET') {
+    const base = (backendFor(String(req.query.surface ?? 'sidebar')) || '').replace(
+      /\/chat\/stream$/,
+      '',
+    );
+    try {
+      const upstream = await fetch(`${base}/v1/search/last`);
+      res.status(upstream.status).json(await upstream.json());
+    } catch (err) {
+      res.status(502).json({
+        error: 'could not read last search result',
+        detail: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return;
+  }
+
   if (req.method !== 'POST') {
     res.status(405).json({ error: 'method not allowed' });
     return;

--- a/services/ui/apps/vss-chat/.gitignore
+++ b/services/ui/apps/vss-chat/.gitignore
@@ -1,0 +1,3 @@
+.next/
+node_modules/
+next-env.d.ts

--- a/services/ui/apps/vss-chat/next.config.js
+++ b/services/ui/apps/vss-chat/next.config.js
@@ -1,0 +1,10 @@
+/** @type {import('next').NextConfig} */
+// SPDX-License-Identifier: MIT
+const nextConfig = {
+  reactStrictMode: true,
+  output: 'standalone',
+  // The chat package ships untranspiled ESM-ish output from swc.
+  transpilePackages: ['@nv-metropolis-bp-vss-ui/chat'],
+};
+
+module.exports = nextConfig;

--- a/services/ui/apps/vss-chat/package.json
+++ b/services/ui/apps/vss-chat/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "vss-chat",
+  "version": "3.3-dev",
+  "private": true,
+  "description": "Standalone VSS chat UI. No NeMo Agent Toolkit dependency, in UI or core.",
+  "scripts": {
+    "dev": "next dev -p 3100",
+    "build": "next build",
+    "start": "next start -p 3100",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf .next node_modules"
+  },
+  "dependencies": {
+    "@nv-metropolis-bp-vss-ui/chat": "*",
+    "next": "15.5.23",
+    "next-runtime-env": "^1.3.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "18.0.28",
+    "@types/react-dom": "18.0.11",
+    "typescript": "4.9.5"
+  }
+}

--- a/services/ui/apps/vss-chat/pages/_app.tsx
+++ b/services/ui/apps/vss-chat/pages/_app.tsx
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+import type { AppProps } from 'next/app';
+
+import '@nv-metropolis-bp-vss-ui/chat/styles';
+import '../styles/global.css';
+
+export default function VssChatApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/services/ui/apps/vss-chat/pages/api/chat.ts
+++ b/services/ui/apps/vss-chat/pages/api/chat.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Server-side proxy to the agent backend.
+ *
+ * The browser must not talk to the adapter directly: it sits on a host-private
+ * port, and keeping it server-side means the adapter's address (and any token)
+ * never reaches the client. The browser calls this same-origin route instead,
+ * and the SSE stream is piped straight through untouched — the parsing all
+ * happens in the chat package.
+ *
+ * Targets are configured with server-only env vars, so they are not inlined
+ * into the client bundle:
+ *
+ *   VSS_CHAT_BACKEND_MAIN      default http://127.0.0.1:9097/chat/stream
+ *   VSS_CHAT_BACKEND_SIDEBAR   default http://127.0.0.1:9098/chat/stream
+ */
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const BACKENDS: Record<string, string> = {
+  main: process.env.VSS_CHAT_BACKEND_MAIN || 'http://127.0.0.1:9097/chat/stream',
+  sidebar: process.env.VSS_CHAT_BACKEND_SIDEBAR || 'http://127.0.0.1:9098/chat/stream',
+};
+
+export const config = { api: { bodyParser: { sizeLimit: '5mb' } } };
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'method not allowed' });
+    return;
+  }
+
+  const surface = String(req.query.surface ?? 'main');
+  const target = BACKENDS[surface];
+  if (!target) {
+    res.status(400).json({ error: `unknown surface: ${surface}` });
+    return;
+  }
+
+  const controller = new AbortController();
+  // If the user navigates away or hits Stop, drop the upstream turn too.
+  req.on('close', () => controller.abort());
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(target, {
+      method: 'POST',
+      signal: controller.signal,
+      headers: {
+        'Content-Type': 'application/json',
+        'Conversation-Id': String(req.headers['conversation-id'] ?? ''),
+      },
+      body: JSON.stringify(req.body ?? {}),
+    });
+  } catch (err) {
+    res.status(502).json({
+      error: `agent backend unreachable at ${target}`,
+      detail: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+
+  if (!upstream.ok || !upstream.body) {
+    res.status(502).json({ error: `agent backend returned HTTP ${upstream.status}` });
+    return;
+  }
+
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache, no-transform',
+    Connection: 'close',
+    'X-Accel-Buffering': 'no',
+  });
+
+  const reader = upstream.body.getReader();
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      res.write(Buffer.from(value));
+      // Next buffers by default; SSE is useless unless each frame is flushed.
+      (res as unknown as { flush?: () => void }).flush?.();
+    }
+  } catch {
+    // Client hung up or upstream died; nothing useful to add to the stream.
+  } finally {
+    reader.releaseLock();
+    res.end();
+  }
+}

--- a/services/ui/apps/vss-chat/pages/index.tsx
+++ b/services/ui/apps/vss-chat/pages/index.tsx
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Standalone VSS chat UI.
+ *
+ * Renders both surfaces the toolkit UI currently provides — a full chat pane
+ * and a docked sidebar — without the toolkit being involved at all.
+ *
+ * Both panels post to this app's own /api/chat route, which proxies to the
+ * agent backend server-side. The adapter therefore stays on a host-private
+ * port and its address never reaches the browser; see pages/api/chat.ts.
+ */
+import { useMemo, useState } from 'react';
+import Head from 'next/head';
+
+import { ChatPanel } from '@nv-metropolis-bp-vss-ui/chat';
+
+export default function Home() {
+  const main = useMemo(() => ({ url: '/api/chat?surface=main' }), []);
+  const sidebar = useMemo(() => ({ url: '/api/chat?surface=sidebar' }), []);
+
+  const [sidebarOpen, setSidebarOpen] = useState(true);
+  // Last answer from either panel, so the layout can demonstrate the hand-off
+  // that feature tabs (search, alerts) will use in the real app.
+  const [lastAnswer, setLastAnswer] = useState<string | null>(null);
+
+  return (
+    <>
+      <Head>
+        <title>VSS Chat</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+
+      <div className="vss-shell">
+        <header className="vss-shell-bar">
+          <strong>VSS Chat</strong>
+          <span className="vss-shell-note">
+            no NeMo Agent Toolkit — UI or core
+          </span>
+          <button type="button" onClick={() => setSidebarOpen((v) => !v)}>
+            {sidebarOpen ? 'Hide sidebar' : 'Show sidebar'}
+          </button>
+        </header>
+
+        <main className="vss-shell-body">
+          <div className="vss-shell-main">
+            <ChatPanel
+              endpoint={main}
+              title="🔮 Hermes Agent"
+              theme="dark"
+              placeholder="Ask about your video…"
+              onAnswer={(answer) => setLastAnswer(answer)}
+            />
+          </div>
+
+          {sidebarOpen && (
+            <aside className="vss-shell-side">
+              <ChatPanel
+                endpoint={sidebar}
+                title="🦙 NemoClaw Agent"
+                theme="light"
+                placeholder="Ask the sandboxed agent…"
+                onAnswer={(answer) => setLastAnswer(answer)}
+              />
+            </aside>
+          )}
+        </main>
+
+        {lastAnswer && (
+          <footer className="vss-shell-foot">
+            last answer forwarded to feature tabs: {lastAnswer.slice(0, 120)}
+            {lastAnswer.length > 120 ? '…' : ''}
+          </footer>
+        )}
+      </div>
+    </>
+  );
+}

--- a/services/ui/apps/vss-chat/styles/global.css
+++ b/services/ui/apps/vss-chat/styles/global.css
@@ -1,0 +1,52 @@
+/* SPDX-License-Identifier: MIT */
+:root { color-scheme: dark; }
+
+html, body, #__next { height: 100%; margin: 0; }
+
+body {
+  background: #0f1115;
+  color: #e8eaed;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+
+.vss-shell { display: flex; flex-direction: column; height: 100%; }
+
+.vss-shell-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-bottom: 1px solid #2c2f36;
+  flex: 0 0 auto;
+}
+.vss-shell-note { color: #9aa0a6; font-size: 13px; margin-right: auto; }
+.vss-shell-bar button {
+  background: transparent;
+  border: 1px solid #2c2f36;
+  color: inherit;
+  border-radius: 8px;
+  padding: 6px 12px;
+  cursor: pointer;
+  font: inherit;
+}
+
+.vss-shell-body { flex: 1 1 auto; display: flex; min-height: 0; }
+.vss-shell-main { flex: 1 1 auto; min-width: 0; }
+.vss-shell-side {
+  flex: 0 0 380px;
+  border-left: 1px solid #2c2f36;
+  min-width: 0;
+}
+
+.vss-shell-foot {
+  flex: 0 0 auto;
+  padding: 8px 16px;
+  border-top: 1px solid #2c2f36;
+  color: #9aa0a6;
+  font-size: 12px;
+}
+
+@media (max-width: 820px) {
+  .vss-shell-body { flex-direction: column; }
+  .vss-shell-side { flex: 1 1 auto; border-left: none; border-top: 1px solid #2c2f36; }
+}

--- a/services/ui/apps/vss-chat/tsconfig.json
+++ b/services/ui/apps/vss-chat/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/services/ui/package-lock.json
+++ b/services/ui/package-lock.json
@@ -3387,6 +3387,32 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
+        "apps/vss-chat": {
+            "version": "3.3-dev",
+            "dependencies": {
+                "@nv-metropolis-bp-vss-ui/chat": "*",
+                "next": "15.5.23",
+                "next-runtime-env": "^1.3.0",
+                "react": "^18.2.0",
+                "react-dom": "^18.2.0"
+            },
+            "devDependencies": {
+                "@types/node": "^20",
+                "@types/react": "18.0.28",
+                "@types/react-dom": "18.0.11",
+                "typescript": "4.9.5"
+            }
+        },
+        "apps/vss-chat/node_modules/@types/node": {
+            "version": "20.19.43",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+            "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.21.0"
+            }
+        },
         "node_modules/@acemir/cssom": {
             "version": "0.9.31",
             "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
@@ -23487,6 +23513,13 @@
                 "node": ">=20.18.1"
             }
         },
+        "node_modules/undici-types": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/unicorn-magic": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
@@ -23911,6 +23944,10 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/vss-chat": {
+            "resolved": "apps/vss-chat",
+            "link": true
         },
         "node_modules/w3c-xmlserializer": {
             "version": "5.0.0",

--- a/services/ui/package-lock.json
+++ b/services/ui/package-lock.json
@@ -6010,6 +6010,13 @@
             "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
             "license": "Apache-2.0"
         },
+        "node_modules/@keyv/serialize": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+            "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@kurkle/color": {
             "version": "0.3.4",
             "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
@@ -6554,6 +6561,10 @@
         },
         "node_modules/@nv-metropolis-bp-vss-ui/all": {
             "resolved": "packages/nv-metropolis-bp-vss-ui/all",
+            "link": true
+        },
+        "node_modules/@nv-metropolis-bp-vss-ui/chat": {
+            "resolved": "packages/nv-metropolis-bp-vss-ui/chat",
             "link": true
         },
         "node_modules/@nv-metropolis-bp-vss-ui/dashboard": {
@@ -8454,6 +8465,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@sec-ant/readable-stream": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+            "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@shikijs/core": {
             "version": "3.23.0",
             "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
@@ -8530,6 +8548,19 @@
             },
             "funding": {
                 "url": "https://github.com/sindresorhus/is?sponsor=1"
+            }
+        },
+        "node_modules/@sindresorhus/merge-streams": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+            "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@sinonjs/commons": {
@@ -11009,6 +11040,215 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/binary-version": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/binary-version/-/binary-version-7.1.0.tgz",
+            "integrity": "sha512-Iy//vPc3ANPNlIWd242Npqc8MK0a/i4kVcHDlDA6HNMv5zMxz4ulIFhOSYJVKw/8AbHdHy0CnGYEt1QqSXxPsw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "execa": "^8.0.1",
+                "find-versions": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/binary-version-check": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/binary-version-check/-/binary-version-check-6.1.0.tgz",
+            "integrity": "sha512-REKdLKmuViV2WrtWXvNSiPX04KbIjfUV3Cy8batUeOg+FtmowavzJorfFhWq95cVJzINnL/44ixP26TrdJZACA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "binary-version": "^7.1.0",
+                "semver": "^7.6.0",
+                "semver-truncate": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/binary-version-check/node_modules/semver": {
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/binary-version/node_modules/execa": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^8.0.1",
+                "human-signals": "^5.0.0",
+                "is-stream": "^3.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^5.1.0",
+                "onetime": "^6.0.0",
+                "signal-exit": "^4.1.0",
+                "strip-final-newline": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/binary-version/node_modules/find-versions": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-6.0.0.tgz",
+            "integrity": "sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver-regex": "^4.0.5",
+                "super-regex": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/binary-version/node_modules/get-stream": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/binary-version/node_modules/human-signals": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+            "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=16.17.0"
+            }
+        },
+        "node_modules/binary-version/node_modules/is-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/binary-version/node_modules/mimic-fn": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/binary-version/node_modules/npm-run-path": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+            "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^4.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/binary-version/node_modules/onetime": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/binary-version/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/binary-version/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/binary-version/node_modules/strip-final-newline": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/brace-expansion": {
             "version": "5.0.5",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
@@ -11155,6 +11395,19 @@
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/byte-counter": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/byte-counter/-/byte-counter-0.1.0.tgz",
+            "integrity": "sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/cacheable-lookup": {
             "version": "7.0.0",
@@ -11640,6 +11893,19 @@
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/convert-hrtime": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+            "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/convert-source-map": {
@@ -13493,6 +13759,22 @@
                 "bser": "2.1.1"
             }
         },
+        "node_modules/figures": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+            "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-unicode-supported": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/file-entry-cache": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -13809,6 +14091,19 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/function-timeout": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
+            "integrity": "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/function.prototype.name": {
@@ -15277,6 +15572,19 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-unicode-supported": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+            "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-weakmap": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -15885,6 +16193,574 @@
             "dev": true,
             "license": "MIT",
             "peer": true
+        },
+        "node_modules/jest-environment-jsdom": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.4.1.tgz",
+            "integrity": "sha512-o3nfaN4zej7qgk2X0j8Jhq/S9nAVKs2xK3QeQxeHVvpkEPxaA1yxDGydR+iVI7zPy7Cp62Aq2h3Ja46QvfWHGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/environment": "30.4.1",
+                "@jest/environment-jsdom-abstract": "30.4.1",
+                "jsdom": "^26.1.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/@asamuzakjp/css-color": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+            "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/css-calc": "^2.1.3",
+                "@csstools/css-color-parser": "^3.0.9",
+                "@csstools/css-parser-algorithms": "^3.0.4",
+                "@csstools/css-tokenizer": "^3.0.3",
+                "lru-cache": "^10.4.3"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/@csstools/color-helpers": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+            "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/@csstools/css-calc": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+            "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/@csstools/css-color-parser": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+            "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/color-helpers": "^5.1.0",
+                "@csstools/css-calc": "^2.1.4"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/@csstools/css-parser-algorithms": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+            "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/@csstools/css-tokenizer": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+            "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/@jest/environment": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+            "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/fake-timers": "30.4.1",
+                "@jest/types": "30.4.1",
+                "@types/node": "*",
+                "jest-mock": "30.4.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/@jest/environment-jsdom-abstract": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.4.1.tgz",
+            "integrity": "sha512-dSlKrqug3siYNHVnjwIldShY12wAH3spwRltO/+8VOjg0X+xEq7vOs3DbBs4LRKsu7OH+NUb9kuZUNBF9Ho3TA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/environment": "30.4.1",
+                "@jest/fake-timers": "30.4.1",
+                "@jest/types": "30.4.1",
+                "@types/jsdom": "^21.1.7",
+                "@types/node": "*",
+                "jest-mock": "30.4.1",
+                "jest-util": "30.4.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/@jest/fake-timers": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+            "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.4.1",
+                "@sinonjs/fake-timers": "^15.4.0",
+                "@types/node": "*",
+                "jest-message-util": "30.4.1",
+                "jest-mock": "30.4.1",
+                "jest-util": "30.4.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/@jest/pattern": {
+            "version": "30.4.0",
+            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "jest-regex-util": "30.4.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/@jest/schemas": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sinclair/typebox": "^0.34.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/@jest/types": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/pattern": "30.4.0",
+                "@jest/schemas": "30.4.1",
+                "@types/istanbul-lib-coverage": "^2.0.6",
+                "@types/istanbul-reports": "^3.0.4",
+                "@types/node": "*",
+                "@types/yargs": "^17.0.33",
+                "chalk": "^4.1.2"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/@sinclair/typebox": {
+            "version": "0.34.52",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+            "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/jest-environment-jsdom/node_modules/@sinonjs/fake-timers": {
+            "version": "15.4.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+            "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.1"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/ci-info": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+            "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/cssstyle": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+            "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/css-color": "^3.2.0",
+                "rrweb-cssom": "^0.8.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/data-urls": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+            "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/html-encoding-sniffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+            "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-encoding": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/jest-message-util": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+            "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.27.1",
+                "@jest/types": "30.4.1",
+                "@types/stack-utils": "^2.0.3",
+                "chalk": "^4.1.2",
+                "graceful-fs": "^4.2.11",
+                "jest-util": "30.4.1",
+                "picomatch": "^4.0.3",
+                "pretty-format": "30.4.1",
+                "slash": "^3.0.0",
+                "stack-utils": "^2.0.6"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/jest-mock": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+            "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.4.1",
+                "@types/node": "*",
+                "jest-util": "30.4.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/jest-regex-util": {
+            "version": "30.4.0",
+            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/jest-util": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+            "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.4.1",
+                "@types/node": "*",
+                "chalk": "^4.1.2",
+                "ci-info": "^4.2.0",
+                "graceful-fs": "^4.2.11",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/jsdom": {
+            "version": "26.1.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+            "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cssstyle": "^4.2.1",
+                "data-urls": "^5.0.0",
+                "decimal.js": "^10.5.0",
+                "html-encoding-sniffer": "^4.0.0",
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.6",
+                "is-potential-custom-element-name": "^1.0.1",
+                "nwsapi": "^2.2.16",
+                "parse5": "^7.2.1",
+                "rrweb-cssom": "^0.8.0",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^5.1.1",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^7.0.0",
+                "whatwg-encoding": "^3.1.1",
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.1.1",
+                "ws": "^8.18.0",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/jest-environment-jsdom/node_modules/picomatch": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+            "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/pretty-format": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+            "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/schemas": "30.4.1",
+                "ansi-styles": "^5.2.0",
+                "react-is-18": "npm:react-is@^18.3.1",
+                "react-is-19": "npm:react-is@^19.2.5"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/tldts": {
+            "version": "6.1.86",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+            "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^6.1.86"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/tldts-core": {
+            "version": "6.1.86",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+            "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/jest-environment-jsdom/node_modules/tough-cookie": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+            "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tldts": "^6.1.32"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/tr46": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+            "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/whatwg-mimetype": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/whatwg-url": {
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+            "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "^5.1.0",
+                "webidl-conversions": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/jest-environment-node": {
             "version": "29.7.0",
@@ -17044,6 +17920,37 @@
             "peer": true,
             "bin": {
                 "lz-string": "bin/bin.js"
+            }
+        },
+        "node_modules/make-asynchronous": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/make-asynchronous/-/make-asynchronous-1.1.0.tgz",
+            "integrity": "sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-event": "^6.0.0",
+                "type-fest": "^4.6.0",
+                "web-worker": "^1.5.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/make-asynchronous/node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/make-dir": {
@@ -18780,6 +19687,22 @@
                 "node": ">=12.20"
             }
         },
+        "node_modules/p-event": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
+            "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-timeout": "^6.1.2"
+            },
+            "engines": {
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/p-limit": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -18807,6 +19730,19 @@
             },
             "engines": {
                 "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-timeout": {
+            "version": "6.1.4",
+            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+            "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -18881,6 +19817,19 @@
             },
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/parse-ms": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+            "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -19454,6 +20403,22 @@
             "license": "MIT",
             "peer": true
         },
+        "node_modules/pretty-ms": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+            "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "parse-ms": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/prismjs": {
             "version": "1.30.0",
             "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
@@ -19785,6 +20750,22 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+            "license": "MIT"
+        },
+        "node_modules/react-is-18": {
+            "name": "react-is",
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/react-is-19": {
+            "name": "react-is",
+            "version": "19.2.8",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+            "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/react-kapsule": {
@@ -21632,6 +22613,24 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/super-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.1.0.tgz",
+            "integrity": "sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "function-timeout": "^1.0.1",
+                "make-asynchronous": "^1.0.1",
+                "time-span": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/supports-color": {
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -21681,6 +22680,19 @@
             },
             "funding": {
                 "url": "https://opencollective.com/synckit"
+            }
+        },
+        "node_modules/system-architecture": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/system-architecture/-/system-architecture-1.0.0.tgz",
+            "integrity": "sha512-0OJWD12D7XX3KUg1DYkMaTTjSTo2k/mhIYI3HlBlceXSMcJhW/1qO735fPKS5prcyjvn57Ub151vvASYXpQrEw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/tailwindcss": {
@@ -21935,6 +22947,22 @@
             "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/time-span": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+            "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "convert-hrtime": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/tiny-invariant": {
             "version": "1.3.3",
@@ -22459,6 +23487,19 @@
                 "node": ">=20.18.1"
             }
         },
+        "node_modules/unicorn-magic": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+            "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/unified": {
             "version": "11.0.5",
             "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
@@ -22912,6 +23953,13 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/web-worker": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+            "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
         "node_modules/webidl-conversions": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -23254,6 +24302,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/yoctocolors": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+            "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -29197,6 +30258,1960 @@
             },
             "engines": {
                 "node": ">=20"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat": {
+            "name": "@nv-metropolis-bp-vss-ui/chat",
+            "version": "3.3-dev",
+            "dependencies": {
+                "@tabler/icons-react": "^2.9.0",
+                "react": "^18.2.0",
+                "react-dom": "^18.2.0",
+                "react-markdown": "^10.1.0",
+                "remark-gfm": "^4.0.1"
+            },
+            "devDependencies": {
+                "@swc/cli": "^0.8.0",
+                "@swc/core": "^1.13.19",
+                "@types/react": "18.0.28",
+                "@types/react-dom": "18.0.11",
+                "identity-obj-proxy": "^3.0.0",
+                "jest": "^30.3.0",
+                "jest-environment-jsdom": "^30.3.0",
+                "ts-jest": "^29.4.9",
+                "typescript": "4.9.5"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@jest/console": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.4.1.tgz",
+            "integrity": "sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.4.1",
+                "@types/node": "*",
+                "chalk": "^4.1.2",
+                "jest-message-util": "30.4.1",
+                "jest-util": "30.4.1",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@jest/core": {
+            "version": "30.4.2",
+            "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
+            "integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/console": "30.4.1",
+                "@jest/pattern": "30.4.0",
+                "@jest/reporters": "30.4.1",
+                "@jest/test-result": "30.4.1",
+                "@jest/transform": "30.4.1",
+                "@jest/types": "30.4.1",
+                "@types/node": "*",
+                "ansi-escapes": "^4.3.2",
+                "chalk": "^4.1.2",
+                "ci-info": "^4.2.0",
+                "exit-x": "^0.2.2",
+                "fast-json-stable-stringify": "^2.1.0",
+                "graceful-fs": "^4.2.11",
+                "jest-changed-files": "30.4.1",
+                "jest-config": "30.4.2",
+                "jest-haste-map": "30.4.1",
+                "jest-message-util": "30.4.1",
+                "jest-regex-util": "30.4.0",
+                "jest-resolve": "30.4.1",
+                "jest-resolve-dependencies": "30.4.2",
+                "jest-runner": "30.4.2",
+                "jest-runtime": "30.4.2",
+                "jest-snapshot": "30.4.1",
+                "jest-util": "30.4.1",
+                "jest-validate": "30.4.1",
+                "jest-watcher": "30.4.1",
+                "pretty-format": "30.4.1",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+            },
+            "peerDependenciesMeta": {
+                "node-notifier": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@jest/core/node_modules/jest-config": {
+            "version": "30.4.2",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
+            "integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.27.4",
+                "@jest/get-type": "30.1.0",
+                "@jest/pattern": "30.4.0",
+                "@jest/test-sequencer": "30.4.1",
+                "@jest/types": "30.4.1",
+                "babel-jest": "30.4.1",
+                "chalk": "^4.1.2",
+                "ci-info": "^4.2.0",
+                "deepmerge": "^4.3.1",
+                "glob": "^10.5.0",
+                "graceful-fs": "^4.2.11",
+                "jest-circus": "30.4.2",
+                "jest-docblock": "30.4.0",
+                "jest-environment-node": "30.4.1",
+                "jest-regex-util": "30.4.0",
+                "jest-resolve": "30.4.1",
+                "jest-runner": "30.4.2",
+                "jest-util": "30.4.1",
+                "jest-validate": "30.4.1",
+                "parse-json": "^5.2.0",
+                "pretty-format": "30.4.1",
+                "slash": "^3.0.0",
+                "strip-json-comments": "^3.1.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "@types/node": "*",
+                "esbuild-register": ">=3.4.0",
+                "ts-node": ">=9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "esbuild-register": {
+                    "optional": true
+                },
+                "ts-node": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@jest/diff-sequences": {
+            "version": "30.4.0",
+            "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+            "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@jest/environment": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+            "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/fake-timers": "30.4.1",
+                "@jest/types": "30.4.1",
+                "@types/node": "*",
+                "jest-mock": "30.4.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@jest/expect": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
+            "integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "expect": "30.4.1",
+                "jest-snapshot": "30.4.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@jest/expect-utils": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+            "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/get-type": "30.1.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@jest/fake-timers": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+            "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.4.1",
+                "@sinonjs/fake-timers": "^15.4.0",
+                "@types/node": "*",
+                "jest-message-util": "30.4.1",
+                "jest-mock": "30.4.1",
+                "jest-util": "30.4.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@jest/globals": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
+            "integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/environment": "30.4.1",
+                "@jest/expect": "30.4.1",
+                "@jest/types": "30.4.1",
+                "jest-mock": "30.4.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@jest/pattern": {
+            "version": "30.4.0",
+            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "jest-regex-util": "30.4.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@jest/reporters": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.4.1.tgz",
+            "integrity": "sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@bcoe/v8-coverage": "^0.2.3",
+                "@jest/console": "30.4.1",
+                "@jest/test-result": "30.4.1",
+                "@jest/transform": "30.4.1",
+                "@jest/types": "30.4.1",
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "@types/node": "*",
+                "chalk": "^4.1.2",
+                "collect-v8-coverage": "^1.0.2",
+                "exit-x": "^0.2.2",
+                "glob": "^10.5.0",
+                "graceful-fs": "^4.2.11",
+                "istanbul-lib-coverage": "^3.0.0",
+                "istanbul-lib-instrument": "^6.0.0",
+                "istanbul-lib-report": "^3.0.0",
+                "istanbul-lib-source-maps": "^5.0.0",
+                "istanbul-reports": "^3.1.3",
+                "jest-message-util": "30.4.1",
+                "jest-util": "30.4.1",
+                "jest-worker": "30.4.1",
+                "slash": "^3.0.0",
+                "string-length": "^4.0.2",
+                "v8-to-istanbul": "^9.0.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+            },
+            "peerDependenciesMeta": {
+                "node-notifier": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@jest/schemas": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sinclair/typebox": "^0.34.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@jest/snapshot-utils": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
+            "integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.4.1",
+                "chalk": "^4.1.2",
+                "graceful-fs": "^4.2.11",
+                "natural-compare": "^1.4.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@jest/source-map": {
+            "version": "30.0.1",
+            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
+            "integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "callsites": "^3.1.0",
+                "graceful-fs": "^4.2.11"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@jest/test-result": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.4.1.tgz",
+            "integrity": "sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/console": "30.4.1",
+                "@jest/types": "30.4.1",
+                "@types/istanbul-lib-coverage": "^2.0.6",
+                "collect-v8-coverage": "^1.0.2"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@jest/test-sequencer": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz",
+            "integrity": "sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/test-result": "30.4.1",
+                "graceful-fs": "^4.2.11",
+                "jest-haste-map": "30.4.1",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@jest/transform": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
+            "integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.27.4",
+                "@jest/types": "30.4.1",
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "babel-plugin-istanbul": "^7.0.1",
+                "chalk": "^4.1.2",
+                "convert-source-map": "^2.0.0",
+                "fast-json-stable-stringify": "^2.1.0",
+                "graceful-fs": "^4.2.11",
+                "jest-haste-map": "30.4.1",
+                "jest-regex-util": "30.4.0",
+                "jest-util": "30.4.1",
+                "pirates": "^4.0.7",
+                "slash": "^3.0.0",
+                "write-file-atomic": "^5.0.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@jest/types": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/pattern": "30.4.0",
+                "@jest/schemas": "30.4.1",
+                "@types/istanbul-lib-coverage": "^2.0.6",
+                "@types/istanbul-reports": "^3.0.4",
+                "@types/node": "*",
+                "@types/yargs": "^17.0.33",
+                "chalk": "^4.1.2"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@sinclair/typebox": {
+            "version": "0.34.52",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+            "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@sindresorhus/is": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+            "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/is?sponsor=1"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@sinonjs/fake-timers": {
+            "version": "15.4.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+            "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.1"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@swc/cli": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@swc/cli/-/cli-0.8.1.tgz",
+            "integrity": "sha512-L+ACCGHCiS0VqHVep/INLVnvRvJ2XooQFLZq4L8snhxw1jsqz+XRcY313UsyPVturPPE1shW3jic7rt3qEQTSQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@swc/counter": "^0.1.3",
+                "@xhmikosr/bin-wrapper": "^14.0.0",
+                "commander": "^8.3.0",
+                "minimatch": "^9.0.3",
+                "piscina": "^4.3.1",
+                "semver": "^7.3.8",
+                "slash": "3.0.0",
+                "source-map": "^0.7.3",
+                "tinyglobby": "^0.2.13"
+            },
+            "bin": {
+                "spack": "bin/spack.js",
+                "swc": "bin/swc.js",
+                "swcx": "bin/swcx.js"
+            },
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "peerDependencies": {
+                "@swc/core": "^1.2.66",
+                "chokidar": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "chokidar": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@xhmikosr/archive-type": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@xhmikosr/archive-type/-/archive-type-8.1.0.tgz",
+            "integrity": "sha512-EXOjEbnZFE5c/nFMf4FOrEURVanzHpnkPYmnmr78u02/8hAhE0FMq8p9TK1IM0/bFr5VcyBUY0gfLm8f7dKy+Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "file-type": "^21.3.4"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@xhmikosr/bin-check": {
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/@xhmikosr/bin-check/-/bin-check-8.2.2.tgz",
+            "integrity": "sha512-Y/b0YJoCDda6DCFj8ikks06GrEWDsz/3vdgGLeectV9p+YJc76YugRjtqFdd2KTf2rnEPjalL2hcXP+x2KcSLQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "execa": "^9.6.1",
+                "isexe": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@xhmikosr/bin-wrapper": {
+            "version": "14.5.1",
+            "resolved": "https://registry.npmjs.org/@xhmikosr/bin-wrapper/-/bin-wrapper-14.5.1.tgz",
+            "integrity": "sha512-UZUuTYWxeAbTIiRKKEAmV3csoE36B3CGFZrYYn87+bSEBTyJ32p5gx5Gmj5HOgyOtioFUypbOZ1V5M/l/VoePw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@xhmikosr/bin-check": "^8.2.2",
+                "@xhmikosr/downloader": "^16.3.1",
+                "@xhmikosr/os-filter-obj": "^4.1.0",
+                "binary-version-check": "^6.1.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@xhmikosr/decompress": {
+            "version": "11.1.4",
+            "resolved": "https://registry.npmjs.org/@xhmikosr/decompress/-/decompress-11.1.4.tgz",
+            "integrity": "sha512-ZbYL7SAfY37/TMpopqBR3mQiuQ76kI/RNpN4q82YHSw/UxktZNy8P4wgiKPSrTImMAWRaUG8UK1pgEa56YdLaw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@xhmikosr/decompress-tar": "^9.0.2",
+                "@xhmikosr/decompress-tarbz2": "^9.0.2",
+                "@xhmikosr/decompress-targz": "^9.0.1",
+                "@xhmikosr/decompress-unzip": "^8.2.1",
+                "graceful-fs": "^4.2.11",
+                "strip-dirs": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@xhmikosr/decompress-tar": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-tar/-/decompress-tar-9.0.2.tgz",
+            "integrity": "sha512-8nPZ6lZ3ExhsSxi/X/PMB3K+Vtsuxk43HowxYpxw4AsCHTYqFBXwC8B3Y+M/meaUOGOVm+2tFNUAfWGRjBt+Ww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "file-type": "^21.3.4",
+                "is-stream": "^4.0.1",
+                "tar-stream": "3.1.7"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@xhmikosr/decompress-tarbz2": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-tarbz2/-/decompress-tarbz2-9.0.2.tgz",
+            "integrity": "sha512-m0DvZhE7remCxtS8xY2iHSjivT4v+iyYDdfNoeuu8Nm+7g8xEXdLKSyDEicu4u1ImJLLGEfjMuTLera/F6UGWw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@xhmikosr/decompress-tar": "^9.0.1",
+                "file-type": "^21.3.4",
+                "is-stream": "^4.0.1",
+                "seek-bzip": "^2.0.0",
+                "unbzip2-stream": "^1.4.3"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@xhmikosr/decompress-targz": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-targz/-/decompress-targz-9.0.1.tgz",
+            "integrity": "sha512-1JXu2b6yrpm5EuBoOzMU57B4qrHXJKWQQ7LlMynNEiz85mEjDciO3ayf//GXaTLLCEKiHjWlU3q3THjgf7uODA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@xhmikosr/decompress-tar": "^9.0.0",
+                "file-type": "^21.3.0",
+                "is-stream": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@xhmikosr/decompress-unzip": {
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-unzip/-/decompress-unzip-8.2.1.tgz",
+            "integrity": "sha512-2MS94QnmXQwjkKN8WyFiu1sU7J3rcWJcMze4kRYsX7tN+CXpUGECgkh4YSOhujpkWPuVlFudIziJHO/TxOqkQQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "file-type": "^21.3.4",
+                "get-stream": "^9.0.1",
+                "yauzl": "^3.4.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@xhmikosr/downloader": {
+            "version": "16.3.1",
+            "resolved": "https://registry.npmjs.org/@xhmikosr/downloader/-/downloader-16.3.1.tgz",
+            "integrity": "sha512-M67dvznaFbsvoqhGT4FsHWysaXXQ8386OViGZm0WOyQS3apW9p16WgvHp9nWj2vfKQAR2ZdqIBPNCHSM5rKSCg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@xhmikosr/archive-type": "^8.1.0",
+                "@xhmikosr/decompress": "^11.1.4",
+                "content-disposition": "^2.0.1",
+                "ext-name": "^5.0.0",
+                "file-type": "^21.3.4",
+                "filenamify": "^7.0.2",
+                "got": "^14.6.6"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/@xhmikosr/os-filter-obj": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@xhmikosr/os-filter-obj/-/os-filter-obj-4.1.0.tgz",
+            "integrity": "sha512-y5ArHvQ7BVule/+L9yE2nYMhceiJhgsqo58lOfnisQ7bg+Kjfmkgr7JBuVFiTkl+ErdShpp829QstZQyLugl8g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "system-architecture": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/babel-jest": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
+            "integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/transform": "30.4.1",
+                "@types/babel__core": "^7.20.5",
+                "babel-plugin-istanbul": "^7.0.1",
+                "babel-preset-jest": "30.4.0",
+                "chalk": "^4.1.2",
+                "graceful-fs": "^4.2.11",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.11.0 || ^8.0.0-0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/babel-jest/node_modules/babel-preset-jest": {
+            "version": "30.4.0",
+            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
+            "integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "babel-plugin-jest-hoist": "30.4.0",
+                "babel-preset-current-node-syntax": "^1.2.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/babel-plugin-istanbul": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+            "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "workspaces": [
+                "test/babel-8"
+            ],
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@istanbuljs/load-nyc-config": "^1.0.0",
+                "@istanbuljs/schema": "^0.1.3",
+                "istanbul-lib-instrument": "^6.0.2",
+                "test-exclude": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/babel-plugin-jest-hoist": {
+            "version": "30.4.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
+            "integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/babel__core": "^7.20.5"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/brace-expansion": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/cacheable-request": {
+            "version": "13.0.19",
+            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-13.0.19.tgz",
+            "integrity": "sha512-SVXGH037+Mo1aIMO5B2UcleR43FGjFdN+M8JObSyEoQ2Mn4CODRWx28gN5jiTF0n5ItsgtIZfyargMNs8GX4kg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/http-cache-semantics": "^4.2.0",
+                "get-stream": "^9.0.1",
+                "http-cache-semantics": "^4.2.0",
+                "keyv": "^5.6.0",
+                "mimic-response": "^4.0.0",
+                "normalize-url": "^8.1.1",
+                "responselike": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/camelcase": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/chokidar": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+            "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "readdirp": "^5.0.0"
+            },
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/ci-info": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+            "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/cjs-module-lexer": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.1.tgz",
+            "integrity": "sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/content-disposition": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-2.0.1.tgz",
+            "integrity": "sha512-e+H0ZXHSWYrENhQzw1LPuP4oF5MzVKmDU6d3hxlvaPEYLLg62MxtQNPRx4SYSuYJSBUgnQIG4HIN2tEtNv7Dog==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/decompress-response": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-10.0.0.tgz",
+            "integrity": "sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-response": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/dedent": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+            "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "babel-plugin-macros": "^3.1.0"
+            },
+            "peerDependenciesMeta": {
+                "babel-plugin-macros": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/execa": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+            "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sindresorhus/merge-streams": "^4.0.0",
+                "cross-spawn": "^7.0.6",
+                "figures": "^6.1.0",
+                "get-stream": "^9.0.0",
+                "human-signals": "^8.0.1",
+                "is-plain-obj": "^4.1.0",
+                "is-stream": "^4.0.1",
+                "npm-run-path": "^6.0.0",
+                "pretty-ms": "^9.2.0",
+                "signal-exit": "^4.1.0",
+                "strip-final-newline": "^4.0.0",
+                "yoctocolors": "^2.1.1"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.5.0"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/expect": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+            "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/expect-utils": "30.4.1",
+                "@jest/get-type": "30.1.0",
+                "jest-matcher-utils": "30.4.1",
+                "jest-message-util": "30.4.1",
+                "jest-mock": "30.4.1",
+                "jest-util": "30.4.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/file-type": {
+            "version": "21.3.4",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+            "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tokenizer/inflate": "^0.4.1",
+                "strtok3": "^10.3.4",
+                "token-types": "^6.1.1",
+                "uint8array-extras": "^1.4.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/filename-reserved-regex": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-4.0.0.tgz",
+            "integrity": "sha512-9ZT504KxEQDamsOogZImAWGEN24R1uFAxU3ZS4AZqn2ooidmN68Olh7n4/RcA4lLatZztjA0ZSuxeLHVoCc8JA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/filenamify": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-7.0.2.tgz",
+            "integrity": "sha512-fz10TUqSZ1lG7ftW1KnRotJzMD8YRb6kaAQKpZJBLvqXXfFgIEpuazy1w2lK3zhMiBSdH/uF9LFlv5smJ2Jl1w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "filename-reserved-regex": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/form-data-encoder": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-4.1.0.tgz",
+            "integrity": "sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/get-stream": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+            "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sec-ant/readable-stream": "^0.4.1",
+                "is-stream": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/glob": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/got": {
+            "version": "14.6.6",
+            "resolved": "https://registry.npmjs.org/got/-/got-14.6.6.tgz",
+            "integrity": "sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sindresorhus/is": "^7.0.1",
+                "byte-counter": "^0.1.0",
+                "cacheable-lookup": "^7.0.0",
+                "cacheable-request": "^13.0.12",
+                "decompress-response": "^10.0.0",
+                "form-data-encoder": "^4.0.2",
+                "http2-wrapper": "^2.2.1",
+                "keyv": "^5.5.3",
+                "lowercase-keys": "^3.0.0",
+                "p-cancelable": "^4.0.1",
+                "responselike": "^4.0.2",
+                "type-fest": "^4.26.1"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/got?sponsor=1"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/human-signals": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+            "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/is-stream": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+            "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/isexe": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+            "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/istanbul-lib-source-maps": {
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+            "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.23",
+                "debug": "^4.1.1",
+                "istanbul-lib-coverage": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest": {
+            "version": "30.4.2",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
+            "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/core": "30.4.2",
+                "@jest/types": "30.4.1",
+                "import-local": "^3.2.0",
+                "jest-cli": "30.4.2"
+            },
+            "bin": {
+                "jest": "bin/jest.js"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+            },
+            "peerDependenciesMeta": {
+                "node-notifier": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-changed-files": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.1.tgz",
+            "integrity": "sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "execa": "^5.1.1",
+                "jest-util": "30.4.1",
+                "p-limit": "^3.1.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-changed-files/node_modules/execa": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-changed-files/node_modules/get-stream": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-changed-files/node_modules/human-signals": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.17.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-changed-files/node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-changed-files/node_modules/npm-run-path": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-changed-files/node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-changed-files/node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-changed-files/node_modules/strip-final-newline": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-circus": {
+            "version": "30.4.2",
+            "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
+            "integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/environment": "30.4.1",
+                "@jest/expect": "30.4.1",
+                "@jest/test-result": "30.4.1",
+                "@jest/types": "30.4.1",
+                "@types/node": "*",
+                "chalk": "^4.1.2",
+                "co": "^4.6.0",
+                "dedent": "^1.6.0",
+                "is-generator-fn": "^2.1.0",
+                "jest-each": "30.4.1",
+                "jest-matcher-utils": "30.4.1",
+                "jest-message-util": "30.4.1",
+                "jest-runtime": "30.4.2",
+                "jest-snapshot": "30.4.1",
+                "jest-util": "30.4.1",
+                "p-limit": "^3.1.0",
+                "pretty-format": "30.4.1",
+                "pure-rand": "^7.0.0",
+                "slash": "^3.0.0",
+                "stack-utils": "^2.0.6"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-cli": {
+            "version": "30.4.2",
+            "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
+            "integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/core": "30.4.2",
+                "@jest/test-result": "30.4.1",
+                "@jest/types": "30.4.1",
+                "chalk": "^4.1.2",
+                "exit-x": "^0.2.2",
+                "import-local": "^3.2.0",
+                "jest-config": "30.4.2",
+                "jest-util": "30.4.1",
+                "jest-validate": "30.4.1",
+                "yargs": "^17.7.2"
+            },
+            "bin": {
+                "jest": "bin/jest.js"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+            },
+            "peerDependenciesMeta": {
+                "node-notifier": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-cli/node_modules/jest-config": {
+            "version": "30.4.2",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
+            "integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.27.4",
+                "@jest/get-type": "30.1.0",
+                "@jest/pattern": "30.4.0",
+                "@jest/test-sequencer": "30.4.1",
+                "@jest/types": "30.4.1",
+                "babel-jest": "30.4.1",
+                "chalk": "^4.1.2",
+                "ci-info": "^4.2.0",
+                "deepmerge": "^4.3.1",
+                "glob": "^10.5.0",
+                "graceful-fs": "^4.2.11",
+                "jest-circus": "30.4.2",
+                "jest-docblock": "30.4.0",
+                "jest-environment-node": "30.4.1",
+                "jest-regex-util": "30.4.0",
+                "jest-resolve": "30.4.1",
+                "jest-runner": "30.4.2",
+                "jest-util": "30.4.1",
+                "jest-validate": "30.4.1",
+                "parse-json": "^5.2.0",
+                "pretty-format": "30.4.1",
+                "slash": "^3.0.0",
+                "strip-json-comments": "^3.1.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "@types/node": "*",
+                "esbuild-register": ">=3.4.0",
+                "ts-node": ">=9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "esbuild-register": {
+                    "optional": true
+                },
+                "ts-node": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-diff": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+            "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/diff-sequences": "30.4.0",
+                "@jest/get-type": "30.1.0",
+                "chalk": "^4.1.2",
+                "pretty-format": "30.4.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-docblock": {
+            "version": "30.4.0",
+            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.4.0.tgz",
+            "integrity": "sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "detect-newline": "^3.1.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-each": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.1.tgz",
+            "integrity": "sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/get-type": "30.1.0",
+                "@jest/types": "30.4.1",
+                "chalk": "^4.1.2",
+                "jest-util": "30.4.1",
+                "pretty-format": "30.4.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-environment-node": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
+            "integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/environment": "30.4.1",
+                "@jest/fake-timers": "30.4.1",
+                "@jest/types": "30.4.1",
+                "@types/node": "*",
+                "jest-mock": "30.4.1",
+                "jest-util": "30.4.1",
+                "jest-validate": "30.4.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-haste-map": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
+            "integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.4.1",
+                "@types/node": "*",
+                "anymatch": "^3.1.3",
+                "fb-watchman": "^2.0.2",
+                "graceful-fs": "^4.2.11",
+                "jest-regex-util": "30.4.0",
+                "jest-util": "30.4.1",
+                "jest-worker": "30.4.1",
+                "picomatch": "^4.0.3",
+                "walker": "^1.0.8"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "^2.3.3"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-leak-detector": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
+            "integrity": "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/get-type": "30.1.0",
+                "pretty-format": "30.4.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-matcher-utils": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+            "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/get-type": "30.1.0",
+                "chalk": "^4.1.2",
+                "jest-diff": "30.4.1",
+                "pretty-format": "30.4.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-message-util": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+            "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.27.1",
+                "@jest/types": "30.4.1",
+                "@types/stack-utils": "^2.0.3",
+                "chalk": "^4.1.2",
+                "graceful-fs": "^4.2.11",
+                "jest-util": "30.4.1",
+                "picomatch": "^4.0.3",
+                "pretty-format": "30.4.1",
+                "slash": "^3.0.0",
+                "stack-utils": "^2.0.6"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-mock": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+            "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.4.1",
+                "@types/node": "*",
+                "jest-util": "30.4.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-regex-util": {
+            "version": "30.4.0",
+            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-resolve": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.1.tgz",
+            "integrity": "sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.1.2",
+                "graceful-fs": "^4.2.11",
+                "jest-haste-map": "30.4.1",
+                "jest-pnp-resolver": "^1.2.3",
+                "jest-util": "30.4.1",
+                "jest-validate": "30.4.1",
+                "slash": "^3.0.0",
+                "unrs-resolver": "^1.7.11"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-resolve-dependencies": {
+            "version": "30.4.2",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
+            "integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "jest-regex-util": "30.4.0",
+                "jest-snapshot": "30.4.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-runner": {
+            "version": "30.4.2",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
+            "integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/console": "30.4.1",
+                "@jest/environment": "30.4.1",
+                "@jest/test-result": "30.4.1",
+                "@jest/transform": "30.4.1",
+                "@jest/types": "30.4.1",
+                "@types/node": "*",
+                "chalk": "^4.1.2",
+                "emittery": "^0.13.1",
+                "exit-x": "^0.2.2",
+                "graceful-fs": "^4.2.11",
+                "jest-docblock": "30.4.0",
+                "jest-environment-node": "30.4.1",
+                "jest-haste-map": "30.4.1",
+                "jest-leak-detector": "30.4.1",
+                "jest-message-util": "30.4.1",
+                "jest-resolve": "30.4.1",
+                "jest-runtime": "30.4.2",
+                "jest-util": "30.4.1",
+                "jest-watcher": "30.4.1",
+                "jest-worker": "30.4.1",
+                "p-limit": "^3.1.0",
+                "source-map-support": "0.5.13"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-runtime": {
+            "version": "30.4.2",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
+            "integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/environment": "30.4.1",
+                "@jest/fake-timers": "30.4.1",
+                "@jest/globals": "30.4.1",
+                "@jest/source-map": "30.0.1",
+                "@jest/test-result": "30.4.1",
+                "@jest/transform": "30.4.1",
+                "@jest/types": "30.4.1",
+                "@types/node": "*",
+                "chalk": "^4.1.2",
+                "cjs-module-lexer": "^2.1.0",
+                "collect-v8-coverage": "^1.0.2",
+                "glob": "^10.5.0",
+                "graceful-fs": "^4.2.11",
+                "jest-haste-map": "30.4.1",
+                "jest-message-util": "30.4.1",
+                "jest-mock": "30.4.1",
+                "jest-regex-util": "30.4.0",
+                "jest-resolve": "30.4.1",
+                "jest-snapshot": "30.4.1",
+                "jest-util": "30.4.1",
+                "slash": "^3.0.0",
+                "strip-bom": "^4.0.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-snapshot": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
+            "integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.27.4",
+                "@babel/generator": "^7.27.5",
+                "@babel/plugin-syntax-jsx": "^7.27.1",
+                "@babel/plugin-syntax-typescript": "^7.27.1",
+                "@babel/types": "^7.27.3",
+                "@jest/expect-utils": "30.4.1",
+                "@jest/get-type": "30.1.0",
+                "@jest/snapshot-utils": "30.4.1",
+                "@jest/transform": "30.4.1",
+                "@jest/types": "30.4.1",
+                "babel-preset-current-node-syntax": "^1.2.0",
+                "chalk": "^4.1.2",
+                "expect": "30.4.1",
+                "graceful-fs": "^4.2.11",
+                "jest-diff": "30.4.1",
+                "jest-matcher-utils": "30.4.1",
+                "jest-message-util": "30.4.1",
+                "jest-util": "30.4.1",
+                "pretty-format": "30.4.1",
+                "semver": "^7.7.2",
+                "synckit": "^0.11.8"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-util": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+            "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.4.1",
+                "@types/node": "*",
+                "chalk": "^4.1.2",
+                "ci-info": "^4.2.0",
+                "graceful-fs": "^4.2.11",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-validate": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.1.tgz",
+            "integrity": "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/get-type": "30.1.0",
+                "@jest/types": "30.4.1",
+                "camelcase": "^6.3.0",
+                "chalk": "^4.1.2",
+                "leven": "^3.1.0",
+                "pretty-format": "30.4.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-watcher": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.1.tgz",
+            "integrity": "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/test-result": "30.4.1",
+                "@jest/types": "30.4.1",
+                "@types/node": "*",
+                "ansi-escapes": "^4.3.2",
+                "chalk": "^4.1.2",
+                "emittery": "^0.13.1",
+                "jest-util": "30.4.1",
+                "string-length": "^4.0.2"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/jest-worker": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
+            "integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "@ungap/structured-clone": "^1.3.0",
+                "jest-util": "30.4.1",
+                "merge-stream": "^2.0.0",
+                "supports-color": "^8.1.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/keyv": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+            "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@keyv/serialize": "^1.1.1"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/npm-run-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+            "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^4.0.0",
+                "unicorn-magic": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/p-cancelable": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-4.0.1.tgz",
+            "integrity": "sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/picomatch": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+            "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/pretty-format": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+            "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/schemas": "30.4.1",
+                "ansi-styles": "^5.2.0",
+                "react-is-18": "npm:react-is@^18.3.1",
+                "react-is-19": "npm:react-is@^19.2.5"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/pure-rand": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+            "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/dubzzz"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fast-check"
+                }
+            ],
+            "license": "MIT"
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/readdirp": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+            "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/responselike": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/responselike/-/responselike-4.0.2.tgz",
+            "integrity": "sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lowercase-keys": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/semver": {
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/source-map": {
+            "version": "0.7.6",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+            "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/strip-final-newline": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+            "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/tar-stream": {
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+            "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "b4a": "^1.6.4",
+                "fast-fifo": "^1.2.0",
+                "streamx": "^2.15.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/tar-stream/node_modules/b4a": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+            "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peerDependencies": {
+                "react-native-b4a": "*"
+            },
+            "peerDependenciesMeta": {
+                "react-native-b4a": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/write-file-atomic": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+            "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "packages/nv-metropolis-bp-vss-ui/chat/node_modules/yauzl": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+            "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "pend": "~1.2.0"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "packages/nv-metropolis-bp-vss-ui/dashboard": {

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/.gitignore
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/.gitignore
@@ -1,0 +1,49 @@
+# dependencies
+node_modules/
+.pnp/
+.pnp.js
+
+# testing
+coverage/
+
+# production
+build/
+
+# lib
+lib/
+
+# next
+.next/
+out/
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# environment files
+public/__ENV.js
+.env*
+
+# TypeScript build cache
+*.tsbuildinfo
+
+# turbo
+.turbo/
+
+# swc
+.swc/
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+yarn.lock
+*.pem
+.vscode
+
+# PyCharm build files
+.idea/
+

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/.swcrc
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/.swcrc
@@ -1,0 +1,22 @@
+{
+  "jsc": {
+    "parser": {
+      "syntax": "typescript",
+      "tsx": true
+    },
+    "transform": {
+      "react": {
+        "runtime": "automatic"
+      }
+    }
+  },
+  "module": {
+    "type": "es6"
+  },
+  "env": {
+    "targets": {
+      "node": "22"
+    }
+  },
+  "sourceMaps": true
+}

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/README.md
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/README.md
@@ -1,0 +1,52 @@
+# @nv-metropolis-bp-vss-ui/chat
+
+VSS chat interface for the chat tab and the docked sidebar.
+
+**No NeMo Agent Toolkit dependency** — that is the reason this package exists.
+It speaks the BYO agent contract directly (OpenAI-shaped request in,
+Server-Sent Events out), so any backend implementing `/chat/stream` works,
+including the VSS agent adapter driving OpenClaw or Hermes.
+
+## Usage
+
+```tsx
+import { ChatPanel } from '@nv-metropolis-bp-vss-ui/chat';
+import '@nv-metropolis-bp-vss-ui/chat/lib/chat.css';
+
+<ChatPanel
+  endpoint={{ url: process.env.NEXT_PUBLIC_HTTP_CHAT_COMPLETION_URL! }}
+  title="Vision Agent"
+  theme="dark"
+  onAnswer={(answer) => forwardToSearchTab(answer)}
+  onSubmit={() => clearStaleResults()}
+/>
+```
+
+`onAnswer` / `onSubmit` are how feature tabs (search, alerts) receive results
+and clear stale state, replacing `registerChatAnswerHandler` and
+`registerSidebarChatEventSubscriber` without the chat package needing to know
+those tabs exist.
+
+## What it renders
+
+- streaming assistant text, markdown with GFM tables
+- collapsed tool/skill progress from `intermediate_data:` frames
+- per-message errors, and a Stop button that aborts the in-flight turn
+
+## Wire protocol
+
+| Line | Meaning |
+|---|---|
+| `data: {"choices":[{"delta":{"content":"…"}}]}` | assistant text |
+| `data: [DONE]` | turn complete |
+| `intermediate_data: {…}` | tool/skill step |
+| `: keepalive` | ignored |
+
+Content is also read from `choices[0].message.content` and the plain
+`value` / `output` / `answer` fields, because agent servers differ.
+
+## Status
+
+Foundation complete and unit-tested (`SseParser`, 14 assertions). Not yet wired
+into `Home.tsx`, and does not yet cover the toolkit's video modal, chunked file
+upload, or conversation history — see DECISIONS.md for the migration plan.

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/README.md
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/README.md
@@ -14,24 +14,91 @@ import { ChatPanel } from '@nv-metropolis-bp-vss-ui/chat';
 import '@nv-metropolis-bp-vss-ui/chat/lib/chat.css';
 
 <ChatPanel
-  endpoint={{ url: process.env.NEXT_PUBLIC_HTTP_CHAT_COMPLETION_URL! }}
+  endpoint={{ url: '/api/vss-chat?surface=sidebar', uploadUrlBase: agentApiBase }}
   title="Vision Agent"
   theme="dark"
-  onAnswer={(answer) => forwardToSearchTab(answer)}
+  storageKeyPrefix="appSidebar"
+  features={{ uploadFile: true, messageCopy: false }}
+  onAnswer={(answer, conversationId) => forwardToSearchTab(answer, conversationId)}
   onSubmit={() => clearStaleResults()}
+  onSubmitMessageReady={(submit) => (submitRef.current = submit)}
+  onAddQueryContextReady={(add) => (addContextRef.current = add)}
+  onControlsReady={(handlers) => setSidebarControls(handlers)}
 />
 ```
 
-`onAnswer` / `onSubmit` are how feature tabs (search, alerts) receive results
-and clear stale state, replacing `registerChatAnswerHandler` and
-`registerSidebarChatEventSubscriber` without the chat package needing to know
-those tabs exist.
+## Feature parity with the toolkit chat bar
 
-## What it renders
+The toolkit chat bar is ~11k lines across `Chat`, `Chatbar`, `Markdown`,
+`Settings` and `Sidebar`. Everything below is reproduced here; the flag column
+gives the `NEXT_PUBLIC_*` variable the deployment already sets, which
+`Home.tsx` maps onto the `features` prop, so an existing deployment needs no
+new configuration.
 
-- streaming assistant text, markdown with GFM tables
-- collapsed tool/skill progress from `intermediate_data:` frames
-- per-message errors, and a Stop button that aborts the in-flight turn
+| Area | Feature | Flag |
+|---|---|---|
+| Conversations | multiple threads, new / rename / delete / clear | — |
+| | tab-scoped IndexedDB persistence, `storageKeyPrefix` | — |
+| | search over names and message text | — |
+| | export / import (toolkit v1–v4 files load) | — |
+| | send full thread vs. latest turn | `CHAT_HISTORY_DEFAULT_ON` |
+| Input | context chips + `[Context: …]` prefix | — |
+| | chunked video upload, drag & drop, progress, cancel | `CHAT_UPLOAD_FILE_ENABLE` |
+| | per-file upload metadata | `CHAT_UPLOAD_FILE_METADATA_ENABLED` |
+| | post-upload auto-prompt | `CHAT_UPLOAD_FILE_HIDDEN_MESSAGE_TEMPLATE` |
+| | agent parameter panel | `CHAT_API_CUSTOM_AGENT_PARAMS_JSON` |
+| | speech-to-text | `CHAT_INPUT_MIC_ENABLED` |
+| | regenerate, stop, scroll-to-latest, auto-grow textarea | — |
+| Messages | streaming markdown, GFM tables, math | — |
+| | images (fullscreen, download), video, charts, incidents | — |
+| | code blocks (highlight, copy, download) | — |
+| | `<agent-think>` reasoning traces | — |
+| | nested intermediate-step tree | `ENABLE_INTERMEDIATE_STEPS` |
+| | copy / speak / edit / delete | `CHAT_MESSAGE_{COPY,SPEAKER,EDIT}_ENABLED` |
+| | caller-info card (sanitised HTML from the host) | — |
+| Shell | welcome screen with drop zone, header menu, theme toggle | `SHOW_THEME_TOGGLE_BUTTON` |
+| Embedding | `onAnswer`, `onAnswerComplete`, `onSubmit` | — |
+| | `onSubmitMessageReady`, `onMessageSubmitted` | — |
+| | `onAddQueryContextReady`, `onChatVideoUploadComplete` | — |
+| | `onBusyChange`, `onControlsReady`, `isActive` | — |
+
+### Per-surface configuration
+
+The chat tab and the docked sidebar are configured independently, exactly as
+they were for the toolkit: the sidebar overrides any main variable by
+re-declaring it under `NEXT_PUBLIC_SIDEBAR_CHAT_`, and falls back to the main
+value otherwise. This deployment relies on it — the sidebar runs a different
+agent from the chat tab and exposes its own parameter fields (search source
+type, critic toggle). `Home.tsx` resolves both surfaces through `surfaceEnv`.
+
+### Deliberately not ported
+
+- **WebSocket transport** and its `webSocketSchema` / connection toggle. The BYO
+  contract is HTTP + SSE (DECISIONS.md 2.2), the deployment ships
+  `NEXT_PUBLIC_WEB_SOCKET_DEFAULT_ON=false`, and the WebSocket path exists to
+  talk to NAT core — the thing being removed. `InteractionModal` survives on an
+  `interaction_data:` SSE frame so human-in-the-loop does not disappear with the
+  transport.
+- **Folders and prompt templates.** Present in the toolkit's Chatbar, never
+  surfaced in VSS. Import still accepts and preserves both keys so a toolkit
+  export round-trips.
+- **`GraphPlot` charts** (`react-force-graph-2d`). Not installed in this
+  workspace and not emitted by any VSS workflow; the type renders as
+  "unsupported" rather than pulling in a graph engine for a case that never
+  fires.
+
+### Deliberate differences
+
+- **Intermediate steps are a React tree, not serialised HTML.** The toolkit
+  rendered steps by writing a `<details>` cascade into the message's markdown
+  and re-parsing it, which is why half its `fixMalformedHtml` helpers exist. The
+  tree stays structured here; the repairs are kept only for markup the *model*
+  emits mid-stream (`markdown/streaming.ts`).
+- **Pie slice colours are a fixed palette.** The toolkit called
+  `getRandomColor()` inside render, so every streamed token recoloured the
+  chart.
+- **Syntax highlighting loads on demand.** Prism and its grammars are several
+  hundred kilobytes and only needed once a fenced block has stopped changing.
 
 ## Wire protocol
 
@@ -39,14 +106,16 @@ those tabs exist.
 |---|---|
 | `data: {"choices":[{"delta":{"content":"…"}}]}` | assistant text |
 | `data: [DONE]` | turn complete |
-| `intermediate_data: {…}` | tool/skill step |
+| `intermediate_data: {…}` | tool/skill step (`parent_id` nests it) |
+| `error_data: {…}` | turn-level failure |
+| `interaction_data: {…}` | agent needs user input |
 | `: keepalive` | ignored |
 
 Content is also read from `choices[0].message.content` and the plain
 `value` / `output` / `answer` fields, because agent servers differ.
 
-## Status
+## Tests
 
-Foundation complete and unit-tested (`SseParser`, 14 assertions). Not yet wired
-into `Home.tsx`, and does not yet cover the toolkit's video modal, chunked file
-upload, or conversation history — see DECISIONS.md for the migration plan.
+`npm test` runs two Jest projects: `logic` (node, no DOM) for the parsers,
+import/export and markdown repairs, and `components` (jsdom) which drives
+`ChatPanel` against a faked SSE stream.

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/__tests__/ChatPanel.test.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/__tests__/ChatPanel.test.tsx
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: MIT
+/**
+ * End-to-end checks against the real SSE path: a fake `fetch` streams the
+ * frames a backend would, and the assertions are on what a user sees.
+ *
+ * IndexedDB is mocked at the storage module rather than shimmed, because the
+ * point here is the panel, not the persistence (covered in conversations.test).
+ */
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { ChatPanel } from '../lib-src/ChatPanel';
+
+jest.mock('../lib-src/storage', () => ({
+  initConversationSessionLifecycle: jest.fn(),
+  loadConversations: jest.fn().mockResolvedValue([]),
+  loadSelectedConversationId: jest.fn().mockResolvedValue(null),
+  saveConversations: jest.fn().mockResolvedValue(undefined),
+  saveSelectedConversationId: jest.fn().mockResolvedValue(undefined),
+  clearAllConversations: jest.fn().mockResolvedValue(undefined),
+}));
+
+/** Build a Response whose body streams `chunks` as an SSE stream. */
+function sseResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder();
+  let i = 0;
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      getReader: () => ({
+        read: async () =>
+          i < chunks.length
+            ? { done: false, value: encoder.encode(chunks[i++]) }
+            : { done: true, value: undefined },
+        releaseLock: () => {},
+      }),
+    },
+  } as unknown as Response;
+}
+
+const endpoint = { url: '/api/vss-chat?surface=main' };
+const noHeader = { headerMenu: false, uploadFile: false };
+
+async function typeAndSend(text: string) {
+  const textarea = screen.getByTestId('chat-textarea');
+  fireEvent.change(textarea, { target: { value: text } });
+  fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
+}
+
+describe('ChatPanel', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('streams an answer and renders it as markdown', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      sseResponse([
+        'data: {"choices":[{"delta":{"content":"**bold** "}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":"answer"}}]}\n\n',
+        'data: [DONE]\n\n',
+      ]),
+    ) as any;
+
+    render(<ChatPanel endpoint={endpoint} features={noHeader} />);
+    await act(async () => typeAndSend('what happened?'));
+
+    await waitFor(() => expect(screen.getByText('bold')).toBeInTheDocument());
+    // Rendered as markdown, not as literal asterisks.
+    expect(screen.getByText('bold').tagName).toBe('STRONG');
+    expect(screen.getByTestId('chat-message-user')).toHaveTextContent('what happened?');
+  });
+
+  it('sends the whole thread when chat history is on, and one turn when off', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(sseResponse(['data: [DONE]\n\n']));
+    global.fetch = fetchMock as any;
+
+    const { rerender } = render(
+      <ChatPanel endpoint={endpoint} features={{ ...noHeader, chatHistory: false }} />,
+    );
+    await act(async () => typeAndSend('first'));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.messages).toEqual([{ role: 'user', content: 'first' }]);
+    rerender(<ChatPanel endpoint={endpoint} features={{ ...noHeader, chatHistory: false }} />);
+  });
+
+  it('reports the answer to the embedder with the conversation id', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      sseResponse(['data: {"choices":[{"delta":{"content":"done"}}]}\n\n', 'data: [DONE]\n\n']),
+    ) as any;
+    const onAnswer = jest.fn();
+    const onSubmit = jest.fn();
+
+    render(
+      <ChatPanel
+        endpoint={endpoint}
+        features={noHeader}
+        onAnswer={onAnswer}
+        onSubmit={onSubmit}
+      />,
+    );
+    await act(async () => typeAndSend('go'));
+
+    await waitFor(() => expect(onAnswer).toHaveBeenCalled());
+    expect(onSubmit).toHaveBeenCalledWith('go');
+    const [answer, conversationId] = onAnswer.mock.calls[0];
+    expect(answer).toBe('done');
+    expect(typeof conversationId).toBe('string');
+    expect(conversationId).not.toHaveLength(0);
+  });
+
+  it('folds a context chip into the request and clears it after sending', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(sseResponse(['data: [DONE]\n\n']));
+    global.fetch = fetchMock as any;
+
+    let addContext: ((item: any) => void) | undefined;
+    render(
+      <ChatPanel
+        endpoint={endpoint}
+        features={noHeader}
+        onAddQueryContextReady={(add) => {
+          addContext = add;
+        }}
+      />,
+    );
+
+    await act(async () => {
+      addContext?.({
+        id: 'chip1',
+        label: 'Camera 3',
+        contextType: 'media/video',
+        data: { videoId: 'v3' },
+      });
+    });
+    expect(screen.getByText('Camera 3')).toBeInTheDocument();
+
+    await act(async () => typeAndSend('summarise'));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    const sent = body.messages[body.messages.length - 1].content;
+    expect(sent).toContain('[Context: [{"videoId":"v3"}]]');
+    expect(sent).toContain('summarise');
+    // Chips apply to one turn only.
+    await waitFor(() => expect(screen.queryByText('Camera 3')).not.toBeInTheDocument());
+  });
+
+  it('lets an embedder submit a message without the user typing', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(sseResponse(['data: [DONE]\n\n']));
+    global.fetch = fetchMock as any;
+
+    let submit: ((message: string) => void) | undefined;
+    const onMessageSubmitted = jest.fn();
+    render(
+      <ChatPanel
+        endpoint={endpoint}
+        features={noHeader}
+        onSubmitMessageReady={(fn) => {
+          submit = fn;
+        }}
+        onMessageSubmitted={onMessageSubmitted}
+      />,
+    );
+
+    await act(async () => submit?.('generate a report'));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(onMessageSubmitted).toHaveBeenCalled();
+    expect(screen.getByTestId('chat-message-user')).toHaveTextContent('generate a report');
+  });
+
+  it('shows an HTTP failure on the message instead of failing silently', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 502 } as Response) as any;
+
+    render(<ChatPanel endpoint={endpoint} features={noHeader} />);
+    await act(async () => typeAndSend('hello'));
+
+    await waitFor(() => expect(screen.getByText(/HTTP 502/)).toBeInTheDocument());
+  });
+
+  it('renders intermediate steps as a nested tree', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      sseResponse([
+        'intermediate_data: {"id":"1","name":"vss-search-archive","status":"complete"}\n',
+        'intermediate_data: {"id":"2","name":"fetch-clip","parent_id":"1","status":"complete"}\n',
+        'data: {"choices":[{"delta":{"content":"found it"}}]}\n\n',
+        'data: [DONE]\n\n',
+      ]),
+    ) as any;
+
+    render(<ChatPanel endpoint={endpoint} features={noHeader} />);
+    await act(async () => typeAndSend('search'));
+
+    await waitFor(() => expect(screen.getByText(/Intermediate steps \(2\)/)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(/Intermediate steps \(2\)/));
+    expect(screen.getByText('vss-search-archive')).toBeInTheDocument();
+  });
+
+  it('notifies the embedder when a turn starts and ends', async () => {
+    global.fetch = jest.fn().mockResolvedValue(sseResponse(['data: [DONE]\n\n'])) as any;
+    const onBusyChange = jest.fn();
+
+    render(<ChatPanel endpoint={endpoint} features={noHeader} onBusyChange={onBusyChange} />);
+    await act(async () => typeAndSend('go'));
+
+    await waitFor(() => expect(onBusyChange).toHaveBeenCalledWith(true));
+    await waitFor(() => expect(onBusyChange).toHaveBeenLastCalledWith(false));
+  });
+
+  it('deletes the message the button belongs to, not the one at that position', async () => {
+    global.fetch = jest
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve(
+          sseResponse(['data: {"choices":[{"delta":{"content":"ok"}}]}\n\n', 'data: [DONE]\n\n']),
+        ),
+      ) as any;
+
+    render(<ChatPanel endpoint={endpoint} features={noHeader} />);
+
+    await act(async () => typeAndSend('first question'));
+    await waitFor(() => expect(screen.getAllByTestId('chat-message-assistant')).toHaveLength(1));
+    await act(async () => typeAndSend('second question'));
+    await waitFor(() => expect(screen.getAllByTestId('chat-message-assistant')).toHaveLength(2));
+
+    // One delete button per user turn; the first belongs to 'first question'.
+    fireEvent.click(screen.getAllByLabelText('Delete message')[0]);
+
+    await waitFor(() =>
+      expect(screen.queryByText('first question')).not.toBeInTheDocument(),
+    );
+    // The other turn is untouched — deletion addressed a message, not a slot.
+    expect(screen.getByText('second question')).toBeInTheDocument();
+  });
+
+  it('hands conversation controls to the host exactly once per meaningful change', async () => {
+    global.fetch = jest.fn().mockResolvedValue(sseResponse(['data: [DONE]\n\n'])) as any;
+    const onControlsReady = jest.fn();
+
+    render(
+      <ChatPanel endpoint={endpoint} features={noHeader} onControlsReady={onControlsReady} />,
+    );
+    await waitFor(() => expect(onControlsReady).toHaveBeenCalled());
+
+    const handlers = onControlsReady.mock.calls.at(-1)![0];
+    expect(handlers.filteredConversations).toHaveLength(1);
+    expect(typeof handlers.onNewConversation).toBe('function');
+    expect(handlers.busy).toBe(false);
+  });
+});

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/__tests__/conversations.test.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/__tests__/conversations.test.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+import {
+  buildExport,
+  createConversation,
+  filterConversations,
+  parseImport,
+  sanitizeForPersistence,
+  titleFromMessage,
+} from '../lib-src/conversations';
+import type { Conversation } from '../lib-src/types';
+
+const conversation = (name: string, texts: string[]): Conversation => ({
+  id: name,
+  name,
+  messages: texts.map((content, i) => ({ id: `${name}-${i}`, role: 'user' as const, content })),
+});
+
+describe('titleFromMessage', () => {
+  it('truncates at 30 characters, as the toolkit did', () => {
+    expect(titleFromMessage('a'.repeat(40))).toBe(`${'a'.repeat(30)}...`);
+  });
+
+  it('falls back for an empty message', () => {
+    expect(titleFromMessage('   ')).toBe('New Conversation');
+  });
+});
+
+describe('filterConversations', () => {
+  const list = [conversation('Cameras', ['show me the loading dock']), conversation('Alerts', [])];
+
+  it('matches on name and on message text', () => {
+    expect(filterConversations(list, 'camera').map((c) => c.name)).toEqual(['Cameras']);
+    expect(filterConversations(list, 'loading dock').map((c) => c.name)).toEqual(['Cameras']);
+  });
+
+  it('returns everything for an empty term', () => {
+    expect(filterConversations(list, '  ')).toHaveLength(2);
+  });
+
+  it('ignores hidden messages so upload auto-prompts are not searchable', () => {
+    const withHidden: Conversation[] = [
+      {
+        id: 'x',
+        name: 'X',
+        messages: [{ id: 'm', role: 'user', content: 'secret prompt', hidden: true }],
+      },
+    ];
+    expect(filterConversations(withHidden, 'secret')).toHaveLength(0);
+  });
+});
+
+describe('sanitizeForPersistence', () => {
+  it('drops streaming state so a reload does not restore a stuck cursor', () => {
+    const [saved] = sanitizeForPersistence([
+      {
+        id: 'c',
+        name: 'c',
+        messages: [
+          { id: 'm', role: 'assistant', content: 'partial', streaming: true, uploadConversationId: 'c' },
+        ],
+      },
+    ]);
+    expect(saved.messages[0]).not.toHaveProperty('streaming');
+    expect(saved.messages[0]).not.toHaveProperty('uploadConversationId');
+    expect(saved.messages[0].content).toBe('partial');
+  });
+});
+
+describe('parseImport', () => {
+  it('round-trips this package’s own export', () => {
+    const original = [conversation('Trip', ['hello'])];
+    const result = parseImport(JSON.stringify(buildExport(original)));
+    expect(result.conversations).toHaveLength(1);
+    expect(result.conversations![0].name).toBe('Trip');
+    expect(result.conversations![0].messages[0].content).toBe('hello');
+  });
+
+  it('accepts the toolkit v4 envelope', () => {
+    const raw = JSON.stringify({
+      version: 4,
+      history: [{ id: 'a', name: 'Old chat', messages: [{ role: 'user', content: 'hi' }] }],
+      folders: [],
+      prompts: [],
+    });
+    expect(parseImport(raw).conversations![0].name).toBe('Old chat');
+  });
+
+  it('accepts a v1 bare array', () => {
+    const raw = JSON.stringify([{ id: 1, name: 'V1', messages: [{ role: 'user', content: 'hi' }] }]);
+    expect(parseImport(raw).conversations![0].name).toBe('V1');
+  });
+
+  it('strips prototype-pollution keys instead of importing them', () => {
+    const raw =
+      '{"version":4,"history":[{"id":"a","name":"n","messages":[],"__proto__":{"polluted":true}}],"folders":[],"prompts":[]}';
+    expect(parseImport(raw).conversations).toHaveLength(1);
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
+  it('reports rather than throws on malformed input', () => {
+    expect(parseImport('not json').error).toBe('Invalid JSON format');
+    expect(parseImport('{"version":4}').error).toBe('Invalid import format');
+    expect(parseImport('').error).toBe('Empty import file');
+  });
+
+  it('rejects a file large enough to be a denial of service', () => {
+    expect(parseImport('x'.repeat(11 * 1024 * 1024)).error).toMatch(/too large/);
+  });
+});
+
+describe('createConversation', () => {
+  it('gives every conversation a distinct id', () => {
+    const ids = new Set(Array.from({ length: 50 }, () => createConversation().id));
+    expect(ids.size).toBe(50);
+  });
+});

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/__tests__/sse.test.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/__tests__/sse.test.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+import { SseParser, extractContent } from '../lib-src/sse';
+
+describe('extractContent', () => {
+  it('reads OpenAI streaming deltas', () => {
+    expect(extractContent({ choices: [{ delta: { content: 'hi' } }] })).toBe('hi');
+  });
+
+  it('reads non-streaming message content', () => {
+    expect(extractContent({ choices: [{ message: { content: 'hi' } }] })).toBe('hi');
+  });
+
+  it('reads the plain field shapes some agent servers return', () => {
+    expect(extractContent({ value: 'a' })).toBe('a');
+    expect(extractContent({ output: 'b' })).toBe('b');
+    expect(extractContent({ answer: 'c' })).toBe('c');
+  });
+
+  it('returns empty rather than throwing on unknown shapes', () => {
+    expect(extractContent({ nothing: 1 })).toBe('');
+    expect(extractContent(null)).toBe('');
+  });
+});
+
+describe('SseParser', () => {
+  it('emits tokens and a terminal done', () => {
+    const p = new SseParser();
+    const events = p.feed(
+      'data: {"choices":[{"delta":{"content":"He"}}]}\n\n' +
+        'data: {"choices":[{"delta":{"content":"llo"}}]}\n\n' +
+        'data: [DONE]\n\n',
+    );
+    expect(events).toEqual([
+      { kind: 'token', text: 'He' },
+      { kind: 'token', text: 'llo' },
+      { kind: 'done' },
+    ]);
+  });
+
+  it('ignores keepalive comments', () => {
+    const p = new SseParser();
+    expect(p.feed(': keepalive\n\n')).toEqual([]);
+  });
+
+  it('handles a frame split across chunk boundaries', () => {
+    const p = new SseParser();
+    // Chunk ends mid-JSON; nothing should be emitted until it completes.
+    expect(p.feed('data: {"choices":[{"delta":{"cont')).toEqual([]);
+    expect(p.feed('ent":"split"}}]}\n\n')).toEqual([{ kind: 'token', text: 'split' }]);
+  });
+
+  it('parses tool steps and numbers them in order', () => {
+    const p = new SseParser();
+    const events = p.feed(
+      'intermediate_data: {"id":"1","name":"read","status":"in_progress","payload":"x"}\n' +
+        'intermediate_data: {"id":"2","name":"exec","status":"complete"}\n',
+    );
+    expect(events).toEqual([
+      { kind: 'step', step: { id: '1', name: 'read', status: 'in_progress', payload: 'x', index: 0 } },
+      { kind: 'step', step: { id: '2', name: 'exec', status: 'complete', payload: undefined, index: 1 } },
+    ]);
+  });
+
+  it('falls back to bare text when a data frame is not JSON', () => {
+    const p = new SseParser();
+    expect(p.feed('data: plain text\n\n')).toEqual([{ kind: 'token', text: 'plain text' }]);
+  });
+
+  it('drops malformed step payloads instead of throwing', () => {
+    const p = new SseParser();
+    expect(p.feed('intermediate_data: {not json\n')).toEqual([]);
+  });
+});

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/__tests__/steps.test.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/__tests__/steps.test.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+import { SseParser, buildStepTree } from '../lib-src/sse';
+import { buildContextPrefix } from '../lib-src/useChatStream';
+import type { ChatStep } from '../lib-src/types';
+
+const step = (id: string, parentId?: string): ChatStep => ({
+  id,
+  name: id,
+  status: 'complete',
+  index: 0,
+  parentId,
+});
+
+describe('buildStepTree', () => {
+  it('nests children under their parent', () => {
+    const tree = buildStepTree([step('a'), step('b', 'a'), step('c', 'b')]);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].children![0].id).toBe('b');
+    expect(tree[0].children![0].children![0].id).toBe('c');
+  });
+
+  it('keeps a child that arrived before its parent', () => {
+    const tree = buildStepTree([step('b', 'a'), step('a')]);
+    expect(tree.map((s) => s.id)).toEqual(['a']);
+    expect(tree[0].children!.map((s) => s.id)).toEqual(['b']);
+  });
+
+  it('shows an orphan at the root rather than dropping it', () => {
+    const tree = buildStepTree([step('b', 'missing')]);
+    expect(tree.map((s) => s.id)).toEqual(['b']);
+  });
+
+  it('does not let a step parent itself into an infinite tree', () => {
+    const tree = buildStepTree([step('a', 'a')]);
+    expect(tree.map((s) => s.id)).toEqual(['a']);
+    expect(tree[0].children).toEqual([]);
+  });
+});
+
+describe('SseParser extras', () => {
+  it('reads parent_id off a step frame', () => {
+    const events = new SseParser().feed(
+      'intermediate_data: {"id":"2","name":"search","parent_id":"1"}\n',
+    );
+    expect(events[0]).toMatchObject({ kind: 'step', step: { id: '2', parentId: '1' } });
+  });
+
+  it('surfaces an error frame', () => {
+    const events = new SseParser().feed('error_data: {"message":"tool exploded"}\n');
+    expect(events[0]).toEqual({ kind: 'error', message: 'tool exploded' });
+  });
+
+  it('surfaces an oauth interaction frame', () => {
+    const events = new SseParser().feed(
+      'interaction_data: {"id":"i1","content":{"input_type":"oauth_consent","oauth_url":"https://idp/x","text":"Sign in"}}\n',
+    );
+    expect(events[0]).toEqual({
+      kind: 'interaction',
+      request: { id: 'i1', prompt: 'Sign in', inputType: 'oauth', url: 'https://idp/x', options: undefined },
+    });
+  });
+
+  it('survives CRLF line endings from a rewriting proxy', () => {
+    const events = new SseParser().feed(
+      'data: {"choices":[{"delta":{"content":"hi"}}]}\r\n\r\ndata: [DONE]\r\n\r\n',
+    );
+    expect(events).toEqual([{ kind: 'token', text: 'hi' }, { kind: 'done' }]);
+  });
+});
+
+describe('buildContextPrefix', () => {
+  it('sends only the data payload, never the UI fields', () => {
+    const prefix = buildContextPrefix([
+      { id: 'chip1', label: 'Camera 3', contextType: 'media/video', data: { videoId: 'v3' } },
+    ]);
+    expect(prefix).toBe('[Context: [{"videoId":"v3"}]]');
+    expect(prefix).not.toContain('chip1');
+    expect(prefix).not.toContain('Camera 3');
+  });
+
+  it('strips contextType even when duplicated inside data', () => {
+    const prefix = buildContextPrefix([
+      {
+        id: 'a',
+        label: 'a',
+        contextType: 'media/video',
+        data: { contextType: 'media/video', videoId: 'v1' },
+      },
+    ]);
+    expect(prefix).toBe('[Context: [{"videoId":"v1"}]]');
+  });
+
+  it('is empty with no chips, so nothing is prepended', () => {
+    expect(buildContextPrefix([])).toBe('');
+  });
+});

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/__tests__/streaming.test.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/__tests__/streaming.test.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+import {
+  fixMalformedHtml,
+  handleIncompleteAgentThinkStepTags,
+  handleIncompleteAgentThinkTags,
+  replaceMalformedHtmlImages,
+  replaceMalformedHtmlVideos,
+  replaceMalformedMarkdownImages,
+} from '../lib-src/markdown/streaming';
+
+describe('half-written media', () => {
+  it('swaps an unfinished markdown image for a placeholder', () => {
+    expect(replaceMalformedMarkdownImages('here: ![frame](https://vst/fra')).toContain(
+      'src="loading"',
+    );
+  });
+
+  it('leaves a finished markdown image alone', () => {
+    const done = 'here: ![frame](https://vst/frame.jpg)';
+    expect(replaceMalformedMarkdownImages(done)).toBe(done);
+  });
+
+  it('swaps an unfinished <img> and <video>', () => {
+    expect(replaceMalformedHtmlImages('<img src="https://vst/f')).toContain('src="loading"');
+    expect(replaceMalformedHtmlVideos('<video src="https://vst/c')).toContain('src="loading"');
+  });
+});
+
+describe('agent-think balancing', () => {
+  it('closes an open trace and marks it streaming', () => {
+    const out = handleIncompleteAgentThinkTags('<agent-think>thinking');
+    expect(out).toContain('data-streaming="true"');
+    expect(out.endsWith('</agent-think>')).toBe(true);
+  });
+
+  it('leaves a balanced trace untouched', () => {
+    const done = '<agent-think>done</agent-think>';
+    expect(handleIncompleteAgentThinkTags(done)).toBe(done);
+  });
+
+  it('clears a stale streaming marker once the tag closes', () => {
+    const out = handleIncompleteAgentThinkTags(
+      '<agent-think title="x" data-streaming="true">done</agent-think>',
+    );
+    expect(out).not.toContain('data-streaming');
+  });
+
+  it('marks only the newest of several open steps', () => {
+    const out = handleIncompleteAgentThinkStepTags(
+      '<agent-think-step>one</agent-think-step><agent-think-step>two',
+    );
+    expect(out.match(/data-streaming="true"/g)).toHaveLength(1);
+    // The marker belongs to the step that is still being written.
+    expect(out.indexOf('data-streaming="true"')).toBeGreaterThan(out.indexOf('one'));
+  });
+
+  it('does not treat agent-think-step as an unclosed agent-think', () => {
+    const balanced = '<agent-think><agent-think-step>a</agent-think-step></agent-think>';
+    expect(handleIncompleteAgentThinkTags(balanced)).toBe(balanced);
+  });
+});
+
+describe('fixMalformedHtml', () => {
+  it('applies every repair and never throws', () => {
+    const out = fixMalformedHtml('<agent-think>x<img src="http');
+    expect(out).toContain('src="loading"');
+    expect(out).toContain('</agent-think>');
+    expect(fixMalformedHtml('')).toBe('');
+  });
+});

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/jest.config.js
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/jest.config.js
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+// No NeMo Agent Toolkit mocks here on purpose: this package has no toolkit
+// dependency, which is the reason it exists.
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+  },
+  testMatch: ['<rootDir>/__tests__/**/*.test.ts?(x)'],
+};

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/jest.config.js
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/jest.config.js
@@ -1,11 +1,39 @@
 // SPDX-License-Identifier: MIT
 // No NeMo Agent Toolkit mocks here on purpose: this package has no toolkit
 // dependency, which is the reason it exists.
+//
+// Two projects because most of the logic here is pure (parsers, import/export,
+// markdown repairs) and runs faster and more honestly without a DOM, while the
+// panel itself needs one.
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node', // parser tests are pure; switch to jsdom when component tests land
-  moduleNameMapper: {
-    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
-  },
-  testMatch: ['<rootDir>/__tests__/**/*.test.ts?(x)'],
+  projects: [
+    {
+      displayName: 'logic',
+      preset: 'ts-jest',
+      testEnvironment: 'node',
+      moduleNameMapper: { '\\.(css|less|scss|sass)$': 'identity-obj-proxy' },
+      testMatch: ['<rootDir>/__tests__/**/*.test.ts'],
+    },
+    {
+      displayName: 'components',
+      preset: 'ts-jest',
+      testEnvironment: 'jsdom',
+      setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+      moduleNameMapper: { '\\.(css|less|scss|sass)$': 'identity-obj-proxy' },
+      testMatch: ['<rootDir>/__tests__/**/*.test.tsx'],
+      transform: {
+        '^.+\\.(t|j)sx?$': [
+          'ts-jest',
+          { tsconfig: { jsx: 'react-jsx', esModuleInterop: true, allowJs: true } },
+        ],
+      },
+      // The unified/remark/rehype chain ships ESM only, and its transitive
+      // deps (hastscript, parse5, micromark, …) do too — so match the whole
+      // ecosystem by substring rather than maintaining an exact package list
+      // that breaks every time one of them gains a dependency.
+      transformIgnorePatterns: [
+        '/node_modules/(?!(.*(react-markdown|remark|rehype|hast|mdast|micromark|unist|unified|vfile|parse5|character-entities|decode-named-character-reference|property-information|space-separated-tokens|comma-separated-tokens|html-void-elements|html-url-attributes|web-namespaces|zwitch|bail|trough|is-plain-obj|stringify-entities|ccount|escape-string-regexp|markdown-table|trim-lines|devlop|longest-streak|estree-util-is-identifier-name|parse-entities|character-reference-invalid|is-alphanumerical|is-decimal|is-hexadecimal)))',
+      ],
+    },
+  ],
 };

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/jest.config.js
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/jest.config.js
@@ -3,7 +3,7 @@
 // dependency, which is the reason it exists.
 module.exports = {
   preset: 'ts-jest',
-  testEnvironment: 'jsdom',
+  testEnvironment: 'node', // parser tests are pure; switch to jsdom when component tests land
   moduleNameMapper: {
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
   },

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/jest.setup.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/jest.setup.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+import { TextDecoder, TextEncoder } from 'node:util';
+
+import '@testing-library/jest-dom';
+
+// jsdom ships neither, and the SSE reader decodes every chunk with them.
+if (!('TextEncoder' in globalThis)) {
+  Object.assign(globalThis, { TextEncoder, TextDecoder });
+}
+
+// jsdom implements neither, and the panel calls both on every message.
+window.HTMLElement.prototype.scrollIntoView = jest.fn();
+if (!('ResizeObserver' in window)) {
+  (window as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/AgentParams.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/AgentParams.tsx
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Per-turn agent parameters.
+ *
+ * The deployment describes the fields as JSON in
+ * NEXT_PUBLIC_CHAT_API_CUSTOM_AGENT_PARAMS_JSON:
+ *
+ *   {"params":[{"name":"top_k","label":"Top K","type":"number","default-value":5}]}
+ *
+ * Values are merged into the request body, so a field named after a fixed field
+ * (`messages`) must not be able to shadow it — `useChatStream` spreads params
+ * first for exactly that reason.
+ */
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import type { CustomAgentParamsValues, ParamField, ParamFieldConfig } from './types';
+
+const STORAGE_KEY = 'vss-chat-custom-agent-params';
+const generateId = () => Math.random().toString(36).substring(2, 11);
+
+export const fieldsToParams = (fields: ParamField[]): CustomAgentParamsValues =>
+  (fields || []).reduce((acc, field) => {
+    if (field.name) acc[field.name] = field.value;
+    return acc;
+  }, {} as CustomAgentParamsValues);
+
+export const parseParamsJson = (jsonString?: string): ParamField[] => {
+  try {
+    if (!jsonString) return [];
+    const parsed = JSON.parse(jsonString) as { params?: ParamFieldConfig[] };
+    if (!Array.isArray(parsed?.params)) return [];
+    return parsed.params.map((item) => ({
+      ...item,
+      id: generateId(),
+      value: item['default-value'],
+    }));
+  } catch (error) {
+    console.warn('vss-chat: could not parse customAgentParamsJson', error);
+    return [];
+  }
+};
+
+function loadSavedValues(): CustomAgentParamsValues {
+  if (typeof window === 'undefined') return {};
+  try {
+    const stored = sessionStorage.getItem(STORAGE_KEY);
+    return stored ? JSON.parse(stored) : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Fields from config, with any value the user previously chose restored.
+ *
+ * A saved value is only applied when its type still matches the field's — the
+ * store is sessionStorage, which page script can write, and a string where a
+ * number is expected would reach the agent as-is.
+ */
+export function useParamFields(
+  customAgentParamsJson?: string,
+): [ParamField[], React.Dispatch<React.SetStateAction<ParamField[]>>] {
+  const [fields, setFields] = useState<ParamField[]>([]);
+  const initialized = useRef(false);
+
+  useEffect(() => {
+    if (initialized.current || !customAgentParamsJson) return;
+    initialized.current = true;
+
+    const saved = loadSavedValues();
+    setFields(
+      parseParamsJson(customAgentParamsJson).map((field) => {
+        if (!field.name || !(field.name in saved)) return field;
+        const value = saved[field.name];
+        const validType =
+          (field.type === 'boolean' && typeof value === 'boolean') ||
+          (field.type === 'number' && typeof value === 'number' && !Number.isNaN(value)) ||
+          ((field.type === 'string' || field.type === 'select') && typeof value === 'string');
+        return validType ? { ...field, value } : field;
+      }),
+    );
+  }, [customAgentParamsJson]);
+
+  useEffect(() => {
+    if (!initialized.current || !fields.length || typeof window === 'undefined') return;
+    try {
+      sessionStorage.setItem(STORAGE_KEY, JSON.stringify(fieldsToParams(fields)));
+    } catch {
+      // Quota or a locked-down storage policy; the values just will not persist.
+    }
+  }, [fields]);
+
+  return [fields, setFields];
+}
+
+const inputClass =
+  'w-full rounded-md border border-gray-200 bg-gray-50 px-2 py-1.5 text-sm text-gray-900 focus:outline-none focus:ring-1 focus:ring-[#76b900] dark:border-gray-600 dark:bg-black dark:text-white';
+
+export interface AgentParamsProps {
+  isOpen: boolean;
+  onClose: () => void;
+  fields: ParamField[];
+  onFieldsChange: (fields: ParamField[]) => void;
+  anchorRef?: React.RefObject<HTMLElement>;
+  /** True while a turn is in flight: values are frozen mid-request. */
+  valuesChangeDisabled?: boolean;
+}
+
+export const AgentParams: React.FC<AgentParamsProps> = ({
+  isOpen,
+  onClose,
+  fields,
+  onFieldsChange,
+  anchorRef,
+  valuesChangeDisabled = false,
+}) => {
+  const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
+
+  // Portalled to <body> so the chat input's overflow cannot clip it, which
+  // means the position has to be tracked by hand.
+  useLayoutEffect(() => {
+    if (!isOpen || !anchorRef?.current) {
+      setAnchorRect(null);
+      return;
+    }
+    const element = anchorRef.current;
+    const update = () => setAnchorRect(element.getBoundingClientRect());
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(element);
+    window.addEventListener('scroll', update, true);
+    window.addEventListener('resize', update);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('scroll', update, true);
+      window.removeEventListener('resize', update);
+    };
+  }, [isOpen, anchorRef]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [isOpen, onClose]);
+
+  const handleFieldChange = useCallback(
+    (id: string, value: string | number | boolean) => {
+      onFieldsChange(fields.map((f) => (f.id === id ? { ...f, value } : f)));
+    },
+    [fields, onFieldsChange],
+  );
+
+  if (!isOpen || typeof document === 'undefined') return null;
+
+  const renderInput = (field: ParamField) => {
+    const editable = field.changeable !== false && !valuesChangeDisabled;
+    const disabledClass = editable ? '' : 'opacity-60 cursor-not-allowed';
+
+    switch (field.type) {
+      case 'boolean':
+        return (
+          <button
+            type="button"
+            role="switch"
+            aria-checked={field.value === true}
+            title={field['tooltip-info']}
+            disabled={!editable}
+            onClick={() => handleFieldChange(field.id, !field.value)}
+            className={`relative inline-flex h-5 w-10 items-center rounded-full transition-colors ${
+              field.value ? 'bg-[#76b900]' : 'bg-gray-300 dark:bg-gray-600'
+            } ${disabledClass}`}
+          >
+            <span
+              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                field.value ? 'translate-x-5' : 'translate-x-0.5'
+              }`}
+            />
+          </button>
+        );
+      case 'number':
+        return (
+          <input
+            type="number"
+            className={`${inputClass} ${disabledClass}`}
+            title={field['tooltip-info']}
+            disabled={!editable}
+            value={String(field.value ?? '')}
+            onChange={(e) => {
+              const next = e.target.value === '' ? '' : Number(e.target.value);
+              // Reject NaN rather than sending it: JSON.stringify turns it into
+              // null and the agent sees a missing parameter.
+              if (next === '' || !Number.isNaN(next)) {
+                handleFieldChange(field.id, next === '' ? '' : (next as number));
+              }
+            }}
+          />
+        );
+      case 'select':
+        return (
+          <select
+            className={`${inputClass} ${disabledClass}`}
+            title={field['tooltip-info']}
+            disabled={!editable}
+            value={String(field.value ?? '')}
+            onChange={(e) => handleFieldChange(field.id, e.target.value)}
+          >
+            {(field.options ?? []).map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        );
+      default:
+        return (
+          <input
+            type="text"
+            className={`${inputClass} ${disabledClass}`}
+            title={field['tooltip-info']}
+            disabled={!editable}
+            value={String(field.value ?? '')}
+            onChange={(e) => handleFieldChange(field.id, e.target.value)}
+          />
+        );
+    }
+  };
+
+  const top = anchorRect ? anchorRect.bottom + 8 : 80;
+  const right = anchorRect ? Math.max(8, window.innerWidth - anchorRect.right) : 16;
+
+  return createPortal(
+    <>
+      <div className="fixed inset-0 z-[99]" onClick={onClose} aria-hidden />
+      <div
+        role="dialog"
+        aria-label="Agent parameters"
+        className="fixed z-[100] w-72 rounded-md border border-gray-200 bg-white p-3 shadow-lg dark:border-gray-700 dark:bg-black"
+        style={{ top, right, maxHeight: '60vh', overflowY: 'auto' }}
+      >
+        <p className="mb-2 text-sm font-medium text-gray-700 dark:text-gray-200">
+          Agent parameters
+        </p>
+        <div className="flex flex-col gap-3">
+          {fields.map((field) => (
+            <label key={field.id} className="flex flex-col gap-1">
+              <span className="text-xs text-gray-600 dark:text-gray-400">{field.label}</span>
+              {renderInput(field)}
+            </label>
+          ))}
+        </div>
+      </div>
+    </>,
+    document.body,
+  );
+};

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/ChatHeader.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/ChatHeader.tsx
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: MIT
+import {
+  IconChevronLeft,
+  IconChevronRight,
+  IconMoonFilled,
+  IconPlus,
+  IconSun,
+  IconUpload,
+} from '@tabler/icons-react';
+import React, { useState } from 'react';
+
+import { ChatUpload } from './ChatUpload';
+import type { ChatFeatureFlags, ChatVideoUploadCompletePayload } from './types';
+
+export interface ChatHeaderProps {
+  workflowName: string;
+  hasMessages: boolean;
+  features: ChatFeatureFlags;
+  theme: 'light' | 'dark';
+  onThemeChange?: (theme: 'light' | 'dark') => void;
+  chatHistory: boolean;
+  onChatHistoryChange: (value: boolean) => void;
+  onNewConversation: () => void;
+  busy: boolean;
+  /** Upload wiring for the welcome drop zone. */
+  uploadUrlBase?: string;
+  uploadConfigTemplateJson?: string;
+  uploadHiddenMessageTemplate?: string;
+  getActiveConversationId?: () => string | undefined;
+  onSendHiddenMessage?: (message: string, uploadConversationId: string) => void;
+  onChatVideoUploadComplete?: (payload: ChatVideoUploadCompletePayload) => void;
+  onUploadFlowActiveChange?: (active: boolean) => void;
+  onNotify?: (message: string) => void;
+}
+
+const Toggle: React.FC<{
+  label: string;
+  checked: boolean;
+  disabled?: boolean;
+  onChange: () => void;
+}> = ({ label, checked, disabled, onChange }) => (
+  <label className="flex flex-shrink-0 cursor-pointer items-center gap-2 whitespace-nowrap">
+    <span className="text-sm font-medium text-black dark:text-white">{label}</span>
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      disabled={disabled}
+      onClick={onChange}
+      className={`relative inline-flex h-5 w-10 items-center rounded-full transition-colors ${
+        checked ? 'bg-black dark:bg-[#76b900]' : 'bg-gray-200'
+      } ${disabled ? 'cursor-not-allowed opacity-40' : ''}`}
+    >
+      <span
+        className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+          checked ? 'translate-x-6' : 'translate-x-0'
+        }`}
+      />
+    </button>
+  </label>
+);
+
+export const ChatHeader: React.FC<ChatHeaderProps> = ({
+  workflowName,
+  hasMessages,
+  features,
+  theme,
+  onThemeChange,
+  chatHistory,
+  onChatHistoryChange,
+  onNewConversation,
+  busy,
+  uploadUrlBase,
+  uploadConfigTemplateJson,
+  uploadHiddenMessageTemplate,
+  getActiveConversationId,
+  onSendHiddenMessage,
+  onChatVideoUploadComplete,
+  onUploadFlowActiveChange,
+  onNotify,
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const uploadEnabled = !!features.uploadFile && !!uploadUrlBase;
+
+  const body = (upload?: {
+    fileInputId: string;
+    isUploading: boolean;
+    isDragging: boolean;
+    dragHandlers: Record<string, (e: React.DragEvent) => void>;
+  }) => (
+    <div className={hasMessages ? 'relative' : 'relative min-h-full'}>
+      <div
+        className={`top-0 z-10 flex h-12 items-center justify-center px-4 py-2 text-sm text-black dark:border-none dark:bg-black dark:text-neutral-200 ${
+          hasMessages ? 'border-b border-gray-200 bg-white' : 'bg-none'
+        }`}
+      >
+        {hasMessages ? (
+          <div className="absolute left-1/2 top-6 -translate-x-1/2 -translate-y-1/2">
+            <span className="text-lg font-semibold text-black dark:text-white">{workflowName}</span>
+          </div>
+        ) : (
+          // Welcome state: the panel is empty, so this is also the drop target.
+          <div
+            className="absolute left-1/2 top-1/2 mx-auto flex -translate-x-1/2 -translate-y-1/2 flex-col items-center px-3 pt-5 text-center sm:max-w-[600px] md:pt-12"
+            {...(upload?.dragHandlers ?? {})}
+          >
+            <div className="mb-4 text-3xl font-semibold text-gray-800 dark:text-white">
+              Hi, I&apos;m {workflowName}
+            </div>
+            <div className="mb-8 text-lg text-gray-600 dark:text-gray-400">
+              How can I assist you today?
+            </div>
+
+            {uploadEnabled && upload && (
+              <label
+                htmlFor={upload.fileInputId}
+                className={`block w-full max-w-md cursor-pointer rounded-xl border-2 border-dashed p-8 transition-all duration-300 ${
+                  upload.isDragging
+                    ? 'scale-105 border-[#76b900] bg-[#76b900]/10 shadow-lg'
+                    : 'border-gray-300 hover:border-[#76b900] hover:bg-gray-50 dark:border-gray-600 dark:hover:bg-black/50'
+                } ${upload.isUploading || busy ? 'pointer-events-none opacity-50' : ''}`}
+              >
+                <div className="flex flex-col items-center gap-4">
+                  <div
+                    className={`rounded-2xl p-4 transition-all duration-300 ${
+                      upload.isDragging
+                        ? 'bg-[#76b900]/20 text-[#76b900]'
+                        : 'bg-[#76b900]/15 text-[#76b900]'
+                    }`}
+                  >
+                    <IconUpload size={48} stroke={1.5} />
+                  </div>
+                  <div data-testid="upload-drop-zone-text" className="text-center">
+                    <p
+                      className={`mb-1 text-base font-medium transition-colors ${
+                        upload.isDragging
+                          ? 'text-[#76b900]'
+                          : 'text-gray-700 dark:text-gray-300'
+                      }`}
+                    >
+                      {upload.isDragging
+                        ? 'Drop files here'
+                        : 'Click or drop files here to upload'}
+                    </p>
+                  </div>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">Movie Files (mp4, mkv)</p>
+                </div>
+              </label>
+            )}
+          </div>
+        )}
+
+        {/* Opaque so the expanded menu covers the title rather than overlapping it. */}
+        <div className="absolute right-0 top-0 z-20 flex h-12 items-center bg-white pl-6 transition-all duration-300 dark:bg-black">
+          <button
+            type="button"
+            onClick={() => setIsExpanded((prev) => !prev)}
+            aria-label={isExpanded ? 'Collapse chat menu' : 'Expand chat menu'}
+            aria-expanded={isExpanded}
+            className="flex p-1 text-black transition-colors dark:text-white"
+          >
+            {isExpanded ? <IconChevronRight size={20} /> : <IconChevronLeft size={20} />}
+          </button>
+
+          <div
+            className={`flex gap-1 overflow-hidden transition-all duration-300 sm:gap-1 md:gap-4 ${
+              isExpanded ? 'w-auto opacity-100' : 'w-0 opacity-0'
+            }`}
+          >
+            <button
+              type="button"
+              onClick={onNewConversation}
+              disabled={busy}
+              title="New chat"
+              aria-label="New chat"
+              className="flex items-center gap-1 whitespace-nowrap text-sm font-medium text-black disabled:opacity-40 dark:text-white"
+            >
+              <IconPlus size={16} /> New chat
+            </button>
+
+            <Toggle
+              label="Chat History"
+              checked={chatHistory}
+              disabled={busy}
+              onChange={() => onChatHistoryChange(!chatHistory)}
+            />
+
+            {features.themeToggle && onThemeChange && (
+              <button
+                type="button"
+                onClick={() => onThemeChange(theme === 'dark' ? 'light' : 'dark')}
+                aria-label="Toggle theme"
+                className="flex items-center rounded-full text-black transition-colors dark:text-white"
+              >
+                {theme === 'dark' ? (
+                  <IconSun className="h-6 w-6 text-yellow-500" />
+                ) : (
+                  <IconMoonFilled className="h-6 w-6 text-gray-800" />
+                )}
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  if (!uploadEnabled) return body();
+
+  return (
+    <ChatUpload
+      agentApiUrlBase={uploadUrlBase}
+      configTemplateJson={uploadConfigTemplateJson}
+      metadataEnabled={features.uploadFileMetadata}
+      hiddenMessageTemplate={uploadHiddenMessageTemplate}
+      disabled={busy}
+      getActiveConversationId={getActiveConversationId}
+      onSendHiddenMessage={onSendHiddenMessage}
+      onUploadBatchComplete={onChatVideoUploadComplete}
+      onUploadFlowActiveChange={onUploadFlowActiveChange}
+      onNotify={onNotify}
+    >
+      {({ fileInputId, isUploading, isDragging, dragHandlers }) =>
+        body({ fileInputId, isUploading, isDragging, dragHandlers })
+      }
+    </ChatUpload>
+  );
+};

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/ChatInput.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/ChatInput.tsx
@@ -1,0 +1,411 @@
+// SPDX-License-Identifier: MIT
+import {
+  IconArrowDown,
+  IconBrain,
+  IconFile,
+  IconMicrophone,
+  IconPaperclip,
+  IconPhoto,
+  IconPlayerStop,
+  IconPlayerStopFilled,
+  IconRepeat,
+  IconSend,
+  IconUpload,
+  IconVideo,
+  IconX,
+} from '@tabler/icons-react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { AgentParams, fieldsToParams, useParamFields } from './AgentParams';
+import { ChatUpload } from './ChatUpload';
+import type {
+  ChatFeatureFlags,
+  ChatVideoUploadCompletePayload,
+  CustomAgentParamsValues,
+  QueryDataContext,
+} from './types';
+
+const CHIP_ICON_SIZE = 12;
+
+/** Leading icon for a context chip, driven by the UI-only `contextType`. */
+const ChipIcon: React.FC<{ contextType: string }> = ({ contextType }) => {
+  const className = 'flex-shrink-0 opacity-90';
+  switch (contextType) {
+    case 'media/video':
+      return <IconVideo size={CHIP_ICON_SIZE} className={className} aria-hidden />;
+    case 'media/image':
+      return <IconPhoto size={CHIP_ICON_SIZE} className={className} aria-hidden />;
+    case 'network-file':
+      return <IconFile size={CHIP_ICON_SIZE} className={className} aria-hidden />;
+    default:
+      return <IconPaperclip size={CHIP_ICON_SIZE} className={className} aria-hidden />;
+  }
+};
+
+/** SpeechRecognition is still vendor-prefixed in Chromium. */
+function getSpeechRecognition(): any {
+  if (typeof window === 'undefined') return null;
+  return (window as any).SpeechRecognition ?? (window as any).webkitSpeechRecognition ?? null;
+}
+
+function isMobile(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini|Mobile|mobile|CriOS/i.test(
+    navigator.userAgent,
+  );
+}
+
+export interface ChatInputProps {
+  onSend: (text: string, params: CustomAgentParamsValues) => void;
+  onRegenerate: () => void;
+  onStop: () => void;
+  onScrollDown: () => void;
+  showScrollDownButton: boolean;
+  busy: boolean;
+  /** True once at least one exchange exists, so Regenerate makes sense. */
+  canRegenerate: boolean;
+  workflowName: string;
+  features: ChatFeatureFlags;
+  customAgentParamsJson?: string;
+  contextItems: QueryDataContext[];
+  onRemoveContext: (id: string) => void;
+  /** Upload wiring; upload is hidden entirely when `uploadUrlBase` is absent. */
+  uploadUrlBase?: string;
+  uploadConfigTemplateJson?: string;
+  uploadHiddenMessageTemplate?: string;
+  getActiveConversationId?: () => string | undefined;
+  onSendHiddenMessage?: (message: string, uploadConversationId: string) => void;
+  onChatVideoUploadComplete?: (payload: ChatVideoUploadCompletePayload) => void;
+  /** True while an upload dialog is open; sending is blocked meanwhile. */
+  onUploadFlowActiveChange?: (active: boolean) => void;
+  chatBlocked?: boolean;
+  onNotify?: (message: string) => void;
+}
+
+export const ChatInput: React.FC<ChatInputProps> = ({
+  onSend,
+  onRegenerate,
+  onStop,
+  onScrollDown,
+  showScrollDownButton,
+  busy,
+  canRegenerate,
+  workflowName,
+  features,
+  customAgentParamsJson,
+  contextItems,
+  onRemoveContext,
+  uploadUrlBase,
+  uploadConfigTemplateJson,
+  uploadHiddenMessageTemplate,
+  getActiveConversationId,
+  onSendHiddenMessage,
+  onChatVideoUploadComplete,
+  onUploadFlowActiveChange,
+  chatBlocked = false,
+  onNotify,
+}) => {
+  const [content, setContent] = useState('');
+  const [isComposing, setIsComposing] = useState(false);
+  const [isRecording, setIsRecording] = useState(false);
+  const [showParams, setShowParams] = useState(false);
+  const [paramFields, setParamFields] = useParamFields(customAgentParamsJson);
+
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const recognitionRef = useRef<any>(null);
+  const paramsButtonRef = useRef<HTMLButtonElement>(null);
+
+  const uploadEnabled = !!features.uploadFile && !!uploadUrlBase;
+  const micEnabled = !!features.inputMic;
+  const disabled = chatBlocked || busy;
+
+  // Freeze the parameter panel mid-request: changing a value after the body
+  // was serialised is a silent no-op that looks like it applied.
+  useEffect(() => {
+    if (disabled) setShowParams(false);
+  }, [disabled]);
+
+  // Grow with content up to a ceiling, then scroll — matching the toolkit.
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = 'inherit';
+    el.style.height = `${el.scrollHeight}px`;
+    el.style.overflow = el.scrollHeight > 400 ? 'auto' : 'hidden';
+  }, [content]);
+
+  useEffect(
+    () => () => {
+      recognitionRef.current?.stop();
+    },
+    [],
+  );
+
+  const handleSend = useCallback(() => {
+    if (disabled) return;
+    if (isRecording) {
+      recognitionRef.current?.stop();
+      setIsRecording(false);
+    }
+    // Chips alone are a valid message: "summarise this" with the clip attached.
+    if (!content.trim() && contextItems.length === 0) {
+      onNotify?.('Please enter a message');
+      return;
+    }
+    onSend(content, fieldsToParams(paramFields));
+    setContent('');
+    if (typeof window !== 'undefined' && window.innerWidth < 640) textareaRef.current?.blur();
+  }, [content, contextItems.length, disabled, isRecording, onNotify, onSend, paramFields]);
+
+  const handleSpeechToText = useCallback(() => {
+    const SpeechRecognition = getSpeechRecognition();
+    if (!SpeechRecognition) {
+      onNotify?.('Speech recognition is not supported in this browser');
+      return;
+    }
+    if (!recognitionRef.current) {
+      const recognition = new SpeechRecognition();
+      recognition.lang = 'en-US';
+      recognition.interimResults = true;
+      recognition.continuous = true;
+      recognition.onresult = (event: any) => {
+        let transcript = '';
+        for (let i = 0; i < event.results.length; i += 1) transcript += event.results[i][0].transcript;
+        setContent(transcript);
+      };
+      recognition.onerror = () => setIsRecording(false);
+      recognitionRef.current = recognition;
+    }
+    if (isRecording) {
+      recognitionRef.current.stop();
+      setIsRecording(false);
+    } else {
+      recognitionRef.current.start();
+      setIsRecording(true);
+    }
+  }, [isRecording, onNotify]);
+
+  const leftButtonCount = (micEnabled ? 1 : 0) + (uploadEnabled ? 1 : 0);
+  const leftPaddingClass =
+    leftButtonCount === 0 ? 'pl-3 sm:pl-4' : leftButtonCount === 2 ? 'pl-[76px]' : 'pl-11';
+  const rightPaddingClass = paramFields.length > 0 ? 'pr-20' : 'pr-12';
+
+  const uploadButton = useMemo(
+    () =>
+      uploadEnabled ? (
+        <ChatUpload
+          agentApiUrlBase={uploadUrlBase}
+          configTemplateJson={uploadConfigTemplateJson}
+          metadataEnabled={features.uploadFileMetadata}
+          hiddenMessageTemplate={uploadHiddenMessageTemplate}
+          disabled={disabled}
+          getActiveConversationId={getActiveConversationId}
+          onSendHiddenMessage={onSendHiddenMessage}
+          onUploadBatchComplete={onChatVideoUploadComplete}
+          onUploadFlowActiveChange={onUploadFlowActiveChange}
+          onNotify={onNotify}
+        >
+          {({ triggerUpload }) => (
+            <button
+              type="button"
+              onClick={triggerUpload}
+              disabled={disabled}
+              title="Upload video"
+              aria-label="Upload video"
+              className={`rounded-sm p-[5px] text-neutral-800 opacity-60 dark:text-neutral-100 ${
+                disabled ? 'text-neutral-400' : 'hover:text-[#76b900]'
+              }`}
+            >
+              <IconUpload size={18} />
+            </button>
+          )}
+        </ChatUpload>
+      ) : null,
+    [
+      uploadEnabled,
+      uploadUrlBase,
+      uploadConfigTemplateJson,
+      uploadHiddenMessageTemplate,
+      features.uploadFileMetadata,
+      disabled,
+      getActiveConversationId,
+      onSendHiddenMessage,
+      onChatVideoUploadComplete,
+      onUploadFlowActiveChange,
+      onNotify,
+    ],
+  );
+
+  return (
+    <div className="pointer-events-none absolute bottom-0 left-0 w-full border-transparent bg-gradient-to-b from-transparent via-white to-white pb-4 pt-6 dark:via-black dark:to-black">
+      <div className="stretch pointer-events-auto mx-auto mt-4 flex w-full max-w-[95%] flex-row gap-3 last:mb-2 md:mt-[52px]">
+        {busy && !chatBlocked && (
+          <button
+            type="button"
+            className="absolute left-0 right-0 top-0 mx-auto mb-3 flex w-fit items-center gap-3 rounded border border-neutral-200 bg-white px-4 py-2 text-black hover:opacity-50 dark:border-neutral-600 dark:bg-black dark:text-white md:mb-0 md:mt-2"
+            onClick={onStop}
+          >
+            <IconPlayerStop size={16} /> Stop Generating
+          </button>
+        )}
+
+        {!busy && !chatBlocked && canRegenerate && (
+          <button
+            type="button"
+            className="absolute left-0 right-0 top-0 mx-auto mb-3 flex w-fit items-center gap-3 rounded border border-neutral-200 bg-white px-4 py-2 text-black hover:opacity-50 dark:border-neutral-600 dark:bg-black dark:text-white md:mb-0 md:mt-2"
+            onClick={onRegenerate}
+          >
+            <IconRepeat size={16} /> Regenerate response
+          </button>
+        )}
+
+        <div className="relative mx-2 flex w-full flex-grow flex-col rounded-md border border-black/10 bg-white shadow-[0_0_10px_rgba(0,0,0,0.10)] dark:border-neutral-700 dark:bg-black dark:text-white sm:mx-4">
+          {!content && !isRecording && contextItems.length === 0 && (
+            <div
+              data-testid="chat-input-placeholder"
+              className={`pointer-events-none absolute inset-0 flex items-center py-2 text-gray-500 dark:text-gray-400 md:py-3 ${leftPaddingClass} ${rightPaddingClass}`}
+              aria-hidden
+            >
+              <span className="min-w-0 truncate">
+                Unlock {workflowName} knowledge and expertise
+              </span>
+            </div>
+          )}
+
+          {contextItems.length > 0 && (
+            <div
+              className={`flex flex-wrap gap-1.5 pr-12 pt-2 ${
+                uploadEnabled ? 'pl-12 sm:pl-18 md:pl-20' : 'pl-10 sm:pl-12 md:pl-14'
+              }`}
+            >
+              {contextItems.map((item) => (
+                <span
+                  key={item.id}
+                  className="inline-flex max-w-[200px] items-center gap-1 rounded-md bg-gray-100 py-1 pl-1.5 pr-1 text-xs text-gray-700 dark:bg-gray-600 dark:text-gray-200"
+                  title={`${item.label} (${item.contextType})`}
+                >
+                  <ChipIcon contextType={item.contextType} />
+                  <span className="truncate">{item.label}</span>
+                  <button
+                    type="button"
+                    onClick={() => onRemoveContext(item.id)}
+                    className="flex-shrink-0 rounded p-0.5 hover:bg-gray-300 dark:hover:bg-gray-500"
+                    aria-label={`Remove ${item.label}`}
+                  >
+                    <IconX size={12} />
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+
+          <textarea
+            data-testid="chat-textarea"
+            ref={textareaRef}
+            rows={1}
+            className={`m-0 w-full resize-none border-0 bg-transparent p-0 py-2 text-black outline-none dark:bg-transparent dark:text-white md:py-3 ${leftPaddingClass} ${rightPaddingClass}`}
+            style={{ minHeight: '44px', maxHeight: '400px' }}
+            placeholder={isRecording ? 'Listening…' : ''}
+            aria-label={
+              isRecording ? 'Listening' : `Unlock ${workflowName} knowledge and expertise`
+            }
+            value={content}
+            disabled={chatBlocked}
+            readOnly={chatBlocked}
+            onChange={(e) => setContent(e.target.value)}
+            onCompositionStart={() => setIsComposing(true)}
+            onCompositionEnd={() => setIsComposing(false)}
+            onKeyDown={(e) => {
+              if (chatBlocked) return;
+              // Never submit mid-IME composition: the Enter that commits a
+              // Japanese candidate would send a half-typed message.
+              if (e.key === 'Enter' && !isComposing && !isMobile() && !e.shiftKey) {
+                e.preventDefault();
+                handleSend();
+              }
+            }}
+          />
+
+          {(micEnabled || uploadEnabled) && (
+            <div className="absolute left-2 top-2 flex gap-1">
+              {micEnabled && (
+                <button
+                  type="button"
+                  onClick={handleSpeechToText}
+                  disabled={disabled}
+                  aria-label={isRecording ? 'Stop recording' : 'Start recording'}
+                  className={`rounded-sm p-[5px] text-neutral-800 opacity-60 dark:text-neutral-100 ${
+                    disabled ? 'text-neutral-400' : 'hover:text-[#76b900]'
+                  }`}
+                >
+                  {isRecording ? (
+                    <IconPlayerStopFilled size={18} className="animate-pulse text-red-500" />
+                  ) : (
+                    <IconMicrophone size={18} />
+                  )}
+                </button>
+              )}
+              {uploadButton}
+            </div>
+          )}
+
+          {paramFields.length > 0 && (
+            <div className="absolute right-10 top-2">
+              <button
+                ref={paramsButtonRef}
+                type="button"
+                title="Agent parameters"
+                aria-label="Agent parameters"
+                disabled={disabled}
+                onClick={() => setShowParams((prev) => !prev)}
+                className={`rounded-sm p-1 text-neutral-800 opacity-60 disabled:cursor-not-allowed disabled:opacity-40 dark:text-neutral-100 ${
+                  showParams ? 'text-[#76b900]' : ''
+                } ${disabled ? 'text-neutral-400' : 'hover:text-[#76b900]'}`}
+              >
+                <IconBrain size={18} />
+              </button>
+              <AgentParams
+                isOpen={showParams}
+                onClose={() => setShowParams(false)}
+                fields={paramFields}
+                onFieldsChange={setParamFields}
+                anchorRef={paramsButtonRef}
+                valuesChangeDisabled={disabled}
+              />
+            </div>
+          )}
+
+          <button
+            type="button"
+            className="absolute right-2 top-2 rounded-sm p-1 text-neutral-800 opacity-60 hover:bg-neutral-200 hover:text-neutral-900 disabled:cursor-not-allowed disabled:opacity-40 dark:text-neutral-100"
+            onClick={handleSend}
+            disabled={disabled}
+            aria-label="Send message"
+          >
+            {busy ? (
+              <div
+                data-testid="chat-loading-spinner"
+                className="h-4 w-4 animate-spin rounded-full border-t-2 border-neutral-800 opacity-60 dark:border-neutral-100"
+              />
+            ) : (
+              <IconSend size={18} />
+            )}
+          </button>
+
+          {showScrollDownButton && (
+            <div className="absolute bottom-12 right-0 lg:-right-10 lg:bottom-2">
+              <button
+                type="button"
+                aria-label="Scroll to latest"
+                className="flex h-7 w-7 items-center justify-center rounded-full bg-neutral-300 text-gray-800 shadow-md hover:shadow-lg dark:bg-gray-900 dark:text-neutral-200"
+                onClick={onScrollDown}
+              >
+                <IconArrowDown size={18} />
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/ChatMessage.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/ChatMessage.tsx
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: MIT
+import {
+  IconCheck,
+  IconCopy,
+  IconEdit,
+  IconPlayerPause,
+  IconTrash,
+  IconUser,
+  IconVolume2,
+} from '@tabler/icons-react';
+import DOMPurify from 'isomorphic-dompurify';
+import React, { memo, useEffect, useMemo, useRef, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import rehypeRaw from 'rehype-raw';
+import remarkGfm from 'remark-gfm';
+import remarkMath from 'remark-math';
+
+import { ChatSteps } from './ChatSteps';
+import { getMarkdownComponents } from './markdown/components';
+import { fixMalformedHtml } from './markdown/streaming';
+import type { ChatFeatureFlags, ChatMessage as ChatMessageType } from './types';
+
+export interface ChatMessageProps {
+  message: ChatMessageType;
+  features: ChatFeatureFlags;
+  /**
+   * Identified by message, not by position.
+   *
+   * The rendered list has hidden messages filtered out, so a rendered index
+   * does not address the same element in the conversation — editing the second
+   * visible message after an upload auto-prompt would rewrite the wrong turn.
+   */
+  onEdit?: (message: ChatMessageType) => void;
+  onDelete?: (messageId: string) => void;
+  onNotify?: (message: string) => void;
+}
+
+const BotAvatar: React.FC = () => (
+  <span
+    aria-hidden
+    className="flex h-[30px] w-[30px] items-center justify-center rounded-full bg-[#76b900] text-xs font-bold text-black"
+  >
+    VSS
+  </span>
+);
+
+export const ChatMessageView: React.FC<ChatMessageProps> = memo(
+  ({ message, features, onEdit, onDelete, onNotify }) => {
+    const [isEditing, setIsEditing] = useState(false);
+    const [isTyping, setIsTyping] = useState(false);
+    const [draft, setDraft] = useState(message.content);
+    const [copied, setCopied] = useState(false);
+    const [isPlaying, setIsPlaying] = useState(false);
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+    const isAssistant = message.role === 'assistant';
+    const isStreaming = !!message.streaming;
+
+    // `messageIsStreaming` is deliberately outside the dep list: including it
+    // rebuilds the whole component map the moment a stream ends, unmounting
+    // every image and code block in the answer at once.
+    const markdownComponents = useMemo(
+      () => getMarkdownComponents({ messageIsStreaming: isStreaming, onDownloadError: onNotify }),
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [message.id, onNotify],
+    );
+
+    // callerInfo is HTML supplied by the embedding app, not by the model, but
+    // it still goes through DOMPurify — the app builds it from search results
+    // that originate upstream.
+    const safeCallerInfo = useMemo(
+      () => DOMPurify.sanitize(message.callerInfo || ''),
+      [message.callerInfo],
+    );
+
+    const content = useMemo(
+      () => (isAssistant ? fixMalformedHtml(message.content).trim() : message.content.trim()),
+      [isAssistant, message.content],
+    );
+
+    useEffect(() => setDraft(message.content), [message.content]);
+
+    useEffect(() => {
+      if (textareaRef.current) {
+        textareaRef.current.style.height = 'inherit';
+        textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
+      }
+    }, [isEditing, draft]);
+
+    useEffect(
+      () => () => {
+        if (typeof window !== 'undefined' && window.speechSynthesis) window.speechSynthesis.cancel();
+      },
+      [],
+    );
+
+    // Hidden messages (upload auto-prompts) are sent but never shown, and an
+    // assistant turn with neither text nor steps is just noise.
+    if (message.hidden) return null;
+    if (isAssistant && !content && !message.steps?.length && !message.error && !isStreaming) {
+      return null;
+    }
+
+    const handleCopy = () => {
+      if (!navigator.clipboard) return;
+      void navigator.clipboard.writeText(message.content).then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      });
+    };
+
+    const handleSpeak = () => {
+      if (typeof window === 'undefined' || !('speechSynthesis' in window)) {
+        onNotify?.('Text-to-speech is not supported in this browser');
+        return;
+      }
+      if (isPlaying) {
+        window.speechSynthesis.cancel();
+        setIsPlaying(false);
+        return;
+      }
+      // URLs read aloud character by character are unbearable; drop them.
+      const utterance = new SpeechSynthesisUtterance(
+        message.content.replace(/(https?:\/\/[^\s]+)/g, ''),
+      );
+      utterance.onend = () => setIsPlaying(false);
+      utterance.onerror = () => setIsPlaying(false);
+      setIsPlaying(true);
+      window.speechSynthesis.speak(utterance);
+    };
+
+    const handleSaveEdit = () => {
+      // Everything from this message on is replaced by the new turn.
+      if (draft !== message.content) onEdit?.({ ...message, content: draft });
+      setIsEditing(false);
+    };
+
+    return (
+      <div
+        data-testid={isAssistant ? 'chat-message-assistant' : 'chat-message-user'}
+        className={`group border-b border-black/10 text-gray-800 dark:border-gray-900/50 dark:text-gray-100 md:px-4 ${
+          isAssistant ? 'bg-gray-50 dark:bg-black' : 'bg-white dark:bg-black'
+        }`}
+        style={{ overflowWrap: 'anywhere' }}
+      >
+        <div className="relative m-auto flex w-full max-w-[95%] text-base sm:p-2 md:gap-6 md:py-6 lg:px-0">
+          <div className="min-w-[40px] text-right font-bold">
+            {isAssistant ? <BotAvatar /> : <IconUser size={30} />}
+          </div>
+
+          <div className="w-full min-w-0 overflow-hidden">
+            {!isAssistant ? (
+              <div className="flex w-full">
+                {isEditing ? (
+                  <div className="flex w-full flex-col">
+                    <textarea
+                      ref={textareaRef}
+                      className="w-full resize-none whitespace-pre-wrap border-none bg-transparent outline-none dark:bg-black"
+                      value={draft}
+                      onChange={(e) => setDraft(e.target.value)}
+                      onCompositionStart={() => setIsTyping(true)}
+                      onCompositionEnd={() => setIsTyping(false)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' && !isTyping && !e.shiftKey) {
+                          e.preventDefault();
+                          handleSaveEdit();
+                        }
+                      }}
+                      style={{ font: 'inherit', padding: 0, margin: 0, overflow: 'hidden' }}
+                    />
+                    <div className="mt-6 flex justify-center space-x-4">
+                      <button
+                        type="button"
+                        className="h-[40px] rounded-md border border-neutral-300 px-4 py-1 text-sm font-medium text-neutral-700 enabled:hover:bg-[#76b900] enabled:hover:text-white disabled:opacity-50 dark:border-neutral-700 dark:text-neutral-300"
+                        onClick={handleSaveEdit}
+                        disabled={!draft.trim()}
+                      >
+                        Save &amp; Submit
+                      </button>
+                      <button
+                        type="button"
+                        className="h-[40px] rounded-md border border-neutral-300 px-4 py-1 text-sm font-medium text-neutral-700 hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800"
+                        onClick={() => {
+                          setDraft(message.content);
+                          setIsEditing(false);
+                        }}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="w-full flex-1 whitespace-pre-wrap break-words">{content}</div>
+                )}
+
+                {!isEditing && (
+                  <div className="absolute right-2 flex flex-col items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100 md:flex-row md:items-start">
+                    {features.messageEdit && (
+                      <button
+                        type="button"
+                        aria-label="Edit message"
+                        className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                        onClick={() => setIsEditing(true)}
+                      >
+                        <IconEdit size={20} />
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      aria-label="Delete message"
+                      className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                      onClick={() => onDelete?.(message.id)}
+                    >
+                      <IconTrash size={20} />
+                    </button>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div className="w-full min-w-0 max-w-full">
+                {features.intermediateSteps && message.steps?.length ? (
+                  <ChatSteps
+                    steps={message.steps}
+                    streaming={isStreaming}
+                    expandByDefault={features.expandIntermediateSteps}
+                  />
+                ) : null}
+
+                {message.error ? (
+                  <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+                    ⚠ {message.error}
+                  </div>
+                ) : null}
+
+                <div className="prose max-w-none break-words dark:prose-invert">
+                  <ReactMarkdown
+                    remarkPlugins={[remarkGfm, [remarkMath, { singleDollarTextMath: false }]]}
+                    rehypePlugins={[rehypeRaw] as any}
+                    components={markdownComponents as any}
+                  >
+                    {content}
+                  </ReactMarkdown>
+                  {isStreaming && !content ? (
+                    <span className="inline-block animate-pulse">▍</span>
+                  ) : null}
+                </div>
+
+                {message.callerInfo ? (
+                  <div className="mt-2 rounded-md border border-black/10 bg-neutral-100 px-4 py-2.5 text-sm text-neutral-800 dark:border-white/10 dark:bg-transparent dark:text-neutral-200">
+                    <div
+                      className="[&_ul]:mt-2 [&_ul]:list-disc [&_ul]:space-y-0.5 [&_ul]:pl-5"
+                      dangerouslySetInnerHTML={{ __html: safeCallerInfo }}
+                    />
+                  </div>
+                ) : null}
+
+                {!isStreaming && (features.messageCopy || features.messageSpeaker) ? (
+                  <div className="mt-1 flex gap-1">
+                    {features.messageCopy &&
+                      (copied ? (
+                        <IconCheck size={20} className="text-[#76b900]" />
+                      ) : (
+                        <button
+                          type="button"
+                          className="text-[#76b900] hover:text-gray-700 dark:hover:text-gray-300"
+                          onClick={handleCopy}
+                          title="Copy to clipboard"
+                          aria-label="Copy to clipboard"
+                        >
+                          <IconCopy size={20} />
+                        </button>
+                      ))}
+                    {features.messageSpeaker && (
+                      <button
+                        type="button"
+                        className="text-[#76b900] hover:text-gray-700 dark:hover:text-gray-300"
+                        onClick={handleSpeak}
+                        aria-label={isPlaying ? 'Stop speaking' : 'Start speaking'}
+                      >
+                        {isPlaying ? (
+                          <IconPlayerPause size={20} className="animate-pulse text-red-400" />
+                        ) : (
+                          <IconVolume2 size={20} />
+                        )}
+                      </button>
+                    )}
+                  </div>
+                ) : null}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  },
+  // Re-render only when something visible changed. Without this every message
+  // in a long thread re-renders on each token of the newest answer.
+  (prev, next) => prev.message === next.message && prev.features === next.features,
+);
+ChatMessageView.displayName = 'ChatMessageView';

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/ChatPanel.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/ChatPanel.tsx
@@ -1,76 +1,46 @@
 // SPDX-License-Identifier: MIT
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
 
+import { ChatHeader } from './ChatHeader';
+import { ChatInput } from './ChatInput';
+import { ChatMessageView } from './ChatMessage';
+import { InteractionModal } from './InteractionModal';
 import { useChatStream } from './useChatStream';
-import type { ChatMessage, ChatPanelProps, ChatStep } from './types';
+import { useConversations } from './useConversations';
+import type {
+  ChatFeatureFlags,
+  ChatPanelProps,
+  ChatSidebarControlHandlers,
+  QueryDataContext,
+} from './types';
+
+/**
+ * Defaults chosen to match what the VSS deployment actually sets in
+ * `deploy/docker/resolved.yml`, so an unconfigured embed behaves like the
+ * toolkit chat bar it replaces rather than like a bare component.
+ */
+const DEFAULT_FEATURES: Required<ChatFeatureFlags> = {
+  chatHistory: true,
+  intermediateSteps: true,
+  expandIntermediateSteps: false,
+  messageCopy: false,
+  messageEdit: false,
+  messageSpeaker: false,
+  inputMic: false,
+  uploadFile: true,
+  uploadFileMetadata: false,
+  themeToggle: false,
+  headerMenu: true,
+};
 
 /** Stable per-mount id so the adapter maps this panel to one agent session. */
-function useConversationId(supplied?: string): string {
+function useFallbackConversationId(supplied?: string): string {
   const ref = useRef(supplied);
   if (!ref.current) {
     ref.current = `vss-${Math.random().toString(36).slice(2, 10)}`;
   }
   return ref.current;
 }
-
-const StepList: React.FC<{ steps: ChatStep[]; streaming?: boolean }> = ({ steps, streaming }) => {
-  // Open while the agent is working, so progress is visible the way the
-  // toolkit UI showed it; collapses once the answer lands so finished steps do
-  // not bury it. An explicit click wins over that default either way.
-  const [manual, setManual] = useState<boolean | null>(null);
-  const open = manual ?? !!streaming;
-  if (!steps.length) return null;
-
-  return (
-    <div className="vss-chat-steps">
-      <button
-        type="button"
-        className="vss-chat-steps-toggle"
-        onClick={() => setManual(!open)}
-        aria-expanded={open}
-      >
-        <span>{open ? '▾' : '▸'}</span>
-        <span>
-          Intermediate steps ({steps.length})
-          {streaming ? ' — running' : ''}
-        </span>
-      </button>
-      {open && (
-        <ul className="vss-chat-steps-list">
-          {steps.map((s) => (
-            <li key={s.id} data-status={s.status}>
-              <span>
-                <span className="vss-chat-step-dot" />
-                <span className="vss-chat-step-name">{s.name}</span>
-              </span>
-              {s.payload ? <pre>{s.payload}</pre> : null}
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
-  );
-};
-
-const Message: React.FC<{ message: ChatMessage; showSteps: boolean }> = ({ message, showSteps }) => (
-  <div className={`vss-chat-msg vss-chat-msg-${message.role}`} data-streaming={!!message.streaming}>
-    {showSteps && message.steps?.length ? (
-      <StepList steps={message.steps} streaming={message.streaming} />
-    ) : null}
-    {message.error ? (
-      <div className="vss-chat-error">⚠ {message.error}</div>
-    ) : message.role === 'assistant' ? (
-      <div className="vss-chat-markdown">
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>{message.content}</ReactMarkdown>
-        {message.streaming && !message.content ? <span className="vss-chat-cursor">▍</span> : null}
-      </div>
-    ) : (
-      <div className="vss-chat-usertext">{message.content}</div>
-    )}
-  </div>
-);
 
 /**
  * VSS chat surface.
@@ -83,13 +53,64 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   endpoint,
   title,
   theme = 'dark',
-  placeholder = 'Ask about your video…',
-  showSteps = true,
+  onThemeChange,
+  placeholder,
+  showSteps,
+  features: featuresProp,
+  customAgentParamsJson,
+  uploadConfigTemplateJson,
+  uploadHiddenMessageTemplate,
+  storageKeyPrefix,
+  isActive = true,
   onAnswer,
+  onAnswerComplete,
   onSubmit,
+  onSubmitMessageReady,
+  onMessageSubmitted,
+  onAddQueryContextReady,
+  onChatVideoUploadComplete,
+  onBusyChange,
+  onControlsReady,
   className,
 }) => {
-  const conversationId = useConversationId(endpoint.conversationId);
+  const features = useMemo<Required<ChatFeatureFlags>>(
+    () => ({
+      ...DEFAULT_FEATURES,
+      // `showSteps` predates the flags object; honour it so existing embeds
+      // that pass it keep working.
+      ...(showSteps === undefined ? {} : { intermediateSteps: showSteps }),
+      ...featuresProp,
+    }),
+    [featuresProp, showSteps],
+  );
+
+  const conversations = useConversations(storageKeyPrefix);
+  const {
+    selected,
+    setMessages,
+    titleIfUntitled,
+    hydrated,
+    create: createConversation,
+  } = conversations;
+
+  // The endpoint's conversation id is what the adapter keys its session on.
+  // Following the selected conversation means switching threads in the UI also
+  // switches the agent's memory, instead of leaking one into the other.
+  const fallbackId = useFallbackConversationId(endpoint.conversationId);
+  const conversationId = endpoint.conversationId ?? selected?.id ?? fallbackId;
+
+  const [chatHistory, setChatHistory] = useState(features.chatHistory);
+  const [contextItems, setContextItems] = useState<QueryDataContext[]>([]);
+  const [uploadFlowActive, setUploadFlowActive] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [autoScroll, setAutoScroll] = useState(true);
+
+  const messages = selected?.messages ?? [];
+  const logRef = useRef<HTMLDivElement | null>(null);
+  const endRef = useRef<HTMLDivElement | null>(null);
+  const selectedIdRef = useRef<string | undefined>(selected?.id);
+  selectedIdRef.current = selected?.id;
+
   const config = useMemo(
     () => ({ ...endpoint, conversationId }),
     [endpoint, conversationId],
@@ -101,67 +122,253 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     (answer: string) => onAnswer?.(answer, conversationId),
     [onAnswer, conversationId],
   );
-  const { messages, busy, send, abort } = useChatStream(config, handleAnswer);
 
-  const [draft, setDraft] = useState('');
-  const endRef = useRef<HTMLDivElement | null>(null);
+  const isConversationStale = useCallback(
+    (uploadConversationId: string) => selectedIdRef.current !== uploadConversationId,
+    [],
+  );
+
+  const { busy, send, abort, interaction, dismissInteraction } = useChatStream(config, {
+    messages,
+    setMessages,
+    chatHistory,
+    onAnswer: handleAnswer,
+    onAnswerComplete,
+    onBusyChange,
+    isConversationStale,
+  });
+
+  const notify = useCallback((message: string) => {
+    setNotice(message);
+    setTimeout(() => setNotice(null), 4000);
+  }, []);
+
+  // Auto-scroll unless the user has scrolled up to read something — pinning
+  // them to the bottom mid-answer is the fastest way to make a long reply
+  // unreadable.
+  const handleScroll = useCallback(() => {
+    const el = logRef.current;
+    if (!el) return;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+    setAutoScroll(atBottom);
+  }, []);
 
   useEffect(() => {
+    if (!isActive || !autoScroll) return;
     endRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
-  }, [messages]);
+  }, [messages, isActive, autoScroll]);
 
-  const submit = useCallback(() => {
-    const text = draft.trim();
-    if (!text || busy) return;
-    setDraft('');
-    onSubmit?.(text);
-    void send(text);
-  }, [busy, draft, onSubmit, send]);
+  const scrollDown = useCallback(() => {
+    setAutoScroll(true);
+    endRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
+  }, []);
+
+  const submitText = useCallback(
+    (text: string, params?: Record<string, string | number | boolean>) => {
+      const items = contextItems;
+      if (items.length) setContextItems([]);
+      titleIfUntitled(text);
+      onSubmit?.(text);
+      void send(text, { params, context: items });
+    },
+    [contextItems, onSubmit, send, titleIfUntitled],
+  );
+
+  // Programmatic submit for the Search / Alerts tabs. Registered once —
+  // `send` is stable, so embedders are not re-registered on every token.
+  const submitRef = useRef(submitText);
+  submitRef.current = submitText;
+  useEffect(() => {
+    onSubmitMessageReady?.((message: string) => {
+      submitRef.current(message);
+      onMessageSubmitted?.();
+    });
+  }, [onSubmitMessageReady, onMessageSubmitted]);
+
+  useEffect(() => {
+    onAddQueryContextReady?.((item: QueryDataContext) => {
+      setContextItems((prev) => (prev.some((c) => c.id === item.id) ? prev : [...prev, item]));
+    });
+  }, [onAddQueryContextReady]);
+
+  const handleImport = useCallback(
+    (raw: unknown) => {
+      const { ok, error } = conversations.importData(String(raw ?? ''));
+      notify(ok ? 'Conversations imported' : (error ?? 'Import failed'));
+    },
+    [conversations, notify],
+  );
+
+  // Hand conversation controls to the host so it can render them in its own
+  // sidebar, the way the toolkit's onControlsReady did.
+  //
+  // Keyed on what the list actually displays — ids, names, selection, search,
+  // busy — rather than on the conversation objects. Those change on every
+  // streamed token, and handing the host a new object each time would push a
+  // setState (and a re-render of the whole app shell) per token.
+  const listSignature = useMemo(
+    () => conversations.filtered.map((c) => `${c.id}:${c.name}`).join('|'),
+    [conversations.filtered],
+  );
+
+  const controlsRef = useRef(conversations);
+  controlsRef.current = conversations;
+
+  const controls = useMemo<ChatSidebarControlHandlers>(
+    () => ({
+      conversations: controlsRef.current.conversations,
+      filteredConversations: controlsRef.current.filtered,
+      selectedConversationId: selected?.id ?? null,
+      searchTerm: controlsRef.current.searchTerm,
+      onSearchTermChange: (term: string) => controlsRef.current.setSearchTerm(term),
+      onSelectConversation: (id: string) => controlsRef.current.select(id),
+      onNewConversation: () => {
+        createConversation();
+      },
+      onRenameConversation: (id: string, name: string) =>
+        controlsRef.current.rename(id, name),
+      onDeleteConversation: (id: string) => controlsRef.current.remove(id),
+      onClearConversations: () => controlsRef.current.clearAll(),
+      onExportData: () => controlsRef.current.exportData(),
+      onImportConversations: handleImport,
+      busy,
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [listSignature, conversations.searchTerm, selected?.id, busy, createConversation, handleImport],
+  );
+
+  useEffect(() => {
+    onControlsReady?.(controls);
+  }, [onControlsReady, controls]);
+
+  const handleRegenerate = useCallback(() => {
+    const lastUser = [...messages].reverse().find((m) => m.role === 'user' && !m.error);
+    if (!lastUser) return;
+    // Drop the previous answer (and the user turn we are about to re-add).
+    const tail = messages.length - messages.lastIndexOf(lastUser);
+    void send(lastUser.content, { deleteCount: tail });
+  }, [messages, send]);
+
+  const handleEdit = useCallback(
+    (message: { id: string; content: string }) => {
+      // Count from the real array: hidden messages sit between the visible
+      // ones, so a count derived from the rendered list truncates too little.
+      const at = messages.findIndex((m) => m.id === message.id);
+      if (at < 0) return;
+      void send(message.content, { deleteCount: messages.length - at });
+    },
+    [messages, send],
+  );
+
+  const handleDelete = useCallback(
+    (messageId: string) => {
+      setMessages((prev) => prev.filter((m) => m.id !== messageId));
+    },
+    [setMessages],
+  );
+
+  const visibleMessages = messages.filter((m) => !m.hidden);
+  const workflowName = title || 'Chat';
 
   return (
-    <section className={`vss-chat vss-chat-${theme}${className ? ` ${className}` : ''}`}>
-      {title ? <header className="vss-chat-header">{title}</header> : null}
+    <section
+      className={`relative flex h-full w-full flex-col overflow-hidden bg-white dark:bg-black ${
+        className ?? ''
+      }`}
+      data-theme={theme}
+    >
+      {features.headerMenu ? (
+        <ChatHeader
+          workflowName={workflowName}
+          hasMessages={visibleMessages.length > 0}
+          features={features}
+          theme={theme}
+          onThemeChange={onThemeChange}
+          chatHistory={chatHistory}
+          onChatHistoryChange={setChatHistory}
+          onNewConversation={() => createConversation()}
+          busy={busy}
+          uploadUrlBase={endpoint.uploadUrlBase}
+          uploadConfigTemplateJson={uploadConfigTemplateJson}
+          uploadHiddenMessageTemplate={uploadHiddenMessageTemplate}
+          getActiveConversationId={() => selectedIdRef.current}
+          onSendHiddenMessage={(message, uploadConversationId) =>
+            void send(message, { hidden: true, uploadConversationId })
+          }
+          onChatVideoUploadComplete={onChatVideoUploadComplete}
+          onUploadFlowActiveChange={setUploadFlowActive}
+          onNotify={notify}
+        />
+      ) : null}
 
-      <div className="vss-chat-log" role="log" aria-live="polite">
-        {messages.length === 0 ? (
-          <p className="vss-chat-empty">{placeholder}</p>
+      <div
+        ref={logRef}
+        onScroll={handleScroll}
+        className="flex-1 overflow-y-auto"
+        role="log"
+        aria-live="polite"
+        aria-busy={busy}
+      >
+        {!hydrated ? null : visibleMessages.length === 0 && !features.headerMenu ? (
+          <p className="p-4 text-sm text-gray-500 dark:text-gray-400">
+            {placeholder ?? 'Ask about your video…'}
+          </p>
         ) : (
-          messages.map((m) => <Message key={m.id} message={m} showSteps={showSteps} />)
+          visibleMessages.map((message) => (
+            <ChatMessageView
+              key={message.id}
+              message={message}
+              features={features}
+              onEdit={handleEdit}
+              onDelete={handleDelete}
+              onNotify={notify}
+            />
+          ))
         )}
-        <div ref={endRef} />
+        {/* Keeps the last message clear of the floating composer. */}
+        <div className="h-[162px]" ref={endRef} />
       </div>
 
-      <form
-        className="vss-chat-input"
-        onSubmit={(e) => {
-          e.preventDefault();
-          submit();
-        }}
-      >
-        <textarea
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-          onKeyDown={(e) => {
-            // Enter sends; Shift+Enter is a newline.
-            if (e.key === 'Enter' && !e.shiftKey) {
-              e.preventDefault();
-              submit();
-            }
-          }}
-          placeholder={placeholder}
-          rows={1}
-          aria-label="Message"
-        />
-        {busy ? (
-          <button type="button" onClick={abort} className="vss-chat-stop">
-            Stop
-          </button>
-        ) : (
-          <button type="submit" disabled={!draft.trim()}>
-            Send
-          </button>
-        )}
-      </form>
+      <ChatInput
+        onSend={submitText}
+        onRegenerate={handleRegenerate}
+        onStop={abort}
+        onScrollDown={scrollDown}
+        showScrollDownButton={!autoScroll}
+        busy={busy}
+        canRegenerate={visibleMessages.length > 1}
+        workflowName={workflowName}
+        features={features}
+        customAgentParamsJson={customAgentParamsJson}
+        contextItems={contextItems}
+        onRemoveContext={(id) => setContextItems((prev) => prev.filter((c) => c.id !== id))}
+        uploadUrlBase={endpoint.uploadUrlBase}
+        uploadConfigTemplateJson={uploadConfigTemplateJson}
+        uploadHiddenMessageTemplate={uploadHiddenMessageTemplate}
+        getActiveConversationId={() => selectedIdRef.current}
+        onSendHiddenMessage={(message, uploadConversationId) =>
+          void send(message, { hidden: true, uploadConversationId })
+        }
+        onChatVideoUploadComplete={onChatVideoUploadComplete}
+        onUploadFlowActiveChange={setUploadFlowActive}
+        chatBlocked={uploadFlowActive}
+        onNotify={notify}
+      />
+
+      <InteractionModal
+        request={interaction}
+        onClose={dismissInteraction}
+        onSubmit={(response) => void send(response)}
+      />
+
+      {notice ? (
+        <div
+          role="status"
+          className="pointer-events-none absolute left-1/2 top-14 z-[120] -translate-x-1/2 rounded-md bg-black/80 px-3 py-1.5 text-sm text-white shadow-lg"
+        >
+          {notice}
+        </div>
+      ) : null}
     </section>
   );
 };

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/ChatPanel.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/ChatPanel.tsx
@@ -15,30 +15,40 @@ function useConversationId(supplied?: string): string {
   return ref.current;
 }
 
-const StepList: React.FC<{ steps: ChatStep[] }> = ({ steps }) => {
-  const [open, setOpen] = useState(false);
+const StepList: React.FC<{ steps: ChatStep[]; streaming?: boolean }> = ({ steps, streaming }) => {
+  // Open while the agent is working, so progress is visible the way the
+  // toolkit UI showed it; collapses once the answer lands so finished steps do
+  // not bury it. An explicit click wins over that default either way.
+  const [manual, setManual] = useState<boolean | null>(null);
+  const open = manual ?? !!streaming;
   if (!steps.length) return null;
-  const active = steps.some((s) => s.status === 'in_progress');
+
   return (
     <div className="vss-chat-steps">
       <button
         type="button"
         className="vss-chat-steps-toggle"
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => setManual(!open)}
         aria-expanded={open}
       >
-        {open ? '▾' : '▸'} {steps.length} step{steps.length === 1 ? '' : 's'}
-        {active ? ' — running…' : ''}
+        <span>{open ? '▾' : '▸'}</span>
+        <span>
+          Intermediate steps ({steps.length})
+          {streaming ? ' — running' : ''}
+        </span>
       </button>
       {open && (
-        <ol className="vss-chat-steps-list">
+        <ul className="vss-chat-steps-list">
           {steps.map((s) => (
             <li key={s.id} data-status={s.status}>
-              <code>{s.name}</code>
+              <span>
+                <span className="vss-chat-step-dot" />
+                <span className="vss-chat-step-name">{s.name}</span>
+              </span>
               {s.payload ? <pre>{s.payload}</pre> : null}
             </li>
           ))}
-        </ol>
+        </ul>
       )}
     </div>
   );
@@ -46,7 +56,9 @@ const StepList: React.FC<{ steps: ChatStep[] }> = ({ steps }) => {
 
 const Message: React.FC<{ message: ChatMessage; showSteps: boolean }> = ({ message, showSteps }) => (
   <div className={`vss-chat-msg vss-chat-msg-${message.role}`} data-streaming={!!message.streaming}>
-    {showSteps && message.steps?.length ? <StepList steps={message.steps} /> : null}
+    {showSteps && message.steps?.length ? (
+      <StepList steps={message.steps} streaming={message.streaming} />
+    ) : null}
     {message.error ? (
       <div className="vss-chat-error">⚠ {message.error}</div>
     ) : message.role === 'assistant' ? (

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/ChatPanel.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/ChatPanel.tsx
@@ -95,7 +95,12 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     [endpoint, conversationId],
   );
 
-  const handleAnswer = useCallback((answer: string) => onAnswer?.(answer), [onAnswer]);
+  // The conversation goes with the answer: consumers fetch per-conversation
+  // artifacts, and a process-wide 'last result' would cross conversations.
+  const handleAnswer = useCallback(
+    (answer: string) => onAnswer?.(answer, conversationId),
+    [onAnswer, conversationId],
+  );
   const { messages, busy, send, abort } = useChatStream(config, handleAnswer);
 
   const [draft, setDraft] = useState('');

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/ChatPanel.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/ChatPanel.tsx
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+import { useChatStream } from './useChatStream';
+import type { ChatMessage, ChatPanelProps, ChatStep } from './types';
+
+/** Stable per-mount id so the adapter maps this panel to one agent session. */
+function useConversationId(supplied?: string): string {
+  const ref = useRef(supplied);
+  if (!ref.current) {
+    ref.current = `vss-${Math.random().toString(36).slice(2, 10)}`;
+  }
+  return ref.current;
+}
+
+const StepList: React.FC<{ steps: ChatStep[] }> = ({ steps }) => {
+  const [open, setOpen] = useState(false);
+  if (!steps.length) return null;
+  const active = steps.some((s) => s.status === 'in_progress');
+  return (
+    <div className="vss-chat-steps">
+      <button
+        type="button"
+        className="vss-chat-steps-toggle"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+      >
+        {open ? '▾' : '▸'} {steps.length} step{steps.length === 1 ? '' : 's'}
+        {active ? ' — running…' : ''}
+      </button>
+      {open && (
+        <ol className="vss-chat-steps-list">
+          {steps.map((s) => (
+            <li key={s.id} data-status={s.status}>
+              <code>{s.name}</code>
+              {s.payload ? <pre>{s.payload}</pre> : null}
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+};
+
+const Message: React.FC<{ message: ChatMessage; showSteps: boolean }> = ({ message, showSteps }) => (
+  <div className={`vss-chat-msg vss-chat-msg-${message.role}`} data-streaming={!!message.streaming}>
+    {showSteps && message.steps?.length ? <StepList steps={message.steps} /> : null}
+    {message.error ? (
+      <div className="vss-chat-error">⚠ {message.error}</div>
+    ) : message.role === 'assistant' ? (
+      <div className="vss-chat-markdown">
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{message.content}</ReactMarkdown>
+        {message.streaming && !message.content ? <span className="vss-chat-cursor">▍</span> : null}
+      </div>
+    ) : (
+      <div className="vss-chat-usertext">{message.content}</div>
+    )}
+  </div>
+);
+
+/**
+ * VSS chat surface.
+ *
+ * Used for both the main chat tab and the docked sidebar; the only difference
+ * is the container it is given. Speaks the BYO agent contract directly, so it
+ * works against any backend implementing `/chat/stream`.
+ */
+export const ChatPanel: React.FC<ChatPanelProps> = ({
+  endpoint,
+  title,
+  theme = 'dark',
+  placeholder = 'Ask about your video…',
+  showSteps = true,
+  onAnswer,
+  onSubmit,
+  className,
+}) => {
+  const conversationId = useConversationId(endpoint.conversationId);
+  const config = useMemo(
+    () => ({ ...endpoint, conversationId }),
+    [endpoint, conversationId],
+  );
+
+  const handleAnswer = useCallback((answer: string) => onAnswer?.(answer), [onAnswer]);
+  const { messages, busy, send, abort } = useChatStream(config, handleAnswer);
+
+  const [draft, setDraft] = useState('');
+  const endRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
+  }, [messages]);
+
+  const submit = useCallback(() => {
+    const text = draft.trim();
+    if (!text || busy) return;
+    setDraft('');
+    onSubmit?.(text);
+    void send(text);
+  }, [busy, draft, onSubmit, send]);
+
+  return (
+    <section className={`vss-chat vss-chat-${theme}${className ? ` ${className}` : ''}`}>
+      {title ? <header className="vss-chat-header">{title}</header> : null}
+
+      <div className="vss-chat-log" role="log" aria-live="polite">
+        {messages.length === 0 ? (
+          <p className="vss-chat-empty">{placeholder}</p>
+        ) : (
+          messages.map((m) => <Message key={m.id} message={m} showSteps={showSteps} />)
+        )}
+        <div ref={endRef} />
+      </div>
+
+      <form
+        className="vss-chat-input"
+        onSubmit={(e) => {
+          e.preventDefault();
+          submit();
+        }}
+      >
+        <textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            // Enter sends; Shift+Enter is a newline.
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              submit();
+            }
+          }}
+          placeholder={placeholder}
+          rows={1}
+          aria-label="Message"
+        />
+        {busy ? (
+          <button type="button" onClick={abort} className="vss-chat-stop">
+            Stop
+          </button>
+        ) : (
+          <button type="submit" disabled={!draft.trim()}>
+            Send
+          </button>
+        )}
+      </form>
+    </section>
+  );
+};
+
+export default ChatPanel;

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/ChatSteps.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/ChatSteps.tsx
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Intermediate-step disclosure.
+ *
+ * The toolkit built this by serialising steps into a `<details>` cascade,
+ * embedding it in the assistant message's markdown, and re-parsing it — which
+ * means a half-written step is a half-written HTML tag, and the repairs in
+ * `markdown/streaming.ts` exist mostly to paper over that. Here the tree stays
+ * structured all the way to render, so a step that is still arriving is just a
+ * node with `status: 'in_progress'`.
+ */
+import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
+import React, { useState } from 'react';
+
+import { buildStepTree } from './sse';
+import type { ChatStep } from './types';
+
+const STATUS_DOT: Record<ChatStep['status'], string> = {
+  in_progress: 'bg-[#76b900] animate-pulse',
+  complete: 'bg-gray-400 dark:bg-gray-500',
+  error: 'bg-red-500',
+};
+
+const StepNode: React.FC<{ step: ChatStep; defaultOpen: boolean }> = ({ step, defaultOpen }) => {
+  const [manual, setManual] = useState<boolean | null>(null);
+  const hasDetail = !!step.payload || !!step.children?.length;
+  const open = manual ?? defaultOpen;
+
+  return (
+    <li className="relative">
+      <div className="flex items-start gap-2">
+        <span className={`mt-[7px] h-2 w-2 flex-shrink-0 rounded-full ${STATUS_DOT[step.status]}`} />
+        {hasDetail ? (
+          <button
+            type="button"
+            aria-expanded={open}
+            onClick={() => setManual(!open)}
+            className="flex items-center gap-1 text-left text-sm text-gray-700 hover:text-[#76b900] dark:text-gray-300"
+          >
+            {open ? <IconChevronDown size={14} /> : <IconChevronRight size={14} />}
+            <span>{step.name}</span>
+          </button>
+        ) : (
+          <span className="pl-[18px] text-sm text-gray-700 dark:text-gray-300">{step.name}</span>
+        )}
+      </div>
+
+      {open && (
+        <div className="ml-[5px] border-l border-gray-300 pl-3 dark:border-gray-600">
+          {step.payload ? (
+            <pre className="my-1 max-h-64 overflow-auto whitespace-pre-wrap break-words rounded bg-gray-100 p-2 text-xs text-gray-800 dark:bg-neutral-800 dark:text-gray-200">
+              {step.payload}
+            </pre>
+          ) : null}
+          {step.children?.length ? (
+            <ul className="flex flex-col gap-1">
+              {step.children.map((child) => (
+                <StepNode key={child.id} step={child} defaultOpen={defaultOpen} />
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      )}
+    </li>
+  );
+};
+
+export interface ChatStepsProps {
+  steps: ChatStep[];
+  /** True while the owning message is still streaming. */
+  streaming?: boolean;
+  /** Keep the list open once the answer lands (NEXT_PUBLIC_ENABLE… default). */
+  expandByDefault?: boolean;
+}
+
+export const ChatSteps: React.FC<ChatStepsProps> = ({ steps, streaming, expandByDefault }) => {
+  // Open while the agent is working so progress is visible the way the toolkit
+  // showed it; collapses once the answer lands so finished steps do not bury
+  // it. An explicit click wins over that default either way.
+  const [manual, setManual] = useState<boolean | null>(null);
+  const open = manual ?? (!!streaming || !!expandByDefault);
+  if (!steps.length) return null;
+
+  const tree = buildStepTree(steps);
+
+  return (
+    <div className="mb-2 rounded-md border border-neutral-200 bg-neutral-50 px-3 py-2 dark:border-neutral-700 dark:bg-neutral-900/60">
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 text-left text-sm text-gray-600 dark:text-gray-300"
+        onClick={() => setManual(!open)}
+        aria-expanded={open}
+      >
+        {open ? <IconChevronDown size={14} /> : <IconChevronRight size={14} />}
+        <span>
+          Intermediate steps ({steps.length}){streaming ? ' — running' : ''}
+        </span>
+      </button>
+      {open && (
+        <ul className="mt-2 flex flex-col gap-1">
+          {tree.map((step) => (
+            <StepNode key={step.id} step={step} defaultOpen={!!streaming} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/ChatUpload.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/ChatUpload.tsx
@@ -1,0 +1,450 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Chunked video upload from the chat surface.
+ *
+ * The dialogs and the upload itself come from `common` — the same components
+ * the toolkit's ChatFileUpload used — so this file is only the coordination:
+ * which files, cancellation, and the auto-prompt sent once a batch lands.
+ *
+ * Chunking is not an optimisation. The agent hands back a VST URL and the
+ * browser POSTs chunks straight to VST, which is what keeps a large file from
+ * dying on the ingress' request timeout.
+ */
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { flushSync } from 'react-dom';
+import {
+  UploadFilesDialog,
+  UploadProgressPopup,
+  UploadSuccessPopup,
+  uploadFileChunked,
+  type FileUploadResult,
+  type UploadFileConfigTemplate,
+  type UploadFileStatus,
+  type UploadFilesDialogEntry,
+} from 'common';
+
+import type { ChatVideoUploadCompletePayload } from './types';
+
+interface PendingFile {
+  id: string;
+  file: File;
+  formData: Record<string, unknown>;
+  uploadFilename?: string;
+  uploadProgress?: number;
+  uploadStatus?: UploadFileStatus;
+  uploadError?: string;
+}
+
+type BatchEntry = {
+  filename: string;
+  result?: FileUploadResult;
+  error?: string;
+  cancelled?: boolean;
+};
+
+export interface ChatUploadRenderProps {
+  /** Open the metadata dialog (the toolbar button). */
+  triggerUpload: () => void;
+  /** Open the OS file picker directly (the welcome drop zone). */
+  triggerFilePicker: () => void;
+  /** Pair with `<label htmlFor>` so the picker opens without a synthetic click. */
+  fileInputId: string;
+  isUploading: boolean;
+  isDragging: boolean;
+  dragHandlers: {
+    onDragEnter: (e: React.DragEvent) => void;
+    onDragLeave: (e: React.DragEvent) => void;
+    onDragOver: (e: React.DragEvent) => void;
+    onDrop: (e: React.DragEvent) => void;
+  };
+}
+
+export interface ChatUploadProps {
+  /** Base URL of the agent API that issues upload URLs. */
+  agentApiUrlBase?: string;
+  configTemplateJson?: string;
+  metadataEnabled?: boolean;
+  /** `{filenames}` is replaced with the uploaded names. */
+  hiddenMessageTemplate?: string;
+  disabled?: boolean;
+  accept?: string;
+  /** Conversation that was active when the batch started. */
+  getActiveConversationId?: () => string | undefined;
+  onSendHiddenMessage?: (message: string, uploadConversationId: string) => void;
+  onUploadBatchComplete?: (payload: ChatVideoUploadCompletePayload) => void;
+  /** True whenever any upload dialog is open, so the input can block sends. */
+  onUploadFlowActiveChange?: (active: boolean) => void;
+  onNotify?: (message: string) => void;
+  children: (props: ChatUploadRenderProps) => React.ReactNode;
+}
+
+const DEFAULT_ACCEPT = '.mp4,.mkv,video/mp4,video/x-matroska';
+let uploadSeq = 0;
+
+export const ChatUpload: React.FC<ChatUploadProps> = ({
+  agentApiUrlBase,
+  configTemplateJson,
+  metadataEnabled,
+  hiddenMessageTemplate,
+  disabled = false,
+  accept = DEFAULT_ACCEPT,
+  getActiveConversationId,
+  onSendHiddenMessage,
+  onUploadBatchComplete,
+  onUploadFlowActiveChange,
+  onNotify,
+  children,
+}) => {
+  const fileInputId = useMemo(() => `vss-chat-upload-${uploadSeq++}`, []);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [isUploading, setIsUploading] = useState(false);
+  const [showSelect, setShowSelect] = useState(false);
+  const [showProgress, setShowProgress] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
+  const [initialFiles, setInitialFiles] = useState<File[] | null>(null);
+  const [uploadingFiles, setUploadingFiles] = useState<PendingFile[]>([]);
+  const [results, setResults] = useState<BatchEntry[]>([]);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const dragCounter = useRef(0);
+  const abortControllers = useRef<Map<string, AbortController>>(new Map());
+  const cancelledIds = useRef<Set<string>>(new Set());
+
+  // Read callbacks through refs: the upload runs for minutes and the parent
+  // re-renders throughout, so capturing them at call time would go stale.
+  const callbacks = useRef({
+    getActiveConversationId,
+    onSendHiddenMessage,
+    onUploadBatchComplete,
+    onUploadFlowActiveChange,
+    onNotify,
+  });
+  callbacks.current = {
+    getActiveConversationId,
+    onSendHiddenMessage,
+    onUploadBatchComplete,
+    onUploadFlowActiveChange,
+    onNotify,
+  };
+
+  const dialogOpen = showSelect || showProgress || showSuccess;
+  useEffect(() => {
+    callbacks.current.onUploadFlowActiveChange?.(dialogOpen);
+    return () => callbacks.current.onUploadFlowActiveChange?.(false);
+  }, [dialogOpen]);
+
+  // Closing the tab mid-upload loses the file with no way to resume.
+  useEffect(() => {
+    if (!isUploading) return;
+    const handler = (e: BeforeUnloadEvent) => e.preventDefault();
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [isUploading]);
+
+  const configTemplate = useMemo<UploadFileConfigTemplate | null>(() => {
+    if (!configTemplateJson) return null;
+    try {
+      return JSON.parse(configTemplateJson);
+    } catch (error) {
+      console.warn('vss-chat: could not parse upload config template', error);
+      return null;
+    }
+  }, [configTemplateJson]);
+
+  const isAllowedVideo = useCallback(
+    (file: File) =>
+      /\.(mp4|mkv)$/i.test(file.name) ||
+      ['video/mp4', 'video/x-matroska'].includes(file.type),
+    [],
+  );
+
+  const openDialogWithFiles = useCallback(
+    (list: FileList | File[]) => {
+      const files = Array.from(list);
+      if (!files.length) return;
+      const valid = files.filter(isAllowedVideo);
+      if (valid.length < files.length) {
+        callbacks.current.onNotify?.('Please choose video files only (mp4, mkv)');
+      }
+      if (!valid.length) return;
+      // flushSync so the dialog sees `initialFiles` on the same commit it opens
+      // on; otherwise it mounts empty and drops the drop.
+      flushSync(() => {
+        setInitialFiles(valid);
+        setShowSelect(true);
+      });
+    },
+    [isAllowedVideo],
+  );
+
+  const triggerUpload = useCallback(() => {
+    if (disabled || isUploading) return;
+    setShowSelect(true);
+  }, [disabled, isUploading]);
+
+  const triggerFilePicker = useCallback(() => {
+    if (disabled || isUploading) return;
+    fileInputRef.current?.click();
+  }, [disabled, isUploading]);
+
+  const dragHandlers = useMemo(
+    () => ({
+      onDragEnter: (e: React.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (disabled || isUploading) return;
+        dragCounter.current += 1;
+        if (e.dataTransfer.items?.length) setIsDragging(true);
+      },
+      onDragLeave: (e: React.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        // Counter, not a boolean: dragging over a child fires leave on the parent.
+        dragCounter.current -= 1;
+        if (dragCounter.current <= 0) setIsDragging(false);
+      },
+      onDragOver: (e: React.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+      },
+      onDrop: (e: React.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setIsDragging(false);
+        dragCounter.current = 0;
+        if (disabled || isUploading) return;
+        if (e.dataTransfer.files?.length) openDialogWithFiles(e.dataTransfer.files);
+      },
+    }),
+    [disabled, isUploading, openDialogWithFiles],
+  );
+
+  const patchFile = useCallback((id: string, patch: Partial<PendingFile>) => {
+    setUploadingFiles((prev) => prev.map((f) => (f.id === id ? { ...f, ...patch } : f)));
+  }, []);
+
+  const cancelSingle = useCallback(
+    (id: string) => {
+      cancelledIds.current.add(id);
+      abortControllers.current.get(id)?.abort();
+      abortControllers.current.delete(id);
+      patchFile(id, { uploadStatus: 'cancelled', uploadError: 'Cancelled' });
+    },
+    [patchFile],
+  );
+
+  const cancelAll = useCallback(() => {
+    setUploadingFiles((prev) =>
+      prev.map((f) => {
+        if (f.uploadStatus === 'pending' || f.uploadStatus === 'uploading') {
+          cancelledIds.current.add(f.id);
+          return { ...f, uploadStatus: 'cancelled' as UploadFileStatus, uploadError: 'Cancelled' };
+        }
+        return f;
+      }),
+    );
+    abortControllers.current.forEach((controller) => controller.abort());
+    abortControllers.current.clear();
+  }, []);
+
+  const uploadOne = useCallback(
+    async (item: PendingFile): Promise<BatchEntry> => {
+      const filename = item.uploadFilename ?? item.file.name;
+      const cancelled: BatchEntry = { filename, error: 'Upload was cancelled', cancelled: true };
+      if (cancelledIds.current.has(item.id)) return cancelled;
+
+      if (!agentApiUrlBase) {
+        const error = 'Agent API URL is not configured';
+        patchFile(item.id, { uploadStatus: 'error', uploadError: error });
+        return { filename, error };
+      }
+
+      patchFile(item.id, { uploadStatus: 'uploading', uploadProgress: 0 });
+      const controller = new AbortController();
+      abortControllers.current.set(item.id, controller);
+
+      try {
+        const result = await uploadFileChunked(
+          item.file,
+          agentApiUrlBase,
+          item.formData,
+          (progress: number) => patchFile(item.id, { uploadProgress: progress }),
+          controller.signal,
+          item.uploadFilename,
+        );
+        abortControllers.current.delete(item.id);
+        // Cancellation can land between the last chunk and here.
+        if (cancelledIds.current.has(item.id)) return cancelled;
+        patchFile(item.id, { uploadStatus: 'success', uploadProgress: 100 });
+        return { filename, result };
+      } catch (error) {
+        abortControllers.current.delete(item.id);
+        const aborted =
+          error instanceof Error &&
+          (error.name === 'AbortError' || error.message === 'Upload was cancelled');
+        if (aborted || cancelledIds.current.has(item.id)) return cancelled;
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        patchFile(item.id, { uploadStatus: 'error', uploadError: message });
+        return { filename, error: message };
+      }
+    },
+    [agentApiUrlBase, patchFile],
+  );
+
+  const runBatch = useCallback(
+    async (files: PendingFile[]) => {
+      const conversationAtStart = callbacks.current.getActiveConversationId?.();
+
+      setShowSelect(false);
+      setShowProgress(true);
+      setIsUploading(true);
+      setResults([]);
+      cancelledIds.current.clear();
+
+      const queued = files.map((f) => ({
+        ...f,
+        uploadStatus: 'pending' as UploadFileStatus,
+        uploadProgress: 0,
+      }));
+      setUploadingFiles(queued);
+
+      try {
+        const batch = await Promise.all(queued.map(uploadOne));
+        setResults(batch);
+
+        const successes = batch.filter(
+          (entry): entry is { filename: string; result: FileUploadResult } => !!entry.result,
+        );
+
+        if (successes.length) {
+          callbacks.current.onUploadBatchComplete?.({
+            results: successes.map(({ filename, result }) => ({ filename, result })),
+          });
+
+          if (conversationAtStart && hiddenMessageTemplate && callbacks.current.onSendHiddenMessage) {
+            // The agent identifies a video by whatever the backend called it,
+            // which is not always the local filename.
+            const names = successes
+              .map(
+                ({ filename, result }) =>
+                  (result as any)?.filename ||
+                  (result as any)?.video_id ||
+                  (result as any)?.id ||
+                  filename,
+              )
+              .filter(Boolean);
+            if (names.length) {
+              callbacks.current.onSendHiddenMessage(
+                hiddenMessageTemplate.replaceAll('{filenames}', names.join(' ')),
+                conversationAtStart,
+              );
+            }
+          }
+        }
+
+        // Let the last progress bar finish drawing before swapping panels.
+        setTimeout(() => {
+          setShowProgress(false);
+          if (batch.length) setShowSuccess(true);
+        }, 1000);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        callbacks.current.onNotify?.(`Upload failed: ${message}`);
+        setShowProgress(false);
+      } finally {
+        setIsUploading(false);
+        abortControllers.current.clear();
+        cancelledIds.current.clear();
+      }
+    },
+    [hiddenMessageTemplate, uploadOne],
+  );
+
+  const progressFiles = useMemo(
+    () =>
+      uploadingFiles.map((f) => ({
+        id: f.id,
+        displayName: f.uploadFilename ?? f.file.name,
+        uploadProgress: f.uploadProgress,
+        uploadStatus: f.uploadStatus,
+        uploadError: f.uploadError,
+      })),
+    [uploadingFiles],
+  );
+
+  const successResults = useMemo(
+    () =>
+      results.map((r) => ({
+        filename: r.filename,
+        result: r.result as Record<string, unknown> | undefined,
+        error: r.error,
+        cancelled: r.cancelled,
+      })),
+    [results],
+  );
+
+  return (
+    <>
+      <input
+        id={fileInputId}
+        type="file"
+        ref={fileInputRef}
+        className="hidden"
+        accept={accept}
+        multiple
+        disabled={disabled || isUploading}
+        onChange={(event) => {
+          const files = event.target.files ? Array.from(event.target.files) : [];
+          // Reset first, or picking the same file twice in a row is a no-op.
+          event.target.value = '';
+          if (files.length) openDialogWithFiles(files);
+        }}
+      />
+
+      {children({ triggerUpload, triggerFilePicker, fileInputId, isUploading, isDragging, dragHandlers })}
+
+      <UploadFilesDialog
+        open={showSelect}
+        configTemplate={configTemplate}
+        onClose={() => {
+          setShowSelect(false);
+          setInitialFiles(null);
+        }}
+        onConfirm={(entries: UploadFilesDialogEntry[]) => {
+          void runBatch(
+            entries.map((e) => ({
+              id: e.id,
+              file: e.file,
+              formData: e.formData,
+              uploadFilename: e.uploadFilename,
+            })),
+          );
+        }}
+        initialFiles={initialFiles}
+        accept={accept}
+        metadata={metadataEnabled ? { enabled: true } : undefined}
+      />
+
+      {showProgress && (
+        <UploadProgressPopup
+          files={progressFiles}
+          onCancelAll={cancelAll}
+          onCancelSingle={cancelSingle}
+        />
+      )}
+
+      {showSuccess && results.length > 0 && (
+        <UploadSuccessPopup
+          results={successResults}
+          onClose={() => {
+            setShowSuccess(false);
+            setShowProgress(false);
+            setResults([]);
+            setUploadingFiles([]);
+          }}
+        />
+      )}
+    </>
+  );
+};

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/ConversationList.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/ConversationList.tsx
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Conversation controls, rendered into whichever container the host app gives
+ * them.
+ *
+ * The toolkit's equivalent (`ChatSidebarContent`) needed two React contexts
+ * passed through props to stay reactive, because the list lived inside the
+ * toolkit's own state tree. Here the panel hands over plain handlers via
+ * `onControlsReady`, so this is a presentational component the host can render
+ * anywhere — its left sidebar, a drawer, or not at all.
+ */
+import {
+  IconCheck,
+  IconDownload,
+  IconMessage,
+  IconPlus,
+  IconSearch,
+  IconTrash,
+  IconUpload,
+  IconX,
+} from '@tabler/icons-react';
+import React, { useRef, useState } from 'react';
+
+import type { ChatSidebarControlHandlers } from './types';
+
+export const ConversationList: React.FC<ChatSidebarControlHandlers> = ({
+  filteredConversations,
+  selectedConversationId,
+  searchTerm,
+  onSearchTermChange,
+  onSelectConversation,
+  onNewConversation,
+  onRenameConversation,
+  onDeleteConversation,
+  onClearConversations,
+  onExportData,
+  onImportConversations,
+  busy,
+}) => {
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [draftName, setDraftName] = useState('');
+  const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(null);
+  const [confirmingClear, setConfirmingClear] = useState(false);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const commitRename = () => {
+    if (renamingId) onRenameConversation(renamingId, draftName);
+    setRenamingId(null);
+  };
+
+  return (
+    <div className="flex h-full flex-col gap-2 p-2 text-sm">
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={onNewConversation}
+          disabled={busy}
+          title={busy ? 'Wait for the current answer to finish' : 'New chat'}
+          className="flex flex-1 items-center gap-2 rounded-md border border-white/20 p-2 text-white transition-colors hover:bg-gray-500/10 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          <IconPlus size={16} /> New chat
+        </button>
+      </div>
+
+      <div className="relative">
+        <IconSearch
+          size={16}
+          className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-neutral-400"
+        />
+        <input
+          type="text"
+          className="w-full rounded-md border border-neutral-600 bg-transparent py-2 pl-8 pr-8 text-white outline-none focus:ring-1 focus:ring-[#76b900]"
+          placeholder="Search conversations…"
+          value={searchTerm}
+          onChange={(e) => onSearchTermChange(e.target.value)}
+          aria-label="Search conversations"
+        />
+        {searchTerm && (
+          <button
+            type="button"
+            onClick={() => onSearchTermChange('')}
+            aria-label="Clear search"
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-neutral-400 hover:text-white"
+          >
+            <IconX size={16} />
+          </button>
+        )}
+      </div>
+
+      <ul className="flex-1 overflow-y-auto">
+        {filteredConversations.length === 0 ? (
+          <li className="p-2 text-neutral-400">No conversations</li>
+        ) : (
+          filteredConversations.map((conversation) => {
+            const active = conversation.id === selectedConversationId;
+            return (
+              <li key={conversation.id}>
+                <div
+                  className={`group flex items-center gap-2 rounded-md p-2 ${
+                    active ? 'bg-[#76b900]/20' : 'hover:bg-gray-500/10'
+                  }`}
+                >
+                  {renamingId === conversation.id ? (
+                    <input
+                      autoFocus
+                      className="min-w-0 flex-1 bg-transparent text-white outline-none"
+                      value={draftName}
+                      onChange={(e) => setDraftName(e.target.value)}
+                      onBlur={commitRename}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') commitRename();
+                        if (e.key === 'Escape') setRenamingId(null);
+                      }}
+                      aria-label="Conversation name"
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => onSelectConversation(conversation.id)}
+                      onDoubleClick={() => {
+                        setRenamingId(conversation.id);
+                        setDraftName(conversation.name);
+                      }}
+                      className="flex min-w-0 flex-1 items-center gap-2 text-left text-white"
+                      title={`${conversation.name} — double-click to rename`}
+                    >
+                      <IconMessage size={16} className="flex-shrink-0" />
+                      <span className="truncate">{conversation.name}</span>
+                    </button>
+                  )}
+
+                  {confirmingDeleteId === conversation.id ? (
+                    <span className="flex flex-shrink-0 gap-1">
+                      <button
+                        type="button"
+                        aria-label="Confirm delete"
+                        onClick={() => {
+                          onDeleteConversation(conversation.id);
+                          setConfirmingDeleteId(null);
+                        }}
+                        className="text-neutral-300 hover:text-[#76b900]"
+                      >
+                        <IconCheck size={16} />
+                      </button>
+                      <button
+                        type="button"
+                        aria-label="Cancel delete"
+                        onClick={() => setConfirmingDeleteId(null)}
+                        className="text-neutral-300 hover:text-white"
+                      >
+                        <IconX size={16} />
+                      </button>
+                    </span>
+                  ) : (
+                    <button
+                      type="button"
+                      aria-label={`Delete ${conversation.name}`}
+                      onClick={() => setConfirmingDeleteId(conversation.id)}
+                      className="flex-shrink-0 text-neutral-400 opacity-0 transition-opacity hover:text-red-400 group-hover:opacity-100"
+                    >
+                      <IconTrash size={16} />
+                    </button>
+                  )}
+                </div>
+              </li>
+            );
+          })
+        )}
+      </ul>
+
+      <div className="flex flex-col gap-1 border-t border-white/10 pt-2">
+        {confirmingClear ? (
+          <div className="flex items-center gap-2 p-2 text-white">
+            <span className="flex-1">Clear all conversations?</span>
+            <button
+              type="button"
+              aria-label="Confirm clear"
+              onClick={() => {
+                onClearConversations();
+                setConfirmingClear(false);
+              }}
+              className="hover:text-[#76b900]"
+            >
+              <IconCheck size={16} />
+            </button>
+            <button
+              type="button"
+              aria-label="Cancel clear"
+              onClick={() => setConfirmingClear(false)}
+              className="hover:text-white"
+            >
+              <IconX size={16} />
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setConfirmingClear(true)}
+            disabled={busy}
+            className="flex items-center gap-2 rounded-md p-2 text-white hover:bg-gray-500/10 disabled:opacity-40"
+          >
+            <IconTrash size={16} /> Clear conversations
+          </button>
+        )}
+
+        <button
+          type="button"
+          onClick={onExportData}
+          className="flex items-center gap-2 rounded-md p-2 text-white hover:bg-gray-500/10"
+        >
+          <IconDownload size={16} /> Export data
+        </button>
+
+        <button
+          type="button"
+          onClick={() => fileRef.current?.click()}
+          className="flex items-center gap-2 rounded-md p-2 text-white hover:bg-gray-500/10"
+        >
+          <IconUpload size={16} /> Import data
+        </button>
+        <input
+          ref={fileRef}
+          type="file"
+          accept=".json"
+          className="hidden"
+          onChange={(event) => {
+            const file = event.target.files?.[0];
+            // Reset so re-importing the same file fires a change event.
+            event.target.value = '';
+            if (!file) return;
+            const reader = new FileReader();
+            reader.onload = (e) => onImportConversations(String(e.target?.result ?? ''));
+            reader.readAsText(file);
+          }}
+        />
+      </div>
+    </div>
+  );
+};

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/InteractionModal.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/InteractionModal.tsx
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Human-in-the-loop prompt.
+ *
+ * The toolkit drove this from a WebSocket `system_interaction_message`. The BYO
+ * contract is HTTP/SSE only, so it is driven by an `interaction_data:` frame
+ * instead (see `sse.ts`). No adapter emits one today; the surface exists so a
+ * harness that needs a mid-turn answer or an OAuth consent has somewhere to put
+ * it, rather than the capability disappearing with the WebSocket transport.
+ */
+import { IconExternalLink, IconX } from '@tabler/icons-react';
+import React, { useState } from 'react';
+
+import type { InteractionRequest } from './sse';
+
+export interface InteractionModalProps {
+  request: InteractionRequest | null;
+  onClose: () => void;
+  onSubmit: (response: string) => void;
+  /** Mirrors NEXT_PUBLIC_INTERACTION_MODAL_CANCEL_ENABLED. */
+  showCancelButton?: boolean;
+}
+
+export const InteractionModal: React.FC<InteractionModalProps> = ({
+  request,
+  onClose,
+  onSubmit,
+  showCancelButton = true,
+}) => {
+  const [value, setValue] = useState('');
+  const [error, setError] = useState('');
+
+  if (!request) return null;
+
+  const submit = (response: string) => {
+    if (!response.trim()) {
+      setError('A response is required.');
+      return;
+    }
+    setError('');
+    onSubmit(response);
+    onClose();
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Agent request"
+      className="fixed inset-0 z-[150] flex items-center justify-center bg-black/60 p-4"
+    >
+      <div className="w-full max-w-md rounded-lg border border-gray-200 bg-white p-4 shadow-xl dark:border-gray-700 dark:bg-black">
+        <div className="mb-3 flex items-start justify-between gap-4">
+          <p className="text-sm text-gray-800 dark:text-gray-100">{request.prompt}</p>
+          {showCancelButton && (
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Dismiss"
+              className="rounded p-1 text-gray-500 hover:bg-gray-100 dark:hover:bg-neutral-800"
+            >
+              <IconX size={16} />
+            </button>
+          )}
+        </div>
+
+        {request.inputType === 'oauth' && request.url ? (
+          <a
+            href={request.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => {
+              onSubmit('consented');
+              onClose();
+            }}
+            className="inline-flex items-center gap-2 rounded-md bg-[#76b900] px-3 py-2 text-sm font-medium text-black"
+          >
+            <IconExternalLink size={16} /> Continue to sign in
+          </a>
+        ) : request.inputType === 'binary' || request.options?.length ? (
+          <div className="flex flex-wrap gap-2">
+            {(request.options ?? ['Yes', 'No']).map((option) => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => submit(option)}
+                className="rounded-md border border-gray-300 px-3 py-1.5 text-sm hover:bg-[#76b900] hover:text-black dark:border-gray-600"
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+        ) : (
+          <>
+            <textarea
+              className="w-full rounded-md border border-gray-300 bg-transparent p-2 text-sm outline-none focus:ring-1 focus:ring-[#76b900] dark:border-gray-600"
+              rows={3}
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              aria-label="Your response"
+            />
+            <div className="mt-3 flex justify-end gap-2">
+              {showCancelButton && (
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="rounded-md border border-gray-300 px-3 py-1.5 text-sm dark:border-gray-600"
+                >
+                  Cancel
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => submit(value)}
+                className="rounded-md bg-[#76b900] px-3 py-1.5 text-sm font-medium text-black"
+              >
+                Send
+              </button>
+            </div>
+          </>
+        )}
+
+        {error ? <p className="mt-2 text-xs text-red-500">{error}</p> : null}
+      </div>
+    </div>
+  );
+};

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/chat.css
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/chat.css
@@ -2,19 +2,24 @@
 /*
  * Styles for the VSS chat surface.
  *
- * Plain CSS with custom properties rather than a utility framework, so the
- * package carries no build-time styling dependency and can be themed by the
- * host app. Light and dark are the same rules with different variables, which
- * is what lets the sidebar render light against a dark app.
+ * Matches the surrounding app: NVIDIA green accent, the same #171717/#262626
+ * surfaces, NVIDIA Sans, JetBrains Mono for code, and square-ish corners
+ * rather than pill shapes.
+ *
+ * Markdown typography is spelled out in full on purpose. The host app loads
+ * Tailwind, whose preflight strips heading sizes, list markers and margins, so
+ * without these rules assistant replies render as undifferentiated text.
  */
 
 .vss-chat {
-  --vss-chat-bg: #16181d;
+  --vss-chat-bg: #171717;
+  --vss-chat-surface: #262626;
   --vss-chat-fg: #e8eaed;
-  --vss-chat-muted: #9aa0a6;
-  --vss-chat-border: #2c2f36;
-  --vss-chat-user-bg: #2a3f5f;
-  --vss-chat-accent: #76b900; /* NVIDIA green */
+  --vss-chat-muted: #9b9b9b;
+  --vss-chat-border: #3a3a3a;
+  --vss-chat-accent: #76b900;
+  --vss-chat-accent-hover: #5a8f00;
+  --vss-chat-radius: 4px;
 
   display: flex;
   flex-direction: column;
@@ -22,32 +27,34 @@
   min-height: 0;
   background: var(--vss-chat-bg);
   color: var(--vss-chat-fg);
+  font-family: 'NVIDIA Sans', system-ui, -apple-system, sans-serif;
   font-size: 14px;
-  line-height: 1.5;
+  line-height: 1.55;
 }
 
 .vss-chat-light {
   --vss-chat-bg: #ffffff;
+  --vss-chat-surface: #f3f4f6;
   --vss-chat-fg: #1f2328;
-  --vss-chat-muted: #6b7280;
-  --vss-chat-border: #e3e6ea;
-  --vss-chat-user-bg: #eef4ff;
+  --vss-chat-muted: #5f6368;
+  --vss-chat-border: #d9dce1;
 }
 
 .vss-chat-header {
-  padding: 10px 14px;
+  padding: 12px 16px;
   border-bottom: 1px solid var(--vss-chat-border);
   font-weight: 600;
+  letter-spacing: 0.01em;
   flex: 0 0 auto;
 }
 
 .vss-chat-log {
   flex: 1 1 auto;
   overflow-y: auto;
-  padding: 14px;
+  padding: 16px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 16px;
 }
 
 .vss-chat-empty {
@@ -56,116 +63,225 @@
   text-align: center;
 }
 
-.vss-chat-msg {
-  max-width: 100%;
-  overflow-wrap: anywhere;
-}
+.vss-chat-msg { max-width: 100%; overflow-wrap: anywhere; }
 
+/* User turns: an elevated surface, not a coloured bubble. */
 .vss-chat-msg-user .vss-chat-usertext {
-  background: var(--vss-chat-user-bg);
-  border-radius: 10px;
-  padding: 8px 12px;
+  background: var(--vss-chat-surface);
+  border: 1px solid var(--vss-chat-border);
+  border-left: 3px solid var(--vss-chat-accent);
+  border-radius: var(--vss-chat-radius);
+  padding: 10px 14px;
   margin-left: auto;
   width: fit-content;
-  max-width: 85%;
+  max-width: 88%;
   white-space: pre-wrap;
 }
 
+/* ---- markdown typography (Tailwind preflight removes all of this) ---- */
 .vss-chat-markdown > :first-child { margin-top: 0; }
 .vss-chat-markdown > :last-child { margin-bottom: 0; }
+.vss-chat-markdown p { margin: 0 0 10px; }
+.vss-chat-markdown h1,
+.vss-chat-markdown h2,
+.vss-chat-markdown h3,
+.vss-chat-markdown h4 {
+  font-weight: 600;
+  line-height: 1.3;
+  margin: 18px 0 8px;
+}
+.vss-chat-markdown h1 { font-size: 1.4em; }
+.vss-chat-markdown h2 { font-size: 1.25em; }
+.vss-chat-markdown h3 { font-size: 1.1em; }
+.vss-chat-markdown h4 { font-size: 1em; }
+.vss-chat-markdown ul,
+.vss-chat-markdown ol {
+  margin: 0 0 10px;
+  padding-left: 22px;
+}
+.vss-chat-markdown ul { list-style: disc; }
+.vss-chat-markdown ol { list-style: decimal; }
+.vss-chat-markdown li { margin: 3px 0; }
+.vss-chat-markdown li > ul,
+.vss-chat-markdown li > ol { margin: 3px 0; }
+.vss-chat-markdown a { color: var(--vss-chat-accent); text-decoration: underline; }
+.vss-chat-markdown strong { font-weight: 600; }
+.vss-chat-markdown em { font-style: italic; }
+.vss-chat-markdown blockquote {
+  margin: 0 0 10px;
+  padding-left: 12px;
+  border-left: 3px solid var(--vss-chat-border);
+  color: var(--vss-chat-muted);
+}
+.vss-chat-markdown hr {
+  border: none;
+  border-top: 1px solid var(--vss-chat-border);
+  margin: 16px 0;
+}
+.vss-chat-markdown code {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 0.88em;
+  background: var(--vss-chat-surface);
+  border: 1px solid var(--vss-chat-border);
+  border-radius: 3px;
+  padding: 1px 5px;
+}
 .vss-chat-markdown pre {
-  background: rgba(127, 127, 127, 0.12);
-  padding: 10px;
-  border-radius: 8px;
+  background: var(--vss-chat-surface);
+  border: 1px solid var(--vss-chat-border);
+  border-radius: var(--vss-chat-radius);
+  padding: 12px;
+  overflow-x: auto;
+  margin: 0 0 10px;
+}
+.vss-chat-markdown pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 0.85em;
+}
+.vss-chat-markdown table {
+  border-collapse: collapse;
+  margin: 0 0 10px;
+  display: block;
   overflow-x: auto;
 }
-.vss-chat-markdown code { font-size: 0.92em; }
-.vss-chat-markdown table { border-collapse: collapse; }
 .vss-chat-markdown th,
 .vss-chat-markdown td {
   border: 1px solid var(--vss-chat-border);
-  padding: 4px 8px;
+  padding: 6px 10px;
+  text-align: left;
 }
+.vss-chat-markdown th { background: var(--vss-chat-surface); font-weight: 600; }
 
 .vss-chat-cursor {
   animation: vss-chat-blink 1s steps(2, start) infinite;
-  color: var(--vss-chat-muted);
+  color: var(--vss-chat-accent);
 }
 @keyframes vss-chat-blink { to { visibility: hidden; } }
-
 @media (prefers-reduced-motion: reduce) {
   .vss-chat-cursor { animation: none; }
-  .vss-chat-log { scroll-behavior: auto; }
 }
 
 .vss-chat-error {
-  color: #d93025;
-  background: rgba(217, 48, 37, 0.1);
-  border-radius: 8px;
-  padding: 8px 12px;
+  color: #ff6b6b;
+  background: rgba(255, 107, 107, 0.1);
+  border: 1px solid rgba(255, 107, 107, 0.35);
+  border-radius: var(--vss-chat-radius);
+  padding: 10px 12px;
 }
 
-/* Tool/skill progress, collapsed by default so it never buries the answer. */
-.vss-chat-steps { margin-bottom: 6px; }
+/* ---- tool / skill progress ---- */
+.vss-chat-steps {
+  margin-bottom: 10px;
+  border: 1px solid var(--vss-chat-border);
+  border-radius: var(--vss-chat-radius);
+  background: var(--vss-chat-surface);
+}
 .vss-chat-steps-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
   background: none;
   border: none;
   color: var(--vss-chat-muted);
   cursor: pointer;
   font: inherit;
-  font-size: 0.9em;
-  padding: 0;
+  font-size: 0.86em;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 8px 12px;
+  text-align: left;
 }
 .vss-chat-steps-toggle:hover { color: var(--vss-chat-fg); }
 .vss-chat-steps-list {
-  margin: 6px 0 0;
-  padding-left: 18px;
-  color: var(--vss-chat-muted);
+  margin: 0;
+  padding: 0 12px 10px 12px;
+  list-style: none;
   font-size: 0.9em;
 }
-.vss-chat-steps-list li[data-status='error'] { color: #d93025; }
+.vss-chat-steps-list li {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 5px 0;
+  border-top: 1px solid var(--vss-chat-border);
+}
+.vss-chat-step-name {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  color: var(--vss-chat-fg);
+}
+.vss-chat-step-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  margin-right: 8px;
+  background: var(--vss-chat-accent);
+  vertical-align: middle;
+}
+.vss-chat-steps-list li[data-status='in_progress'] .vss-chat-step-dot {
+  background: var(--vss-chat-accent);
+  animation: vss-chat-pulse 1.2s ease-in-out infinite;
+}
+.vss-chat-steps-list li[data-status='error'] .vss-chat-step-dot { background: #ff6b6b; }
+@keyframes vss-chat-pulse { 50% { opacity: 0.3; } }
+@media (prefers-reduced-motion: reduce) {
+  .vss-chat-steps-list li .vss-chat-step-dot { animation: none; }
+}
 .vss-chat-steps-list pre {
-  margin: 4px 0;
+  margin: 0;
+  padding: 6px 8px;
+  background: var(--vss-chat-bg);
+  border: 1px solid var(--vss-chat-border);
+  border-radius: 3px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 0.85em;
+  color: var(--vss-chat-muted);
   white-space: pre-wrap;
-  opacity: 0.85;
+  max-height: 160px;
+  overflow-y: auto;
 }
 
+/* ---- composer ---- */
 .vss-chat-input {
   flex: 0 0 auto;
   display: flex;
   gap: 8px;
-  padding: 10px;
+  padding: 12px;
   border-top: 1px solid var(--vss-chat-border);
+  background: var(--vss-chat-bg);
 }
 .vss-chat-input textarea {
   flex: 1 1 auto;
   resize: none;
   max-height: 160px;
-  padding: 8px 10px;
-  border-radius: 8px;
+  padding: 10px 12px;
+  border-radius: var(--vss-chat-radius);
   border: 1px solid var(--vss-chat-border);
-  background: transparent;
+  background: var(--vss-chat-surface);
   color: inherit;
   font: inherit;
 }
+.vss-chat-input textarea::placeholder { color: var(--vss-chat-muted); }
 .vss-chat-input textarea:focus-visible,
 .vss-chat-input button:focus-visible {
   outline: 2px solid var(--vss-chat-accent);
   outline-offset: 1px;
 }
 .vss-chat-input button {
-  padding: 8px 16px;
-  border-radius: 8px;
+  padding: 0 20px;
+  border-radius: var(--vss-chat-radius);
   border: none;
   background: var(--vss-chat-accent);
-  color: #0b0d10;
+  color: #111;
+  font: inherit;
   font-weight: 600;
   cursor: pointer;
 }
-.vss-chat-input button:disabled {
-  opacity: 0.45;
-  cursor: default;
-}
+.vss-chat-input button:hover:not(:disabled) { background: var(--vss-chat-accent-hover); }
+.vss-chat-input button:disabled { opacity: 0.4; cursor: default; }
 .vss-chat-stop {
   background: transparent !important;
   color: var(--vss-chat-fg) !important;

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/chat.css
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/chat.css
@@ -1,0 +1,173 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Styles for the VSS chat surface.
+ *
+ * Plain CSS with custom properties rather than a utility framework, so the
+ * package carries no build-time styling dependency and can be themed by the
+ * host app. Light and dark are the same rules with different variables, which
+ * is what lets the sidebar render light against a dark app.
+ */
+
+.vss-chat {
+  --vss-chat-bg: #16181d;
+  --vss-chat-fg: #e8eaed;
+  --vss-chat-muted: #9aa0a6;
+  --vss-chat-border: #2c2f36;
+  --vss-chat-user-bg: #2a3f5f;
+  --vss-chat-accent: #76b900; /* NVIDIA green */
+
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  background: var(--vss-chat-bg);
+  color: var(--vss-chat-fg);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.vss-chat-light {
+  --vss-chat-bg: #ffffff;
+  --vss-chat-fg: #1f2328;
+  --vss-chat-muted: #6b7280;
+  --vss-chat-border: #e3e6ea;
+  --vss-chat-user-bg: #eef4ff;
+}
+
+.vss-chat-header {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--vss-chat-border);
+  font-weight: 600;
+  flex: 0 0 auto;
+}
+
+.vss-chat-log {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.vss-chat-empty {
+  color: var(--vss-chat-muted);
+  margin: auto;
+  text-align: center;
+}
+
+.vss-chat-msg {
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+
+.vss-chat-msg-user .vss-chat-usertext {
+  background: var(--vss-chat-user-bg);
+  border-radius: 10px;
+  padding: 8px 12px;
+  margin-left: auto;
+  width: fit-content;
+  max-width: 85%;
+  white-space: pre-wrap;
+}
+
+.vss-chat-markdown > :first-child { margin-top: 0; }
+.vss-chat-markdown > :last-child { margin-bottom: 0; }
+.vss-chat-markdown pre {
+  background: rgba(127, 127, 127, 0.12);
+  padding: 10px;
+  border-radius: 8px;
+  overflow-x: auto;
+}
+.vss-chat-markdown code { font-size: 0.92em; }
+.vss-chat-markdown table { border-collapse: collapse; }
+.vss-chat-markdown th,
+.vss-chat-markdown td {
+  border: 1px solid var(--vss-chat-border);
+  padding: 4px 8px;
+}
+
+.vss-chat-cursor {
+  animation: vss-chat-blink 1s steps(2, start) infinite;
+  color: var(--vss-chat-muted);
+}
+@keyframes vss-chat-blink { to { visibility: hidden; } }
+
+@media (prefers-reduced-motion: reduce) {
+  .vss-chat-cursor { animation: none; }
+  .vss-chat-log { scroll-behavior: auto; }
+}
+
+.vss-chat-error {
+  color: #d93025;
+  background: rgba(217, 48, 37, 0.1);
+  border-radius: 8px;
+  padding: 8px 12px;
+}
+
+/* Tool/skill progress, collapsed by default so it never buries the answer. */
+.vss-chat-steps { margin-bottom: 6px; }
+.vss-chat-steps-toggle {
+  background: none;
+  border: none;
+  color: var(--vss-chat-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.9em;
+  padding: 0;
+}
+.vss-chat-steps-toggle:hover { color: var(--vss-chat-fg); }
+.vss-chat-steps-list {
+  margin: 6px 0 0;
+  padding-left: 18px;
+  color: var(--vss-chat-muted);
+  font-size: 0.9em;
+}
+.vss-chat-steps-list li[data-status='error'] { color: #d93025; }
+.vss-chat-steps-list pre {
+  margin: 4px 0;
+  white-space: pre-wrap;
+  opacity: 0.85;
+}
+
+.vss-chat-input {
+  flex: 0 0 auto;
+  display: flex;
+  gap: 8px;
+  padding: 10px;
+  border-top: 1px solid var(--vss-chat-border);
+}
+.vss-chat-input textarea {
+  flex: 1 1 auto;
+  resize: none;
+  max-height: 160px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--vss-chat-border);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+}
+.vss-chat-input textarea:focus-visible,
+.vss-chat-input button:focus-visible {
+  outline: 2px solid var(--vss-chat-accent);
+  outline-offset: 1px;
+}
+.vss-chat-input button {
+  padding: 8px 16px;
+  border-radius: 8px;
+  border: none;
+  background: var(--vss-chat-accent);
+  color: #0b0d10;
+  font-weight: 600;
+  cursor: pointer;
+}
+.vss-chat-input button:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+.vss-chat-stop {
+  background: transparent !important;
+  color: var(--vss-chat-fg) !important;
+  border: 1px solid var(--vss-chat-border) !important;
+}

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/conversations.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/conversations.ts
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Conversation list logic, kept free of React so it can be unit tested.
+ *
+ * Export/import stay wire-compatible with the toolkit's v4 format
+ * (`{version: 4, history, folders, prompts}`) so a file exported from the old
+ * chat bar imports into this one. Folders and prompts are accepted and
+ * round-tripped but not rendered — VSS never surfaced either.
+ */
+import type { ChatMessage, Conversation } from './types';
+
+export const NEW_CONVERSATION_NAME = 'New Conversation';
+
+/** Export envelope, matching the toolkit's `ExportFormatV4`. */
+export interface ChatExportV4 {
+  version: 4;
+  history: Conversation[];
+  folders: unknown[];
+  prompts: unknown[];
+}
+
+let seq = 0;
+export const newId = (): string =>
+  `c${Date.now().toString(36)}-${(seq++).toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+export function createConversation(name = NEW_CONVERSATION_NAME): Conversation {
+  return { id: newId(), name, messages: [] };
+}
+
+/**
+ * Name a conversation after its first user message.
+ *
+ * The toolkit truncates at 30 characters; matched here so titles look the same
+ * in a sidebar that may show both during the migration.
+ */
+export function titleFromMessage(content: string): string {
+  const trimmed = content.trim();
+  if (!trimmed) return NEW_CONVERSATION_NAME;
+  return trimmed.length > 30 ? `${trimmed.substring(0, 30)}...` : trimmed;
+}
+
+/** Case-insensitive match over conversation names and message text. */
+export function filterConversations(
+  conversations: Conversation[],
+  searchTerm: string,
+): Conversation[] {
+  const term = searchTerm.trim().toLowerCase();
+  if (!term) return conversations;
+  return conversations.filter((c) => {
+    if (c.name.toLowerCase().includes(term)) return true;
+    return c.messages.some((m) => !m.hidden && m.content.toLowerCase().includes(term));
+  });
+}
+
+/**
+ * Strip fields that should never outlive the turn that created them.
+ *
+ * `streaming` would restore a conversation stuck mid-answer with a blinking
+ * cursor and no request behind it; `uploadConversationId` is only meaningful
+ * while an upload is in flight.
+ */
+export function sanitizeForPersistence(conversations: Conversation[]): Conversation[] {
+  return conversations.map((c) => ({
+    ...c,
+    messages: c.messages.map(({ streaming: _s, uploadConversationId: _u, ...rest }) => rest),
+  }));
+}
+
+export function buildExport(conversations: Conversation[]): ChatExportV4 {
+  return {
+    version: 4,
+    history: sanitizeForPersistence(conversations),
+    folders: [],
+    prompts: [],
+  };
+}
+
+export function exportFilename(): string {
+  const date = new Date();
+  return `vss_chat_history_${date.getMonth() + 1}-${date.getDate()}.json`;
+}
+
+const DANGEROUS_KEYS = ['__proto__', 'constructor', 'prototype'];
+
+/**
+ * Recursively drop prototype-pollution keys.
+ *
+ * Imports are user-supplied JSON that we spread into React state; without this
+ * a crafted file can reach `Object.prototype`. Ported from the toolkit's
+ * `utils/security/import-validation.ts` rather than reinvented.
+ */
+function sanitizeObject(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(sanitizeObject);
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+    if (DANGEROUS_KEYS.includes(key)) continue;
+    out[key] = sanitizeObject(val);
+  }
+  return out;
+}
+
+function isConversationLike(value: unknown): value is Conversation {
+  if (!value || typeof value !== 'object') return false;
+  const c = value as Record<string, unknown>;
+  return (
+    (typeof c.id === 'string' || typeof c.id === 'number') &&
+    typeof c.name === 'string' &&
+    Array.isArray(c.messages)
+  );
+}
+
+function normalizeMessages(messages: unknown[]): ChatMessage[] {
+  return messages
+    .filter((m): m is Record<string, unknown> => !!m && typeof m === 'object')
+    .map((m) => ({
+      id: typeof m.id === 'string' ? m.id : newId(),
+      role: m.role === 'assistant' ? ('assistant' as const) : ('user' as const),
+      content: typeof m.content === 'string' ? m.content : '',
+      steps: Array.isArray(m.steps) ? (m.steps as ChatMessage['steps']) : undefined,
+      callerInfo: typeof m.callerInfo === 'string' ? m.callerInfo : undefined,
+      hidden: m.hidden === true,
+    }));
+}
+
+export const MAX_IMPORT_BYTES = 10 * 1024 * 1024;
+
+export interface ImportResult {
+  conversations: Conversation[] | null;
+  error?: string;
+}
+
+/**
+ * Parse an exported file back into conversations.
+ *
+ * Accepts every format the toolkit accepted (v1 bare array through v4) so old
+ * exports still load, and returns a message rather than throwing so the caller
+ * can toast it.
+ */
+export function parseImport(rawJson: string): ImportResult {
+  if (!rawJson || typeof rawJson !== 'string') {
+    return { conversations: null, error: 'Empty import file' };
+  }
+  if (rawJson.length > MAX_IMPORT_BYTES) {
+    return {
+      conversations: null,
+      error: `Import file too large (max ${Math.round(MAX_IMPORT_BYTES / (1024 * 1024))}MB)`,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawJson);
+  } catch {
+    return { conversations: null, error: 'Invalid JSON format' };
+  }
+  if (parsed === null || typeof parsed !== 'object') {
+    return { conversations: null, error: 'Import data must be an object or array' };
+  }
+
+  const clean = sanitizeObject(parsed);
+
+  // v1: a bare array of conversations.
+  const history: unknown = Array.isArray(clean)
+    ? clean
+    : (clean as Record<string, unknown>).history;
+
+  if (!Array.isArray(history)) {
+    return { conversations: null, error: 'Invalid import format' };
+  }
+
+  const conversations = history.filter(isConversationLike).map((c) => ({
+    id: String(c.id),
+    name: c.name,
+    messages: normalizeMessages(c.messages as unknown[]),
+  }));
+
+  if (!conversations.length) {
+    return { conversations: null, error: 'No conversations found in file' };
+  }
+  return { conversations };
+}

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/index.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/index.ts
@@ -9,15 +9,56 @@
  * Hermes.
  */
 export { ChatPanel, default as default } from './ChatPanel';
-export { useChatStream } from './useChatStream';
-export type { UseChatStreamResult } from './useChatStream';
-export { SseParser, extractContent } from './sse';
-export type { SseEvent } from './sse';
+export { ConversationList } from './ConversationList';
+export { ChatSteps } from './ChatSteps';
+export { InteractionModal } from './InteractionModal';
+export { ChatUpload } from './ChatUpload';
+export { AgentParams, fieldsToParams, parseParamsJson, useParamFields } from './AgentParams';
+
+export { useChatStream, buildContextPrefix } from './useChatStream';
+export type { UseChatStreamResult, UseChatStreamOptions, SendOptions } from './useChatStream';
+export { useConversations } from './useConversations';
+export type { UseConversationsResult } from './useConversations';
+
+export { SseParser, extractContent, buildStepTree } from './sse';
+export type { SseEvent, InteractionRequest } from './sse';
+
+export {
+  buildExport,
+  createConversation,
+  filterConversations,
+  parseImport,
+  sanitizeForPersistence,
+  titleFromMessage,
+} from './conversations';
+export type { ChatExportV4, ImportResult } from './conversations';
+
+export {
+  clearAllConversations,
+  initConversationSessionLifecycle,
+  loadConversations,
+  saveConversations,
+} from './storage';
+
+export { getMarkdownComponents } from './markdown/components';
+export { fixMalformedHtml } from './markdown/streaming';
+
 export type {
+  CallerInfo,
   ChatAnswerHandler,
+  ChatAttachment,
   ChatEndpointConfig,
+  ChatFeatureFlags,
   ChatMessage,
   ChatPanelProps,
   ChatRole,
+  ChatSidebarControlHandlers,
   ChatStep,
+  ChatVideoUploadCompletePayload,
+  Conversation,
+  CustomAgentParamsValues,
+  ParamField,
+  ParamFieldConfig,
+  ParamType,
+  QueryDataContext,
 } from './types';

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/index.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/index.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+/**
+ * VSS chat interface.
+ *
+ * Replaces the NeMo Agent Toolkit chat UI for the chat tab and the docked
+ * sidebar. Depends on no toolkit code: it speaks the BYO agent contract
+ * (OpenAI-shaped request, SSE response) directly, so any backend implementing
+ * `/chat/stream` works, including the VSS agent adapter driving OpenClaw or
+ * Hermes.
+ */
+export { ChatPanel, default as default } from './ChatPanel';
+export { useChatStream } from './useChatStream';
+export type { UseChatStreamResult } from './useChatStream';
+export { SseParser, extractContent } from './sse';
+export type { SseEvent } from './sse';
+export type {
+  ChatAnswerHandler,
+  ChatEndpointConfig,
+  ChatMessage,
+  ChatPanelProps,
+  ChatRole,
+  ChatStep,
+} from './types';

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/markdown/AgentThink.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/markdown/AgentThink.tsx
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+/**
+ * `<agent-think>` / `<agent-think-step>` renderers for agent markdown.
+ *
+ * The backend emits reasoning traces as these two custom tags. Formatting
+ * rules the backend must follow (unchanged from the toolkit, because the
+ * prompts that produce them are unchanged):
+ *
+ *   - blank line before `<agent-think>` and after `</agent-think>`, so the
+ *     markdown parser treats them as block-level rather than wrapping them in
+ *     a `<p>`;
+ *   - no blank line straight after the opening tag, or the content becomes a
+ *     sibling instead of a child;
+ *   - `<agent-think-step>` tags on their own lines.
+ *
+ * `data-streaming="true"` on the tag marks the trace still being written.
+ */
+import { IconChevronDown, IconChevronUp, IconLoader2 } from '@tabler/icons-react';
+import React, { useEffect, useState } from 'react';
+
+/** How long a finished trace stays open before collapsing itself. */
+const AUTO_COLLAPSE_MS = 3000;
+
+interface ThinkProps {
+  children: React.ReactNode;
+  title?: string;
+  'data-streaming'?: string;
+  messageIsStreaming?: boolean;
+}
+
+export const AgentThink: React.FC<ThinkProps> = ({
+  children,
+  title,
+  messageIsStreaming,
+  ...props
+}) => {
+  const isStreaming = props['data-streaming'] === 'true' && !!messageIsStreaming;
+  const [isOpen, setIsOpen] = useState(false);
+  const [wasStreaming, setWasStreaming] = useState(false);
+
+  // Open while the trace is being written, then collapse a beat after it
+  // finishes so a long trace does not bury the answer under it.
+  useEffect(() => {
+    if (isStreaming) {
+      setIsOpen(true);
+      setWasStreaming(true);
+      return;
+    }
+    if (wasStreaming) {
+      const timer = setTimeout(() => {
+        setIsOpen(false);
+        setWasStreaming(false);
+      }, AUTO_COLLAPSE_MS);
+      return () => clearTimeout(timer);
+    }
+    return;
+  }, [isStreaming, wasStreaming]);
+
+  return (
+    <div className="my-3 overflow-hidden rounded-lg border border-neutral-300 bg-neutral-100 shadow-sm dark:border-neutral-700 dark:bg-neutral-900">
+      <button
+        type="button"
+        aria-expanded={isOpen}
+        disabled={isStreaming}
+        onClick={() => !isStreaming && setIsOpen((prev) => !prev)}
+        className={`flex w-full items-center justify-between p-3 text-left transition-colors ${
+          isStreaming ? 'cursor-default' : 'hover:bg-neutral-200 dark:hover:bg-neutral-800'
+        }`}
+      >
+        <span className="flex items-center gap-2">
+          {isStreaming && (
+            <IconLoader2 size={20} className="flex-shrink-0 animate-spin text-[#76b900]" />
+          )}
+          <span className="font-medium text-gray-700 dark:text-gray-200">
+            <strong>Reasoning Trace</strong>
+            {title ? ` - ${title}` : ''}
+          </span>
+        </span>
+        {!isStreaming &&
+          (isOpen ? (
+            <IconChevronUp size={20} className="text-gray-600 dark:text-gray-300" />
+          ) : (
+            <IconChevronDown size={20} className="text-gray-600 dark:text-gray-300" />
+          ))}
+      </button>
+
+      {isOpen && (
+        <div className="border-t border-neutral-300 px-4 pb-4 pt-2 text-gray-700 dark:border-zinc-600 dark:text-gray-300">
+          <div className="whitespace-pre-wrap break-words">{children}</div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const AgentThinkStep: React.FC<ThinkProps> = ({
+  children,
+  title,
+  messageIsStreaming,
+  ...props
+}) => {
+  const isStreaming = props['data-streaming'] === 'true' && !!messageIsStreaming;
+  // Steps stay open once written — unlike the parent trace, a finished step is
+  // the part a user goes back to read.
+  const [isOpen, setIsOpen] = useState(true);
+
+  useEffect(() => {
+    if (isStreaming) setIsOpen(true);
+  }, [isStreaming]);
+
+  return (
+    <div className="relative my-2 pl-6">
+      {/* Storyline rail: a head circle at the step, a line down to the next. */}
+      <div className="absolute bottom-0 left-0 top-0 flex flex-col items-center">
+        <div className="mt-2 h-3 w-3 flex-shrink-0 rounded-full bg-gray-500 dark:bg-gray-400" />
+        <div className="w-1 flex-1 bg-gray-400 dark:bg-gray-500" />
+      </div>
+
+      <div className="overflow-hidden rounded-md bg-gray-100/50 shadow-sm dark:bg-neutral-800/50">
+        <button
+          type="button"
+          aria-expanded={isOpen}
+          disabled={isStreaming}
+          onClick={() => !isStreaming && setIsOpen((prev) => !prev)}
+          className={`flex w-full items-center justify-between rounded-md px-3 py-2 text-left transition-colors ${
+            isStreaming ? 'cursor-default' : 'hover:bg-gray-200/50 dark:hover:bg-neutral-700/50'
+          }`}
+        >
+          <span className="flex items-center gap-2">
+            {isStreaming && (
+              <IconLoader2 size={16} className="flex-shrink-0 animate-spin text-[#76b900]" />
+            )}
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-200">
+              <strong>Step</strong>
+              {title ? ` - ${title}` : ''}
+            </span>
+          </span>
+          {!isStreaming &&
+            (isOpen ? (
+              <IconChevronUp size={16} className="text-gray-600 dark:text-gray-300" />
+            ) : (
+              <IconChevronDown size={16} className="text-gray-600 dark:text-gray-300" />
+            ))}
+        </button>
+
+        {isOpen && (
+          <div className="border-t border-gray-300 px-3 pb-2 pt-1 text-sm text-gray-700 dark:border-zinc-500 dark:text-gray-300">
+            <div className="whitespace-pre-wrap break-words">{children}</div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/markdown/Chart.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/markdown/Chart.tsx
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: MIT
+/**
+ * `<chart>` renderer for agent markdown.
+ *
+ * Payload shape is the toolkit's, unchanged, so a workflow that already emits
+ * charts keeps working:
+ *
+ *   <chart>{"Label":"…","ChartType":"BarChart","Data":[…],"XAxisKey":"…"}</chart>
+ *
+ * The toolkit also had a `GraphPlot` type backed by react-force-graph-2d. That
+ * dependency is not installed in this workspace and no VSS workflow emits the
+ * type, so it renders as "unsupported" rather than pulling in a force-directed
+ * graph engine for a case that never fires.
+ */
+import { IconDownload } from '@tabler/icons-react';
+import React, { useCallback, useMemo } from 'react';
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ComposedChart,
+  Legend,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  PolarAngleAxis,
+  PolarGrid,
+  PolarRadiusAxis,
+  Radar,
+  RadarChart,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+export interface ChartPayload {
+  Label?: string;
+  ChartType?: string;
+  Data?: Record<string, unknown>[];
+  XAxisKey?: string;
+  YAxisKey?: string;
+  ValueKey?: string;
+  NameKey?: string;
+  PolarAngleKey?: string;
+  PolarValueKey?: string;
+  BarKey?: string;
+  LineKey?: string;
+}
+
+const BRAND = '#76b900';
+const STROKE = '#1f2937';
+
+/**
+ * Fixed palette indexed by slice position.
+ *
+ * The toolkit generated a random colour per cell inside render, so every
+ * re-render — one per streamed token — recoloured the pie. Deterministic
+ * colours also mean a downloaded PNG matches what was on screen.
+ */
+const SLICE_COLORS = [
+  '#76b900',
+  '#0072ce',
+  '#e57200',
+  '#8a2be2',
+  '#00a3a1',
+  '#c2185b',
+  '#f2c500',
+  '#5c6bc0',
+];
+
+export const Chart: React.FC<{ payload: ChartPayload }> = ({ payload }) => {
+  const {
+    Label = '',
+    ChartType = '',
+    Data = [],
+    XAxisKey = '',
+    YAxisKey = '',
+    ValueKey = '',
+    NameKey = '',
+    PolarAngleKey = '',
+    PolarValueKey = '',
+    BarKey = '',
+    LineKey = '',
+  } = payload ?? {};
+
+  // Ids must be unique per chart on the page or the download grabs the wrong one.
+  const domId = useMemo(
+    () => `vss-chart-${(Label || 'untitled').replace(/\W+/g, '-')}-${ChartType || 'chart'}`,
+    [Label, ChartType],
+  );
+
+  const handleDownload = useCallback(async () => {
+    const element = document.getElementById(domId);
+    if (!element) return;
+    // html-to-image is only needed on an explicit click; keep it out of the
+    // initial chunk.
+    const htmlToImage = await import('html-to-image');
+    const previousBackground = element.style.background;
+    // Recharts draws on transparency; without this the PNG is unreadable in
+    // any viewer that defaults to a dark backdrop.
+    element.style.background = 'white';
+    try {
+      const dataUrl = await htmlToImage.toPng(element);
+      const link = document.createElement('a');
+      link.href = dataUrl;
+      link.download = `${Label || 'chart'}-${ChartType || 'chart'}.png`;
+      link.click();
+    } catch (error) {
+      console.warn('vss-chat: chart download failed', error);
+    } finally {
+      element.style.background = previousBackground;
+    }
+  }, [domId, Label, ChartType]);
+
+  const chart = () => {
+    switch (ChartType) {
+      case 'BarChart':
+        return (
+          <BarChart data={Data}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey={XAxisKey} />
+            <YAxis />
+            <Tooltip />
+            <Legend />
+            <Bar dataKey={YAxisKey} fill={BRAND} />
+          </BarChart>
+        );
+      case 'LineChart':
+        return (
+          <LineChart data={Data}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey={XAxisKey} />
+            <YAxis />
+            <Tooltip />
+            <Legend />
+            <Line type="monotone" dataKey={YAxisKey} stroke={BRAND} />
+          </LineChart>
+        );
+      case 'PieChart':
+        return (
+          <PieChart>
+            <Tooltip />
+            <Legend />
+            <Pie data={Data} dataKey={ValueKey} nameKey={NameKey} fill={BRAND} label>
+              {Data.map((_entry, index) => (
+                <Cell key={`cell-${index}`} fill={SLICE_COLORS[index % SLICE_COLORS.length]} />
+              ))}
+            </Pie>
+          </PieChart>
+        );
+      case 'AreaChart':
+        return (
+          <AreaChart data={Data}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey={XAxisKey} />
+            <YAxis />
+            <Tooltip />
+            <Legend />
+            <Area type="monotone" dataKey={YAxisKey} stroke={STROKE} fill={BRAND} />
+          </AreaChart>
+        );
+      case 'RadarChart':
+        return (
+          <RadarChart data={Data}>
+            <PolarGrid />
+            <PolarAngleAxis dataKey={PolarAngleKey} />
+            <PolarRadiusAxis />
+            <Radar
+              name="Metrics"
+              dataKey={PolarValueKey}
+              stroke={STROKE}
+              fill={BRAND}
+              fillOpacity={0.6}
+            />
+            <Legend />
+          </RadarChart>
+        );
+      case 'ScatterChart':
+        return (
+          <ScatterChart>
+            <CartesianGrid />
+            <XAxis type="number" dataKey={XAxisKey} name={XAxisKey} />
+            <YAxis type="number" dataKey={YAxisKey} name={YAxisKey} />
+            <Tooltip cursor={{ strokeDasharray: '3 3' }} />
+            <Legend />
+            <Scatter name={Label || 'Series'} data={Data} fill={BRAND} />
+          </ScatterChart>
+        );
+      case 'ComposedChart':
+        return (
+          <ComposedChart data={Data}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey={XAxisKey} />
+            <YAxis />
+            <Tooltip />
+            <Legend />
+            <Bar dataKey={BarKey} fill={BRAND} />
+            <Line type="monotone" dataKey={LineKey} stroke={STROKE} />
+          </ComposedChart>
+        );
+      default:
+        return null;
+    }
+  };
+
+  const body = chart();
+  if (!body) {
+    return (
+      <div className="my-2 rounded-md border border-dashed border-gray-300 p-3 text-sm text-gray-500 dark:border-gray-600 dark:text-gray-400">
+        Unsupported chart type: {ChartType || '(none)'}
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative my-2 pb-2">
+      <button
+        type="button"
+        onClick={handleDownload}
+        title="Download chart"
+        aria-label="Download chart"
+        className="absolute right-2 top-2 z-10 rounded p-1 text-gray-500 hover:text-[#76b900] dark:text-gray-400"
+      >
+        <IconDownload className="h-4 w-4" />
+      </button>
+      <div id={domId} className="pt-4">
+        {Label ? <div className="pl-4 font-medium">{Label}</div> : null}
+        <ResponsiveContainer width="100%" height={300} className="p-2">
+          {body}
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+};
+
+export default Chart;

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/markdown/CodeBlock.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/markdown/CodeBlock.tsx
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MIT
+import { IconCheck, IconClipboard, IconDownload } from '@tabler/icons-react';
+import React, { Suspense, lazy, memo, useEffect, useMemo, useRef, useState } from 'react';
+import { copyToClipboard as copyToClipboardUtil } from 'common';
+
+/**
+ * Syntax highlighting, loaded on demand.
+ *
+ * react-syntax-highlighter pulls in refractor and the whole Prism grammar set —
+ * several hundred kilobytes for a feature that only fires when an answer
+ * contains a fenced code block, and never during streaming (see the stability
+ * gate below). Loading it lazily keeps it out of the chat chunk entirely for
+ * the common case, and the plain-text renderer is the Suspense fallback, so
+ * nothing flashes empty while it arrives.
+ */
+const LazyHighlighter = lazy(async () => {
+  const [{ Prism }, styles] = await Promise.all([
+    import('react-syntax-highlighter'),
+    import('react-syntax-highlighter/dist/esm/styles/prism/one-dark'),
+  ]);
+  const oneDark = (styles as any).default ?? styles;
+  return {
+    default: ({ language, children }: { language: string; children: string }) => (
+      <Prism language={language} style={oneDark} customStyle={{ margin: 0 }}>
+        {children}
+      </Prism>
+    ),
+  };
+});
+
+/** Extension used when a block is downloaded. Keys match markdown info strings. */
+const EXTENSIONS: Record<string, string> = {
+  javascript: '.js',
+  typescript: '.ts',
+  python: '.py',
+  java: '.java',
+  c: '.c',
+  cpp: '.cpp',
+  'c++': '.cpp',
+  'c#': '.cs',
+  ruby: '.rb',
+  php: '.php',
+  go: '.go',
+  rust: '.rs',
+  kotlin: '.kt',
+  swift: '.swift',
+  scala: '.scala',
+  haskell: '.hs',
+  lua: '.lua',
+  perl: '.pl',
+  shell: '.sh',
+  bash: '.sh',
+  sql: '.sql',
+  html: '.html',
+  css: '.css',
+  json: '.json',
+  yaml: '.yaml',
+  xml: '.xml',
+};
+
+// Highlighting a large block costs more than it is worth, and re-running it on
+// every token during a stream is what makes the toolkit's chat stutter.
+const VERY_LARGE_CONTENT_THRESHOLD = 50_000;
+const CONTENT_STABLE_DELAY_MS = 500;
+
+export interface CodeBlockProps {
+  language: string;
+  value: string;
+}
+
+export const CodeBlock: React.FC<CodeBlockProps> = memo(({ language, value }) => {
+  const [isCopied, setIsCopied] = useState(false);
+  // Derived from the content itself rather than a streaming prop: the parent is
+  // memoised, so its `isStreaming` can be stale exactly when it matters.
+  const [contentStable, setContentStable] = useState(false);
+  const lastValueRef = useRef(value);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const formattedValue = useMemo(() => {
+    // Agents commonly emit near-JSON with single quotes; pretty-print when we
+    // can and fall back to the raw text when we cannot.
+    const candidate = language === 'json' ? value.replaceAll("'", '"') : value;
+    try {
+      return JSON.stringify(JSON.parse(candidate), null, 2);
+    } catch {
+      return value;
+    }
+  }, [language, value]);
+
+  useEffect(() => {
+    if (lastValueRef.current !== value) {
+      lastValueRef.current = value;
+      setContentStable(false);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setContentStable(true), CONTENT_STABLE_DELAY_MS);
+    }
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [value]);
+
+  // Mark a block that never changes (restored from history) stable immediately.
+  useEffect(() => {
+    const initial = setTimeout(() => setContentStable(true), CONTENT_STABLE_DELAY_MS);
+    return () => clearTimeout(initial);
+  }, []);
+
+  const usePlainText = formattedValue.length > VERY_LARGE_CONTENT_THRESHOLD || !contentStable;
+
+  const handleCopy = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (await copyToClipboardUtil(formattedValue)) {
+      setIsCopied(true);
+      setTimeout(() => setIsCopied(false), 2000);
+    }
+  };
+
+  const handleDownload = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const extension = EXTENSIONS[language] || '.txt';
+    const blob = new Blob([formattedValue], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `agent-output-${Date.now()}${extension}`;
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const plain = (
+    <pre className="m-0 overflow-x-auto p-4 text-[#abb2bf]">
+      <code>{formattedValue}</code>
+    </pre>
+  );
+
+  return (
+    <div className="codeblock relative my-2 rounded-md bg-[#282c34] font-mono text-sm">
+      <div className="flex items-center justify-between px-4 py-1.5 text-xs text-gray-300">
+        <span className="lowercase">{language}</span>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className="flex items-center gap-1 rounded bg-none p-1 text-xs text-white hover:bg-white/10"
+            onClick={handleCopy}
+            aria-label="Copy code"
+          >
+            {isCopied ? <IconCheck size={16} /> : <IconClipboard size={16} />}
+            {isCopied ? 'Copied!' : 'Copy code'}
+          </button>
+          <button
+            type="button"
+            className="rounded bg-none p-1 text-white hover:bg-white/10"
+            onClick={handleDownload}
+            aria-label="Download code"
+          >
+            <IconDownload size={16} />
+          </button>
+        </div>
+      </div>
+
+      {usePlainText ? (
+        plain
+      ) : (
+        <Suspense fallback={plain}>
+          <LazyHighlighter language={language || 'text'}>{formattedValue}</LazyHighlighter>
+        </Suspense>
+      )}
+    </div>
+  );
+});
+CodeBlock.displayName = 'CodeBlock';

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/markdown/Incidents.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/markdown/Incidents.tsx
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: MIT
+/**
+ * `<incidents>` renderer for agent markdown.
+ *
+ * Copied from the toolkit's `components/Markdown/CustomIncidents.tsx` rather
+ * than rewritten: it imports nothing from the toolkit (only React, Tabler and
+ * `common`), and it is 300 lines of alert-card layout whose exact appearance is
+ * the thing we are trying not to change. Copying keeps the migration a
+ * deletion.
+ */
+
+import React, { memo, useState, useMemo } from 'react';
+import { IconChevronDown, IconChevronUp, IconPlayerPlay, IconCopy } from '@tabler/icons-react';
+import { VideoModal, copyToClipboard, formatTimestamp } from 'common';
+
+// Constants
+const INITIAL_VISIBLE_COUNT = 3;
+const INCREMENT_COUNT = 3;
+
+interface CVMetadata {
+  Box_on_floor?: string;
+  Number_of_people?: string;
+  PPE?: string;
+}
+
+interface ClipInformation {
+  Timestamp: string;
+  Stream: string;
+  Alerts: string;
+  snapshot_url?: string;
+  video_url?: string;
+  'CV Metadata': CVMetadata;
+}
+
+interface AlertDetails {
+  'Alert Triggered': string;
+  Validation: boolean;
+  'Alert Description': string;
+}
+
+interface Incident {
+  'Alert Title': string;
+  'Clip Information': ClipInformation;
+  'Alert Details': AlertDetails;
+}
+
+interface IncidentsData {
+  incidents: Incident[];
+  message?: string;
+}
+
+interface CustomIncidentsProps {
+  payload?: IncidentsData;
+  [key: string]: any;
+}
+
+export const CustomIncidents = memo<CustomIncidentsProps>(
+  ({ payload, ...props }) => {
+    const [expandedItem, setExpandedItem] = useState<number | null>(null);
+    const [expandedClipInfo, setExpandedClipInfo] = useState<number | null>(null);
+    const [expandedAlertDetails, setExpandedAlertDetails] = useState<number | null>(null);
+    const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE_COUNT);
+    const [videoModal, setVideoModal] = useState<{ isOpen: boolean; videoUrl: string; title: string }>({
+      isOpen: false,
+      videoUrl: '',
+      title: ''
+    });
+
+    // Parse incidents data and message
+    const { incidents, message } = useMemo(() => {
+      if (!payload || !payload.incidents) {
+        return { incidents: [], message: '' };
+      }
+
+      const incidentsArray = Array.isArray(payload.incidents) ? payload.incidents : [];
+      const messageText = typeof payload.message === 'string' ? payload.message.trim() : '';
+
+      return { incidents: incidentsArray, message: messageText };
+    }, [payload]);
+
+    const toggleExpanded = (index: number) => {
+      if (expandedItem === index) {
+        // If clicking on already expanded item, collapse it
+        setExpandedItem(null);
+        // Also collapse sub-sections
+        setExpandedClipInfo(null);
+        setExpandedAlertDetails(null);
+      } else {
+        // Expand new item and collapse sub-sections
+        setExpandedItem(index);
+        setExpandedClipInfo(null);
+        setExpandedAlertDetails(null);
+      }
+    };
+
+    const toggleClipInfo = (index: number) => {
+      if (expandedClipInfo === index) {
+        setExpandedClipInfo(null);
+      } else {
+        setExpandedClipInfo(index);
+      }
+    };
+
+    const toggleAlertDetails = (index: number) => {
+      if (expandedAlertDetails === index) {
+        setExpandedAlertDetails(null);
+      } else {
+        setExpandedAlertDetails(index);
+      }
+    };
+
+    const handleViewMore = () => {
+      setVisibleCount(prev => Math.min(prev + INCREMENT_COUNT, incidents.length));
+    };
+
+    const handleViewLess = () => {
+      setVisibleCount(INITIAL_VISIBLE_COUNT);
+    };
+
+    const openVideoModal = (videoUrl: string, title: string) => {
+      setVideoModal({
+        isOpen: true,
+        videoUrl,
+        title
+      });
+    };
+
+    const closeVideoModal = () => {
+      setVideoModal({
+        isOpen: false,
+        videoUrl: '',
+        title: ''
+      });
+    };
+
+
+    if (incidents.length === 0) {
+      return <div className="text-gray-500 dark:text-gray-400">No incidents found</div>;
+    }
+
+    // Show incidents based on visibleCount
+    const incidentsToShow = incidents.slice(0, visibleCount);
+    const hasMoreItems = visibleCount < incidents.length;
+    const canShowLess = visibleCount > INITIAL_VISIBLE_COUNT;
+
+    return (
+      <div className="incidents-container space-y-2 text-sm">
+        {message && (
+          <div className="flex items-start mb-6">
+            <div className="w-5 h-5 mr-3 mt-0.5 bg-green-600 rounded-sm flex items-center justify-center">
+              <svg className="w-3 h-3 text-white" fill="currentColor" viewBox="0 0 20 20">
+                <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+              </svg>
+            </div>
+            <span className="text-gray-800 dark:text-gray-100">
+              {message}
+            </span>
+          </div>
+        )}
+        
+        {/* Incidents List */}
+        {incidentsToShow.map((incident, index) => {
+          const isExpanded = expandedItem === index;
+          const isClipInfoExpanded = expandedClipInfo === index;
+          const isAlertDetailsExpanded = expandedAlertDetails === index;
+          const alertNumber = index + 1;
+          const timestamp = formatTimestamp(incident['Clip Information'].Timestamp);
+
+          return (
+            <div key={index} className="rounded-lg overflow-hidden bg-white dark:bg-black hover:bg-gray-50 dark:hover:bg-neutral-800 transition-all hover:shadow-md border border-gray-200 dark:border-gray-600">
+              {/* Alert Header */}
+              <div 
+                className="flex items-center justify-between p-2 cursor-pointer transition-colors"
+                onClick={() => toggleExpanded(index)}
+              >
+                <div className="flex items-center space-x-3">
+                  {isExpanded ? (
+                    <IconChevronUp className="w-4 h-4 text-gray-600 dark:text-gray-400" />
+                  ) : (
+                    <IconChevronDown className="w-4 h-4 text-gray-600 dark:text-gray-400" />
+                  )}
+                  <div className="text-gray-900 dark:text-white text-sm">
+                    <span className="font-bold">Alert Triggered {alertNumber}:</span> {incident['Alert Details']['Alert Triggered']} at {timestamp}
+                  </div>
+                </div>
+                <div className="flex items-center space-x-2">
+                  <button 
+                    className="flex items-center justify-center w-8 h-8 bg-gray-100 dark:bg-gray-900 rounded-md hover:bg-gray-200 dark:hover:bg-neutral-800 transition-colors group border border-gray-200 dark:border-gray-500"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      const videoUrl = incident['Clip Information'].video_url;
+                      const title = `Alert Triggered ${alertNumber}: ${incident['Alert Details']['Alert Triggered']}`;
+                      if (videoUrl) {
+                        openVideoModal(videoUrl, title);
+                      }
+                    }}
+                  >
+                    <IconPlayerPlay className="w-4 h-4 text-gray-600 dark:text-gray-300 group-hover:text-gray-800 dark:group-hover:text-white transition-colors" />
+                  </button>
+                </div>
+              </div>
+
+              {/* Expanded Content */}
+              {isExpanded && (
+                <div className="bg-gray-50 dark:bg-gray-900 rounded-lg ml-8 mb-3 mr-3 border border-gray-200 dark:border-gray-600">
+                  {/* Clip Information */}
+                  <div 
+                    className="flex items-center justify-between px-4 py-3 cursor-pointer hover:bg-gray-100 dark:hover:bg-neutral-800 transition-colors rounded-t-lg"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      toggleClipInfo(index);
+                    }}
+                  >
+                    <div className="flex items-center space-x-2">
+                      {isClipInfoExpanded ? (
+                        <IconChevronUp className="w-4 h-4 text-gray-600 dark:text-gray-400" />
+                      ) : (
+                        <IconChevronDown className="w-4 h-4 text-gray-600 dark:text-gray-400" />
+                      )}
+                      <h4 className="font-medium text-gray-900 dark:text-white text-sm m-0">Clip Information</h4>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                      <button 
+                        className="flex items-center justify-center w-6 h-6 bg-gray-200 dark:bg-gray-600 rounded hover:bg-gray-300 dark:hover:bg-gray-500 transition-colors group border border-gray-300 dark:border-gray-500"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          copyToClipboard(JSON.stringify(incident['Clip Information'], null, 2));
+                        }}
+                        title="Copy Clip Information JSON"
+                      >
+                        <IconCopy className="w-3 h-3 text-gray-600 dark:text-gray-300 group-hover:text-gray-800 dark:group-hover:text-white transition-colors" />
+                      </button>
+                    </div>
+                  </div>
+                  {isClipInfoExpanded && (
+                    <div className="px-4 pb-4 pt-2">
+                      <div className="bg-gray-50 dark:bg-gray-900 text-gray-800 dark:text-gray-100 p-4 rounded-md font-mono text-xs whitespace-pre-wrap">
+                        {JSON.stringify(incident['Clip Information'], null, 2)}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Alert Details */}
+                  <div 
+                    className="flex items-center justify-between px-4 py-3 cursor-pointer hover:bg-gray-100 dark:hover:bg-neutral-800 transition-colors rounded-t-lg"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      toggleAlertDetails(index);
+                    }}
+                  >
+                    <div className="flex items-center space-x-2">
+                      {isAlertDetailsExpanded ? (
+                        <IconChevronUp className="w-4 h-4 text-gray-600 dark:text-gray-400" />
+                      ) : (
+                        <IconChevronDown className="w-4 h-4 text-gray-600 dark:text-gray-400" />
+                      )}
+                      <h4 className="font-medium text-gray-900 dark:text-white text-sm m-0">Alert Details</h4>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                      <button 
+                        className="flex items-center justify-center w-6 h-6 bg-gray-200 dark:bg-gray-600 rounded hover:bg-gray-300 dark:hover:bg-gray-500 transition-colors group border border-gray-300 dark:border-gray-500"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          copyToClipboard(JSON.stringify(incident['Alert Details'], null, 2));
+                        }}
+                        title="Copy Alert Details JSON"
+                      >
+                        <IconCopy className="w-3 h-3 text-gray-600 dark:text-gray-300 group-hover:text-gray-800 dark:group-hover:text-white transition-colors" />
+                      </button>
+                    </div>
+                  </div>
+                  {isAlertDetailsExpanded && (
+                    <div className="px-4 pb-4 pt-2">
+                      <div className="bg-gray-50 dark:bg-gray-900 text-gray-800 dark:text-gray-100 p-4 rounded-md font-mono text-xs whitespace-pre-wrap">
+                        {JSON.stringify(incident['Alert Details'], null, 2)}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+
+        {/* View More/Less Buttons */}
+        {(hasMoreItems || canShowLess) && (
+          <div className="flex justify-center mt-6 space-x-3">
+            {hasMoreItems && (
+              <button 
+                onClick={handleViewMore}
+                className="px-6 py-3 bg-white dark:bg-black hover:bg-gray-50 dark:hover:bg-neutral-800 text-gray-800 dark:text-gray-100 rounded-lg border border-gray-300 dark:border-gray-600 transition-all hover:shadow-md font-medium"
+              >
+                Show more ({incidents.length - visibleCount} more)
+              </button>
+            )}
+            {canShowLess && (
+              <button 
+                onClick={handleViewLess}
+                className="px-6 py-3 bg-gray-100 dark:bg-gray-900 hover:bg-gray-200 dark:hover:bg-neutral-800 text-gray-700 dark:text-gray-200 rounded-lg border border-gray-300 dark:border-gray-600 transition-all hover:shadow-md font-medium"
+              >
+                Show less
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* Video Modal */}
+        <VideoModal
+          isOpen={videoModal.isOpen}
+          videoUrl={videoModal.videoUrl}
+          title={videoModal.title}
+          onClose={closeVideoModal}
+        />
+      </div>
+    );
+  },
+  (prevProps, nextProps) => 
+    prevProps.payload === nextProps.payload
+);
+
+CustomIncidents.displayName = 'CustomIncidents';

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/markdown/Media.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/markdown/Media.tsx
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Image and video renderers for agent markdown.
+ *
+ * The agent answers with `<img>` / `<video>` pointing at VST media, so these
+ * two carry most of what a VSS answer actually looks like.
+ */
+import { IconDownload, IconExclamationCircle, IconX } from '@tabler/icons-react';
+import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import { downloadImageFromUrl } from './download';
+
+/** Placeholder shown while a src is still streaming in as `loading`. */
+export const MediaLoading: React.FC<{ label?: string }> = ({ label = 'Loading…' }) => (
+  <div className="flex min-h-[200px] items-center justify-center rounded-lg border border-slate-200 bg-slate-50 p-8 dark:border-slate-600 dark:bg-slate-800">
+    <div className="text-center">
+      <div className="mx-auto h-10 w-10 animate-spin rounded-full border-4 border-gray-200 border-t-[#76b900] dark:border-gray-600 dark:border-t-[#76b900]" />
+      <p className="mt-2 text-gray-500 dark:text-gray-400">{label}</p>
+    </div>
+  </div>
+);
+
+interface ImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+  src: string;
+  alt?: string;
+  /** Show a download button (agent-emitted images). */
+  showDownload?: boolean;
+  onDownloadError?: (message: string) => void;
+}
+
+export const MarkdownImage = memo(
+  ({ src, alt, showDownload = false, onDownloadError, ...props }: ImageProps) => {
+    const [error, setError] = useState(false);
+    const [isFullscreen, setIsFullscreen] = useState(false);
+    const prevSrcRef = useRef(src);
+
+    // Compare through a ref rather than in a dependency array: `src` can be a
+    // multi-megabyte data URL and React would diff it on every render.
+    useEffect(() => {
+      if (prevSrcRef.current !== src) {
+        setError(false);
+        prevSrcRef.current = src;
+      }
+    }, [src]);
+
+    const closeFullscreen = useCallback(() => setIsFullscreen(false), []);
+
+    // The overlay is portalled to <body>, so scroll locking and Escape have to
+    // be handled here rather than by an ancestor.
+    useEffect(() => {
+      if (!isFullscreen) return;
+      const previousOverflow = document.body.style.overflow;
+      document.body.style.overflow = 'hidden';
+      const onKeyDown = (event: KeyboardEvent) => {
+        if (event.key === 'Escape') closeFullscreen();
+      };
+      document.addEventListener('keydown', onKeyDown);
+      return () => {
+        document.body.style.overflow = previousOverflow;
+        document.removeEventListener('keydown', onKeyDown);
+      };
+    }, [isFullscreen, closeFullscreen]);
+
+    const handleDownload = useCallback(
+      async (e: React.MouseEvent) => {
+        e.stopPropagation();
+        try {
+          await downloadImageFromUrl(src, alt);
+        } catch (err) {
+          onDownloadError?.(err instanceof Error ? err.message : 'Failed to download image');
+        }
+      },
+      [src, alt, onDownloadError],
+    );
+
+    if (src === 'loading') return <MediaLoading />;
+
+    if (error) {
+      return (
+        <span className="inline-flex items-center gap-2 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          <IconExclamationCircle size={16} />
+          {alt || 'Image failed to load'}
+        </span>
+      );
+    }
+
+    return (
+      <>
+        <span className="group relative inline-block max-w-full">
+          <img
+            src={src}
+            alt={alt}
+            onError={() => setError(true)}
+            onClick={() => setIsFullscreen(true)}
+            className="max-w-full cursor-zoom-in rounded-md border border-slate-300 dark:border-slate-600"
+            {...props}
+          />
+          {showDownload && (
+            <button
+              type="button"
+              onClick={handleDownload}
+              title="Download image"
+              aria-label="Download image"
+              className="absolute right-2 top-2 rounded-md bg-black/60 p-1.5 text-white opacity-0 transition-opacity group-hover:opacity-100 focus:opacity-100"
+            >
+              <IconDownload size={16} />
+            </button>
+          )}
+        </span>
+
+        {isFullscreen &&
+          typeof document !== 'undefined' &&
+          createPortal(
+            <div
+              role="dialog"
+              aria-modal="true"
+              aria-label={alt || 'Image preview'}
+              className="fixed inset-0 z-[200] flex items-center justify-center bg-black/90 p-4"
+              onClick={closeFullscreen}
+            >
+              <button
+                type="button"
+                onClick={closeFullscreen}
+                aria-label="Close preview"
+                className="absolute right-4 top-4 rounded-md p-2 text-white hover:bg-white/10"
+              >
+                <IconX size={24} />
+              </button>
+              <img
+                src={src}
+                alt={alt}
+                className="max-h-full max-w-full object-contain"
+                onClick={(e) => e.stopPropagation()}
+              />
+            </div>,
+            document.body,
+          )}
+      </>
+    );
+  },
+  // Large data URLs make a full string compare expensive; length plus both
+  // ends is enough to tell two different frames apart.
+  (prev, next) => {
+    if (prev.alt !== next.alt) return false;
+    const a = prev.src ?? '';
+    const b = next.src ?? '';
+    if (a.length > 1000 || b.length > 1000) {
+      return (
+        a.length === b.length &&
+        a.slice(0, 100) === b.slice(0, 100) &&
+        a.slice(-100) === b.slice(-100)
+      );
+    }
+    return a === b;
+  },
+);
+MarkdownImage.displayName = 'MarkdownImage';
+
+interface VideoProps extends React.VideoHTMLAttributes<HTMLVideoElement> {
+  src: string;
+}
+
+export const MarkdownVideo = memo(
+  ({ src, controls = true, muted = false, ...props }: VideoProps) => {
+    if (src === 'loading') return <MediaLoading />;
+    return (
+      <video
+        src={src}
+        controls={controls}
+        muted={muted}
+        autoPlay={false}
+        loop={false}
+        playsInline
+        className="max-w-full rounded-md border border-slate-400 bg-slate-50 shadow-sm dark:border-slate-600 dark:bg-slate-800/50"
+        {...props}
+      >
+        Your browser does not support the video tag.
+      </video>
+    );
+  },
+  (prev, next) => prev.src === next.src,
+);
+MarkdownVideo.displayName = 'MarkdownVideo';

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/markdown/components.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/markdown/components.tsx
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: MIT
+/**
+ * react-markdown component overrides for agent answers.
+ *
+ * Custom element names (`chart`, `incidents`, `agent-think`, …) reach this map
+ * because the renderer runs `rehype-raw`, which keeps raw HTML in the tree
+ * instead of escaping it. Without rehype-raw an answer containing `<video>`
+ * shows up as literal text.
+ *
+ * Everything is memoised on `children`: an assistant message re-renders once
+ * per streamed token, and re-mounting an `<img>` or a highlighted code block
+ * that often is what makes a long answer crawl.
+ */
+import isEqual from 'lodash/isEqual';
+import React, { memo } from 'react';
+
+import { AgentThink, AgentThinkStep } from './AgentThink';
+import Chart from './Chart';
+import { CodeBlock } from './CodeBlock';
+import { CustomIncidents } from './Incidents';
+import { MarkdownImage, MarkdownVideo } from './Media';
+
+const sameChildren = (prev: any, next: any) => isEqual(prev.children, next.children);
+
+/**
+ * Large `src` values (base64 frames) make a full compare expensive, so match
+ * on length plus both ends — enough to distinguish two different frames.
+ */
+function sameSrc(prev: any, next: any) {
+  const a: string = prev.src ?? '';
+  const b: string = next.src ?? '';
+  if (a.length > 1000 || b.length > 1000) {
+    return (
+      a.length === b.length && a.slice(0, 100) === b.slice(0, 100) && a.slice(-100) === b.slice(-100)
+    );
+  }
+  return a === b && prev.alt === next.alt;
+}
+
+/** Custom tags carry their payload as a JSON string child. */
+function parseJsonChild(children: unknown): any | null {
+  let raw: unknown = children;
+  if (Array.isArray(children)) raw = children[0];
+  if (raw && typeof raw === 'object') return raw;
+  if (typeof raw !== 'string') return null;
+  const cleaned = raw.replaceAll('\n', '').trim();
+  if (!cleaned.startsWith('{')) return null;
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    return null;
+  }
+}
+
+export interface MarkdownComponentOptions {
+  /** True while the message these components belong to is still streaming. */
+  messageIsStreaming?: boolean;
+  onDownloadError?: (message: string) => void;
+}
+
+export function getMarkdownComponents({
+  messageIsStreaming = false,
+  onDownloadError,
+}: MarkdownComponentOptions = {}) {
+  return {
+    code: memo(({ className, children, ...props }: any) => {
+      const match = /language-(\w+)/.exec(className || '');
+      const value = String(children).replace(/\n$/, '');
+      // Inline spans have no language class and no newline; rendering them as a
+      // full code block would break a sentence into a card.
+      if (!match && !value.includes('\n')) {
+        return (
+          <code
+            className="rounded bg-gray-200 px-1 py-0.5 font-mono text-[0.9em] dark:bg-neutral-800"
+            {...props}
+          >
+            {children}
+          </code>
+        );
+      }
+      return <CodeBlock language={match?.[1] ?? ''} value={value} />;
+    }, sameChildren),
+
+    chart: memo(({ children }: any) => {
+      const payload = parseJsonChild(children);
+      return payload ? <Chart payload={payload} /> : null;
+    }, sameChildren),
+
+    incidents: memo(({ children }: any) => {
+      const payload = parseJsonChild(children);
+      if (!payload || !Array.isArray(payload.incidents)) return null;
+      return <CustomIncidents payload={payload} />;
+    }, sameChildren),
+
+    table: memo(
+      ({ children }: any) => (
+        <div className="w-full overflow-x-auto">
+          <table className="border-collapse border border-black px-3 py-1 dark:border-white">
+            {children}
+          </table>
+        </div>
+      ),
+      sameChildren,
+    ),
+
+    th: memo(
+      ({ children }: any) => (
+        <th className="break-words border border-black bg-gray-500 px-3 py-1 text-white dark:border-white dark:bg-neutral-800">
+          {children}
+        </th>
+      ),
+      sameChildren,
+    ),
+
+    td: memo(
+      ({ children }: any) => (
+        <td className="break-words border border-black px-3 py-1 dark:border-white">{children}</td>
+      ),
+      sameChildren,
+    ),
+
+    a: memo(({ href, children, ...props }: any) => {
+      const isPdf = typeof href === 'string' && href.toLowerCase().endsWith('.pdf');
+      return (
+        <a
+          href={href}
+          className="text-[#76b900] no-underline hover:underline"
+          // Agent answers link out to VST and report files; without noopener the
+          // opened page gets a handle on this window.
+          target="_blank"
+          rel="noopener noreferrer"
+          {...(isPdf ? { 'data-testid': 'pdf-report-link' } : {})}
+          {...props}
+        >
+          {children}
+        </a>
+      );
+    }, sameChildren),
+
+    li: memo(
+      ({ children, ordered: _ordered, ...props }: any) => (
+        <li className="mb-1 list-disc leading-[1.35rem]" {...props}>
+          {children}
+        </li>
+      ),
+      sameChildren,
+    ),
+
+    sup: memo(({ children, ...props }: any) => {
+      // Citation markers arrive as `<sup>1</sup>` but also as stray commas
+      // between them; rendering those produces floating punctuation.
+      const text = Array.isArray(children)
+        ? children.filter((c) => typeof c === 'string' && c.trim() && c.trim() !== ',').join('')
+        : typeof children === 'string' && children.trim() && children.trim() !== ','
+          ? children
+          : null;
+      if (!text) return null;
+      return (
+        <sup
+          className="ml-0.5 rounded-md border border-[#e7ece0] bg-gray-100 px-1 py-0.5 text-[0.7rem] font-bold text-[#76b900] shadow-sm"
+          {...props}
+        >
+          {text}
+        </sup>
+      );
+    }, sameChildren),
+
+    img: memo(
+      (props: any) => (
+        <MarkdownImage {...props} showDownload onDownloadError={onDownloadError} />
+      ),
+      sameSrc,
+    ),
+
+    video: memo((props: any) => <MarkdownVideo {...props} />, sameSrc),
+
+    details: memo(
+      ({ children, ...props }: any) => (
+        <details
+          className="my-2 rounded-md border border-neutral-300 bg-neutral-50 px-3 py-2 dark:border-neutral-700 dark:bg-neutral-900"
+          {...props}
+        >
+          {children}
+        </details>
+      ),
+      sameChildren,
+    ),
+
+    summary: memo(
+      ({ children, ...props }: any) => (
+        <summary className="cursor-pointer font-medium text-gray-700 dark:text-gray-200" {...props}>
+          {children}
+        </summary>
+      ),
+      sameChildren,
+    ),
+
+    // The agent wraps answers in <workflow> metadata that is not for the user.
+    workflow: memo(() => null, () => true),
+
+    'agent-think': memo(
+      ({ children, ...props }: any) => (
+        <AgentThink messageIsStreaming={messageIsStreaming} {...props}>
+          {children}
+        </AgentThink>
+      ),
+      (prev, next) =>
+        sameChildren(prev, next) && prev['data-streaming'] === next['data-streaming'],
+    ),
+
+    'agent-think-step': memo(
+      ({ children, ...props }: any) => (
+        <AgentThinkStep messageIsStreaming={messageIsStreaming} {...props}>
+          {children}
+        </AgentThinkStep>
+      ),
+      (prev, next) =>
+        sameChildren(prev, next) && prev['data-streaming'] === next['data-streaming'],
+    ),
+  };
+}

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/markdown/download.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/markdown/download.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Image download for agent-rendered media.
+ *
+ * Always goes through a Blob rather than `<a download>`: an anonymous download
+ * attribute is ignored for cross-origin hrefs, so the browser navigates away
+ * from the app instead of saving. VSS media comes from VST on another origin,
+ * which is exactly that case.
+ *
+ * Ported from the toolkit's `utils/media/download.ts`.
+ */
+/**
+ * Save a Blob under a chosen filename.
+ *
+ * Written out rather than pulling in `file-saver` (which ships no types) —
+ * every browser this app supports honours `download` for a blob: URL, which is
+ * the only case that reaches here.
+ */
+function saveAs(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.rel = 'noopener';
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  // Revoking synchronously can cancel the download in Safari.
+  setTimeout(() => URL.revokeObjectURL(url), 10_000);
+}
+
+function sanitizeFilename(name: string): string {
+  return name.replace(/[^\w\s.-]/g, '_').trim().slice(0, 100) || 'image';
+}
+
+function extensionFromDataUrl(src: string): string {
+  const match = /^data:image\/(\w+)/.exec(src);
+  if (!match) return 'png';
+  return match[1] === 'jpeg' ? 'jpg' : match[1];
+}
+
+function extensionFromUrl(src: string): string {
+  const pathname = src.split('?')[0]?.split('#')[0] ?? '';
+  const ext = pathname.split('.').pop()?.toLowerCase();
+  if (ext && ['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp'].includes(ext)) {
+    return ext === 'jpeg' ? 'jpg' : ext;
+  }
+  return 'jpg';
+}
+
+function mimeToExt(mime: string): string | null {
+  if (!mime || typeof mime !== 'string') return null;
+  if (mime.includes('jpeg')) return 'jpg';
+  if (mime.includes('png')) return 'png';
+  if (mime.includes('gif')) return 'gif';
+  if (mime.includes('webp')) return 'webp';
+  if (mime.includes('bmp')) return 'bmp';
+  return null;
+}
+
+/** Read bytes directly. Works same-origin, or cross-origin when CORS allows. */
+async function blobFromHttpUrl(url: string): Promise<Blob | null> {
+  // Two attempts because a proxy may require cookies while a public bucket
+  // rejects them; neither ordering works for both.
+  const attempts: RequestInit[] = [
+    { mode: 'cors', credentials: 'omit', cache: 'no-cache', redirect: 'follow' },
+    { mode: 'cors', credentials: 'include', cache: 'no-cache', redirect: 'follow' },
+  ];
+
+  for (const init of attempts) {
+    try {
+      const response = await fetch(url, init);
+      if (!response.ok) continue;
+      const blob = await response.blob();
+      if (blob.size > 0) return blob;
+    } catch {
+      // Try the next credential mode.
+    }
+  }
+  return null;
+}
+
+/**
+ * Fallback for when fetch cannot read bytes but the image still decodes:
+ * redraw it into a canvas. Needs the same CORS headers `<img crossOrigin>` does.
+ */
+function blobFromImageDecode(url: string): Promise<Blob | null> {
+  return new Promise((resolve) => {
+    const img = new window.Image();
+    img.crossOrigin = 'anonymous';
+    const timer = window.setTimeout(() => resolve(null), 45_000);
+    img.onload = () => {
+      window.clearTimeout(timer);
+      try {
+        const { naturalWidth: w, naturalHeight: h } = img;
+        if (!w || !h) return resolve(null);
+        const canvas = document.createElement('canvas');
+        canvas.width = w;
+        canvas.height = h;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) return resolve(null);
+        ctx.drawImage(img, 0, 0);
+        canvas.toBlob((b) => resolve(b ?? null), 'image/png', 0.92);
+      } catch {
+        resolve(null);
+      }
+    };
+    img.onerror = () => {
+      window.clearTimeout(timer);
+      resolve(null);
+    };
+    img.src = url;
+  });
+}
+
+export async function downloadImageFromUrl(src: string, filename?: string): Promise<void> {
+  if (!src || src === 'loading') throw new Error('Image is not ready to download');
+
+  const safeName = sanitizeFilename(filename || 'image');
+
+  if (src.startsWith('data:')) {
+    const blob = await (await fetch(src)).blob();
+    if (!blob?.size) throw new Error('Could not read image data');
+    saveAs(blob, `${safeName}.${mimeToExt(blob.type) ?? extensionFromDataUrl(src)}`);
+    return;
+  }
+
+  let blob = await blobFromHttpUrl(src);
+  let usedCanvas = false;
+  if (!blob) {
+    blob = await blobFromImageDecode(src);
+    usedCanvas = !!blob;
+  }
+  if (!blob?.size) {
+    throw new Error(
+      'Unable to save this image (browser blocked access). Ask your admin for CORS on media URLs.',
+    );
+  }
+
+  // The canvas path always re-encodes to PNG, whatever the source was.
+  const ext = usedCanvas
+    ? 'png'
+    : (mimeToExt(blob.type) ?? (/^https?:\/\//i.test(src) ? extensionFromUrl(src) : 'png'));
+  saveAs(blob, `${safeName}.${ext}`);
+}

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/markdown/streaming.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/markdown/streaming.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Repairs for markdown that is only half-written.
+ *
+ * A streamed answer is re-parsed on every token, so the parser routinely sees a
+ * tag that has been opened but not closed and an `<img src="` with no closing
+ * quote. Left alone, react-markdown renders the raw text of the broken tag and
+ * the message visibly flickers between garbage and content.
+ *
+ * Each repair swaps the incomplete fragment for a placeholder that renders
+ * cleanly, and marks the still-open element with `data-streaming="true"` so the
+ * component can show a spinner. Ported from the toolkit's `fixMalformedHtml`.
+ *
+ * Pure string functions, kept out of the components so they can be tested.
+ */
+
+const LOADING_IMG = '<img src="loading" alt="loading" style="max-width: 100%; height: 100%;" />';
+const LOADING_VIDEO =
+  '<video controls width="400" height="200"><source src="loading" type="video/mp4"></video>';
+
+/** `![alt](https://…` with no closing paren yet. */
+export function replaceMalformedMarkdownImages(str = ''): string {
+  return str.replace(/!\[.*?\]\(([^)]*)$/, LOADING_IMG);
+}
+
+/** `<img src="…` with no closing `>` yet. */
+export function replaceMalformedHtmlImages(str = ''): string {
+  return str.replace(/<img\s+[^>]*$/, LOADING_IMG);
+}
+
+/** `<video …` with no closing `>` yet. */
+export function replaceMalformedHtmlVideos(str = ''): string {
+  return str.replace(/<video\s+[^>]*$/, LOADING_VIDEO);
+}
+
+/**
+ * Balance an unclosed custom tag and flag the newest one as still streaming.
+ *
+ * Only the *last* unclosed opener is marked: earlier ones are complete as far
+ * as the reader is concerned, and marking them all would spin every step in the
+ * trace at once.
+ */
+function balanceTag(str: string, tag: string, notFollowedBy?: string): string {
+  const suffix = notFollowedBy ? `(?!${notFollowedBy})` : '';
+  // Clear stale markers first, so a tag that closed since the last frame stops
+  // claiming to be in flight.
+  str = str.replace(
+    new RegExp(`<${tag}([^>]*)\\s+data-streaming="true"([^>]*)>`, 'g'),
+    `<${tag}$1$2>`,
+  );
+
+  const openers: { index: number; fullTag: string }[] = [];
+  const openRegex = new RegExp(`<${tag}(\\s[^>]*)?>${suffix}`, 'g');
+  let match: RegExpExecArray | null;
+  while ((match = openRegex.exec(str)) !== null) {
+    openers.push({ index: match.index, fullTag: match[0] });
+  }
+
+  const closeRegex = new RegExp(`</${tag}>${suffix}`, 'g');
+  let closeCount = 0;
+  while (closeRegex.exec(str) !== null) closeCount += 1;
+
+  const incomplete = openers.length - closeCount;
+  if (incomplete <= 0 || !openers.length) return str;
+
+  const last = openers[openers.length - 1];
+  const marked = last.fullTag.replace(/>$/, ' data-streaming="true">');
+  return (
+    str.substring(0, last.index) +
+    marked +
+    str.substring(last.index + last.fullTag.length) +
+    Array(incomplete).fill(`</${tag}>`).join('')
+  );
+}
+
+export function handleIncompleteAgentThinkTags(str = ''): string {
+  // `-step` excluded so `<agent-think-step>` is not counted as `<agent-think>`.
+  return balanceTag(str, 'agent-think', '-step');
+}
+
+export function handleIncompleteAgentThinkStepTags(str = ''): string {
+  return balanceTag(str, 'agent-think-step');
+}
+
+export function fixMalformedHtml(content = ''): string {
+  try {
+    let fixed = replaceMalformedHtmlImages(content);
+    fixed = replaceMalformedHtmlVideos(fixed);
+    fixed = replaceMalformedMarkdownImages(fixed);
+    fixed = handleIncompleteAgentThinkTags(fixed);
+    fixed = handleIncompleteAgentThinkStepTags(fixed);
+    return fixed;
+  } catch {
+    return content;
+  }
+}

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/sse.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/sse.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Parser for the BYO agent SSE contract.
+ *
+ * The stream carries three kinds of line:
+ *
+ *   data: {"choices":[{"delta":{"content":"..."}}]}   assistant text
+ *   data: [DONE]                                      terminal
+ *   intermediate_data: {...}                          tool/skill progress
+ *   : keepalive                                       comment, ignored
+ *
+ * Content is read from several shapes because backends differ: OpenAI-style
+ * `choices[0].delta.content` and `choices[0].message.content`, plus the plain
+ * `value` / `output` / `answer` fields some agent servers return.
+ *
+ * Kept free of React so it can be unit tested directly, which matters — this is
+ * the one piece where a silent mistake shows up as "the agent said nothing".
+ */
+
+import type { ChatStep } from './types';
+
+export type SseEvent =
+  | { kind: 'token'; text: string }
+  | { kind: 'step'; step: ChatStep }
+  | { kind: 'done' };
+
+const CONTENT_PATHS = ['value', 'output', 'answer'] as const;
+
+/** Pull assistant text out of one parsed `data:` payload. */
+export function extractContent(parsed: unknown): string {
+  if (typeof parsed === 'string') return parsed;
+  if (!parsed || typeof parsed !== 'object') return '';
+  const obj = parsed as Record<string, any>;
+
+  const choice = Array.isArray(obj.choices) ? obj.choices[0] : undefined;
+  const fromChoice = choice?.delta?.content ?? choice?.message?.content;
+  if (typeof fromChoice === 'string') return fromChoice;
+
+  for (const path of CONTENT_PATHS) {
+    if (typeof obj[path] === 'string') return obj[path];
+  }
+  return '';
+}
+
+/**
+ * Incremental SSE reader.
+ *
+ * Feed it decoded chunks; it holds a partial trailing line between calls, since
+ * a chunk boundary can land mid-line.
+ */
+export class SseParser {
+  private buffer = '';
+  private stepIndex = 0;
+
+  feed(chunk: string): SseEvent[] {
+    this.buffer += chunk;
+    const lines = this.buffer.split('\n');
+    // The last element is either an incomplete line or '' — keep it for later.
+    this.buffer = lines.pop() ?? '';
+
+    const events: SseEvent[] = [];
+    for (const raw of lines) {
+      const line = raw.trimEnd();
+      if (!line || line.startsWith(':')) continue; // blank or keepalive comment
+
+      if (line.startsWith('data: ')) {
+        const payload = line.slice(6).trim();
+        if (payload === '[DONE]') {
+          events.push({ kind: 'done' });
+          continue;
+        }
+        let text = '';
+        try {
+          text = extractContent(JSON.parse(payload));
+        } catch {
+          // Not JSON: some backends stream bare text after `data: `.
+          text = payload;
+        }
+        if (text) events.push({ kind: 'token', text });
+        continue;
+      }
+
+      if (line.startsWith('intermediate_data: ')) {
+        const step = this.parseStep(line.slice('intermediate_data: '.length));
+        if (step) events.push({ kind: 'step', step });
+      }
+    }
+    return events;
+  }
+
+  private parseStep(payload: string): ChatStep | null {
+    try {
+      const d = JSON.parse(payload) as Record<string, any>;
+      const status = d.status === 'complete' || d.status === 'error' ? d.status : 'in_progress';
+      return {
+        id: String(d.id ?? this.stepIndex),
+        name: String(d.name ?? d.content?.name ?? 'step'),
+        status,
+        payload:
+          typeof d.payload === 'string'
+            ? d.payload
+            : typeof d.content?.payload === 'string'
+              ? d.content.payload
+              : undefined,
+        index: this.stepIndex++,
+      };
+    } catch {
+      return null;
+    }
+  }
+}

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/sse.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/sse.ts
@@ -2,11 +2,13 @@
 /**
  * Parser for the BYO agent SSE contract.
  *
- * The stream carries three kinds of line:
+ * The stream carries these kinds of line:
  *
  *   data: {"choices":[{"delta":{"content":"..."}}]}   assistant text
  *   data: [DONE]                                      terminal
  *   intermediate_data: {...}                          tool/skill progress
+ *   error_data: {...}                                 turn-level failure
+ *   interaction_data: {...}                           agent needs user input
  *   : keepalive                                       comment, ignored
  *
  * Content is read from several shapes because backends differ: OpenAI-style
@@ -19,9 +21,20 @@
 
 import type { ChatStep } from './types';
 
+export interface InteractionRequest {
+  id: string;
+  prompt: string;
+  inputType: 'text' | 'oauth' | 'binary';
+  /** Present for `oauth`: the consent URL to open. */
+  url?: string;
+  options?: string[];
+}
+
 export type SseEvent =
   | { kind: 'token'; text: string }
   | { kind: 'step'; step: ChatStep }
+  | { kind: 'error'; message: string }
+  | { kind: 'interaction'; request: InteractionRequest }
   | { kind: 'done' };
 
 const CONTENT_PATHS = ['value', 'output', 'answer'] as const;
@@ -43,6 +56,34 @@ export function extractContent(parsed: unknown): string {
 }
 
 /**
+ * Assemble a flat list of steps into the tree their `parentId`s describe.
+ *
+ * Steps arrive in completion order, not tree order, and a child can land
+ * before its parent. Orphans are kept at the root rather than dropped, because
+ * losing a step silently is worse than showing it at the wrong depth.
+ */
+export function buildStepTree(steps: ChatStep[]): ChatStep[] {
+  const byId = new Map<string, ChatStep>();
+  for (const step of steps) byId.set(step.id, { ...step, children: [] });
+
+  const roots: ChatStep[] = [];
+  for (const step of steps) {
+    const node = byId.get(step.id)!;
+    const parent = step.parentId ? byId.get(step.parentId) : undefined;
+    if (parent && parent !== node) parent.children!.push(node);
+    else roots.push(node);
+  }
+  return roots;
+}
+
+const PREFIXES = {
+  data: 'data: ',
+  step: 'intermediate_data: ',
+  error: 'error_data: ',
+  interaction: 'interaction_data: ',
+} as const;
+
+/**
  * Incremental SSE reader.
  *
  * Feed it decoded chunks; it holds a partial trailing line between calls, since
@@ -53,7 +94,9 @@ export class SseParser {
   private stepIndex = 0;
 
   feed(chunk: string): SseEvent[] {
-    this.buffer += chunk;
+    // Normalise CRLF first: a proxy that rewrites line endings would otherwise
+    // leave a stray \r on every payload and break JSON.parse.
+    this.buffer += chunk.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
     const lines = this.buffer.split('\n');
     // The last element is either an incomplete line or '' — keep it for later.
     this.buffer = lines.pop() ?? '';
@@ -63,8 +106,8 @@ export class SseParser {
       const line = raw.trimEnd();
       if (!line || line.startsWith(':')) continue; // blank or keepalive comment
 
-      if (line.startsWith('data: ')) {
-        const payload = line.slice(6).trim();
+      if (line.startsWith(PREFIXES.data)) {
+        const payload = line.slice(PREFIXES.data.length).trim();
         if (payload === '[DONE]') {
           events.push({ kind: 'done' });
           continue;
@@ -80,9 +123,21 @@ export class SseParser {
         continue;
       }
 
-      if (line.startsWith('intermediate_data: ')) {
-        const step = this.parseStep(line.slice('intermediate_data: '.length));
+      if (line.startsWith(PREFIXES.step)) {
+        const step = this.parseStep(line.slice(PREFIXES.step.length));
         if (step) events.push({ kind: 'step', step });
+        continue;
+      }
+
+      if (line.startsWith(PREFIXES.error)) {
+        const message = this.parseError(line.slice(PREFIXES.error.length));
+        if (message) events.push({ kind: 'error', message });
+        continue;
+      }
+
+      if (line.startsWith(PREFIXES.interaction)) {
+        const request = this.parseInteraction(line.slice(PREFIXES.interaction.length));
+        if (request) events.push({ kind: 'interaction', request });
       }
     }
     return events;
@@ -92,6 +147,7 @@ export class SseParser {
     try {
       const d = JSON.parse(payload) as Record<string, any>;
       const status = d.status === 'complete' || d.status === 'error' ? d.status : 'in_progress';
+      const parentId = d.parent_id ?? d.parentId;
       return {
         id: String(d.id ?? this.stepIndex),
         name: String(d.name ?? d.content?.name ?? 'step'),
@@ -102,7 +158,44 @@ export class SseParser {
             : typeof d.content?.payload === 'string'
               ? d.content.payload
               : undefined,
-        index: this.stepIndex++,
+        index: typeof d.index === 'number' ? d.index : this.stepIndex++,
+        parentId: parentId == null ? undefined : String(parentId),
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private parseError(payload: string): string | null {
+    try {
+      const d = JSON.parse(payload) as Record<string, any>;
+      const message = d.message ?? d.error ?? d.content?.text ?? d.content;
+      return typeof message === 'string' ? message : JSON.stringify(d);
+    } catch {
+      return payload.trim() || null;
+    }
+  }
+
+  private parseInteraction(payload: string): InteractionRequest | null {
+    try {
+      const d = JSON.parse(payload) as Record<string, any>;
+      const content = d.content ?? d;
+      const rawType = String(content.input_type ?? content.inputType ?? 'text');
+      const url = content.oauth_url ?? content.redirect_url ?? content.url;
+      const inputType: InteractionRequest['inputType'] =
+        rawType === 'oauth_consent' || rawType === 'oauth'
+          ? 'oauth'
+          : rawType === 'binary_choice' || rawType === 'binary'
+            ? 'binary'
+            : 'text';
+      return {
+        id: String(d.id ?? `interaction-${this.stepIndex}`),
+        prompt: String(content.text ?? content.prompt ?? 'The agent needs your input.'),
+        inputType,
+        url: typeof url === 'string' ? url : undefined,
+        options: Array.isArray(content.options)
+          ? content.options.map((o: unknown) => String(o))
+          : undefined,
       };
     } catch {
       return null;

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/storage.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/storage.ts
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Conversation persistence.
+ *
+ * Ported from the toolkit's `utils/app/conversationDb.ts`, including the part
+ * that is easy to miss: conversations live in IndexedDB but are *scoped to the
+ * lifetime of a browser tab*. Every key is tagged with a per-tab id kept in
+ * sessionStorage (which dies with the tab); on startup a BroadcastChannel
+ * discovers which tab ids are still live and sweeps the rest. That reproduces
+ * sessionStorage's wipe semantics — survives reload, cleared on tab close and
+ * on browser restart — while allowing payloads far larger than sessionStorage
+ * would hold.
+ *
+ * Dropping this and using plain sessionStorage would look identical until a
+ * conversation with a few base64 frames in it blew the 5 MB quota.
+ */
+import { openDB, type IDBPDatabase } from 'idb';
+
+import type { Conversation } from './types';
+
+const DB_NAME = 'vss-chat';
+const DB_VERSION = 1;
+const STORE_NAME = 'conversations';
+
+const TAB_SESSION_STORAGE_KEY = 'vss-chat-tab-session';
+const TAB_KEY_SEPARATOR = '__';
+const BROADCAST_CHANNEL_NAME = 'vss-chat-tab-presence';
+const ORPHAN_CLEANUP_DISCOVERY_MS = 300;
+
+let dbPromise: Promise<IDBPDatabase> | null = null;
+let lifecycleInitialized = false;
+
+function getDb(): Promise<IDBPDatabase> {
+  if (!dbPromise) {
+    dbPromise = openDB(DB_NAME, DB_VERSION, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          db.createObjectStore(STORE_NAME);
+        }
+      },
+    });
+  }
+  return dbPromise;
+}
+
+function getTabSessionId(): string {
+  if (typeof window === 'undefined') return 'ssr';
+  try {
+    let id = window.sessionStorage.getItem(TAB_SESSION_STORAGE_KEY);
+    if (!id) {
+      id = `tab_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+      window.sessionStorage.setItem(TAB_SESSION_STORAGE_KEY, id);
+    }
+    return id;
+  } catch {
+    return 'ssr';
+  }
+}
+
+/** `<tabId>__<prefix>_<base>` — the prefix is what separates two panels. */
+export function storeKey(base: string, prefix?: string | null): string {
+  const userPrefix = prefix ? `${prefix}_` : '';
+  return `${getTabSessionId()}${TAB_KEY_SEPARATOR}${userPrefix}${base}`;
+}
+
+export async function saveConversations(
+  conversations: Conversation[],
+  prefix?: string | null,
+): Promise<void> {
+  const db = await getDb();
+  await db.put(STORE_NAME, conversations, storeKey('conversationHistory', prefix));
+}
+
+export async function loadConversations(prefix?: string | null): Promise<Conversation[]> {
+  const db = await getDb();
+  const data = await db.get(STORE_NAME, storeKey('conversationHistory', prefix));
+  return (data as Conversation[]) ?? [];
+}
+
+export async function saveSelectedConversationId(
+  id: string | null,
+  prefix?: string | null,
+): Promise<void> {
+  const db = await getDb();
+  await db.put(STORE_NAME, id, storeKey('selectedConversationId', prefix));
+}
+
+export async function loadSelectedConversationId(
+  prefix?: string | null,
+): Promise<string | null> {
+  const db = await getDb();
+  return ((await db.get(STORE_NAME, storeKey('selectedConversationId', prefix))) as string) ?? null;
+}
+
+export async function clearAllConversations(prefix?: string | null): Promise<void> {
+  const db = await getDb();
+  await db.delete(STORE_NAME, storeKey('conversationHistory', prefix));
+  await db.delete(STORE_NAME, storeKey('selectedConversationId', prefix));
+}
+
+function extractTabIdFromKey(key: unknown): string | null {
+  if (typeof key !== 'string') return null;
+  const sepIdx = key.indexOf(TAB_KEY_SEPARATOR);
+  return sepIdx <= 0 ? null : key.substring(0, sepIdx);
+}
+
+async function deleteKeysForTabIds(shouldDelete: (id: string) => boolean): Promise<void> {
+  const db = await getDb();
+  const keys = await db.getAllKeys(STORE_NAME);
+  if (!keys?.length) return;
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  const store = tx.objectStore(STORE_NAME);
+  const deletions: Promise<void>[] = [];
+  for (const key of keys) {
+    const tabId = extractTabIdFromKey(key);
+    // Untagged keys predate the per-tab namespacing and are stale by definition.
+    if (tabId === null || shouldDelete(tabId)) {
+      deletions.push(store.delete(key as IDBValidKey));
+    }
+  }
+  await Promise.all(deletions);
+  await tx.done;
+}
+
+async function discoverLiveTabIds(currentTabId: string): Promise<Set<string>> {
+  const liveTabIds = new Set<string>([currentTabId]);
+  if (typeof BroadcastChannel === 'undefined') return liveTabIds;
+
+  const channel = new BroadcastChannel(BROADCAST_CHANNEL_NAME);
+  channel.onmessage = (event: MessageEvent) => {
+    const data = event.data;
+    if (!data || typeof data !== 'object') return;
+    if (data.type === 'announce' && typeof data.tabId === 'string') {
+      liveTabIds.add(data.tabId);
+    } else if (data.type === 'request-presence') {
+      try {
+        channel.postMessage({ type: 'announce', tabId: currentTabId });
+      } catch {
+        // Channel closed because the tab is unloading.
+      }
+    }
+  };
+
+  try {
+    channel.postMessage({ type: 'request-presence' });
+    channel.postMessage({ type: 'announce', tabId: currentTabId });
+  } catch {
+    // Best effort: without replies we only keep this tab's keys.
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, ORPHAN_CLEANUP_DISCOVERY_MS));
+  return liveTabIds;
+}
+
+/**
+ * Call once on mount. Sweeps keys belonging to tabs that are no longer open,
+ * and registers a pagehide handler to drop this tab's keys on close.
+ */
+export function initConversationSessionLifecycle(): void {
+  if (typeof window === 'undefined' || lifecycleInitialized) return;
+  lifecycleInitialized = true;
+
+  const currentTabId = getTabSessionId();
+
+  void (async () => {
+    try {
+      const liveTabIds = await discoverLiveTabIds(currentTabId);
+      await deleteKeysForTabIds((tabId) => !liveTabIds.has(tabId));
+    } catch (error) {
+      console.warn('vss-chat: could not sweep orphaned conversations', error);
+    }
+  })();
+
+  window.addEventListener('pagehide', () => {
+    // Fire and forget — the orphan sweep on next load is the safety net.
+    deleteKeysForTabIds((tabId) => tabId === currentTabId).catch(() => {});
+  });
+}
+
+export function __resetStorageForTests(): void {
+  lifecycleInitialized = false;
+  dbPromise = null;
+}

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/types.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/types.ts
@@ -48,7 +48,11 @@ export interface ChatEndpointConfig {
  * package knowing anything about them. Returning true means the handler
  * consumed the answer.
  */
-export type ChatAnswerHandler = (answer: string) => boolean | void;
+export type ChatAnswerHandler = (
+  answer: string,
+  /** Scopes any per-conversation artifact the consumer fetches for this answer. */
+  conversationId: string,
+) => boolean | void;
 
 export interface ChatPanelProps {
   endpoint: Omit<ChatEndpointConfig, 'conversationId'> & {

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/types.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/types.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Types for the VSS chat interface.
+ *
+ * This package deliberately has no dependency on the NeMo Agent Toolkit UI.
+ * It speaks the BYO agent contract directly: an OpenAI-shaped request in,
+ * Server-Sent Events out. Any backend implementing that contract works here.
+ */
+
+export type ChatRole = 'user' | 'assistant';
+
+/** One tool/skill step reported by the agent while it works. */
+export interface ChatStep {
+  id: string;
+  name: string;
+  status: 'in_progress' | 'complete' | 'error';
+  /** Raw detail, shown only when the step is expanded. */
+  payload?: string;
+  index: number;
+}
+
+export interface ChatMessage {
+  id: string;
+  role: ChatRole;
+  content: string;
+  /** Populated for assistant messages that reported tool activity. */
+  steps?: ChatStep[];
+  /** True while tokens are still arriving. */
+  streaming?: boolean;
+  error?: string;
+}
+
+/** Everything the panel needs to reach a backend. */
+export interface ChatEndpointConfig {
+  /** e.g. http://172.19.0.1:9098/chat/stream */
+  url: string;
+  /** Sent as Conversation-Id; the adapter maps it to one agent session. */
+  conversationId: string;
+  /** Merged into the request body (the UI's custom agent params). */
+  extraParams?: Record<string, string | number | boolean>;
+  headers?: Record<string, string>;
+}
+
+/**
+ * Called with each completed assistant answer.
+ *
+ * This is how feature tabs (search, alerts) receive results without the chat
+ * package knowing anything about them. Returning true means the handler
+ * consumed the answer.
+ */
+export type ChatAnswerHandler = (answer: string) => boolean | void;
+
+export interface ChatPanelProps {
+  endpoint: Omit<ChatEndpointConfig, 'conversationId'> & {
+    conversationId?: string;
+  };
+  title?: string;
+  /** Light surface against a dark app, or vice versa. */
+  theme?: 'light' | 'dark';
+  placeholder?: string;
+  /** Show the tool-step disclosure. */
+  showSteps?: boolean;
+  /** Notified with each finished assistant answer. */
+  onAnswer?: ChatAnswerHandler;
+  /** Notified when the user sends, so tabs can clear stale results. */
+  onSubmit?: (message: string) => void;
+  className?: string;
+}

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/types.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/types.ts
@@ -5,11 +5,23 @@
  * This package deliberately has no dependency on the NeMo Agent Toolkit UI.
  * It speaks the BYO agent contract directly: an OpenAI-shaped request in,
  * Server-Sent Events out. Any backend implementing that contract works here.
+ *
+ * The shapes below mirror the toolkit's `types/chat.ts` closely enough that a
+ * feature ported from there behaves the same, without importing it.
  */
+
+import type { FileUploadResult } from 'common';
 
 export type ChatRole = 'user' | 'assistant';
 
-/** One tool/skill step reported by the agent while it works. */
+/**
+ * One tool/skill step reported by the agent while it works.
+ *
+ * `children` makes this a tree: the toolkit nests steps by `parent_id` and
+ * renders the result as a `<details>` cascade. We keep the tree structured and
+ * render it as React instead of serialising to HTML and re-parsing it, which is
+ * where the toolkit's version leaks (half-written tags mid-stream).
+ */
 export interface ChatStep {
   id: string;
   name: string;
@@ -17,6 +29,18 @@ export interface ChatStep {
   /** Raw detail, shown only when the step is expanded. */
   payload?: string;
   index: number;
+  parentId?: string;
+  children?: ChatStep[];
+}
+
+/** Parent-provided renderable HTML shown under an assistant response. */
+export type CallerInfo = string;
+
+export interface ChatAttachment {
+  /** data: URL. Images only, matching the toolkit. */
+  content: string;
+  type: 'image';
+  name?: string;
 }
 
 export interface ChatMessage {
@@ -28,31 +52,139 @@ export interface ChatMessage {
   /** True while tokens are still arriving. */
   streaming?: boolean;
   error?: string;
+  attachments?: ChatAttachment[];
+  /** Sent to the agent but never rendered (upload auto-prompts). */
+  hidden?: boolean;
+  /**
+   * Conversation active when an upload batch started. Used to drop a stale
+   * auto-prompt if the user switched conversations mid-upload.
+   */
+  uploadConversationId?: string;
+  /** HTML card rendered under an assistant answer, supplied by the embedder. */
+  callerInfo?: CallerInfo;
+  timestamp?: number;
+}
+
+/** A named thread of messages. Mirrors the toolkit's `Conversation`. */
+export interface Conversation {
+  id: string;
+  name: string;
+  messages: ChatMessage[];
+}
+
+/**
+ * UI-only chip attached to the next message.
+ *
+ * `contextType` drives the chip icon and is never sent to the backend — only
+ * `data` is, inside the `[Context: …]` prefix. Same contract as the toolkit's
+ * `QueryDataContext`, so the Search tab's existing `addChatQueryContext` calls
+ * work unchanged.
+ */
+export interface QueryDataContext {
+  id: string;
+  label: string;
+  contextType: string;
+  data: Record<string, unknown>;
 }
 
 /** Everything the panel needs to reach a backend. */
 export interface ChatEndpointConfig {
-  /** e.g. http://172.19.0.1:9098/chat/stream */
+  /** e.g. /api/vss-chat?surface=sidebar */
   url: string;
   /** Sent as Conversation-Id; the adapter maps it to one agent session. */
   conversationId: string;
   /** Merged into the request body (the UI's custom agent params). */
   extraParams?: Record<string, string | number | boolean>;
   headers?: Record<string, string>;
+  /** Base URL for chunked video upload; enables the upload button when set. */
+  uploadUrlBase?: string;
 }
 
 /**
  * Called with each completed assistant answer.
  *
  * This is how feature tabs (search, alerts) receive results without the chat
- * package knowing anything about them. Returning true means the handler
- * consumed the answer.
+ * package knowing anything about them. Returning a string renders it as the
+ * message's caller-info card, matching the toolkit's `onAnswerCompleteWithContent`.
  */
 export type ChatAnswerHandler = (
   answer: string,
   /** Scopes any per-conversation artifact the consumer fetches for this answer. */
   conversationId: string,
-) => boolean | void;
+) => CallerInfo | boolean | void;
+
+/**
+ * Payload for a finished upload batch.
+ *
+ * `FileUploadResult` is re-used from `common` rather than widened to a plain
+ * record: the app's existing upload-complete handlers are typed against it, and
+ * a looser type here would fail to assign at the call site.
+ */
+export interface ChatVideoUploadCompletePayload {
+  results: { filename: string; result: FileUploadResult }[];
+}
+
+/** Handlers handed to an embedder that renders conversation controls itself. */
+export interface ChatSidebarControlHandlers {
+  conversations: Conversation[];
+  filteredConversations: Conversation[];
+  selectedConversationId: string | null;
+  searchTerm: string;
+  onSearchTermChange: (term: string) => void;
+  onSelectConversation: (id: string) => void;
+  onNewConversation: () => void;
+  onRenameConversation: (id: string, name: string) => void;
+  onDeleteConversation: (id: string) => void;
+  onClearConversations: () => void;
+  onExportData: () => void;
+  onImportConversations: (data: unknown) => void;
+  /** True while a turn is in flight; controls are disabled. */
+  busy: boolean;
+}
+
+/** A field in the agent-parameters panel, parsed from the deployment's JSON. */
+export type ParamType = 'string' | 'number' | 'boolean' | 'select';
+
+export interface ParamFieldConfig {
+  name: string;
+  label: string;
+  type: ParamType;
+  'default-value': string | number | boolean;
+  options?: string[];
+  /** false = shown but read-only. */
+  changeable?: boolean;
+  'tooltip-info'?: string;
+}
+
+export interface ParamField extends ParamFieldConfig {
+  id: string;
+  value: string | number | boolean;
+}
+
+export type CustomAgentParamsValues = Record<string, string | number | boolean>;
+
+/** Feature switches, mirroring the toolkit's NEXT_PUBLIC_CHAT_* env flags. */
+export interface ChatFeatureFlags {
+  /** Send the whole thread rather than just the latest turn. */
+  chatHistory?: boolean;
+  /** Show the tool-step disclosure. */
+  intermediateSteps?: boolean;
+  /** Expand intermediate steps by default. */
+  expandIntermediateSteps?: boolean;
+  messageCopy?: boolean;
+  messageEdit?: boolean;
+  messageSpeaker?: boolean;
+  /** Show the mic button (browser SpeechRecognition). */
+  inputMic?: boolean;
+  /** Show the video upload button and welcome drop zone. */
+  uploadFile?: boolean;
+  /** Collect per-file metadata in the upload dialog. */
+  uploadFileMetadata?: boolean;
+  /** Show the theme toggle in the header menu. */
+  themeToggle?: boolean;
+  /** Show the conversation controls the panel owns (header menu). */
+  headerMenu?: boolean;
+}
 
 export interface ChatPanelProps {
   endpoint: Omit<ChatEndpointConfig, 'conversationId'> & {
@@ -61,12 +193,43 @@ export interface ChatPanelProps {
   title?: string;
   /** Light surface against a dark app, or vice versa. */
   theme?: 'light' | 'dark';
+  onThemeChange?: (theme: 'light' | 'dark') => void;
   placeholder?: string;
-  /** Show the tool-step disclosure. */
+  /** @deprecated use `features.intermediateSteps` */
   showSteps?: boolean;
+  features?: ChatFeatureFlags;
+  /** JSON describing the agent-parameter fields; from NEXT_PUBLIC_CHAT_API_CUSTOM_AGENT_PARAMS_JSON. */
+  customAgentParamsJson?: string;
+  /** JSON template for the upload dialog's metadata fields. */
+  uploadConfigTemplateJson?: string;
+  /** Auto-prompt sent after a successful upload; `{filenames}` is substituted. */
+  uploadHiddenMessageTemplate?: string;
+  /**
+   * Separates this instance's persisted conversations from another's, exactly
+   * as the toolkit's prop of the same name does.
+   */
+  storageKeyPrefix?: string;
+  /** False while the surface is hidden; suppresses autoscroll work. */
+  isActive?: boolean;
+
   /** Notified with each finished assistant answer. */
   onAnswer?: ChatAnswerHandler;
+  /** Notified when a turn finishes, without the content. */
+  onAnswerComplete?: () => void;
   /** Notified when the user sends, so tabs can clear stale results. */
   onSubmit?: (message: string) => void;
+  /** Receives a function the embedder can call to submit a message itself. */
+  onSubmitMessageReady?: (submit: (message: string) => void) => void;
+  /** Notified when a message was submitted programmatically. */
+  onMessageSubmitted?: () => void;
+  /** Receives a function the embedder can call to add a context chip. */
+  onAddQueryContextReady?: (add: (item: QueryDataContext) => void) => void;
+  /** Notified when an upload batch finishes with at least one success. */
+  onChatVideoUploadComplete?: (payload: ChatVideoUploadCompletePayload) => void;
+  /** Notified whenever a turn starts or ends. */
+  onBusyChange?: (busy: boolean) => void;
+  /** Receives conversation controls so an external sidebar can render them. */
+  onControlsReady?: (handlers: ChatSidebarControlHandlers) => void;
+
   className?: string;
 }

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/useChatStream.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/useChatStream.ts
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+import { useCallback, useRef, useState } from 'react';
+
+import { SseParser } from './sse';
+import type { ChatEndpointConfig, ChatMessage, ChatStep } from './types';
+
+let seq = 0;
+const nextId = () => `m${Date.now().toString(36)}-${seq++}`;
+
+export interface UseChatStreamResult {
+  messages: ChatMessage[];
+  busy: boolean;
+  send: (text: string) => Promise<void>;
+  abort: () => void;
+  reset: () => void;
+}
+
+/**
+ * Drives one conversation against a BYO agent backend.
+ *
+ * Posts the OpenAI-shaped body the contract expects and consumes the SSE
+ * response, appending tokens to the in-flight assistant message and collecting
+ * tool steps alongside it.
+ */
+export function useChatStream(
+  endpoint: ChatEndpointConfig,
+  onAnswer?: (answer: string) => void,
+): UseChatStreamResult {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [busy, setBusy] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const abort = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setBusy(false);
+  }, []);
+
+  const reset = useCallback(() => {
+    abort();
+    setMessages([]);
+  }, [abort]);
+
+  const send = useCallback(
+    async (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed || busy) return;
+
+      const history = messages
+        .filter((m) => !m.error)
+        .map((m) => ({ role: m.role, content: m.content }));
+
+      const userMsg: ChatMessage = { id: nextId(), role: 'user', content: trimmed };
+      const replyId = nextId();
+      setMessages((prev) => [
+        ...prev,
+        userMsg,
+        { id: replyId, role: 'assistant', content: '', steps: [], streaming: true },
+      ]);
+      setBusy(true);
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      const patchReply = (fn: (m: ChatMessage) => ChatMessage) =>
+        setMessages((prev) => prev.map((m) => (m.id === replyId ? fn(m) : m)));
+
+      let answer = '';
+      try {
+        const res = await fetch(endpoint.url, {
+          method: 'POST',
+          signal: controller.signal,
+          headers: {
+            'Content-Type': 'application/json',
+            'Conversation-Id': endpoint.conversationId,
+            ...(endpoint.headers ?? {}),
+          },
+          body: JSON.stringify({
+            messages: [...history, { role: 'user', content: trimmed }],
+            ...(endpoint.extraParams ?? {}),
+          }),
+        });
+
+        if (!res.ok) throw new Error(`backend returned HTTP ${res.status}`);
+        if (!res.body) throw new Error('backend returned no response body');
+
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        const parser = new SseParser();
+        const steps: ChatStep[] = [];
+
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          for (const ev of parser.feed(decoder.decode(value, { stream: true }))) {
+            if (ev.kind === 'token') {
+              answer += ev.text;
+              patchReply((m) => ({ ...m, content: answer }));
+            } else if (ev.kind === 'step') {
+              // Steps arrive keyed by id; a later frame updates an earlier step.
+              const at = steps.findIndex((s) => s.id === ev.step.id);
+              if (at >= 0) steps[at] = ev.step;
+              else steps.push(ev.step);
+              patchReply((m) => ({ ...m, steps: [...steps] }));
+            } else {
+              patchReply((m) => ({ ...m, streaming: false }));
+            }
+          }
+        }
+        patchReply((m) => ({ ...m, content: answer, streaming: false }));
+        if (answer) onAnswer?.(answer);
+      } catch (err) {
+        const aborted = err instanceof DOMException && err.name === 'AbortError';
+        patchReply((m) => ({
+          ...m,
+          streaming: false,
+          error: aborted ? 'cancelled' : err instanceof Error ? err.message : String(err),
+        }));
+      } finally {
+        abortRef.current = null;
+        setBusy(false);
+      }
+    },
+    [busy, endpoint, messages, onAnswer],
+  );
+
+  return { messages, busy, send, abort, reset };
+}

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/useChatStream.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/useChatStream.ts
@@ -1,18 +1,68 @@
 // SPDX-License-Identifier: MIT
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { SseParser } from './sse';
-import type { ChatEndpointConfig, ChatMessage, ChatStep } from './types';
+import { SseParser, type InteractionRequest } from './sse';
+import type {
+  CallerInfo,
+  ChatEndpointConfig,
+  ChatMessage,
+  ChatStep,
+  QueryDataContext,
+} from './types';
 
 let seq = 0;
-const nextId = () => `m${Date.now().toString(36)}-${seq++}`;
+export const nextId = (): string => `m${Date.now().toString(36)}-${seq++}`;
+
+export interface SendOptions {
+  /** Drop this many trailing messages first — regenerate (1) and edit (n). */
+  deleteCount?: number;
+  /** Sent to the agent but never rendered. */
+  hidden?: boolean;
+  /** Conversation that was active when an upload started. */
+  uploadConversationId?: string;
+  /** Merged into the request body for this turn. */
+  params?: Record<string, string | number | boolean>;
+  /** Chips to fold into the message as a `[Context: …]` prefix. */
+  context?: QueryDataContext[];
+}
+
+export interface UseChatStreamOptions {
+  messages: ChatMessage[];
+  setMessages: (updater: (prev: ChatMessage[]) => ChatMessage[]) => void;
+  /** Send the whole thread rather than only the latest turn. */
+  chatHistory?: boolean;
+  /** Returning a string renders it as the answer's caller-info card. */
+  onAnswer?: (answer: string) => CallerInfo | boolean | void;
+  onAnswerComplete?: () => void;
+  onBusyChange?: (busy: boolean) => void;
+  /** Called when the turn's conversation is no longer the selected one. */
+  isConversationStale?: (uploadConversationId: string) => boolean;
+}
 
 export interface UseChatStreamResult {
-  messages: ChatMessage[];
   busy: boolean;
-  send: (text: string) => Promise<void>;
+  send: (text: string, options?: SendOptions) => Promise<void>;
   abort: () => void;
-  reset: () => void;
+  interaction: InteractionRequest | null;
+  dismissInteraction: () => void;
+}
+
+/**
+ * Turn context chips into the prefix the backend sees.
+ *
+ * Only `data` crosses the wire: `id`, `label` and `contextType` exist for the
+ * chip UI. `contextType` is stripped even if a caller duplicated it inside
+ * `data`, matching the toolkit's Chat.tsx exactly — the agent prompt is written
+ * against that shape.
+ */
+export function buildContextPrefix(items: QueryDataContext[]): string {
+  if (!items.length) return '';
+  const payload = items.map(({ data }) => {
+    const rest: Record<string, unknown> = { ...(data as Record<string, unknown>) };
+    delete rest.contextType;
+    return rest;
+  });
+  return `[Context: ${JSON.stringify(payload)}]`;
 }
 
 /**
@@ -24,40 +74,80 @@ export interface UseChatStreamResult {
  */
 export function useChatStream(
   endpoint: ChatEndpointConfig,
-  onAnswer?: (answer: string) => void,
+  options: UseChatStreamOptions,
 ): UseChatStreamResult {
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const { messages, setMessages, chatHistory = true } = options;
   const [busy, setBusy] = useState(false);
+  const [interaction, setInteraction] = useState<InteractionRequest | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+
+  // Callbacks and message state are read through refs so `send` stays stable:
+  // it is handed to embedders via onSubmitMessageReady, and a new identity on
+  // every token would make them re-register mid-stream.
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+  const messagesRef = useRef(messages);
+  messagesRef.current = messages;
+  const endpointRef = useRef(endpoint);
+  endpointRef.current = endpoint;
+  const busyRef = useRef(false);
+
+  useEffect(() => {
+    optionsRef.current.onBusyChange?.(busy);
+  }, [busy]);
+
+  const setBusyBoth = useCallback((value: boolean) => {
+    busyRef.current = value;
+    setBusy(value);
+  }, []);
 
   const abort = useCallback(() => {
     abortRef.current?.abort();
     abortRef.current = null;
-    setBusy(false);
-  }, []);
+    setBusyBoth(false);
+  }, [setBusyBoth]);
 
-  const reset = useCallback(() => {
-    abort();
-    setMessages([]);
-  }, [abort]);
+  // Abandon an in-flight turn if the panel unmounts, so the reader loop does
+  // not keep writing into a dead component.
+  useEffect(() => () => abortRef.current?.abort(), []);
 
   const send = useCallback(
-    async (text: string) => {
-      const trimmed = text.trim();
-      if (!trimmed || busy) return;
+    async (text: string, sendOptions: SendOptions = {}) => {
+      const { deleteCount = 0, hidden, uploadConversationId, params, context = [] } = sendOptions;
 
-      const history = messages
+      const prefix = buildContextPrefix(context);
+      const body = prefix ? (text.trim() ? `${prefix}\n\n${text}` : prefix) : text;
+      const trimmed = body.trim();
+      if (!trimmed || busyRef.current) return;
+
+      const userMsg: ChatMessage = {
+        id: nextId(),
+        role: 'user',
+        content: trimmed,
+        hidden,
+        uploadConversationId,
+        timestamp: Date.now(),
+      };
+      const replyId = nextId();
+
+      // Compute history from the same slice we are about to render, so a
+      // regenerate sends the thread as it will look, not as it looked.
+      const kept = deleteCount
+        ? messagesRef.current.slice(0, Math.max(0, messagesRef.current.length - deleteCount))
+        : messagesRef.current;
+      const history = kept
         .filter((m) => !m.error)
         .map((m) => ({ role: m.role, content: m.content }));
 
-      const userMsg: ChatMessage = { id: nextId(), role: 'user', content: trimmed };
-      const replyId = nextId();
-      setMessages((prev) => [
-        ...prev,
-        userMsg,
-        { id: replyId, role: 'assistant', content: '', steps: [], streaming: true },
-      ]);
-      setBusy(true);
+      setMessages((prev) => {
+        const base = deleteCount ? prev.slice(0, Math.max(0, prev.length - deleteCount)) : prev;
+        return [
+          ...base,
+          userMsg,
+          { id: replyId, role: 'assistant', content: '', steps: [], streaming: true },
+        ];
+      });
+      setBusyBoth(true);
 
       const controller = new AbortController();
       abortRef.current = controller;
@@ -66,18 +156,25 @@ export function useChatStream(
         setMessages((prev) => prev.map((m) => (m.id === replyId ? fn(m) : m)));
 
       let answer = '';
+      let failed = '';
       try {
-        const res = await fetch(endpoint.url, {
+        const res = await fetch(endpointRef.current.url, {
           method: 'POST',
           signal: controller.signal,
           headers: {
             'Content-Type': 'application/json',
-            'Conversation-Id': endpoint.conversationId,
-            ...(endpoint.headers ?? {}),
+            'Conversation-Id': endpointRef.current.conversationId,
+            'User-Message-ID': userMsg.id,
+            ...(endpointRef.current.headers ?? {}),
           },
           body: JSON.stringify({
-            messages: [...history, { role: 'user', content: trimmed }],
-            ...(endpoint.extraParams ?? {}),
+            // Custom params first so the fixed fields always win, as the
+            // toolkit does — a param named `messages` must not shadow the turn.
+            ...(endpointRef.current.extraParams ?? {}),
+            ...(params ?? {}),
+            messages: chatHistory
+              ? [...history, { role: 'user', content: trimmed }]
+              : [{ role: 'user', content: trimmed }],
           }),
         });
 
@@ -102,13 +199,33 @@ export function useChatStream(
               if (at >= 0) steps[at] = ev.step;
               else steps.push(ev.step);
               patchReply((m) => ({ ...m, steps: [...steps] }));
+            } else if (ev.kind === 'error') {
+              failed = ev.message;
+            } else if (ev.kind === 'interaction') {
+              setInteraction(ev.request);
             } else {
               patchReply((m) => ({ ...m, streaming: false }));
             }
           }
         }
-        patchReply((m) => ({ ...m, content: answer, streaming: false }));
-        if (answer) onAnswer?.(answer);
+
+        // An upload auto-prompt whose conversation the user has since left
+        // would drop its answer into the wrong thread.
+        const stale =
+          !!uploadConversationId &&
+          !!optionsRef.current.isConversationStale?.(uploadConversationId);
+
+        const callerInfo =
+          !stale && answer ? optionsRef.current.onAnswer?.(answer) : undefined;
+
+        patchReply((m) => ({
+          ...m,
+          content: answer,
+          streaming: false,
+          error: failed || undefined,
+          callerInfo: typeof callerInfo === 'string' ? callerInfo : undefined,
+        }));
+        if (!stale) optionsRef.current.onAnswerComplete?.();
       } catch (err) {
         const aborted = err instanceof DOMException && err.name === 'AbortError';
         patchReply((m) => ({
@@ -118,11 +235,13 @@ export function useChatStream(
         }));
       } finally {
         abortRef.current = null;
-        setBusy(false);
+        setBusyBoth(false);
       }
     },
-    [busy, endpoint, messages, onAnswer],
+    [chatHistory, setMessages, setBusyBoth],
   );
 
-  return { messages, busy, send, abort, reset };
+  const dismissInteraction = useCallback(() => setInteraction(null), []);
+
+  return { busy, send, abort, interaction, dismissInteraction };
 }

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/useConversations.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/useConversations.ts
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: MIT
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import {
+  buildExport,
+  createConversation,
+  exportFilename,
+  filterConversations,
+  parseImport,
+  sanitizeForPersistence,
+  titleFromMessage,
+} from './conversations';
+import {
+  clearAllConversations,
+  initConversationSessionLifecycle,
+  loadConversations,
+  loadSelectedConversationId,
+  saveConversations,
+  saveSelectedConversationId,
+} from './storage';
+import type { ChatMessage, Conversation } from './types';
+
+export interface UseConversationsResult {
+  conversations: Conversation[];
+  selected: Conversation | null;
+  /** False until IndexedDB has been read, so the UI does not flash an empty thread. */
+  hydrated: boolean;
+  searchTerm: string;
+  setSearchTerm: (term: string) => void;
+  filtered: Conversation[];
+  select: (id: string) => void;
+  create: () => Conversation;
+  rename: (id: string, name: string) => void;
+  remove: (id: string) => void;
+  clearAll: () => void;
+  /** Replace the selected conversation's messages. */
+  setMessages: (updater: (prev: ChatMessage[]) => ChatMessage[]) => void;
+  /** Name an untitled conversation after its first user message. */
+  titleIfUntitled: (content: string) => void;
+  exportData: () => void;
+  importData: (rawJson: string) => { ok: boolean; error?: string };
+}
+
+/**
+ * Owns the conversation list and keeps it in IndexedDB.
+ *
+ * Writes are debounced: streaming replaces the assistant message on every
+ * token, and persisting each one would put a transaction on the critical path
+ * of the render loop.
+ */
+export function useConversations(storageKeyPrefix?: string): UseConversationsResult {
+  // Start with a real conversation rather than an empty list. Reading
+  // IndexedDB is async, and anything the user types in that window — a
+  // keystroke, or an embedder calling submitChatMessage on mount — would
+  // otherwise be written into a conversation that does not exist yet and
+  // silently vanish.
+  const [conversations, setConversations] = useState<Conversation[]>(() => [createConversation()]);
+  const [selectedId, setSelectedId] = useState<string | null>(() => conversations[0]?.id ?? null);
+  const [hydrated, setHydrated] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const conversationsRef = useRef(conversations);
+  conversationsRef.current = conversations;
+
+  // Hydrate once, then never read again — this hook is the source of truth.
+  useEffect(() => {
+    let cancelled = false;
+    initConversationSessionLifecycle();
+    void (async () => {
+      try {
+        const [stored, storedId] = await Promise.all([
+          loadConversations(storageKeyPrefix),
+          loadSelectedConversationId(storageKeyPrefix),
+        ]);
+        if (cancelled || !stored.length) return;
+        // Keep anything already typed into the placeholder conversation; a
+        // slow disk should not discard the user's first message.
+        setConversations((current) => {
+          const started = current.filter((c) => c.messages.length > 0);
+          return [...stored, ...started];
+        });
+        setSelectedId((current) => {
+          const startedTyping = conversationsRef.current.some(
+            (c) => c.id === current && c.messages.length > 0,
+          );
+          if (startedTyping) return current;
+          return stored.some((c) => c.id === storedId) ? storedId : stored[0].id;
+        });
+      } catch (error) {
+        console.warn('vss-chat: could not load conversations', error);
+      } finally {
+        if (!cancelled) setHydrated(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [storageKeyPrefix]);
+
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (!hydrated) return;
+    if (saveTimer.current) clearTimeout(saveTimer.current);
+    saveTimer.current = setTimeout(() => {
+      saveConversations(sanitizeForPersistence(conversations), storageKeyPrefix).catch((error) =>
+        console.warn('vss-chat: could not save conversations', error),
+      );
+    }, 400);
+    return () => {
+      if (saveTimer.current) clearTimeout(saveTimer.current);
+    };
+  }, [conversations, hydrated, storageKeyPrefix]);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    saveSelectedConversationId(selectedId, storageKeyPrefix).catch(() => {});
+  }, [selectedId, hydrated, storageKeyPrefix]);
+
+  const selected = useMemo(
+    () => conversations.find((c) => c.id === selectedId) ?? null,
+    [conversations, selectedId],
+  );
+
+  const filtered = useMemo(
+    () => filterConversations(conversations, searchTerm),
+    [conversations, searchTerm],
+  );
+
+  const setMessages = useCallback(
+    (updater: (prev: ChatMessage[]) => ChatMessage[]) => {
+      setConversations((prev) =>
+        prev.map((c) => (c.id === selectedId ? { ...c, messages: updater(c.messages) } : c)),
+      );
+    },
+    [selectedId],
+  );
+
+  const titleIfUntitled = useCallback(
+    (content: string) => {
+      setConversations((prev) =>
+        prev.map((c) =>
+          // Only the first user turn names the thread; a rename must stick.
+          c.id === selectedId && c.messages.filter((m) => !m.hidden).length <= 1
+            ? { ...c, name: titleFromMessage(content) }
+            : c,
+        ),
+      );
+    },
+    [selectedId],
+  );
+
+  const create = useCallback(() => {
+    const fresh = createConversation();
+    setConversations((prev) => [...prev, fresh]);
+    setSelectedId(fresh.id);
+    return fresh;
+  }, []);
+
+  const remove = useCallback((id: string) => {
+    setConversations((prev) => {
+      const next = prev.filter((c) => c.id !== id);
+      if (next.length) {
+        setSelectedId((cur) => (cur === id ? next[next.length - 1].id : cur));
+        return next;
+      }
+      // Never leave the panel with no conversation to render into.
+      const fresh = createConversation();
+      setSelectedId(fresh.id);
+      return [fresh];
+    });
+  }, []);
+
+  const rename = useCallback((id: string, name: string) => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    setConversations((prev) => prev.map((c) => (c.id === id ? { ...c, name: trimmed } : c)));
+  }, []);
+
+  const clearAll = useCallback(() => {
+    const fresh = createConversation();
+    setConversations([fresh]);
+    setSelectedId(fresh.id);
+    clearAllConversations(storageKeyPrefix).catch(() => {});
+  }, [storageKeyPrefix]);
+
+  const exportData = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    const blob = new Blob([JSON.stringify(buildExport(conversations), null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = exportFilename();
+    link.click();
+    URL.revokeObjectURL(url);
+  }, [conversations]);
+
+  const importData = useCallback((rawJson: string) => {
+    const { conversations: imported, error } = parseImport(rawJson);
+    if (!imported) return { ok: false, error };
+    // Append rather than replace: an import should not destroy live threads.
+    setConversations((prev) => [...prev, ...imported]);
+    setSelectedId(imported[imported.length - 1].id);
+    return { ok: true };
+  }, []);
+
+  // Memoised: this object is a dependency of the `onControlsReady` handshake,
+  // and a fresh identity every render would call the embedder's setState on
+  // every render — an infinite loop rather than a slow one.
+  return useMemo(
+    () => ({
+      conversations,
+      selected,
+      hydrated,
+      searchTerm,
+      setSearchTerm,
+      filtered,
+      select: setSelectedId,
+      create,
+      rename,
+      remove,
+      clearAll,
+      setMessages,
+      titleIfUntitled,
+      exportData,
+      importData,
+    }),
+    [
+      conversations,
+      selected,
+      hydrated,
+      searchTerm,
+      filtered,
+      create,
+      rename,
+      remove,
+      clearAll,
+      setMessages,
+      titleIfUntitled,
+      exportData,
+      importData,
+    ],
+  );
+}

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/package.json
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/package.json
@@ -8,13 +8,15 @@
     ".": {
       "types": "./lib/index.d.ts",
       "default": "./lib/index.js"
-    }
+    },
+    "./lib/chat.css": "./lib/chat.css",
+    "./styles": "./lib/chat.css"
   },
   "files": [
     "lib/**/*"
   ],
   "scripts": {
-    "build": "rm -rf lib && swc lib-src -d lib --config-file .swcrc && mv lib/lib-src/* lib/ && rmdir lib/lib-src && tsc --project tsconfig.lib.json",
+    "build": "rm -rf lib && swc lib-src -d lib --config-file .swcrc && mv lib/lib-src/* lib/ && rmdir lib/lib-src && cp lib-src/*.css lib/ && tsc --project tsconfig.lib.json",
     "dev": "swc lib-src -d lib --config-file .swcrc -w",
     "clean": "rm -rf lib && rm -rf node_modules",
     "typecheck": "tsc --noEmit",
@@ -27,5 +29,16 @@
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1"
+  },
+  "devDependencies": {
+    "@swc/cli": "^0.8.0",
+    "@swc/core": "^1.13.19",
+    "@types/react": "18.0.28",
+    "@types/react-dom": "18.0.11",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^30.3.0",
+    "jest-environment-jsdom": "^30.3.0",
+    "ts-jest": "^29.4.9",
+    "typescript": "4.9.5"
   }
 }

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/package.json
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@nv-metropolis-bp-vss-ui/chat",
+  "version": "3.3-dev",
+  "description": "VSS chat interface. Speaks the BYO agent contract (OpenAI-shaped chat in, SSE out) with no dependency on the NeMo Agent Toolkit UI.",
+  "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    }
+  },
+  "files": [
+    "lib/**/*"
+  ],
+  "scripts": {
+    "build": "rm -rf lib && swc lib-src -d lib --config-file .swcrc && mv lib/lib-src/* lib/ && rmdir lib/lib-src && tsc --project tsconfig.lib.json",
+    "dev": "swc lib-src -d lib --config-file .swcrc -w",
+    "clean": "rm -rf lib && rm -rf node_modules",
+    "typecheck": "tsc --noEmit",
+    "test": "jest --runInBand",
+    "test:watch": "jest --watch"
+  },
+  "dependencies": {
+    "@tabler/icons-react": "^2.9.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1"
+  }
+}

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/package.json
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/package.json
@@ -25,14 +25,26 @@
   },
   "dependencies": {
     "@tabler/icons-react": "^2.9.0",
+    "common": "*",
+    "html-to-image": "^1.11.11",
+    "idb": "^8.0.3",
+    "isomorphic-dompurify": "^2.26.0",
+    "lodash": "^4.18.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.1"
+    "react-syntax-highlighter": "^16.1.0",
+    "recharts": "^2.12.7",
+    "rehype-raw": "^7.0.0",
+    "remark-gfm": "^4.0.1",
+    "remark-math": "^6.0.0"
   },
   "devDependencies": {
     "@swc/cli": "^0.8.0",
     "@swc/core": "^1.13.19",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
+    "@types/lodash": "^4.17.13",
     "@types/react": "18.0.28",
     "@types/react-dom": "18.0.11",
     "identity-obj-proxy": "^3.0.0",

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/tsconfig.json
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["lib-src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/tsconfig.lib.json
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./lib"
+  },
+  "include": ["lib-src/**/*"]
+}


### PR DESCRIPTION
Toolkit-free chat surface for the VSS UI, behind `NEXT_PUBLIC_USE_VSS_CHAT`.

**Stacked on #1903** — base is `feat/byo-agent-adapter`, not `develop`. GitHub will
retarget to `develop` automatically once #1903 merges. Reviewing against `develop`
would show the adapter twice.

### What is here

- New `@nv-metropolis-bp-vss-ui/chat` package: `ChatPanel`, `useChatStream`, SSE parsing,
  styles, and a test. No NeMo Agent Toolkit dependency.
- `Home.tsx` renders it for both the chat tab and the docked sidebar when the flag is on;
  unset, nothing changes, so the two can be compared in place.
- `pages/api/vss-chat.ts` proxies server-side (the configured backends are host-private
  ports a browser cannot reach) and serves the last search result so the Search tab can
  render hits without the model retyping them.
- Ingress: `/api/vss-chat` routed to the UI backend, mirroring the existing `/api/chat`
  rule. Without it the chat works on localhost and 404s through any ingress.

### Notes for review

- `package-lock.json` accounts for ~12k of the diff; the hand-written change is ~1,700 lines.
- `apps/vss-chat` (8 files) was the standalone proving ground before `ChatPanel` moved into
  the product UI. It may be redundant now — happy to drop it.
- Runtime dependency on the adapter is hard (the panel proxies to it); build dependency is none.

### Verification

Built against current `develop` and deployed: UI reachable on localhost, through haproxy,
and through the public ingress; end-to-end chat returned real archive-search hits, and the
search-artifact endpoint returned structured results for the Search tab.
