### PR TITLE
fix(ci): scan SonarQube projects only when their trees change

### DIFF
--- a/.github/scripts/detect_sonarqube_projects.py
+++ b/.github/scripts/detect_sonarqube_projects.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Decide which SonarQube matrix legs a workflow run must execute.
+
+Emits a GitHub Actions matrix (JSON) with one entry per catalogued project
+that needs a scan.
+
+Diff-range rules:
+
+* ``pull_request`` → diff ``merge-base(PR base, HEAD)..HEAD`` so the matrix
+  reflects the whole PR, not just its last push. Every catalogued
+  ``SonarQube Scan (<name>)`` check is still *reported* (GitHub has no
+  path filter on required contexts, and the same no-op is used for the
+  rest so a later ruleset addition cannot stall merge). Untouched legs
+  run as no-ops (``scan=false``). A real scan runs only when that tree
+  changed — that is when the check can fail and actually gate the PR.
+* ``push`` to ``main`` / ``develop`` / ``release/**``, and
+  ``workflow_dispatch`` → scan every project. Branch analysis and a manual
+  run must not silently drop a leg.
+* Unresolvable PR base, or a failed ``git diff`` → **scan everything**.
+  Scanning too much is safe; skipping a project that changed is the
+  failure mode this replaces.
+* A change to this script or ``.github/workflows/sonarqube.yml`` also
+  scans every project (the scan contract changed).
+
+Do not put a top-level ``paths:`` filter on the workflow. GitHub evaluates
+that against the pushed commits, not the cumulative PR, and can skip the
+workflow entirely on an unrelated follow-up push.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from detect_changed_images import (  # noqa: E402
+    changed_paths,
+    commit_exists,
+    paths_changed_under,
+    run_git,
+)
+
+CONTRACT_PATHS = (
+    ".github/workflows/sonarqube.yml",
+    ".github/scripts/detect_sonarqube_projects.py",
+)
+
+SONAR_RUNNER = "sonarqube-workflows-bp-sre"
+SKIP_RUNNER = "ubuntu-latest"
+
+# ``paths`` is the skip gate. ``sources`` / ``tests`` stay the scanner
+# configuration and may be a narrower list than the directory we watch.
+PROJECTS: list[dict[str, Any]] = [
+    {
+        "name": "agent",
+        "project_key": (
+            "TEGRASW_metropolis_video-search-and-summarization-agent"
+            "_video-search-and-summarization"
+        ),
+        "project_name": "video-search-and-summarization-agent",
+        "sources": "services/agent",
+        "tests": (
+            "services/agent/packages/vss_core/tests,"
+            "services/agent/packages/vss_agents/tests,"
+            "services/agent/packages/vss_cli/tests"
+        ),
+        "python_version": "3.13",
+        "paths": ["services/agent"],
+    },
+    {
+        "name": "alert",
+        "project_key": "TEGRASW_metropolis_vss-alert-verification_alert_agent",
+        "project_name": "metropolis-vss-alert-verification",
+        "sources": "services/alert/src",
+        "tests": "services/alert/test/unit",
+        "python_version": "3.13",
+        "paths": ["services/alert"],
+    },
+    {
+        "name": "ui",
+        "project_key": (
+            "TEGRASW_metropolis_video-search-and-summarization-ui"
+            "_video-search-and-summarization"
+        ),
+        "project_name": "video-search-and-summarization-ui",
+        "sources": "services/ui",
+        "tests": "",
+        "paths": ["services/ui"],
+    },
+    {
+        "name": "skills",
+        "project_key": (
+            "TEGRASW_metropolis_video-search-and-summarization-skills"
+            "_video-search-and-summarization"
+        ),
+        "project_name": "video-search-and-summarization-skills",
+        "sources": "skills",
+        "tests": "",
+        "paths": ["skills"],
+    },
+    {
+        "name": "behavior-analytics",
+        "project_key": "TEGRASW_metropolis_vss-behavior-analytics_py-analytics-stream",
+        "project_name": "metropolis-vss-behavior-analytics",
+        "sources": (
+            "services/analytics/behavior-analytics/src,"
+            "services/analytics/behavior-analytics/docker"
+        ),
+        "tests": "services/analytics/behavior-analytics/tests",
+        "python_version": "3.13",
+        "paths": ["services/analytics/behavior-analytics"],
+    },
+    {
+        "name": "video-analytics-api",
+        "project_key": "TEGRASW_metropolis_vss-video-analytics-api_mdata_web-apis",
+        "project_name": "metropolis-vss-video-analytics-api",
+        "sources": (
+            "services/analytics/video-analytics-api/src,"
+            "services/analytics/video-analytics-api/docker"
+        ),
+        "tests": "services/analytics/video-analytics-api/test",
+        "node_version": "22.22.3",
+        "paths": ["services/analytics/video-analytics-api"],
+    },
+    {
+        "name": "spatialai-data-utils",
+        "project_key": (
+            "TEGRASW_METROPOLIS_spatialai-data-utils_video-search-and-summarization"
+        ),
+        "project_name": "METROPOLIS-spatialai-data-utils",
+        "sources": "libs/analytics/spatialai-data-utils/spatialai_data_utils",
+        "tests": "libs/analytics/spatialai-data-utils/tests",
+        "python_version": "3.13",
+        "paths": ["libs/analytics/spatialai-data-utils"],
+    },
+    {
+        "name": "sdr-mw-l",
+        "project_key": "TEGRASW_A3IENG_embedded-metropolis-sdr_wdm",
+        "project_name": "embedded-metropolis-sdr",
+        "sources": (
+            "services/sdrc/app.py,services/sdrc/config.py,"
+            "services/sdrc/run_workloads.py,services/sdrc/lib,services/sdrc/envoy"
+        ),
+        "tests": "services/sdrc/tests",
+        "python_version": "3.10",
+        "paths": ["services/sdrc"],
+    },
+    {
+        "name": "vss-configurator",
+        "project_key": "TEGRASW_metropolis_vss-configurator_blueprint-configurator",
+        "project_name": "metropolis-vss-configurator",
+        "sources": (
+            "services/configurators/vss-configurator/app,"
+            "services/configurators/vss-configurator/docker"
+        ),
+        "tests": "services/configurators/vss-configurator/tests",
+        "python_version": "3.13",
+        "paths": ["services/configurators/vss-configurator"],
+    },
+    {
+        "name": "vss-rt-config-adaptor",
+        "project_key": "TEGRASW_metropolis_vss-rt-config-adaptor_ds-configurator",
+        "project_name": "metropolis-vss-rt-config-adaptor",
+        "sources": (
+            "services/configurators/vss-rt-config-adaptor/app,"
+            "services/configurators/vss-rt-config-adaptor/docker"
+        ),
+        "tests": "services/configurators/vss-rt-config-adaptor/tests",
+        "python_version": "3.13",
+        "paths": ["services/configurators/vss-rt-config-adaptor"],
+    },
+]
+
+
+def resolve_sonar_diff_base(
+    repo: Path, event_name: str, base_ref: str, pr_base_sha: str
+) -> tuple[str | None, str]:
+    """Return ``(base_commit, reason)``; ``None`` means scan every project."""
+    if event_name != "pull_request":
+        return None, f"{event_name}; scanning all projects"
+
+    candidates: list[str] = []
+    if pr_base_sha:
+        candidates.append(pr_base_sha)
+    if base_ref:
+        candidates.extend((f"origin/{base_ref}", base_ref))
+
+    for candidate in candidates:
+        if candidate == pr_base_sha and not commit_exists(repo, pr_base_sha):
+            continue
+        result = run_git(repo, "merge-base", candidate, "HEAD")
+        if result.returncode == 0:
+            base = result.stdout.strip()
+            return base, f"PR merge-base with {candidate}: {base[:12]}"
+    return None, "could not resolve PR base; scanning all projects"
+
+
+def matrix_entry(project: dict[str, Any], *, scan: bool) -> dict[str, Any]:
+    entry = {key: value for key, value in project.items() if key != "paths"}
+    entry["scan"] = "true" if scan else "false"
+    entry["runner"] = SONAR_RUNNER if scan else SKIP_RUNNER
+    return entry
+
+
+def to_matrix(entries: list[dict[str, Any]]) -> dict[str, Any]:
+    return {"include": entries}
+
+
+def matrix_for(
+    selected: list[dict[str, Any]], event_name: str, _base_ref: str
+) -> list[dict[str, Any]]:
+    """On PRs, report every project; scan only those whose trees changed."""
+    selected_names = {project["name"] for project in selected}
+    if event_name == "pull_request":
+        return [
+            matrix_entry(project, scan=project["name"] in selected_names)
+            for project in PROJECTS
+        ]
+    return [matrix_entry(project, scan=True) for project in selected]
+
+
+def contract_changed(changed: list[str]) -> bool:
+    return any(
+        path == contract or path.startswith(contract.rstrip("/") + "/")
+        for path in changed
+        for contract in CONTRACT_PATHS
+    )
+
+
+def select_projects(
+    changed: list[str] | None,
+) -> tuple[list[dict[str, Any]], str]:
+    if changed is None:
+        return list(PROJECTS), "scanning all SonarQube projects"
+    if contract_changed(changed):
+        return list(PROJECTS), "scan contract changed; scanning all projects"
+    selected = [
+        project
+        for project in PROJECTS
+        if any(paths_changed_under(changed, directory) for directory in project["paths"])
+    ]
+    if selected:
+        names = ", ".join(project["name"] for project in selected)
+        return selected, f"scanning {names}"
+    return [], f"0 of {len(PROJECTS)} projects changed"
+
+
+def plan(
+    repo: Path, event_name: str, base_ref: str, pr_base_sha: str
+) -> dict[str, Any]:
+    base, reason = resolve_sonar_diff_base(repo, event_name, base_ref, pr_base_sha)
+    changed = changed_paths(repo, base) if base else None
+    if base and changed is None:
+        reason += "; diff failed; scanning all projects"
+        changed = None
+    selected, selection_reason = select_projects(changed)
+    include = matrix_for(selected, event_name, base_ref)
+    noop_count = sum(1 for row in include if row["scan"] != "true")
+    if noop_count:
+        selection_reason += f"; {noop_count} no-op report(s)"
+    return {
+        "reason": f"{reason}; {selection_reason}",
+        "count": len(selected),
+        "any": len(include) > 0,
+        "projects": [project["name"] for project in selected],
+        "matrix": to_matrix(include),
+    }
+
+
+def write_github_output(path: Path, result: dict[str, Any]) -> None:
+    matrix_json = json.dumps(result["matrix"], separators=(",", ":"))
+    projects_json = json.dumps(result["projects"], separators=(",", ":"))
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"any={str(result['any']).lower()}\n")
+        handle.write(f"count={result['count']}\n")
+        handle.write(f"projects={projects_json}\n")
+        handle.write(f"matrix={matrix_json}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--event-name", required=True)
+    parser.add_argument("--base-ref", default="")
+    parser.add_argument("--pr-base-sha", default="")
+    parser.add_argument(
+        "--github-output",
+        type=Path,
+        default=None,
+        help="Append GITHUB_OUTPUT keys (any, count, projects, matrix).",
+    )
+    args = parser.parse_args()
+    result = plan(
+        args.repo_root.resolve(),
+        args.event_name,
+        args.base_ref,
+        args.pr_base_sha,
+    )
+    print(json.dumps(result, indent=2))
+    print(result["reason"], file=sys.stderr)
+    if args.github_output is not None:
+        write_github_output(args.github_output, result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/detect_sonarqube_projects.py
+++ b/.github/scripts/detect_sonarqube_projects.py
@@ -21,8 +21,9 @@ Diff-range rules:
 * Unresolvable PR base, or a failed ``git diff`` → **scan everything**.
   Scanning too much is safe; skipping a project that changed is the
   failure mode this replaces.
-* A change to this script or ``.github/workflows/sonarqube.yml`` also
-  scans every project (the scan contract changed).
+* A change to this script, ``.github/workflows/sonarqube.yml``, or
+  ``detect_changed_images.py`` (diff helpers used for skip decisions)
+  also scans every project (the scan contract changed).
 
 Do not put a top-level ``paths:`` filter on the workflow. GitHub evaluates
 that against the pushed commits, not the cumulative PR, and can skip the
@@ -49,6 +50,7 @@ from detect_changed_images import (  # noqa: E402
 CONTRACT_PATHS = (
     ".github/workflows/sonarqube.yml",
     ".github/scripts/detect_sonarqube_projects.py",
+    ".github/scripts/detect_changed_images.py",
 )
 
 SONAR_RUNNER = "sonarqube-workflows-bp-sre"
@@ -213,7 +215,7 @@ def to_matrix(entries: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 def matrix_for(
-    selected: list[dict[str, Any]], event_name: str, _base_ref: str
+    selected: list[dict[str, Any]], event_name: str
 ) -> list[dict[str, Any]]:
     """On PRs, report every project; scan only those whose trees changed."""
     selected_names = {project["name"] for project in selected}
@@ -260,14 +262,13 @@ def plan(
         reason += "; diff failed; scanning all projects"
         changed = None
     selected, selection_reason = select_projects(changed)
-    include = matrix_for(selected, event_name, base_ref)
+    include = matrix_for(selected, event_name)
     noop_count = sum(1 for row in include if row["scan"] != "true")
     if noop_count:
         selection_reason += f"; {noop_count} no-op report(s)"
     return {
         "reason": f"{reason}; {selection_reason}",
         "count": len(selected),
-        "any": len(include) > 0,
         "projects": [project["name"] for project in selected],
         "matrix": to_matrix(include),
     }
@@ -277,7 +278,6 @@ def write_github_output(path: Path, result: dict[str, Any]) -> None:
     matrix_json = json.dumps(result["matrix"], separators=(",", ":"))
     projects_json = json.dumps(result["projects"], separators=(",", ":"))
     with path.open("a", encoding="utf-8") as handle:
-        handle.write(f"any={str(result['any']).lower()}\n")
         handle.write(f"count={result['count']}\n")
         handle.write(f"projects={projects_json}\n")
         handle.write(f"matrix={matrix_json}\n")
@@ -293,7 +293,7 @@ def main() -> int:
         "--github-output",
         type=Path,
         default=None,
-        help="Append GITHUB_OUTPUT keys (any, count, projects, matrix).",
+        help="Append GITHUB_OUTPUT keys (count, projects, matrix).",
     )
     args = parser.parse_args()
     result = plan(

--- a/.github/scripts/test_detect_sonarqube_projects.py
+++ b/.github/scripts/test_detect_sonarqube_projects.py
@@ -92,6 +92,13 @@ class SelectProjectsTest(unittest.TestCase):
         self.assertEqual(len(selected), len(dsp.PROJECTS))
         self.assertIn("contract", reason)
 
+    def test_diff_helper_contract_scans_everything(self):
+        selected, reason = dsp.select_projects(
+            [".github/scripts/detect_changed_images.py"]
+        )
+        self.assertEqual(len(selected), len(dsp.PROJECTS))
+        self.assertIn("contract", reason)
+
     def test_matrix_entry_omits_paths_and_sets_scan_runner(self):
         entry = dsp.matrix_entry(dsp.PROJECTS[0], scan=True)
         self.assertNotIn("paths", entry)
@@ -104,7 +111,7 @@ class SelectProjectsTest(unittest.TestCase):
         self.assertEqual(skip["runner"], dsp.SKIP_RUNNER)
 
     def test_pr_reports_every_project_as_noop_when_nothing_changed(self):
-        include = dsp.matrix_for([], "pull_request", "develop")
+        include = dsp.matrix_for([], "pull_request")
         self.assertEqual(len(include), len(dsp.PROJECTS))
         self.assertEqual({row["scan"] for row in include}, {"false"})
         self.assertEqual(
@@ -114,7 +121,7 @@ class SelectProjectsTest(unittest.TestCase):
 
     def test_pr_scans_only_the_changed_project(self):
         ui = next(project for project in dsp.PROJECTS if project["name"] == "ui")
-        include = dsp.matrix_for([ui], "pull_request", "main")
+        include = dsp.matrix_for([ui], "pull_request")
         by_name = {row["name"]: row["scan"] for row in include}
         self.assertEqual(len(by_name), len(dsp.PROJECTS))
         self.assertEqual(by_name["ui"], "true")
@@ -125,7 +132,7 @@ class SelectProjectsTest(unittest.TestCase):
 
     def test_push_does_not_pad_unselected_projects(self):
         ui = next(project for project in dsp.PROJECTS if project["name"] == "ui")
-        include = dsp.matrix_for([ui], "push", "develop")
+        include = dsp.matrix_for([ui], "push")
         self.assertEqual([(row["name"], row["scan"]) for row in include], [("ui", "true")])
 
     def test_project_names_are_unique(self):
@@ -139,7 +146,6 @@ class PlanTest(unittest.TestCase):
             repo = make_repo(tmp)
             commit_change(repo, "docs/readme.md", "v2\n", "docs")
             result = dsp.plan(repo, "push", "develop", "")
-            self.assertTrue(result["any"])
             self.assertEqual(result["count"], len(dsp.PROJECTS))
             self.assertIn("push", result["reason"])
 
@@ -158,7 +164,6 @@ class PlanTest(unittest.TestCase):
             result = dsp.plan(repo, "pull_request", "develop", base_sha)
             self.assertEqual(result["count"], 0)
             self.assertEqual(result["projects"], [])
-            self.assertTrue(result["any"])
             include = result["matrix"]["include"]
             self.assertEqual(len(include), len(dsp.PROJECTS))
             self.assertEqual({row["scan"] for row in include}, {"false"})
@@ -170,7 +175,6 @@ class PlanTest(unittest.TestCase):
             git(repo, "checkout", "-q", "-b", "feature")
             commit_change(repo, "docs/readme.md", "v2\n", "docs only")
             result = dsp.plan(repo, "pull_request", "main", base_sha)
-            self.assertTrue(result["any"])
             self.assertEqual(result["count"], 0)
             self.assertEqual(len(result["matrix"]["include"]), len(dsp.PROJECTS))
 
@@ -207,7 +211,7 @@ class PlanTest(unittest.TestCase):
                 line.split("=", 1)[0]: line.split("=", 1)[1]
                 for line in output.read_text().splitlines()
             }
-            self.assertEqual(lines["any"], "true")
+            self.assertNotIn("any", lines)
             self.assertEqual(int(lines["count"]), len(dsp.PROJECTS))
             self.assertNotIn("\n", lines["matrix"])
             parsed = json.loads(lines["matrix"])

--- a/.github/scripts/test_detect_sonarqube_projects.py
+++ b/.github/scripts/test_detect_sonarqube_projects.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for detect_sonarqube_projects.py. Run directly:
+
+    python3 .github/scripts/test_detect_sonarqube_projects.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import detect_sonarqube_projects as dsp  # noqa: E402
+
+
+def git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.stdout.strip()
+
+
+def make_repo(tmp: str) -> Path:
+    repo = Path(tmp)
+    git(repo, "init", "-q", "-b", "develop")
+    git(repo, "config", "user.email", "test@test")
+    git(repo, "config", "user.name", "test")
+    for rel in (
+        "services/agent/app.py",
+        "services/ui/app.js",
+        "skills/README.md",
+        "docs/readme.md",
+        ".github/workflows/sonarqube.yml",
+        ".github/scripts/detect_sonarqube_projects.py",
+    ):
+        path = repo / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("v1\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "initial")
+    return repo
+
+
+def commit_change(repo: Path, rel: str, content: str, message: str) -> str:
+    path = repo / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", message)
+    return git(repo, "rev-parse", "HEAD")
+
+
+class SelectProjectsTest(unittest.TestCase):
+    def test_none_diff_scans_everything(self):
+        selected, reason = dsp.select_projects(None)
+        self.assertEqual(len(selected), len(dsp.PROJECTS))
+        self.assertIn("all", reason)
+
+    def test_unrelated_paths_scan_nothing(self):
+        selected, reason = dsp.select_projects(["docs/readme.md", "README.md"])
+        self.assertEqual(selected, [])
+        self.assertIn("0 of", reason)
+
+    def test_agent_change_scans_only_agent(self):
+        selected, _ = dsp.select_projects(["services/agent/packages/vss_cli/src/x.py"])
+        self.assertEqual([project["name"] for project in selected], ["agent"])
+
+    def test_sibling_directory_does_not_match(self):
+        selected, _ = dsp.select_projects(["services/agent-old/app.py"])
+        self.assertEqual(selected, [])
+
+    def test_workflow_contract_scans_everything(self):
+        selected, reason = dsp.select_projects([".github/workflows/sonarqube.yml"])
+        self.assertEqual(len(selected), len(dsp.PROJECTS))
+        self.assertIn("contract", reason)
+
+    def test_script_contract_scans_everything(self):
+        selected, reason = dsp.select_projects(
+            [".github/scripts/detect_sonarqube_projects.py"]
+        )
+        self.assertEqual(len(selected), len(dsp.PROJECTS))
+        self.assertIn("contract", reason)
+
+    def test_matrix_entry_omits_paths_and_sets_scan_runner(self):
+        entry = dsp.matrix_entry(dsp.PROJECTS[0], scan=True)
+        self.assertNotIn("paths", entry)
+        self.assertEqual(entry["name"], "agent")
+        self.assertEqual(entry["python_version"], "3.13")
+        self.assertEqual(entry["scan"], "true")
+        self.assertEqual(entry["runner"], dsp.SONAR_RUNNER)
+        skip = dsp.matrix_entry(dsp.PROJECTS[0], scan=False)
+        self.assertEqual(skip["scan"], "false")
+        self.assertEqual(skip["runner"], dsp.SKIP_RUNNER)
+
+    def test_pr_reports_every_project_as_noop_when_nothing_changed(self):
+        include = dsp.matrix_for([], "pull_request", "develop")
+        self.assertEqual(len(include), len(dsp.PROJECTS))
+        self.assertEqual({row["scan"] for row in include}, {"false"})
+        self.assertEqual(
+            [row["name"] for row in include],
+            [project["name"] for project in dsp.PROJECTS],
+        )
+
+    def test_pr_scans_only_the_changed_project(self):
+        ui = next(project for project in dsp.PROJECTS if project["name"] == "ui")
+        include = dsp.matrix_for([ui], "pull_request", "main")
+        by_name = {row["name"]: row["scan"] for row in include}
+        self.assertEqual(len(by_name), len(dsp.PROJECTS))
+        self.assertEqual(by_name["ui"], "true")
+        self.assertEqual(
+            {name for name, scan in by_name.items() if scan == "true"},
+            {"ui"},
+        )
+
+    def test_push_does_not_pad_unselected_projects(self):
+        ui = next(project for project in dsp.PROJECTS if project["name"] == "ui")
+        include = dsp.matrix_for([ui], "push", "develop")
+        self.assertEqual([(row["name"], row["scan"]) for row in include], [("ui", "true")])
+
+    def test_project_names_are_unique(self):
+        names = [project["name"] for project in dsp.PROJECTS]
+        self.assertEqual(names, list(dict.fromkeys(names)))
+
+
+class PlanTest(unittest.TestCase):
+    def test_push_scans_all_even_when_only_docs_changed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(tmp)
+            commit_change(repo, "docs/readme.md", "v2\n", "docs")
+            result = dsp.plan(repo, "push", "develop", "")
+            self.assertTrue(result["any"])
+            self.assertEqual(result["count"], len(dsp.PROJECTS))
+            self.assertIn("push", result["reason"])
+
+    def test_workflow_dispatch_scans_all(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(tmp)
+            result = dsp.plan(repo, "workflow_dispatch", "", "")
+            self.assertEqual(result["count"], len(dsp.PROJECTS))
+
+    def test_pull_request_skips_unrelated_trees(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(tmp)
+            base_sha = git(repo, "rev-parse", "HEAD")
+            git(repo, "checkout", "-q", "-b", "feature")
+            commit_change(repo, "docs/readme.md", "v2\n", "docs only")
+            result = dsp.plan(repo, "pull_request", "develop", base_sha)
+            self.assertEqual(result["count"], 0)
+            self.assertEqual(result["projects"], [])
+            self.assertTrue(result["any"])
+            include = result["matrix"]["include"]
+            self.assertEqual(len(include), len(dsp.PROJECTS))
+            self.assertEqual({row["scan"] for row in include}, {"false"})
+
+    def test_pull_request_to_main_also_reports_every_project(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(tmp)
+            base_sha = git(repo, "rev-parse", "HEAD")
+            git(repo, "checkout", "-q", "-b", "feature")
+            commit_change(repo, "docs/readme.md", "v2\n", "docs only")
+            result = dsp.plan(repo, "pull_request", "main", base_sha)
+            self.assertTrue(result["any"])
+            self.assertEqual(result["count"], 0)
+            self.assertEqual(len(result["matrix"]["include"]), len(dsp.PROJECTS))
+
+    def test_pull_request_scans_only_changed_project(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(tmp)
+            base_sha = git(repo, "rev-parse", "HEAD")
+            git(repo, "checkout", "-q", "-b", "feature")
+            commit_change(repo, "services/ui/app.js", "v2\n", "ui")
+            result = dsp.plan(repo, "pull_request", "develop", base_sha)
+            self.assertEqual(result["projects"], ["ui"])
+            by_name = {row["name"]: row for row in result["matrix"]["include"]}
+            self.assertEqual(len(by_name), len(dsp.PROJECTS))
+            self.assertEqual(by_name["ui"]["scan"], "true")
+            self.assertEqual(by_name["agent"]["scan"], "false")
+            self.assertEqual(by_name["alert"]["scan"], "false")
+            self.assertEqual(by_name["skills"]["scan"], "false")
+            self.assertNotIn("python_version", by_name["ui"])
+
+    def test_missing_pr_base_fails_open(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(tmp)
+            result = dsp.plan(repo, "pull_request", "no-such-branch", "0" * 40)
+            self.assertEqual(result["count"], len(dsp.PROJECTS))
+            self.assertIn("could not resolve PR base", result["reason"])
+
+    def test_github_output_is_single_line_json(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(tmp)
+            result = dsp.plan(repo, "workflow_dispatch", "", "")
+            output = Path(tmp) / "github-output"
+            dsp.write_github_output(output, result)
+            lines = {
+                line.split("=", 1)[0]: line.split("=", 1)[1]
+                for line in output.read_text().splitlines()
+            }
+            self.assertEqual(lines["any"], "true")
+            self.assertEqual(int(lines["count"]), len(dsp.PROJECTS))
+            self.assertNotIn("\n", lines["matrix"])
+            parsed = json.loads(lines["matrix"])
+            self.assertEqual(len(parsed["include"]), len(dsp.PROJECTS))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/scripts/test_prepare_downstream_release_set.py
+++ b/.github/scripts/test_prepare_downstream_release_set.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import sys
 import tempfile
 import unittest
@@ -141,27 +140,30 @@ class WorkflowSeparationTest(unittest.TestCase):
         self.assertIn("DOWNSTREAM_REF: main", sdu)
         self.assertIn('"SPATIALAI_PIPELINE": "true"', sdu)
         sonar = (workflows / "sonarqube.yml").read_text()
-        match = re.search(
-            r"^          - name: spatialai-data-utils\n(?P<entry>(?:            .*\n)+)",
-            sonar,
-            flags=re.MULTILINE,
+        self.assertIn("detect_sonarqube_projects.py", sonar)
+        self.assertIn("fromJSON(needs.detect.outputs.matrix)", sonar)
+
+        import detect_sonarqube_projects as dsp
+
+        sdu = next(
+            project
+            for project in dsp.PROJECTS
+            if project["name"] == "spatialai-data-utils"
         )
-        self.assertIsNotNone(match, "SDU SonarQube matrix entry is missing")
-        assert match is not None
-        entry = match.group("entry")
-        self.assertIn(
+        self.assertEqual(
+            sdu["project_key"],
             "TEGRASW_METROPOLIS_spatialai-data-utils_video-search-and-summarization",
-            entry,
         )
-        self.assertIn(
-            "sources: libs/analytics/spatialai-data-utils/spatialai_data_utils",
-            entry,
+        self.assertEqual(
+            sdu["sources"],
+            "libs/analytics/spatialai-data-utils/spatialai_data_utils",
         )
-        self.assertIn(
-            "tests: libs/analytics/spatialai-data-utils/tests",
-            entry,
+        self.assertEqual(
+            sdu["tests"],
+            "libs/analytics/spatialai-data-utils/tests",
         )
-        self.assertIn('python_version: "3.13"', entry)
+        self.assertEqual(sdu["python_version"], "3.13")
+        self.assertEqual(sdu["paths"], ["libs/analytics/spatialai-data-utils"])
 
     def test_release_set_preparation_has_no_sdu_transport(self):
         script = Path(module.__file__).read_text()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1477,6 +1477,7 @@ jobs:
       - name: Unit-test the build change detection
         run: |
           python3 .github/scripts/test_detect_changed_images.py
+          python3 .github/scripts/test_detect_sonarqube_projects.py
           python3 .github/scripts/test_container_build_plan.py
 
       - name: Unit-test the downstream GHCR candidate reporter

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,5 +1,15 @@
 name: SonarQube Analysis
 
+# No top-level `paths:` filter: GitHub evaluates that against the pushed
+# commits, not the cumulative PR, and can skip this workflow on an
+# unrelated follow-up push. The per-project gate lives in the `detect`
+# job (detect_sonarqube_projects.py) and compares PR-base...HEAD.
+#
+# Protect develop currently requires SonarQube Scan (agent|ui|skills).
+# Every catalogued scan still reports on PRs: untouched legs no-op, only a
+# changed tree runs the scanner and can fail. Same pattern if more legs
+# are added to the ruleset later.
+
 on:
   push:
     branches:
@@ -21,75 +31,13 @@ permissions:
   contents: read
 
 jobs:
-  sonarqube:
-    name: SonarQube Scan (${{ matrix.name }})
-    runs-on: sonarqube-workflows-bp-sre
-    timeout-minutes: 30
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: agent
-            project_key: TEGRASW_metropolis_video-search-and-summarization-agent_video-search-and-summarization
-            project_name: video-search-and-summarization-agent
-            sources: services/agent
-            tests: services/agent/packages/vss_core/tests,services/agent/packages/vss_agents/tests,services/agent/packages/vss_cli/tests
-            python_version: "3.13"
-          - name: alert
-            project_key: TEGRASW_metropolis_vss-alert-verification_alert_agent
-            project_name: metropolis-vss-alert-verification
-            sources: services/alert/src
-            tests: services/alert/test/unit
-            python_version: "3.13"
-          - name: ui
-            project_key: TEGRASW_metropolis_video-search-and-summarization-ui_video-search-and-summarization
-            project_name: video-search-and-summarization-ui
-            sources: services/ui
-            tests: ""
-          - name: skills
-            project_key: TEGRASW_metropolis_video-search-and-summarization-skills_video-search-and-summarization
-            project_name: video-search-and-summarization-skills
-            sources: skills
-            tests: ""
-          - name: behavior-analytics
-            project_key: TEGRASW_metropolis_vss-behavior-analytics_py-analytics-stream
-            project_name: metropolis-vss-behavior-analytics
-            sources: services/analytics/behavior-analytics/src,services/analytics/behavior-analytics/docker
-            tests: services/analytics/behavior-analytics/tests
-            python_version: "3.13"
-          - name: video-analytics-api
-            project_key: TEGRASW_metropolis_vss-video-analytics-api_mdata_web-apis
-            project_name: metropolis-vss-video-analytics-api
-            sources: services/analytics/video-analytics-api/src,services/analytics/video-analytics-api/docker
-            tests: services/analytics/video-analytics-api/test
-            node_version: "22.22.3"
-          - name: spatialai-data-utils
-            project_key: TEGRASW_METROPOLIS_spatialai-data-utils_video-search-and-summarization
-            project_name: METROPOLIS-spatialai-data-utils
-            sources: libs/analytics/spatialai-data-utils/spatialai_data_utils
-            tests: libs/analytics/spatialai-data-utils/tests
-            python_version: "3.13"
-          - name: sdr-mw-l
-            project_key: TEGRASW_A3IENG_embedded-metropolis-sdr_wdm
-            project_name: embedded-metropolis-sdr
-            sources: services/sdrc/app.py,services/sdrc/config.py,services/sdrc/run_workloads.py,services/sdrc/lib,services/sdrc/envoy
-            tests: services/sdrc/tests
-            python_version: "3.10"
-          - name: vss-configurator
-            project_key: TEGRASW_metropolis_vss-configurator_blueprint-configurator
-            project_name: metropolis-vss-configurator
-            sources: services/configurators/vss-configurator/app,services/configurators/vss-configurator/docker
-            tests: services/configurators/vss-configurator/tests
-            python_version: "3.13"
-          - name: vss-rt-config-adaptor
-            project_key: TEGRASW_metropolis_vss-rt-config-adaptor_ds-configurator
-            project_name: metropolis-vss-rt-config-adaptor
-            sources: services/configurators/vss-rt-config-adaptor/app,services/configurators/vss-rt-config-adaptor/docker
-            tests: services/configurators/vss-rt-config-adaptor/tests
-            python_version: "3.13"
-
+  detect:
+    name: Detect SonarQube projects
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      any: ${{ steps.plan.outputs.any }}
+      matrix: ${{ steps.plan.outputs.matrix }}
     steps:
       - name: Checkout source
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -97,7 +45,44 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Plan SonarQube matrix
+        id: plan
+        run: |
+          python3 .github/scripts/detect_sonarqube_projects.py \
+            --event-name "${{ github.event_name }}" \
+            --base-ref "${{ github.base_ref }}" \
+            --pr-base-sha "${{ github.event.pull_request.base.sha }}" \
+            --github-output "$GITHUB_OUTPUT"
+
+  sonarqube:
+    name: SonarQube Scan (${{ matrix.name }})
+    needs: detect
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    if: >-
+      needs.detect.outputs.any == 'true'
+      && (github.event_name != 'pull_request'
+          || github.event.pull_request.head.repo.full_name == github.repository)
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.detect.outputs.matrix) }}
+
+    steps:
+      - name: Skip scan for untouched project
+        if: matrix.scan != 'true'
+        run: |
+          echo "No changes in ${{ matrix.name }}; reporting success without scanning."
+
+      - name: Checkout source
+        if: matrix.scan == 'true'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
       - name: Validate SonarQube secrets
+        if: matrix.scan == 'true'
         env:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -112,6 +97,7 @@ jobs:
           fi
 
       - name: Write SonarQube configuration
+        if: matrix.scan == 'true'
         env:
           EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -245,25 +231,25 @@ jobs:
           sed -E 's/(sonar.token|SONAR_TOKEN).*/[REDACTED]/g' sonar-project.properties
 
       - name: Install uv
-        if: matrix.python_version != null
+        if: matrix.scan == 'true' && matrix.python_version != null
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           version: "0.6.2"
 
       - name: Set up Python
-        if: matrix.python_version != null
+        if: matrix.scan == 'true' && matrix.python_version != null
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python_version }}
 
       - name: Set up Node.js for Video Analytics API
-        if: matrix.node_version != null
+        if: matrix.scan == 'true' && matrix.node_version != null
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node_version }}
 
       - name: Generate agent coverage
-        if: matrix.name == 'agent'
+        if: matrix.scan == 'true' && matrix.name == 'agent'
         working-directory: services/agent
         run: |
           # The Sonar self-hosted runner cannot install system packages.
@@ -277,7 +263,7 @@ jobs:
             -m "not slow and not integration"
 
       - name: Generate lib coverage (NAT-free surface)
-        if: matrix.name == 'agent'
+        if: matrix.scan == 'true' && matrix.name == 'agent'
         working-directory: services/agent
         run: |
           # Both packages, matching the same invocation in ci.yml. The
@@ -294,14 +280,14 @@ jobs:
             -m "not slow and not integration"
 
       - name: Install Alert MS test dependencies
-        if: matrix.name == 'alert'
+        if: matrix.scan == 'true' && matrix.name == 'alert'
         working-directory: services/alert
         run: |
           uv venv --python "${{ matrix.python_version }}"
           uv pip install --python .venv/bin/python -r requirements.txt pytest pytest-asyncio pytest-cov
 
       - name: Generate Alert MS coverage
-        if: matrix.name == 'alert'
+        if: matrix.scan == 'true' && matrix.name == 'alert'
         working-directory: services/alert
         run: |
           .venv/bin/pytest test/unit \
@@ -310,7 +296,7 @@ jobs:
             --cov-report=term-missing
 
       - name: Generate Behavior Analytics coverage
-        if: matrix.name == 'behavior-analytics'
+        if: matrix.scan == 'true' && matrix.name == 'behavior-analytics'
         working-directory: services/analytics/behavior-analytics
         run: |
           python -m pip install --upgrade pip pipenv
@@ -321,7 +307,7 @@ jobs:
           pipenv run coverage report
 
       - name: Generate Video Analytics API coverage
-        if: matrix.name == 'video-analytics-api'
+        if: matrix.scan == 'true' && matrix.name == 'video-analytics-api'
         working-directory: services/analytics/video-analytics-api
         run: |
           cd src/web-api-core && npm install && cd ../..
@@ -329,7 +315,7 @@ jobs:
           cd test && npm install --save ../src/web-api-core && npm install --save ../src/app && npm install && npm run ci
 
       - name: Generate SDRC coverage
-        if: matrix.name == 'sdr-mw-l'
+        if: matrix.scan == 'true' && matrix.name == 'sdr-mw-l'
         working-directory: services/sdrc
         run: |
           mkdir -p test/coverage
@@ -344,7 +330,7 @@ jobs:
             --cov-report=term-missing
 
       - name: Generate VSS Configurator coverage
-        if: matrix.name == 'vss-configurator'
+        if: matrix.scan == 'true' && matrix.name == 'vss-configurator'
         working-directory: services/configurators/vss-configurator
         run: |
           mkdir -p test/coverage
@@ -362,7 +348,7 @@ jobs:
             --cov-report=term-missing
 
       - name: Generate VSS RT Config Adaptor coverage
-        if: matrix.name == 'vss-rt-config-adaptor'
+        if: matrix.scan == 'true' && matrix.name == 'vss-rt-config-adaptor'
         working-directory: services/configurators/vss-rt-config-adaptor
         run: |
           uv sync --python 3.13 --frozen --group dev
@@ -374,6 +360,7 @@ jobs:
             --cov-report=term-missing
 
       - name: Run SonarQube scanner
+        if: matrix.scan == 'true'
         uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6
         env:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
@@ -383,7 +370,34 @@ jobs:
       # NVIDIA SonarQube/network outages from repository-specific findings so a
       # transient "No route to host" failure is not misrouted to code owners.
       - name: Classify SonarQube connectivity failure
-        if: failure()
+        if: failure() && matrix.scan == 'true'
         env:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
         run: python3 .github/scripts/diagnose_sonarqube_failure.py
+
+  # Always-run wrap-up so a PR that touches none of the scanned trees still
+  # has a concluding check, and so a skipped matrix (empty / fork) is not
+  # reported as a scan failure.
+  sonarqube-gate:
+    name: SonarQube
+    needs: [detect, sonarqube]
+    if: always() && !cancelled()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check scan outcome
+        env:
+          DETECT: ${{ needs.detect.result }}
+          SCAN: ${{ needs.sonarqube.result }}
+        run: |
+          set -euo pipefail
+          if [ "$DETECT" != "success" ]; then
+            echo "detect job result: $DETECT"
+            exit 1
+          fi
+          # skipped = no matching projects, or a fork PR that cannot use secrets
+          if [ "$SCAN" = "failure" ]; then
+            echo "scan job result: $SCAN"
+            exit 1
+          fi
+          echo "detect=$DETECT scan=$SCAN"

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -6,9 +6,9 @@ name: SonarQube Analysis
 # job (detect_sonarqube_projects.py) and compares PR-base...HEAD.
 #
 # Protect develop currently requires SonarQube Scan (agent|ui|skills).
-# Every catalogued scan still reports on PRs: untouched legs no-op, only a
-# changed tree runs the scanner and can fail. Same pattern if more legs
-# are added to the ruleset later.
+# After this workflow lands, require the wrap-up job named SonarQube
+# instead of those three legs: a green per-leg check can be a no-op.
+# Untouched legs still report so a stale ruleset cannot stall merge.
 
 on:
   push:
@@ -36,7 +36,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      any: ${{ steps.plan.outputs.any }}
       matrix: ${{ steps.plan.outputs.matrix }}
     steps:
       - name: Checkout source
@@ -60,9 +59,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     if: >-
-      needs.detect.outputs.any == 'true'
-      && (github.event_name != 'pull_request'
-          || github.event.pull_request.head.repo.full_name == github.repository)
+      github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.full_name == github.repository
 
     strategy:
       fail-fast: false
@@ -375,9 +373,9 @@ jobs:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
         run: python3 .github/scripts/diagnose_sonarqube_failure.py
 
-  # Always-run wrap-up so a PR that touches none of the scanned trees still
-  # has a concluding check, and so a skipped matrix (empty / fork) is not
-  # reported as a scan failure.
+  # Always-run wrap-up. Require this job name (SonarQube) on Protect
+  # develop: it fails when detect fails, and skipped per-leg scans are
+  # not a merge bypass. Fork PRs skip the scan job (no secrets) and pass.
   sonarqube-gate:
     name: SonarQube
     needs: [detect, sonarqube]
@@ -395,7 +393,7 @@ jobs:
             echo "detect job result: $DETECT"
             exit 1
           fi
-          # skipped = no matching projects, or a fork PR that cannot use secrets
+          # skipped = fork PR that cannot use secrets
           if [ "$SCAN" = "failure" ]; then
             echo "scan job result: $SCAN"
             exit 1


### PR DESCRIPTION
On PRs, still report every SonarQube Scan check so required develop contexts are not left pending, but only run the scanner for projects whose sources actually changed.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
