### PR TITLE
fix(ci): stop leftover PR and downstream jobs after merge

### DIFF
--- a/.github/scripts/cancel_downstream_pipeline.py
+++ b/.github/scripts/cancel_downstream_pipeline.py
@@ -15,7 +15,8 @@ correlation token — never the ref/SHA pair, which a concurrent run of the
 same commit would also carry. A sibling pipeline that finishes or 404s
 while its variables are fetched is skipped so discovery can still reach
 this run's pipeline. Transient 5xx or connection errors while listing
-pipelines are retried; they do not abort the search on the first blip.
+pipelines or reading their variables are retried; they do not abort the
+search on the first blip, and they do not count as a successful miss.
 """
 from __future__ import annotations
 
@@ -275,12 +276,10 @@ def list_ref_pipelines(
     return found
 
 
-# HTTP statuses that mean "this candidate is gone or temporarily unreadable".
-# 401/403 are not included: a token that cannot read variables must fail
-# cleanup, not look like "no matching pipeline".
-CANDIDATE_SKIP_HTTP = frozenset(
-    {400, 404, 408, 409, 410, 422, 429, 500, 502, 503, 504}
-)
+# HTTP statuses that mean this listed pipeline is gone, not "try again".
+# 401/403 still abort. Transient 5xx/429/connection errors retry discovery
+# so an empty variable list is not mistaken for "no matching pipeline".
+CANDIDATE_GONE_HTTP = frozenset({400, 404, 409, 410, 422})
 
 
 def fetch_pipeline_variables(
@@ -290,19 +289,18 @@ def fetch_pipeline_variables(
     pipeline_id: int,
     open_func: Any = urlopen,
 ) -> list[Any]:
-    """Variables for one pipeline, or empty if that candidate cannot be inspected.
+    """Variables for one pipeline, or empty if that candidate is gone.
 
-    Discovery lists several live pipelines. One of them finishing (or a
-    transient 5xx) before ``/variables`` returns must not abort the search
-    for this run's correlation token.
+    A 404 on a sibling must not abort the search. A 5xx or connection error
+    is retryable so this run's token is not treated as a successful miss.
     """
     url = f"{base_url}/projects/{project}/pipelines/{pipeline_id}/variables"
     payload = gitlab_json(
         url,
         token,
         open_func=open_func,
-        ignore_http=CANDIDATE_SKIP_HTTP,
-        skip_connection_errors=True,
+        ignore_http=CANDIDATE_GONE_HTTP,
+        retryable=True,
     )
     return payload if isinstance(payload, list) else []
 
@@ -319,19 +317,29 @@ def discover_matching_pipeline_ids(
 ) -> list[int]:
     pipelines = list_ref_pipelines(base_url, token, project, ref, open_func)
     variables_by_id: dict[int, list[Any]] = {}
+    transient: GitLabTransientError | None = None
     for pipe in pipelines:
         if not isinstance(pipe, dict) or not isinstance(pipe.get("id"), int):
             continue
         pid = int(pipe["id"])
-        variables_by_id[pid] = fetch_pipeline_variables(
-            base_url, token, project, pid, open_func=open_func
-        )
-    return matching_pipeline_ids(
+        try:
+            variables_by_id[pid] = fetch_pipeline_variables(
+                base_url, token, project, pid, open_func=open_func
+            )
+        except GitLabTransientError as exc:
+            transient = exc
+            variables_by_id[pid] = []
+    found = matching_pipeline_ids(
         pipelines,
         variables_by_id,
         correlation_id=correlation_id,
         started_at=started_at,
     )
+    if found:
+        return found
+    if transient is not None:
+        raise transient
+    return []
 
 
 def search_matching_pipeline_ids(
@@ -372,7 +380,7 @@ def search_matching_pipeline_ids(
             sleep(delay)
     if last_transient is not None:
         emit_error(
-            "GitLab listing failed after retries: " + str(last_transient)
+            "GitLab discovery failed after retries: " + str(last_transient)
         )
         raise SystemExit(1) from last_transient
     return []

--- a/.github/scripts/cancel_downstream_pipeline.py
+++ b/.github/scripts/cancel_downstream_pipeline.py
@@ -7,15 +7,20 @@ Used when the GitHub Actions job is cancelled (PR closed, superseded
 mirror push, or a human cancel). The poller is killed; GitLab would
 otherwise keep running.
 
-GitHub only publishes a step's ``GITHUB_OUTPUT`` when that step finishes,
-so this script also reads the fsynced handoff file the trigger writes
-immediately after GitLab creates the pipeline.
+GitHub only publishes a step's ``GITHUB_OUTPUT`` when that step finishes.
+The trigger also fsyncs a handoff file. If cancel hits after GitLab has
+created the pipeline but before the id is on disk, cleanup lists recent
+pipelines on the recorded ref whose variables match the recorded SHA.
 """
 from __future__ import annotations
 
 import json
 import os
 import sys
+import time
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
 from pathlib import Path
 from typing import Any
 from urllib.error import ContentTooShortError
@@ -34,6 +39,15 @@ from trigger_downstream_pipeline import emit_error  # noqa: E402
 from trigger_downstream_pipeline import handoff_path  # noqa: E402
 from trigger_downstream_pipeline import require_env  # noqa: E402
 
+ACTIVE_PIPELINE_STATUSES = (
+    "created",
+    "waiting_for_resource",
+    "preparing",
+    "pending",
+    "running",
+    "scheduled",
+)
+
 
 def cancel_pipeline(
     base_url: str,
@@ -45,13 +59,7 @@ def cancel_pipeline(
     open_func: Any = urlopen,
 ) -> str:
     """POST GitLab's pipeline cancel. 404/409 mean it is already gone."""
-    if project_id is not None:
-        project = str(int(project_id))
-    elif project_path:
-        project = quote(project_path, safe="")
-    else:
-        emit_error("Need a GitLab project id or project path to cancel")
-        raise SystemExit(1)
+    project = encode_project(project_id=project_id, project_path=project_path)
     url = f"{base_url}/projects/{project}/pipelines/{int(pipeline_id)}/cancel"
     request = Request(
         url,
@@ -79,24 +87,190 @@ def cancel_pipeline(
     return "cancelled"
 
 
+def encode_project(*, project_id: int | None = None, project_path: str = "") -> str:
+    if project_id is not None:
+        return str(int(project_id))
+    if project_path:
+        return quote(project_path, safe="")
+    emit_error("Need a GitLab project id or project path to cancel")
+    raise SystemExit(1)
+
+
+def load_handoff() -> dict[str, str]:
+    path = Path(handoff_path())
+    if not path.is_file():
+        return {}
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return {}
+    if not isinstance(loaded, dict):
+        return {}
+    payload: dict[str, str] = {}
+    for key, value in loaded.items():
+        if isinstance(key, str) and isinstance(value, (str, int)) and str(value):
+            payload[key] = str(value)
+    return payload
+
+
 def resolve_pipeline_ids() -> tuple[str, str]:
     """Prefer step env; fall back to the trigger step's fsynced handoff file."""
     env_project = os.environ.get("DOWNSTREAM_PROJECT_ID", "").strip()
     env_pipeline = os.environ.get("DOWNSTREAM_PIPELINE_ID", "").strip()
     if env_project and env_pipeline:
         return env_project, env_pipeline
-    path = Path(handoff_path())
-    payload: dict[str, Any] = {}
-    if path.is_file():
-        try:
-            loaded = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-            loaded = {}
-        if isinstance(loaded, dict):
-            payload = loaded
-    project_id = env_project or str(payload.get("project_id") or "").strip()
-    pipeline_id = env_pipeline or str(payload.get("pipeline_id") or "").strip()
+    payload = load_handoff()
+    project_id = env_project or payload.get("project_id", "")
+    pipeline_id = env_pipeline or payload.get("pipeline_id", "")
     return project_id, pipeline_id
+
+
+def parse_gitlab_time(value: str) -> datetime | None:
+    text = value.strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def created_at_is_recent(created_at: str, started_at: str, slack_seconds: int = 60) -> bool:
+    created = parse_gitlab_time(created_at)
+    started = parse_gitlab_time(started_at)
+    if created is None or started is None:
+        return True
+    return created >= started - timedelta(seconds=slack_seconds)
+
+
+def pipeline_variables_match(
+    variables: list[Any], variable_name: str, commit_sha: str
+) -> bool:
+    for item in variables:
+        if not isinstance(item, dict):
+            continue
+        if item.get("key") == variable_name and str(item.get("value") or "") == commit_sha:
+            return True
+    return False
+
+
+def matching_pipeline_ids(
+    pipelines: list[Any],
+    variables_by_id: dict[int, list[Any]],
+    *,
+    variable_name: str,
+    commit_sha: str,
+    started_at: str,
+) -> list[int]:
+    found: list[int] = []
+    for pipe in pipelines:
+        if not isinstance(pipe, dict):
+            continue
+        pid = pipe.get("id")
+        if not isinstance(pid, int):
+            continue
+        if not created_at_is_recent(str(pipe.get("created_at") or ""), started_at):
+            continue
+        if pipeline_variables_match(
+            variables_by_id.get(pid) or [], variable_name, commit_sha
+        ):
+            found.append(pid)
+    return found
+
+
+def gitlab_json(
+    url: str,
+    token: str,
+    *,
+    method: str = "GET",
+    data: bytes | None = None,
+    open_func: Any = urlopen,
+    ignore_http: frozenset[int] | None = None,
+) -> Any:
+    request = Request(
+        url,
+        data=data,
+        method=method,
+        headers={
+            "PRIVATE-TOKEN": token,
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with open_func(request) as response:
+            body = response.read().decode("utf-8")
+    except HTTPError as exc:
+        if ignore_http and exc.code in ignore_http:
+            return []
+        emit_error(f"GitLab request failed with status {exc.code}")
+        raise SystemExit(1) from exc
+    except (URLError, ContentTooShortError) as exc:
+        emit_error(
+            "GitLab request failed due to a connection error: "
+            + connection_error_detail(exc)
+        )
+        raise SystemExit(1) from exc
+    if not body:
+        return None
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError as exc:
+        emit_error("GitLab returned an unexpected response")
+        raise SystemExit(1) from exc
+
+
+def list_ref_pipelines(
+    base_url: str,
+    token: str,
+    project: str,
+    ref: str,
+    open_func: Any = urlopen,
+) -> list[Any]:
+    found: list[Any] = []
+    for status in ACTIVE_PIPELINE_STATUSES:
+        quoted_ref = quote(ref, safe="")
+        url = (
+            f"{base_url}/projects/{project}/pipelines"
+            f"?ref={quoted_ref}&status={status}&per_page=20&order_by=id&sort=desc"
+        )
+        payload = gitlab_json(url, token, open_func=open_func)
+        if isinstance(payload, list):
+            found.extend(payload)
+    return found
+
+
+def discover_matching_pipeline_ids(
+    base_url: str,
+    token: str,
+    *,
+    project: str,
+    ref: str,
+    variable_name: str,
+    commit_sha: str,
+    started_at: str,
+    open_func: Any = urlopen,
+) -> list[int]:
+    pipelines = list_ref_pipelines(base_url, token, project, ref, open_func)
+    variables_by_id: dict[int, list[Any]] = {}
+    for pipe in pipelines:
+        if not isinstance(pipe, dict) or not isinstance(pipe.get("id"), int):
+            continue
+        pid = int(pipe["id"])
+        url = f"{base_url}/projects/{project}/pipelines/{pid}/variables"
+        payload = gitlab_json(url, token, open_func=open_func)
+        variables_by_id[pid] = payload if isinstance(payload, list) else []
+    return matching_pipeline_ids(
+        pipelines,
+        variables_by_id,
+        variable_name=variable_name,
+        commit_sha=commit_sha,
+        started_at=started_at,
+    )
 
 
 def main() -> int:
@@ -104,20 +278,60 @@ def main() -> int:
     token = require_env("DOWNSTREAM_CI_TOKEN")
     project_path = os.environ.get("DOWNSTREAM_PROJECT_PATH", "").strip()
     project_id, pipeline_id = resolve_pipeline_ids()
-    if not pipeline_id:
-        print("No downstream pipeline id; trigger never published one")
-        return 0
+    handoff = load_handoff()
     base_url = api_base_url(raw_url)
     for value in (raw_url, base_url, token, project_path):
         add_mask(value)
-    outcome = cancel_pipeline(
-        base_url,
-        token,
-        int(pipeline_id),
-        project_id=int(project_id) if project_id.isdigit() else None,
-        project_path=project_path,
-    )
-    print(f"Downstream pipeline {pipeline_id}: {outcome}")
+
+    ids: list[int] = []
+    if pipeline_id.isdigit():
+        ids = [int(pipeline_id)]
+    else:
+        commit_sha = handoff.get("commit_sha", "")
+        variable_name = handoff.get("variable_name", "")
+        ref = handoff.get("ref", "") or os.environ.get("DOWNSTREAM_REF", "").strip()
+        started_at = handoff.get("trigger_started_at", "")
+        project = encode_project(
+            project_id=int(project_id) if project_id.isdigit() else None,
+            project_path=project_path,
+        ) if (project_id.isdigit() or project_path) else ""
+        if not (commit_sha and variable_name and ref and started_at and project):
+            print("No downstream pipeline id; trigger never published one")
+            return 0
+        print(
+            "Pipeline id missing after cancel; searching recent GitLab "
+            f"pipelines on {ref} for {variable_name}"
+        )
+        attempts = int(os.environ.get("DOWNSTREAM_CANCEL_SEARCH_ATTEMPTS", "3"))
+        delay = float(os.environ.get("DOWNSTREAM_CANCEL_SEARCH_SECONDS", "2"))
+        for attempt in range(max(1, attempts)):
+            ids = discover_matching_pipeline_ids(
+                base_url,
+                token,
+                project=project,
+                ref=ref,
+                variable_name=variable_name,
+                commit_sha=commit_sha,
+                started_at=started_at,
+            )
+            if ids:
+                break
+            if attempt + 1 < max(1, attempts) and delay > 0:
+                time.sleep(delay)
+        if not ids:
+            print("No matching live downstream pipeline found")
+            return 0
+
+    numeric_project = int(project_id) if project_id.isdigit() else None
+    for pid in ids:
+        outcome = cancel_pipeline(
+            base_url,
+            token,
+            pid,
+            project_id=numeric_project,
+            project_path=project_path,
+        )
+        print(f"Downstream pipeline {pid}: {outcome}")
     return 0
 
 

--- a/.github/scripts/cancel_downstream_pipeline.py
+++ b/.github/scripts/cancel_downstream_pipeline.py
@@ -12,7 +12,9 @@ The trigger also fsyncs a handoff file. If cancel hits after GitLab has
 created the pipeline but before the id is on disk, cleanup lists recent
 pipelines on the recorded ref and matches this trigger attempt's own
 correlation token — never the ref/SHA pair, which a concurrent run of the
-same commit would also carry.
+same commit would also carry. A sibling pipeline that finishes or 404s
+while its variables are fetched is skipped so discovery can still reach
+this run's pipeline.
 """
 from __future__ import annotations
 
@@ -199,6 +201,7 @@ def gitlab_json(
     data: bytes | None = None,
     open_func: Any = urlopen,
     ignore_http: frozenset[int] | None = None,
+    skip_connection_errors: bool = False,
 ) -> Any:
     request = Request(
         url,
@@ -218,6 +221,8 @@ def gitlab_json(
         emit_error(f"GitLab request failed with status {exc.code}")
         raise SystemExit(1) from exc
     except (URLError, ContentTooShortError) as exc:
+        if skip_connection_errors:
+            return []
         emit_error(
             "GitLab request failed due to a connection error: "
             + connection_error_detail(exc)
@@ -252,6 +257,37 @@ def list_ref_pipelines(
     return found
 
 
+# HTTP statuses that mean "this candidate is gone or temporarily unreadable".
+# 401 is not included: a bad token must still fail the whole cleanup.
+CANDIDATE_SKIP_HTTP = frozenset(
+    {400, 403, 404, 408, 409, 410, 422, 429, 500, 502, 503, 504}
+)
+
+
+def fetch_pipeline_variables(
+    base_url: str,
+    token: str,
+    project: str,
+    pipeline_id: int,
+    open_func: Any = urlopen,
+) -> list[Any]:
+    """Variables for one pipeline, or empty if that candidate cannot be inspected.
+
+    Discovery lists several live pipelines. One of them finishing (or a
+    transient 5xx) before ``/variables`` returns must not abort the search
+    for this run's correlation token.
+    """
+    url = f"{base_url}/projects/{project}/pipelines/{pipeline_id}/variables"
+    payload = gitlab_json(
+        url,
+        token,
+        open_func=open_func,
+        ignore_http=CANDIDATE_SKIP_HTTP,
+        skip_connection_errors=True,
+    )
+    return payload if isinstance(payload, list) else []
+
+
 def discover_matching_pipeline_ids(
     base_url: str,
     token: str,
@@ -268,9 +304,9 @@ def discover_matching_pipeline_ids(
         if not isinstance(pipe, dict) or not isinstance(pipe.get("id"), int):
             continue
         pid = int(pipe["id"])
-        url = f"{base_url}/projects/{project}/pipelines/{pid}/variables"
-        payload = gitlab_json(url, token, open_func=open_func)
-        variables_by_id[pid] = payload if isinstance(payload, list) else []
+        variables_by_id[pid] = fetch_pipeline_variables(
+            base_url, token, project, pid, open_func=open_func
+        )
     return matching_pipeline_ids(
         pipelines,
         variables_by_id,

--- a/.github/scripts/cancel_downstream_pipeline.py
+++ b/.github/scripts/cancel_downstream_pipeline.py
@@ -14,7 +14,8 @@ pipelines on the recorded ref and matches this trigger attempt's own
 correlation token — never the ref/SHA pair, which a concurrent run of the
 same commit would also carry. A sibling pipeline that finishes or 404s
 while its variables are fetched is skipped so discovery can still reach
-this run's pipeline.
+this run's pipeline. Transient 5xx or connection errors while listing
+pipelines are retried; they do not abort the search on the first blip.
 """
 from __future__ import annotations
 
@@ -52,6 +53,13 @@ ACTIVE_PIPELINE_STATUSES = (
     "running",
     "scheduled",
 )
+
+# Listing/discovery should retry these rather than abort the outer search loop.
+TRANSIENT_HTTP = frozenset({408, 429, 500, 502, 503, 504})
+
+
+class GitLabTransientError(Exception):
+    """GitLab was unreachable or returned a transient error; retry discovery."""
 
 
 def cancel_pipeline(
@@ -202,6 +210,7 @@ def gitlab_json(
     open_func: Any = urlopen,
     ignore_http: frozenset[int] | None = None,
     skip_connection_errors: bool = False,
+    retryable: bool = False,
 ) -> Any:
     request = Request(
         url,
@@ -218,11 +227,20 @@ def gitlab_json(
     except HTTPError as exc:
         if ignore_http and exc.code in ignore_http:
             return []
+        if retryable and exc.code in TRANSIENT_HTTP:
+            raise GitLabTransientError(
+                f"GitLab request failed with status {exc.code}"
+            ) from exc
         emit_error(f"GitLab request failed with status {exc.code}")
         raise SystemExit(1) from exc
     except (URLError, ContentTooShortError) as exc:
         if skip_connection_errors:
             return []
+        if retryable:
+            raise GitLabTransientError(
+                "GitLab request failed due to a connection error: "
+                + connection_error_detail(exc)
+            ) from exc
         emit_error(
             "GitLab request failed due to a connection error: "
             + connection_error_detail(exc)
@@ -251,7 +269,7 @@ def list_ref_pipelines(
             f"{base_url}/projects/{project}/pipelines"
             f"?ref={quoted_ref}&status={status}&per_page=20&order_by=id&sort=desc"
         )
-        payload = gitlab_json(url, token, open_func=open_func)
+        payload = gitlab_json(url, token, open_func=open_func, retryable=True)
         if isinstance(payload, list):
             found.extend(payload)
     return found
@@ -316,6 +334,50 @@ def discover_matching_pipeline_ids(
     )
 
 
+def search_matching_pipeline_ids(
+    base_url: str,
+    token: str,
+    *,
+    project: str,
+    ref: str,
+    correlation_id: str,
+    started_at: str,
+    attempts: int,
+    delay: float,
+    open_func: Any = urlopen,
+    sleep: Any = time.sleep,
+) -> list[int]:
+    """Retry discovery on transient GitLab errors; fail if they never clear."""
+    last_transient: GitLabTransientError | None = None
+    ids: list[int] = []
+    total = max(1, attempts)
+    for attempt in range(total):
+        try:
+            ids = discover_matching_pipeline_ids(
+                base_url,
+                token,
+                project=project,
+                ref=ref,
+                correlation_id=correlation_id,
+                started_at=started_at,
+                open_func=open_func,
+            )
+            last_transient = None
+        except GitLabTransientError as exc:
+            last_transient = exc
+            ids = []
+        if ids:
+            return ids
+        if attempt + 1 < total and delay > 0:
+            sleep(delay)
+    if last_transient is not None:
+        emit_error(
+            "GitLab listing failed after retries: " + str(last_transient)
+        )
+        raise SystemExit(1) from last_transient
+    return []
+
+
 def main() -> int:
     raw_url = require_env("DOWNSTREAM_CI_URL")
     token = require_env("DOWNSTREAM_CI_TOKEN")
@@ -347,19 +409,16 @@ def main() -> int:
         )
         attempts = int(os.environ.get("DOWNSTREAM_CANCEL_SEARCH_ATTEMPTS", "3"))
         delay = float(os.environ.get("DOWNSTREAM_CANCEL_SEARCH_SECONDS", "2"))
-        for attempt in range(max(1, attempts)):
-            ids = discover_matching_pipeline_ids(
-                base_url,
-                token,
-                project=project,
-                ref=ref,
-                correlation_id=correlation_id,
-                started_at=started_at,
-            )
-            if ids:
-                break
-            if attempt + 1 < max(1, attempts) and delay > 0:
-                time.sleep(delay)
+        ids = search_matching_pipeline_ids(
+            base_url,
+            token,
+            project=project,
+            ref=ref,
+            correlation_id=correlation_id,
+            started_at=started_at,
+            attempts=attempts,
+            delay=delay,
+        )
         if not ids:
             print("No matching live downstream pipeline found")
             return 0

--- a/.github/scripts/cancel_downstream_pipeline.py
+++ b/.github/scripts/cancel_downstream_pipeline.py
@@ -10,7 +10,9 @@ otherwise keep running.
 GitHub only publishes a step's ``GITHUB_OUTPUT`` when that step finishes.
 The trigger also fsyncs a handoff file. If cancel hits after GitLab has
 created the pipeline but before the id is on disk, cleanup lists recent
-pipelines on the recorded ref whose variables match the recorded SHA.
+pipelines on the recorded ref and matches this trigger attempt's own
+correlation token — never the ref/SHA pair, which a concurrent run of the
+same commit would also carry.
 """
 from __future__ import annotations
 
@@ -35,6 +37,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from trigger_downstream_pipeline import add_mask  # noqa: E402
 from trigger_downstream_pipeline import api_base_url  # noqa: E402
 from trigger_downstream_pipeline import connection_error_detail  # noqa: E402
+from trigger_downstream_pipeline import CORRELATION_VARIABLE  # noqa: E402
 from trigger_downstream_pipeline import emit_error  # noqa: E402
 from trigger_downstream_pipeline import handoff_path  # noqa: E402
 from trigger_downstream_pipeline import require_env  # noqa: E402
@@ -148,13 +151,21 @@ def created_at_is_recent(created_at: str, started_at: str, slack_seconds: int = 
     return created >= started - timedelta(seconds=slack_seconds)
 
 
-def pipeline_variables_match(
-    variables: list[Any], variable_name: str, commit_sha: str
-) -> bool:
+def pipeline_variables_match(variables: list[Any], correlation_id: str) -> bool:
+    """Match only this trigger attempt's own correlation token.
+
+    Matching on ref + submodule SHA alone would also match a concurrent
+    run of the same commit and cancel work this job does not own.
+    """
+    if not correlation_id:
+        return False
     for item in variables:
         if not isinstance(item, dict):
             continue
-        if item.get("key") == variable_name and str(item.get("value") or "") == commit_sha:
+        if (
+            item.get("key") == CORRELATION_VARIABLE
+            and str(item.get("value") or "") == correlation_id
+        ):
             return True
     return False
 
@@ -163,8 +174,7 @@ def matching_pipeline_ids(
     pipelines: list[Any],
     variables_by_id: dict[int, list[Any]],
     *,
-    variable_name: str,
-    commit_sha: str,
+    correlation_id: str,
     started_at: str,
 ) -> list[int]:
     found: list[int] = []
@@ -176,9 +186,7 @@ def matching_pipeline_ids(
             continue
         if not created_at_is_recent(str(pipe.get("created_at") or ""), started_at):
             continue
-        if pipeline_variables_match(
-            variables_by_id.get(pid) or [], variable_name, commit_sha
-        ):
+        if pipeline_variables_match(variables_by_id.get(pid) or [], correlation_id):
             found.append(pid)
     return found
 
@@ -250,8 +258,7 @@ def discover_matching_pipeline_ids(
     *,
     project: str,
     ref: str,
-    variable_name: str,
-    commit_sha: str,
+    correlation_id: str,
     started_at: str,
     open_func: Any = urlopen,
 ) -> list[int]:
@@ -267,8 +274,7 @@ def discover_matching_pipeline_ids(
     return matching_pipeline_ids(
         pipelines,
         variables_by_id,
-        variable_name=variable_name,
-        commit_sha=commit_sha,
+        correlation_id=correlation_id,
         started_at=started_at,
     )
 
@@ -287,20 +293,20 @@ def main() -> int:
     if pipeline_id.isdigit():
         ids = [int(pipeline_id)]
     else:
-        commit_sha = handoff.get("commit_sha", "")
-        variable_name = handoff.get("variable_name", "")
+        correlation_id = handoff.get("correlation_id", "")
         ref = handoff.get("ref", "") or os.environ.get("DOWNSTREAM_REF", "").strip()
         started_at = handoff.get("trigger_started_at", "")
         project = encode_project(
             project_id=int(project_id) if project_id.isdigit() else None,
             project_path=project_path,
         ) if (project_id.isdigit() or project_path) else ""
-        if not (commit_sha and variable_name and ref and started_at and project):
+        if not (correlation_id and ref and started_at and project):
             print("No downstream pipeline id; trigger never published one")
             return 0
+        add_mask(correlation_id)
         print(
             "Pipeline id missing after cancel; searching recent GitLab "
-            f"pipelines on {ref} for {variable_name}"
+            f"pipelines on {ref} for this run's correlation token"
         )
         attempts = int(os.environ.get("DOWNSTREAM_CANCEL_SEARCH_ATTEMPTS", "3"))
         delay = float(os.environ.get("DOWNSTREAM_CANCEL_SEARCH_SECONDS", "2"))
@@ -310,8 +316,7 @@ def main() -> int:
                 token,
                 project=project,
                 ref=ref,
-                variable_name=variable_name,
-                commit_sha=commit_sha,
+                correlation_id=correlation_id,
                 started_at=started_at,
             )
             if ids:

--- a/.github/scripts/cancel_downstream_pipeline.py
+++ b/.github/scripts/cancel_downstream_pipeline.py
@@ -256,6 +256,17 @@ def gitlab_json(
         raise SystemExit(1) from exc
 
 
+LIST_PAGE_SIZE = 20
+
+
+def list_page_limit() -> int:
+    raw = os.environ.get("DOWNSTREAM_CANCEL_LIST_PAGES", "10").strip() or "10"
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return 10
+
+
 def list_ref_pipelines(
     base_url: str,
     token: str,
@@ -264,15 +275,21 @@ def list_ref_pipelines(
     open_func: Any = urlopen,
 ) -> list[Any]:
     found: list[Any] = []
+    page_limit = list_page_limit()
     for status in ACTIVE_PIPELINE_STATUSES:
         quoted_ref = quote(ref, safe="")
-        url = (
-            f"{base_url}/projects/{project}/pipelines"
-            f"?ref={quoted_ref}&status={status}&per_page=20&order_by=id&sort=desc"
-        )
-        payload = gitlab_json(url, token, open_func=open_func, retryable=True)
-        if isinstance(payload, list):
+        for page in range(1, page_limit + 1):
+            url = (
+                f"{base_url}/projects/{project}/pipelines"
+                f"?ref={quoted_ref}&status={status}"
+                f"&per_page={LIST_PAGE_SIZE}&page={page}&order_by=id&sort=desc"
+            )
+            payload = gitlab_json(url, token, open_func=open_func, retryable=True)
+            if not isinstance(payload, list) or not payload:
+                break
             found.extend(payload)
+            if len(payload) < LIST_PAGE_SIZE:
+                break
     return found
 
 

--- a/.github/scripts/cancel_downstream_pipeline.py
+++ b/.github/scripts/cancel_downstream_pipeline.py
@@ -258,9 +258,10 @@ def list_ref_pipelines(
 
 
 # HTTP statuses that mean "this candidate is gone or temporarily unreadable".
-# 401 is not included: a bad token must still fail the whole cleanup.
+# 401/403 are not included: a token that cannot read variables must fail
+# cleanup, not look like "no matching pipeline".
 CANDIDATE_SKIP_HTTP = frozenset(
-    {400, 403, 404, 408, 409, 410, 422, 429, 500, 502, 503, 504}
+    {400, 404, 408, 409, 410, 422, 429, 500, 502, 503, 504}
 )
 
 

--- a/.github/scripts/cancel_downstream_pipeline.py
+++ b/.github/scripts/cancel_downstream_pipeline.py
@@ -355,7 +355,11 @@ def search_matching_pipeline_ids(
     open_func: Any = urlopen,
     sleep: Any = time.sleep,
 ) -> list[int]:
-    """Retry discovery on transient GitLab errors; fail if they never clear."""
+    """Retry discovery on transient GitLab errors; fail if they never clear.
+
+    An empty later attempt does not erase an earlier transient: GitLab may
+    have only been temporarily unable to show this run's pipeline.
+    """
     last_transient: GitLabTransientError | None = None
     ids: list[int] = []
     total = max(1, attempts)
@@ -370,7 +374,6 @@ def search_matching_pipeline_ids(
                 started_at=started_at,
                 open_func=open_func,
             )
-            last_transient = None
         except GitLabTransientError as exc:
             last_transient = exc
             ids = []

--- a/.github/scripts/cancel_downstream_pipeline.py
+++ b/.github/scripts/cancel_downstream_pipeline.py
@@ -6,9 +6,14 @@
 Used when the GitHub Actions job is cancelled (PR closed, superseded
 mirror push, or a human cancel). The poller is killed; GitLab would
 otherwise keep running.
+
+GitHub only publishes a step's ``GITHUB_OUTPUT`` when that step finishes,
+so this script also reads the fsynced handoff file the trigger writes
+immediately after GitLab creates the pipeline.
 """
 from __future__ import annotations
 
+import json
 import os
 import sys
 from pathlib import Path
@@ -16,6 +21,7 @@ from typing import Any
 from urllib.error import ContentTooShortError
 from urllib.error import HTTPError
 from urllib.error import URLError
+from urllib.parse import quote
 from urllib.request import Request
 from urllib.request import urlopen
 
@@ -25,20 +31,28 @@ from trigger_downstream_pipeline import add_mask  # noqa: E402
 from trigger_downstream_pipeline import api_base_url  # noqa: E402
 from trigger_downstream_pipeline import connection_error_detail  # noqa: E402
 from trigger_downstream_pipeline import emit_error  # noqa: E402
+from trigger_downstream_pipeline import handoff_path  # noqa: E402
 from trigger_downstream_pipeline import require_env  # noqa: E402
 
 
 def cancel_pipeline(
     base_url: str,
     token: str,
-    project_id: int,
     pipeline_id: int,
+    *,
+    project_id: int | None = None,
+    project_path: str = "",
     open_func: Any = urlopen,
 ) -> str:
     """POST GitLab's pipeline cancel. 404/409 mean it is already gone."""
-    url = (
-        f"{base_url}/projects/{int(project_id)}/pipelines/{int(pipeline_id)}/cancel"
-    )
+    if project_id is not None:
+        project = str(int(project_id))
+    elif project_path:
+        project = quote(project_path, safe="")
+    else:
+        emit_error("Need a GitLab project id or project path to cancel")
+        raise SystemExit(1)
+    url = f"{base_url}/projects/{project}/pipelines/{int(pipeline_id)}/cancel"
     request = Request(
         url,
         data=b"",
@@ -65,15 +79,44 @@ def cancel_pipeline(
     return "cancelled"
 
 
+def resolve_pipeline_ids() -> tuple[str, str]:
+    """Prefer step env; fall back to the trigger step's fsynced handoff file."""
+    env_project = os.environ.get("DOWNSTREAM_PROJECT_ID", "").strip()
+    env_pipeline = os.environ.get("DOWNSTREAM_PIPELINE_ID", "").strip()
+    if env_project and env_pipeline:
+        return env_project, env_pipeline
+    path = Path(handoff_path())
+    payload: dict[str, Any] = {}
+    if path.is_file():
+        try:
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            loaded = {}
+        if isinstance(loaded, dict):
+            payload = loaded
+    project_id = env_project or str(payload.get("project_id") or "").strip()
+    pipeline_id = env_pipeline or str(payload.get("pipeline_id") or "").strip()
+    return project_id, pipeline_id
+
+
 def main() -> int:
     raw_url = require_env("DOWNSTREAM_CI_URL")
     token = require_env("DOWNSTREAM_CI_TOKEN")
-    project_id = int(require_env("DOWNSTREAM_PROJECT_ID"))
-    pipeline_id = int(require_env("DOWNSTREAM_PIPELINE_ID"))
+    project_path = os.environ.get("DOWNSTREAM_PROJECT_PATH", "").strip()
+    project_id, pipeline_id = resolve_pipeline_ids()
+    if not pipeline_id:
+        print("No downstream pipeline id; trigger never published one")
+        return 0
     base_url = api_base_url(raw_url)
-    for value in (raw_url, base_url, token):
+    for value in (raw_url, base_url, token, project_path):
         add_mask(value)
-    outcome = cancel_pipeline(base_url, token, project_id, pipeline_id)
+    outcome = cancel_pipeline(
+        base_url,
+        token,
+        int(pipeline_id),
+        project_id=int(project_id) if project_id.isdigit() else None,
+        project_path=project_path,
+    )
     print(f"Downstream pipeline {pipeline_id}: {outcome}")
     return 0
 

--- a/.github/scripts/cancel_downstream_pipeline.py
+++ b/.github/scripts/cancel_downstream_pipeline.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Cancel a downstream GitLab pipeline that this GitHub job already started.
+
+Used when the GitHub Actions job is cancelled (PR closed, superseded
+mirror push, or a human cancel). The poller is killed; GitLab would
+otherwise keep running.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.error import ContentTooShortError
+from urllib.error import HTTPError
+from urllib.error import URLError
+from urllib.request import Request
+from urllib.request import urlopen
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from trigger_downstream_pipeline import add_mask  # noqa: E402
+from trigger_downstream_pipeline import api_base_url  # noqa: E402
+from trigger_downstream_pipeline import connection_error_detail  # noqa: E402
+from trigger_downstream_pipeline import emit_error  # noqa: E402
+from trigger_downstream_pipeline import require_env  # noqa: E402
+
+
+def cancel_pipeline(
+    base_url: str,
+    token: str,
+    project_id: int,
+    pipeline_id: int,
+    open_func: Any = urlopen,
+) -> str:
+    """POST GitLab's pipeline cancel. 404/409 mean it is already gone."""
+    url = (
+        f"{base_url}/projects/{int(project_id)}/pipelines/{int(pipeline_id)}/cancel"
+    )
+    request = Request(
+        url,
+        data=b"",
+        method="POST",
+        headers={
+            "PRIVATE-TOKEN": token,
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with open_func(request) as response:
+            response.read()
+    except HTTPError as exc:
+        if exc.code in {404, 409}:
+            return f"already finished ({exc.code})"
+        emit_error(f"Pipeline cancel failed with status {exc.code}")
+        raise SystemExit(1) from exc
+    except (URLError, ContentTooShortError) as exc:
+        emit_error(
+            "Pipeline cancel failed due to a connection error: "
+            + connection_error_detail(exc)
+        )
+        raise SystemExit(1) from exc
+    return "cancelled"
+
+
+def main() -> int:
+    raw_url = require_env("DOWNSTREAM_CI_URL")
+    token = require_env("DOWNSTREAM_CI_TOKEN")
+    project_id = int(require_env("DOWNSTREAM_PROJECT_ID"))
+    pipeline_id = int(require_env("DOWNSTREAM_PIPELINE_ID"))
+    base_url = api_base_url(raw_url)
+    for value in (raw_url, base_url, token):
+        add_mask(value)
+    outcome = cancel_pipeline(base_url, token, project_id, pipeline_id)
+    print(f"Downstream pipeline {pipeline_id}: {outcome}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/cancel_downstream_pipeline.py
+++ b/.github/scripts/cancel_downstream_pipeline.py
@@ -17,6 +17,7 @@ while its variables are fetched is skipped so discovery can still reach
 this run's pipeline. Transient 5xx or connection errors while listing
 pipelines or reading their variables are retried; they do not abort the
 search on the first blip, and they do not count as a successful miss.
+Listing paginates so a busy shared ref is not truncated at 20 pipelines.
 """
 from __future__ import annotations
 

--- a/.github/scripts/cancel_stale_pr_ci.py
+++ b/.github/scripts/cancel_stale_pr_ci.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Cancel in-flight CI on ``pull-request/<N>`` after the source PR moves.
+"""Cancel leftover PR CI after the source PR moves or closes.
 
-PR CI is gated on copy-pr-bot updating the mirror (``/ok to test``). Until
-that push, GitHub concurrency cannot see a new run and will not cancel the
-old one. This helper is the source-PR side of that: on synchronize or close,
-cancel mirror runs that are not testing the current source head.
+On synchronize, cancel ``pull-request/<N>`` runs that are not testing the
+current source head. On close (merge or abandon), cancel every remaining
+PR run — required or not — except close-path workflows such as tag cleanup.
 
 copy-pr-bot often pushes a merge of the approved SHA into the PR base, so
 the run's tree is the merge result, not the source-head tree. A current run
@@ -29,6 +28,10 @@ GITHUB_API = "https://api.github.com"
 ACTIVE_STATUSES = frozenset(
     {"in_progress", "pending", "queued", "requested", "waiting"}
 )
+# Close handlers that must finish after merge. Everything else on the PR,
+# required or not, is leftover work.
+PROTECTED_WORKFLOWS = frozenset({"Cancel Stale PR CI", "Cleanup PR Tags"})
+PR_EVENTS = ("pull_request", "pull_request_target")
 
 
 class CancelError(RuntimeError):
@@ -114,19 +117,18 @@ def load_commit(
     return info
 
 
-def list_active_runs(
+def _collect_status_pages(
     repo: str,
-    branch: str,
-    get: Callable[..., Any] = github,
+    extra_query: str,
+    get: Callable[..., Any],
 ) -> list[dict[str, Any]]:
     seen: set[int] = set()
     runs: list[dict[str, Any]] = []
-    quoted = urllib.parse.quote(branch, safe="")
     for status in sorted(ACTIVE_STATUSES):
         page = 1
         while page <= 20:
             path = (
-                f"/actions/runs?branch={quoted}&status={status}"
+                f"/actions/runs?{extra_query}&status={status}"
                 f"&per_page=100&page={page}"
             )
             try:
@@ -146,6 +148,65 @@ def list_active_runs(
             if len(batch) < 100:
                 break
             page += 1
+    return runs
+
+
+def list_active_runs(
+    repo: str,
+    branch: str,
+    get: Callable[..., Any] = github,
+) -> list[dict[str, Any]]:
+    quoted = urllib.parse.quote(branch, safe="")
+    return _collect_status_pages(repo, f"branch={quoted}", get)
+
+
+def list_active_runs_for_event(
+    repo: str,
+    event: str,
+    get: Callable[..., Any] = github,
+) -> list[dict[str, Any]]:
+    quoted = urllib.parse.quote(event, safe="")
+    return _collect_status_pages(repo, f"event={quoted}", get)
+
+
+def run_belongs_to_pr(run: dict[str, Any], pr_number: int) -> bool:
+    for pr in run.get("pull_requests") or []:
+        number = pr.get("number") if isinstance(pr, dict) else None
+        if number == pr_number or str(number) == str(pr_number):
+            return True
+    return str(run.get("head_branch") or "") == f"pull-request/{pr_number}"
+
+
+def collect_runs_to_consider(
+    repo: str,
+    pr_number: int,
+    closed: bool,
+    get: Callable[..., Any] = github,
+) -> list[dict[str, Any]]:
+    """Mirror-branch runs always; on close, also native PR-event runs.
+
+    SonarQube and other optional checks use ``pull_request`` / 
+    ``pull_request_target`` on the contributor branch, not ``pull-request/N``.
+    """
+    branch = f"pull-request/{pr_number}"
+    seen: set[int] = set()
+    runs: list[dict[str, Any]] = []
+    for run in list_active_runs(repo, branch, get):
+        run_id = run.get("id")
+        if isinstance(run_id, int) and run_id not in seen:
+            seen.add(run_id)
+            runs.append(run)
+    if not closed:
+        return runs
+    for event in PR_EVENTS:
+        for run in list_active_runs_for_event(repo, event, get):
+            run_id = run.get("id")
+            if not isinstance(run_id, int) or run_id in seen:
+                continue
+            if not run_belongs_to_pr(run, pr_number):
+                continue
+            seen.add(run_id)
+            runs.append(run)
     return runs
 
 
@@ -181,6 +242,8 @@ def should_cancel_run(
 ) -> bool:
     run_id = run.get("id")
     if this_run_id is not None and run_id == this_run_id:
+        return False
+    if str(run.get("name") or "") in PROTECTED_WORKFLOWS:
         return False
     if run.get("status") not in ACTIVE_STATUSES:
         return False
@@ -234,7 +297,6 @@ def main() -> int:
     closed = os.environ.get("PR_CLOSED", "").strip().lower() in {"1", "true", "yes"}
     this_run_raw = os.environ.get("GITHUB_RUN_ID", "").strip()
     this_run_id = int(this_run_raw) if this_run_raw.isdigit() else None
-    branch = f"pull-request/{pr_number}"
     cache: dict[str, CommitInfo | None] = {}
 
     source_commit = load_commit(repo, source_sha, cache) if source_sha else None
@@ -247,7 +309,8 @@ def main() -> int:
         return 0
 
     cancelled = 0
-    for run in list_active_runs(repo, branch):
+    pr_id = int(pr_number)
+    for run in collect_runs_to_consider(repo, pr_id, closed):
         run_id = run.get("id")
         if not isinstance(run_id, int):
             continue
@@ -265,7 +328,7 @@ def main() -> int:
         print(f"Cancelling run {run_id} ({run.get('name')}) sha={head_sha[:12]}")
         cancel_run(repo, run_id)
         cancelled += 1
-    print(f"Cancelled {cancelled} stale run(s) on {branch}")
+    print(f"Cancelled {cancelled} leftover run(s) for PR {pr_number}")
     return 0
 
 

--- a/.github/scripts/cancel_stale_pr_ci.py
+++ b/.github/scripts/cancel_stale_pr_ci.py
@@ -169,12 +169,30 @@ def list_active_runs_for_event(
     return _collect_status_pages(repo, f"event={quoted}", get)
 
 
-def run_belongs_to_pr(run: dict[str, Any], pr_number: int) -> bool:
+def run_belongs_to_pr(
+    run: dict[str, Any],
+    pr_number: int,
+    source_branch: str = "",
+    source_sha: str = "",
+) -> bool:
+    """Attribute a run to a PR using keys that survive the PR closing.
+
+    GitHub empties ``pull_requests`` as soon as the PR closes, which is
+    exactly when the close path runs, so it cannot be the only key. The
+    ``pull-request/<N>`` fallback never matches a native ``pull_request``
+    run either — that run's ``head_branch`` is the contributor branch. The
+    source branch and head SHA carried by the close event are what remain.
+    """
     for pr in run.get("pull_requests") or []:
         number = pr.get("number") if isinstance(pr, dict) else None
         if number == pr_number or str(number) == str(pr_number):
             return True
-    return str(run.get("head_branch") or "") == f"pull-request/{pr_number}"
+    head_branch = str(run.get("head_branch") or "")
+    if head_branch == f"pull-request/{pr_number}":
+        return True
+    if source_branch and head_branch == source_branch:
+        return True
+    return bool(source_sha) and str(run.get("head_sha") or "") == source_sha
 
 
 def collect_runs_to_consider(
@@ -182,11 +200,16 @@ def collect_runs_to_consider(
     pr_number: int,
     closed: bool,
     get: Callable[..., Any] = github,
+    *,
+    source_branch: str = "",
+    source_sha: str = "",
 ) -> list[dict[str, Any]]:
     """Mirror-branch runs always; on close, also native PR-event runs.
 
-    SonarQube and other optional checks use ``pull_request`` / 
+    SonarQube and other optional checks use ``pull_request`` /
     ``pull_request_target`` on the contributor branch, not ``pull-request/N``.
+    ``source_branch`` / ``source_sha`` come from the close event; they are the
+    only attribution left once GitHub has emptied ``pull_requests``.
     """
     branch = f"pull-request/{pr_number}"
     seen: set[int] = set()
@@ -203,7 +226,9 @@ def collect_runs_to_consider(
             run_id = run.get("id")
             if not isinstance(run_id, int) or run_id in seen:
                 continue
-            if not run_belongs_to_pr(run, pr_number):
+            if not run_belongs_to_pr(
+                run, pr_number, source_branch=source_branch, source_sha=source_sha
+            ):
                 continue
             seen.add(run_id)
             runs.append(run)
@@ -310,7 +335,14 @@ def main() -> int:
 
     cancelled = 0
     pr_id = int(pr_number)
-    for run in collect_runs_to_consider(repo, pr_id, closed):
+    source_branch = os.environ.get("SOURCE_BRANCH", "").strip()
+    for run in collect_runs_to_consider(
+        repo,
+        pr_id,
+        closed,
+        source_branch=source_branch,
+        source_sha=source_sha,
+    ):
         run_id = run.get("id")
         if not isinstance(run_id, int):
             continue

--- a/.github/scripts/test_cancel_downstream_pipeline.py
+++ b/.github/scripts/test_cancel_downstream_pipeline.py
@@ -240,6 +240,25 @@ class SearchFallbackTest(unittest.TestCase):
                 open_func=open_func,
             )
 
+    def test_forbidden_variables_read_still_aborts_discovery(self):
+        def open_func(req):
+            raise HTTPError(
+                req.full_url,
+                403,
+                "Forbidden",
+                hdrs=None,  # type: ignore[arg-type]
+                fp=io.BytesIO(b"{}"),
+            )
+
+        with self.assertRaises(SystemExit):
+            module.fetch_pipeline_variables(
+                "https://gitlab.example/api/v4",
+                "token",
+                "1",
+                10,
+                open_func=open_func,
+            )
+
 
 class WorkflowWiringTest(unittest.TestCase):
     def test_ci_cancels_downstream_when_the_github_job_is_cancelled(self):

--- a/.github/scripts/test_cancel_downstream_pipeline.py
+++ b/.github/scripts/test_cancel_downstream_pipeline.py
@@ -353,6 +353,158 @@ class SearchFallbackTest(unittest.TestCase):
                 open_func=open_func,
             )
 
+    def test_variables_503_is_retried_then_finds_ours(self):
+        class JsonResponse:
+            def __init__(self, payload: object) -> None:
+                self._body = json.dumps(payload).encode("utf-8")
+
+            def read(self) -> bytes:
+                return self._body
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+        reads = {"n": 0}
+
+        def open_func(req):
+            url = req.full_url
+            if "/pipelines?" in url:
+                if "status=running" in url:
+                    return JsonResponse(
+                        [{"id": 11, "created_at": "2026-08-28T08:12:31Z"}]
+                    )
+                return JsonResponse([])
+            if url.endswith("/pipelines/11/variables"):
+                reads["n"] += 1
+                if reads["n"] == 1:
+                    raise HTTPError(
+                        url,
+                        503,
+                        "Service Unavailable",
+                        hdrs=None,  # type: ignore[arg-type]
+                        fp=io.BytesIO(b"{}"),
+                    )
+                return JsonResponse(
+                    [{"key": module.CORRELATION_VARIABLE, "value": "gh-1-1-mine"}]
+                )
+            raise AssertionError(url)
+
+        self.assertEqual(
+            module.search_matching_pipeline_ids(
+                "https://gitlab.example/api/v4",
+                "token",
+                project="1",
+                ref="main",
+                correlation_id="gh-1-1-mine",
+                started_at="2026-08-28T08:12:00Z",
+                attempts=3,
+                delay=0,
+                open_func=open_func,
+            ),
+            [11],
+        )
+        self.assertEqual(reads["n"], 2)
+
+    def test_variables_5xx_exhausted_fails_cleanup(self):
+        class JsonResponse:
+            def __init__(self, payload: object) -> None:
+                self._body = json.dumps(payload).encode("utf-8")
+
+            def read(self) -> bytes:
+                return self._body
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+        def open_func(req):
+            url = req.full_url
+            if "/pipelines?" in url:
+                if "status=running" in url:
+                    return JsonResponse(
+                        [{"id": 11, "created_at": "2026-08-28T08:12:31Z"}]
+                    )
+                return JsonResponse([])
+            if url.endswith("/pipelines/11/variables"):
+                raise HTTPError(
+                    url,
+                    502,
+                    "Bad Gateway",
+                    hdrs=None,  # type: ignore[arg-type]
+                    fp=io.BytesIO(b"{}"),
+                )
+            raise AssertionError(url)
+
+        with self.assertRaises(SystemExit):
+            module.search_matching_pipeline_ids(
+                "https://gitlab.example/api/v4",
+                "token",
+                project="1",
+                ref="main",
+                correlation_id="gh-1-1-mine",
+                started_at="2026-08-28T08:12:00Z",
+                attempts=2,
+                delay=0,
+                open_func=open_func,
+            )
+
+    def test_sibling_variables_5xx_does_not_hide_ours(self):
+        class JsonResponse:
+            def __init__(self, payload: object) -> None:
+                self._body = json.dumps(payload).encode("utf-8")
+
+            def read(self) -> bytes:
+                return self._body
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+        def open_func(req):
+            url = req.full_url
+            if "/pipelines?" in url:
+                if "status=running" in url:
+                    return JsonResponse(
+                        [
+                            {"id": 10, "created_at": "2026-08-28T08:12:30Z"},
+                            {"id": 11, "created_at": "2026-08-28T08:12:31Z"},
+                        ]
+                    )
+                return JsonResponse([])
+            if url.endswith("/pipelines/10/variables"):
+                raise HTTPError(
+                    url,
+                    503,
+                    "Service Unavailable",
+                    hdrs=None,  # type: ignore[arg-type]
+                    fp=io.BytesIO(b"{}"),
+                )
+            if url.endswith("/pipelines/11/variables"):
+                return JsonResponse(
+                    [{"key": module.CORRELATION_VARIABLE, "value": "gh-1-1-mine"}]
+                )
+            raise AssertionError(url)
+
+        self.assertEqual(
+            module.discover_matching_pipeline_ids(
+                "https://gitlab.example/api/v4",
+                "token",
+                project="1",
+                ref="main",
+                correlation_id="gh-1-1-mine",
+                started_at="2026-08-28T08:12:00Z",
+                open_func=open_func,
+            ),
+            [11],
+        )
+
 
 class WorkflowWiringTest(unittest.TestCase):
     def test_ci_cancels_downstream_when_the_github_job_is_cancelled(self):

--- a/.github/scripts/test_cancel_downstream_pipeline.py
+++ b/.github/scripts/test_cancel_downstream_pipeline.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import importlib.util
+import io
+import unittest
+from pathlib import Path
+from urllib.error import HTTPError
+
+SCRIPT = Path(__file__).with_name("cancel_downstream_pipeline.py")
+SPEC = importlib.util.spec_from_file_location("cancel_downstream_pipeline", SCRIPT)
+assert SPEC and SPEC.loader
+module = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(module)
+
+
+class FakeResponse:
+    def read(self) -> bytes:
+        return b"{}"
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+
+class CancelPipelineTest(unittest.TestCase):
+    def test_success(self):
+        self.assertEqual(
+            module.cancel_pipeline(
+                "https://gitlab.example/api/v4",
+                "token",
+                1,
+                99,
+                open_func=lambda _req: FakeResponse(),
+            ),
+            "cancelled",
+        )
+
+    def test_already_finished_is_ok(self):
+        def open_func(_req):
+            raise HTTPError(
+                "https://gitlab.example/api/v4/projects/1/pipelines/99/cancel",
+                409,
+                "Conflict",
+                hdrs=None,  # type: ignore[arg-type]
+                fp=io.BytesIO(b"{}"),
+            )
+
+        self.assertEqual(
+            module.cancel_pipeline(
+                "https://gitlab.example/api/v4",
+                "token",
+                1,
+                99,
+                open_func=open_func,
+            ),
+            "already finished (409)",
+        )
+
+
+class WorkflowWiringTest(unittest.TestCase):
+    def test_ci_cancels_downstream_when_the_github_job_is_cancelled(self):
+        ci = (
+            Path(__file__).resolve().parent.parent / "workflows" / "ci.yml"
+        ).read_text()
+        self.assertIn("cancel_downstream_pipeline.py", ci)
+        self.assertIn("if: cancelled()", ci)
+
+    def test_ci_runs_these_tests(self):
+        ci = (
+            Path(__file__).resolve().parent.parent / "workflows" / "ci.yml"
+        ).read_text()
+        self.assertIn(
+            "python3 .github/scripts/test_cancel_downstream_pipeline.py", ci
+        )
+
+    def test_downstream_trigger_workflows_cancel_gitlab_on_github_cancel(self):
+        workflows = Path(__file__).resolve().parent.parent / "workflows"
+        for name in (
+            "ci.yml",
+            "spatialai-data-utils.yml",
+            "osrb-review.yml",
+        ):
+            text = (workflows / name).read_text()
+            self.assertIn(
+                "cancel_downstream_pipeline.py",
+                text,
+                f"{name} must cancel GitLab when the GitHub job is cancelled",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_cancel_downstream_pipeline.py
+++ b/.github/scripts/test_cancel_downstream_pipeline.py
@@ -112,6 +112,40 @@ class HandoffTest(unittest.TestCase):
                 self.assertEqual(module.resolve_pipeline_ids(), ("8", "9"))
 
 
+class SearchFallbackTest(unittest.TestCase):
+    def test_matches_recent_pipeline_with_the_recorded_sha(self):
+        pipelines = [
+            {"id": 10, "created_at": "2026-08-28T08:12:30Z"},
+            {"id": 11, "created_at": "2026-08-28T07:00:00Z"},
+        ]
+        variables = {
+            10: [{"key": "VSS_SUBMODULE_HASH", "value": "abc"}],
+            11: [{"key": "VSS_SUBMODULE_HASH", "value": "abc"}],
+        }
+        self.assertEqual(
+            module.matching_pipeline_ids(
+                pipelines,
+                variables,
+                variable_name="VSS_SUBMODULE_HASH",
+                commit_sha="abc",
+                started_at="2026-08-28T08:12:00Z",
+            ),
+            [10],
+        )
+
+    def test_ignores_pipelines_for_a_different_sha(self):
+        self.assertEqual(
+            module.matching_pipeline_ids(
+                [{"id": 10, "created_at": "2026-08-28T08:12:30Z"}],
+                {10: [{"key": "VSS_SUBMODULE_HASH", "value": "other"}]},
+                variable_name="VSS_SUBMODULE_HASH",
+                commit_sha="abc",
+                started_at="2026-08-28T08:12:00Z",
+            ),
+            [],
+        )
+
+
 class WorkflowWiringTest(unittest.TestCase):
     def test_ci_cancels_downstream_when_the_github_job_is_cancelled(self):
         ci = (

--- a/.github/scripts/test_cancel_downstream_pipeline.py
+++ b/.github/scripts/test_cancel_downstream_pipeline.py
@@ -113,33 +113,57 @@ class HandoffTest(unittest.TestCase):
 
 
 class SearchFallbackTest(unittest.TestCase):
-    def test_matches_recent_pipeline_with_the_recorded_sha(self):
+    def test_matches_this_runs_correlation_token(self):
         pipelines = [
             {"id": 10, "created_at": "2026-08-28T08:12:30Z"},
             {"id": 11, "created_at": "2026-08-28T07:00:00Z"},
         ]
         variables = {
-            10: [{"key": "VSS_SUBMODULE_HASH", "value": "abc"}],
-            11: [{"key": "VSS_SUBMODULE_HASH", "value": "abc"}],
+            10: [{"key": module.CORRELATION_VARIABLE, "value": "gh-1-1-aaa"}],
+            11: [{"key": module.CORRELATION_VARIABLE, "value": "gh-1-1-aaa"}],
         }
         self.assertEqual(
             module.matching_pipeline_ids(
                 pipelines,
                 variables,
-                variable_name="VSS_SUBMODULE_HASH",
-                commit_sha="abc",
+                correlation_id="gh-1-1-aaa",
                 started_at="2026-08-28T08:12:00Z",
             ),
             [10],
         )
 
-    def test_ignores_pipelines_for_a_different_sha(self):
+    def test_leaves_a_concurrent_run_on_the_same_sha_alone(self):
+        """Two runs share ref + VSS_SUBMODULE_HASH; only ours may be cancelled."""
+        pipelines = [
+            {"id": 20, "created_at": "2026-08-28T08:12:30Z"},
+            {"id": 21, "created_at": "2026-08-28T08:12:31Z"},
+        ]
+        variables = {
+            20: [
+                {"key": "VSS_SUBMODULE_HASH", "value": "abc"},
+                {"key": module.CORRELATION_VARIABLE, "value": "gh-1-1-mine"},
+            ],
+            21: [
+                {"key": "VSS_SUBMODULE_HASH", "value": "abc"},
+                {"key": module.CORRELATION_VARIABLE, "value": "gh-2-1-theirs"},
+            ],
+        }
+        self.assertEqual(
+            module.matching_pipeline_ids(
+                pipelines,
+                variables,
+                correlation_id="gh-1-1-mine",
+                started_at="2026-08-28T08:12:00Z",
+            ),
+            [20],
+        )
+
+    def test_no_correlation_token_cancels_nothing(self):
         self.assertEqual(
             module.matching_pipeline_ids(
                 [{"id": 10, "created_at": "2026-08-28T08:12:30Z"}],
-                {10: [{"key": "VSS_SUBMODULE_HASH", "value": "other"}]},
-                variable_name="VSS_SUBMODULE_HASH",
-                commit_sha="abc",
+                {10: [{"key": "VSS_SUBMODULE_HASH", "value": "abc"}]},
+                correlation_id="",
                 started_at="2026-08-28T08:12:00Z",
             ),
             [],

--- a/.github/scripts/test_cancel_downstream_pipeline.py
+++ b/.github/scripts/test_cancel_downstream_pipeline.py
@@ -503,6 +503,87 @@ class SearchFallbackTest(unittest.TestCase):
                 open_func=open_func,
             ),
             [11],
+            )
+
+
+    def test_empty_retry_after_transient_still_fails_cleanup(self):
+        class JsonResponse:
+            def __init__(self, payload: object) -> None:
+                self._body = json.dumps(payload).encode("utf-8")
+
+            def read(self) -> bytes:
+                return self._body
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+        waves = {"n": 0}
+
+        def open_func(req):
+            url = req.full_url
+            if "/pipelines?" in url:
+                if "status=created" in url:
+                    waves["n"] += 1
+                    if waves["n"] == 1:
+                        raise HTTPError(
+                            url,
+                            503,
+                            "Service Unavailable",
+                            hdrs=None,  # type: ignore[arg-type]
+                            fp=io.BytesIO(b"{}"),
+                        )
+                return JsonResponse([])
+            raise AssertionError(url)
+
+        with self.assertRaises(SystemExit):
+            module.search_matching_pipeline_ids(
+                "https://gitlab.example/api/v4",
+                "token",
+                project="1",
+                ref="main",
+                correlation_id="gh-1-1-mine",
+                started_at="2026-08-28T08:12:00Z",
+                attempts=2,
+                delay=0,
+                open_func=open_func,
+            )
+
+    def test_empty_discovery_without_transient_is_a_real_miss(self):
+        class JsonResponse:
+            def __init__(self, payload: object) -> None:
+                self._body = json.dumps(payload).encode("utf-8")
+
+            def read(self) -> bytes:
+                return self._body
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+        def open_func(req):
+            url = req.full_url
+            if "/pipelines?" in url:
+                return JsonResponse([])
+            raise AssertionError(url)
+
+        self.assertEqual(
+            module.search_matching_pipeline_ids(
+                "https://gitlab.example/api/v4",
+                "token",
+                project="1",
+                ref="main",
+                correlation_id="gh-1-1-mine",
+                started_at="2026-08-28T08:12:00Z",
+                attempts=2,
+                delay=0,
+                open_func=open_func,
+            ),
+            [],
         )
 
 

--- a/.github/scripts/test_cancel_downstream_pipeline.py
+++ b/.github/scripts/test_cancel_downstream_pipeline.py
@@ -12,6 +12,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 from urllib.error import HTTPError
+from urllib.error import URLError
 
 SCRIPT = Path(__file__).with_name("cancel_downstream_pipeline.py")
 SPEC = importlib.util.spec_from_file_location("cancel_downstream_pipeline", SCRIPT)
@@ -256,6 +257,99 @@ class SearchFallbackTest(unittest.TestCase):
                 "token",
                 "1",
                 10,
+                open_func=open_func,
+            )
+
+    def test_listing_503_is_retried_then_finds_ours(self):
+        class JsonResponse:
+            def __init__(self, payload: object) -> None:
+                self._body = json.dumps(payload).encode("utf-8")
+
+            def read(self) -> bytes:
+                return self._body
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+        waves = {"n": 0}
+
+        def open_func(req):
+            url = req.full_url
+            if "/pipelines?" in url:
+                if "status=created" in url:
+                    waves["n"] += 1
+                    if waves["n"] == 1:
+                        raise HTTPError(
+                            url,
+                            503,
+                            "Service Unavailable",
+                            hdrs=None,  # type: ignore[arg-type]
+                            fp=io.BytesIO(b"{}"),
+                        )
+                    return JsonResponse([])
+                if "status=running" in url:
+                    return JsonResponse(
+                        [{"id": 11, "created_at": "2026-08-28T08:12:31Z"}]
+                    )
+                return JsonResponse([])
+            if url.endswith("/pipelines/11/variables"):
+                return JsonResponse(
+                    [{"key": module.CORRELATION_VARIABLE, "value": "gh-1-1-mine"}]
+                )
+            raise AssertionError(url)
+
+        self.assertEqual(
+            module.search_matching_pipeline_ids(
+                "https://gitlab.example/api/v4",
+                "token",
+                project="1",
+                ref="main",
+                correlation_id="gh-1-1-mine",
+                started_at="2026-08-28T08:12:00Z",
+                attempts=3,
+                delay=0,
+                open_func=open_func,
+            ),
+            [11],
+        )
+        self.assertEqual(waves["n"], 2)
+
+    def test_listing_5xx_exhausted_fails_cleanup(self):
+        def open_func(req):
+            raise HTTPError(
+                req.full_url,
+                502,
+                "Bad Gateway",
+                hdrs=None,  # type: ignore[arg-type]
+                fp=io.BytesIO(b"{}"),
+            )
+
+        with self.assertRaises(SystemExit):
+            module.search_matching_pipeline_ids(
+                "https://gitlab.example/api/v4",
+                "token",
+                project="1",
+                ref="main",
+                correlation_id="gh-1-1-mine",
+                started_at="2026-08-28T08:12:00Z",
+                attempts=2,
+                delay=0,
+                open_func=open_func,
+            )
+
+    def test_listing_connection_error_is_retryable(self):
+        def open_func(_req):
+            raise URLError("temporary failure")
+
+        with self.assertRaises(module.GitLabTransientError):
+            module.list_ref_pipelines(
+                "https://gitlab.example/api/v4",
+                "token",
+                "1",
+                "main",
                 open_func=open_func,
             )
 

--- a/.github/scripts/test_cancel_downstream_pipeline.py
+++ b/.github/scripts/test_cancel_downstream_pipeline.py
@@ -169,6 +169,77 @@ class SearchFallbackTest(unittest.TestCase):
             [],
         )
 
+    def test_skips_a_gone_candidate_and_still_finds_ours(self):
+        class JsonResponse:
+            def __init__(self, payload: object) -> None:
+                self._body = json.dumps(payload).encode("utf-8")
+
+            def read(self) -> bytes:
+                return self._body
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+        def open_func(req):
+            url = req.full_url
+            if "/pipelines?" in url:
+                if "status=running" in url:
+                    return JsonResponse(
+                        [
+                            {"id": 10, "created_at": "2026-08-28T08:12:30Z"},
+                            {"id": 11, "created_at": "2026-08-28T08:12:31Z"},
+                        ]
+                    )
+                return JsonResponse([])
+            if url.endswith("/pipelines/10/variables"):
+                raise HTTPError(
+                    url,
+                    404,
+                    "Not Found",
+                    hdrs=None,  # type: ignore[arg-type]
+                    fp=io.BytesIO(b"{}"),
+                )
+            if url.endswith("/pipelines/11/variables"):
+                return JsonResponse(
+                    [{"key": module.CORRELATION_VARIABLE, "value": "gh-1-1-mine"}]
+                )
+            raise AssertionError(url)
+
+        self.assertEqual(
+            module.discover_matching_pipeline_ids(
+                "https://gitlab.example/api/v4",
+                "token",
+                project="1",
+                ref="main",
+                correlation_id="gh-1-1-mine",
+                started_at="2026-08-28T08:12:00Z",
+                open_func=open_func,
+            ),
+            [11],
+        )
+
+    def test_unauthorized_still_aborts_discovery(self):
+        def open_func(req):
+            raise HTTPError(
+                req.full_url,
+                401,
+                "Unauthorized",
+                hdrs=None,  # type: ignore[arg-type]
+                fp=io.BytesIO(b"{}"),
+            )
+
+        with self.assertRaises(SystemExit):
+            module.fetch_pipeline_variables(
+                "https://gitlab.example/api/v4",
+                "token",
+                "1",
+                10,
+                open_func=open_func,
+            )
+
 
 class WorkflowWiringTest(unittest.TestCase):
     def test_ci_cancels_downstream_when_the_github_job_is_cancelled(self):

--- a/.github/scripts/test_cancel_downstream_pipeline.py
+++ b/.github/scripts/test_cancel_downstream_pipeline.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from unittest import mock
 from urllib.error import HTTPError
 from urllib.error import URLError
+from urllib.parse import parse_qs
+from urllib.parse import urlparse
 
 SCRIPT = Path(__file__).with_name("cancel_downstream_pipeline.py")
 SPEC = importlib.util.spec_from_file_location("cancel_downstream_pipeline", SCRIPT)
@@ -584,6 +586,61 @@ class SearchFallbackTest(unittest.TestCase):
                 open_func=open_func,
             ),
             [],
+            )
+
+
+    def test_paginates_past_the_first_twenty_on_a_busy_ref(self):
+        class JsonResponse:
+            def __init__(self, payload: object) -> None:
+                self._body = json.dumps(payload).encode("utf-8")
+
+            def read(self) -> bytes:
+                return self._body
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+        def open_func(req):
+            url = req.full_url
+            if "/pipelines?" in url:
+                qs = parse_qs(urlparse(url).query)
+                if qs.get("status") != ["running"]:
+                    return JsonResponse([])
+                page = int((qs.get("page") or ["1"])[0])
+                if page == 1:
+                    return JsonResponse(
+                        [
+                            {"id": i, "created_at": "2026-08-28T08:12:00Z"}
+                            for i in range(1, 21)
+                        ]
+                    )
+                if page == 2:
+                    return JsonResponse(
+                        [{"id": 99, "created_at": "2026-08-28T08:12:31Z"}]
+                    )
+                return JsonResponse([])
+            if url.endswith("/pipelines/99/variables"):
+                return JsonResponse(
+                    [{"key": module.CORRELATION_VARIABLE, "value": "gh-1-1-mine"}]
+                )
+            if "/variables" in url:
+                return JsonResponse([])
+            raise AssertionError(url)
+
+        self.assertEqual(
+            module.discover_matching_pipeline_ids(
+                "https://gitlab.example/api/v4",
+                "token",
+                project="1",
+                ref="main",
+                correlation_id="gh-1-1-mine",
+                started_at="2026-08-28T08:12:00Z",
+                open_func=open_func,
+            ),
+            [99],
         )
 
 

--- a/.github/scripts/test_cancel_downstream_pipeline.py
+++ b/.github/scripts/test_cancel_downstream_pipeline.py
@@ -505,8 +505,7 @@ class SearchFallbackTest(unittest.TestCase):
                 open_func=open_func,
             ),
             [11],
-            )
-
+        )
 
     def test_empty_retry_after_transient_still_fails_cleanup(self):
         class JsonResponse:
@@ -586,8 +585,7 @@ class SearchFallbackTest(unittest.TestCase):
                 open_func=open_func,
             ),
             [],
-            )
-
+        )
 
     def test_paginates_past_the_first_twenty_on_a_busy_ref(self):
         class JsonResponse:

--- a/.github/scripts/test_cancel_downstream_pipeline.py
+++ b/.github/scripts/test_cancel_downstream_pipeline.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 
 import importlib.util
 import io
+import json
+import os
+import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 from urllib.error import HTTPError
 
 SCRIPT = Path(__file__).with_name("cancel_downstream_pipeline.py")
@@ -14,6 +18,12 @@ SPEC = importlib.util.spec_from_file_location("cancel_downstream_pipeline", SCRI
 assert SPEC and SPEC.loader
 module = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(module)
+
+TRIGGER = Path(__file__).with_name("trigger_downstream_pipeline.py")
+TSPEC = importlib.util.spec_from_file_location("trigger_downstream_pipeline", TRIGGER)
+assert TSPEC and TSPEC.loader
+trigger = importlib.util.module_from_spec(TSPEC)
+TSPEC.loader.exec_module(trigger)
 
 
 class FakeResponse:
@@ -33,8 +43,8 @@ class CancelPipelineTest(unittest.TestCase):
             module.cancel_pipeline(
                 "https://gitlab.example/api/v4",
                 "token",
-                1,
                 99,
+                project_id=1,
                 open_func=lambda _req: FakeResponse(),
             ),
             "cancelled",
@@ -54,12 +64,52 @@ class CancelPipelineTest(unittest.TestCase):
             module.cancel_pipeline(
                 "https://gitlab.example/api/v4",
                 "token",
-                1,
                 99,
+                project_id=1,
                 open_func=open_func,
             ),
             "already finished (409)",
         )
+
+
+class HandoffTest(unittest.TestCase):
+    def test_handoff_survives_missing_step_outputs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "downstream-pipeline.json"
+            with mock.patch.dict(
+                os.environ, {"DOWNSTREAM_HANDOFF_PATH": str(path)}, clear=False
+            ):
+                trigger.persist_handoff(project_id=11)
+                trigger.persist_handoff(pipeline_id=99)
+                with mock.patch.dict(
+                    os.environ,
+                    {
+                        "DOWNSTREAM_HANDOFF_PATH": str(path),
+                        "DOWNSTREAM_PROJECT_ID": "",
+                        "DOWNSTREAM_PIPELINE_ID": "",
+                    },
+                    clear=False,
+                ):
+                    self.assertEqual(module.resolve_pipeline_ids(), ("11", "99"))
+            self.assertEqual(
+                json.loads(path.read_text()),
+                {"project_id": "11", "pipeline_id": "99"},
+            )
+
+    def test_env_ids_win_over_handoff(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "downstream-pipeline.json"
+            path.write_text('{"project_id":"1","pipeline_id":"2"}', encoding="utf-8")
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "DOWNSTREAM_HANDOFF_PATH": str(path),
+                    "DOWNSTREAM_PROJECT_ID": "8",
+                    "DOWNSTREAM_PIPELINE_ID": "9",
+                },
+                clear=False,
+            ):
+                self.assertEqual(module.resolve_pipeline_ids(), ("8", "9"))
 
 
 class WorkflowWiringTest(unittest.TestCase):
@@ -69,6 +119,12 @@ class WorkflowWiringTest(unittest.TestCase):
         ).read_text()
         self.assertIn("cancel_downstream_pipeline.py", ci)
         self.assertIn("if: cancelled()", ci)
+        self.assertNotIn(
+            "steps.trigger.outputs.pipeline_id != ''",
+            ci.split("Cancel downstream if this GitHub job was cancelled", 1)[1].split(
+                "- name:", 1
+            )[0],
+        )
 
     def test_ci_runs_these_tests(self):
         ci = (

--- a/.github/scripts/test_cancel_stale_pr_ci.py
+++ b/.github/scripts/test_cancel_stale_pr_ci.py
@@ -103,6 +103,16 @@ class ShouldCancelTest(unittest.TestCase):
             )
         )
 
+    def test_closed_pr_does_not_cancel_tag_cleanup(self):
+        self.assertFalse(
+            module.should_cancel_run(
+                run=run() | {"name": "Cleanup PR Tags"},
+                matches_source=True,
+                closed=True,
+                this_run_id=99,
+            )
+        )
+
     def test_does_not_cancel_self(self):
         self.assertFalse(
             module.should_cancel_run(
@@ -176,6 +186,66 @@ class ListActiveRunsTest(unittest.TestCase):
         runs = module.list_active_runs("owner/repo", "pull-request/1900", get)
         self.assertEqual([run["id"] for run in runs], [7])
         self.assertTrue(any("status=requested" in path for path in calls))
+
+
+class ClosedPrCoverageTest(unittest.TestCase):
+    def test_run_belongs_to_pr_via_pull_requests_field(self):
+        sonar = {
+            "id": 8,
+            "name": "SonarQube Analysis",
+            "status": "in_progress",
+            "head_branch": "feat/foo",
+            "pull_requests": [{"number": 1900}],
+        }
+        self.assertTrue(module.run_belongs_to_pr(sonar, 1900))
+        self.assertFalse(module.run_belongs_to_pr(sonar, 1))
+
+    def test_closed_collects_native_pr_event_runs(self):
+        def get(_method: str, _repo: str, path: str):
+            if "event=pull_request&" in path and "status=in_progress" in path:
+                return {
+                    "workflow_runs": [
+                        {
+                            "id": 8,
+                            "name": "SonarQube Analysis",
+                            "status": "in_progress",
+                            "head_branch": "feat/foo",
+                            "pull_requests": [{"number": 42}],
+                        },
+                        {
+                            "id": 9,
+                            "name": "SonarQube Analysis",
+                            "status": "in_progress",
+                            "head_branch": "feat/other",
+                            "pull_requests": [{"number": 7}],
+                        },
+                    ]
+                }
+            if "branch=pull-request%2F42" in path and "status=in_progress" in path:
+                return {
+                    "workflow_runs": [
+                        {
+                            "id": 3,
+                            "name": "CI",
+                            "status": "in_progress",
+                            "head_branch": "pull-request/42",
+                        }
+                    ]
+                }
+            return {"workflow_runs": []}
+
+        runs = module.collect_runs_to_consider("owner/repo", 42, True, get)
+        self.assertEqual(sorted(run["id"] for run in runs), [3, 8])
+
+    def test_open_pr_does_not_scan_native_pr_events(self):
+        calls: list[str] = []
+
+        def get(_method: str, _repo: str, path: str):
+            calls.append(path)
+            return {"workflow_runs": []}
+
+        module.collect_runs_to_consider("owner/repo", 42, False, get)
+        self.assertFalse(any("event=pull_request" in path for path in calls))
 
 
 class WorkflowTest(unittest.TestCase):

--- a/.github/scripts/test_cancel_stale_pr_ci.py
+++ b/.github/scripts/test_cancel_stale_pr_ci.py
@@ -273,11 +273,14 @@ class ClosedPrCoverageTest(unittest.TestCase):
 
 
 class WorkflowTest(unittest.TestCase):
-    def test_pull_request_target_does_not_checkout_the_pr_head(self):
+    def test_pull_request_fires_for_main_and_develop(self):
         text = WORKFLOW.read_text()
-        self.assertIn("pull_request_target:", text)
+        self.assertIn("pull_request:", text)
+        self.assertNotIn("pull_request_target:", text)
         self.assertIn("persist-credentials: false", text)
         self.assertNotIn("ref: ${{ github.event.pull_request.head", text)
+        self.assertIn("- main", text)
+        self.assertIn("- develop", text)
         self.assertIn("actions: write", text)
         self.assertIn("SOURCE_BRANCH: ${{ github.event.pull_request.head.ref }}", text)
 

--- a/.github/scripts/test_cancel_stale_pr_ci.py
+++ b/.github/scripts/test_cancel_stale_pr_ci.py
@@ -200,6 +200,28 @@ class ClosedPrCoverageTest(unittest.TestCase):
         self.assertTrue(module.run_belongs_to_pr(sonar, 1900))
         self.assertFalse(module.run_belongs_to_pr(sonar, 1))
 
+    def test_run_belongs_to_pr_after_close_empties_pull_requests(self):
+        # The shape the close path actually sees: GitHub drops the PR
+        # association the moment the PR closes.
+        sonar = {
+            "id": 8,
+            "name": "SonarQube Analysis",
+            "status": "in_progress",
+            "head_branch": "feat/foo",
+            "head_sha": "a" * 40,
+            "pull_requests": [],
+        }
+        self.assertFalse(module.run_belongs_to_pr(sonar, 1900))
+        self.assertTrue(
+            module.run_belongs_to_pr(sonar, 1900, source_branch="feat/foo")
+        )
+        self.assertTrue(
+            module.run_belongs_to_pr(sonar, 1900, source_sha="a" * 40)
+        )
+        self.assertFalse(
+            module.run_belongs_to_pr(sonar, 1900, source_branch="feat/other")
+        )
+
     def test_closed_collects_native_pr_event_runs(self):
         def get(_method: str, _repo: str, path: str):
             if "event=pull_request&" in path and "status=in_progress" in path:
@@ -210,14 +232,14 @@ class ClosedPrCoverageTest(unittest.TestCase):
                             "name": "SonarQube Analysis",
                             "status": "in_progress",
                             "head_branch": "feat/foo",
-                            "pull_requests": [{"number": 42}],
+                            "pull_requests": [],
                         },
                         {
                             "id": 9,
                             "name": "SonarQube Analysis",
                             "status": "in_progress",
                             "head_branch": "feat/other",
-                            "pull_requests": [{"number": 7}],
+                            "pull_requests": [],
                         },
                     ]
                 }
@@ -234,7 +256,9 @@ class ClosedPrCoverageTest(unittest.TestCase):
                 }
             return {"workflow_runs": []}
 
-        runs = module.collect_runs_to_consider("owner/repo", 42, True, get)
+        runs = module.collect_runs_to_consider(
+            "owner/repo", 42, True, get, source_branch="feat/foo"
+        )
         self.assertEqual(sorted(run["id"] for run in runs), [3, 8])
 
     def test_open_pr_does_not_scan_native_pr_events(self):
@@ -255,6 +279,7 @@ class WorkflowTest(unittest.TestCase):
         self.assertIn("persist-credentials: false", text)
         self.assertNotIn("ref: ${{ github.event.pull_request.head", text)
         self.assertIn("actions: write", text)
+        self.assertIn("SOURCE_BRANCH: ${{ github.event.pull_request.head.ref }}", text)
 
     def test_ci_runs_these_tests(self):
         ci = (Path(__file__).resolve().parent.parent / "workflows" / "ci.yml").read_text()

--- a/.github/scripts/test_trigger_downstream_pipeline.py
+++ b/.github/scripts/test_trigger_downstream_pipeline.py
@@ -109,6 +109,43 @@ class ExtraPipelineVariablesTest(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 module.resolve_branches()
 
+    def test_correlation_id_is_unique_per_trigger_attempt(self):
+        with mock.patch.dict(
+            os.environ,
+            {"GITHUB_RUN_ID": "42", "GITHUB_RUN_ATTEMPT": "2"},
+            clear=False,
+        ):
+            first = module.new_correlation_id()
+            second = module.new_correlation_id()
+        self.assertTrue(first.startswith("gh-42-2-"))
+        self.assertNotEqual(first, second)
+
+    def test_correlation_id_is_sent_as_a_pipeline_variable(self):
+        payload = module.pipeline_request_data(
+            ref="main",
+            variable_name="VSS_SUBMODULE_HASH",
+            commit_sha="a" * 40,
+            target_branch="develop",
+            compare_branch="pull-request/1906",
+            correlation_id="gh-42-2-abc",
+        )
+        parsed = parse_qs(payload.decode())
+        self.assertIn(module.CORRELATION_VARIABLE, parsed["variables[][key]"])
+        self.assertIn("gh-42-2-abc", parsed["variables[][value]"])
+
+    def test_extra_variables_cannot_forge_the_correlation_token(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "DOWNSTREAM_EXTRA_VARIABLES_JSON": json.dumps(
+                    {module.CORRELATION_VARIABLE: "forged"}
+                )
+            },
+            clear=True,
+        ):
+            with self.assertRaises(SystemExit):
+                module.extra_pipeline_variables()
+
     def test_persist_handoff_writes_ids_before_step_outputs_would_publish(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "handoff.json"

--- a/.github/scripts/test_trigger_downstream_pipeline.py
+++ b/.github/scripts/test_trigger_downstream_pipeline.py
@@ -158,6 +158,32 @@ class ExtraPipelineVariablesTest(unittest.TestCase):
                 {"project_id": "4", "pipeline_id": "88"},
             )
 
+    def test_handoff_path_keys_by_github_run_so_runners_do_not_reuse_a_file(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "GITHUB_RUN_ID": "77",
+                "GITHUB_RUN_ATTEMPT": "2",
+                "DOWNSTREAM_HANDOFF_PATH": "",
+            },
+            clear=False,
+        ):
+            self.assertEqual(
+                module.handoff_path(),
+                ".ci/downstream-pipeline-77-2.json",
+            )
+
+    def test_handoff_path_override_still_wins(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "DOWNSTREAM_HANDOFF_PATH": "/tmp/explicit.json",
+                "GITHUB_RUN_ID": "77",
+            },
+            clear=False,
+        ):
+            self.assertEqual(module.handoff_path(), "/tmp/explicit.json")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/.github/scripts/test_trigger_downstream_pipeline.py
+++ b/.github/scripts/test_trigger_downstream_pipeline.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
+import tempfile
 import unittest
 from urllib.parse import parse_qs
 from pathlib import Path
@@ -106,6 +108,18 @@ class ExtraPipelineVariablesTest(unittest.TestCase):
         ):
             with self.assertRaises(SystemExit):
                 module.resolve_branches()
+
+    def test_persist_handoff_writes_ids_before_step_outputs_would_publish(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "handoff.json"
+            with mock.patch.dict(
+                os.environ, {"DOWNSTREAM_HANDOFF_PATH": str(path)}, clear=False
+            ):
+                module.persist_handoff(project_id=4, pipeline_id=88)
+            self.assertEqual(
+                json.loads(path.read_text()),
+                {"project_id": "4", "pipeline_id": "88"},
+            )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/trigger_downstream_pipeline.py
+++ b/.github/scripts/trigger_downstream_pipeline.py
@@ -8,6 +8,8 @@ import re
 import socket
 import ssl
 import sys
+from datetime import datetime
+from datetime import timezone
 from pathlib import Path
 from typing import Any
 from urllib.error import ContentTooShortError
@@ -169,7 +171,16 @@ def trigger_pipeline(
         compare_branch=compare_branch,
         extra_variables=extra_variables,
     )
-    return request_json("Pipeline trigger", f"{base_url}/projects/{project_id}/pipeline", token, data=payload)
+    response = request_json(
+        "Pipeline trigger",
+        f"{base_url}/projects/{project_id}/pipeline",
+        token,
+        data=payload,
+    )
+    pipeline_id = str(response.get("id") or "")
+    if pipeline_id:
+        persist_handoff(pipeline_id=pipeline_id)
+    return response
 
 
 def pipeline_request_data(
@@ -392,12 +403,13 @@ def handoff_path() -> str:
     )
 
 
-def persist_handoff(*, project_id: str | int = "", pipeline_id: str | int = "") -> None:
-    """Record GitLab ids on disk so a cancelled trigger step can still cancel.
+def persist_handoff(**fields: object) -> None:
+    """Record GitLab trigger identity on disk for a cancelled cleanup step.
 
-    GitHub only publishes ``GITHUB_OUTPUT`` when the step finishes. A cancel
-    between ``POST /pipeline`` and step completion would otherwise lose the
-    new pipeline id.
+    GitHub only publishes ``GITHUB_OUTPUT`` when the step finishes. The
+    pipeline id is written the instant GitLab returns it. ``ref`` /
+    ``commit_sha`` / ``trigger_started_at`` are written *before* POST so
+    cleanup can still find the pipeline if cancel lands in the HTTP window.
     """
     path = Path(handoff_path())
     payload: dict[str, str] = {}
@@ -407,14 +419,13 @@ def persist_handoff(*, project_id: str | int = "", pipeline_id: str | int = "") 
         except (OSError, UnicodeDecodeError, json.JSONDecodeError):
             loaded = {}
         if isinstance(loaded, dict):
-            for key in ("project_id", "pipeline_id"):
-                value = loaded.get(key)
-                if isinstance(value, (str, int)) and str(value):
+            for key, value in loaded.items():
+                if isinstance(key, str) and isinstance(value, (str, int)) and str(value):
                     payload[key] = str(value)
-    if project_id:
-        payload["project_id"] = str(project_id)
-    if pipeline_id:
-        payload["pipeline_id"] = str(pipeline_id)
+    for key, value in fields.items():
+        if value is None or value == "":
+            continue
+        payload[str(key)] = str(value)
     path.parent.mkdir(parents=True, exist_ok=True)
     encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     tmp = path.with_name(path.name + ".tmp")
@@ -516,7 +527,15 @@ def main() -> int:
             return 0
 
         project_id = fetch_project_id(base_url, token, project_path)
-        persist_handoff(project_id=project_id)
+        persist_handoff(
+            project_id=project_id,
+            ref=ref,
+            commit_sha=commit_sha,
+            variable_name=variable_name,
+            trigger_started_at=datetime.now(timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            ),
+        )
         pipeline = trigger_pipeline(
             base_url,
             token,

--- a/.github/scripts/trigger_downstream_pipeline.py
+++ b/.github/scripts/trigger_downstream_pipeline.py
@@ -425,10 +425,11 @@ def handoff_path() -> str:
 def persist_handoff(**fields: object) -> None:
     """Record GitLab trigger identity on disk for a cancelled cleanup step.
 
-    GitHub only publishes ``GITHUB_OUTPUT`` when the step finishes. The
-    pipeline id is written the instant GitLab returns it. ``ref`` /
-    ``commit_sha`` / ``trigger_started_at`` are written *before* POST so
-    cleanup can still find the pipeline if cancel lands in the HTTP window.
+    GitHub only publishes ``GITHUB_OUTPUT`` when the step finishes, so the
+    ids go to disk instead. ``ref`` / ``correlation_id`` /
+    ``trigger_started_at`` are written *before* POST so cleanup can still
+    find the pipeline if cancel lands in the HTTP window; ``pipeline_id``
+    is written the instant GitLab returns it.
     """
     path = Path(handoff_path())
     payload: dict[str, str] = {}
@@ -554,8 +555,6 @@ def main() -> int:
         persist_handoff(
             project_id=project_id,
             ref=ref,
-            commit_sha=commit_sha,
-            variable_name=variable_name,
             correlation_id=correlation_id,
             trigger_started_at=datetime.now(timezone.utc).strftime(
                 "%Y-%m-%dT%H:%M:%SZ"
@@ -622,9 +621,11 @@ def main() -> int:
             summary_lines.append(f"- **Created at:** {pipeline_created_at}")
         write_summary("\n".join(summary_lines))
 
-        # Remaining identifiers for the poll step. pipeline_id / project_id
-        # were already flushed above, immediately after GitLab created the
-        # pipeline, so a cancel during this summary still has a handoff file.
+        # Remaining identifiers for the poll step. Ordering these writes
+        # buys nothing on cancel: GitHub only publishes a step's outputs
+        # once the step completes. What covers a cancel during this summary
+        # is the fsynced handoff file, written right after GitLab created
+        # the pipeline.
         write_output("pipeline_sha", pipeline_sha)
         write_output("pipeline_created_at", pipeline_created_at)
         return 0

--- a/.github/scripts/trigger_downstream_pipeline.py
+++ b/.github/scripts/trigger_downstream_pipeline.py
@@ -8,6 +8,7 @@ import re
 import socket
 import ssl
 import sys
+import uuid
 from datetime import datetime
 from datetime import timezone
 from pathlib import Path
@@ -21,6 +22,7 @@ from urllib.parse import urlencode
 from urllib.request import Request
 from urllib.request import urlopen
 
+CORRELATION_VARIABLE = "VSS_TRIGGER_CORRELATION_ID"
 LAUNCHABLE_NOTEBOOK_PATH = "deploy/docker/scripts/deploy_vss_launchable.ipynb"
 LAUNCHABLE_NOTEBOOK_TRIGGER_VARIABLE = "BREV_LAUNCHABLE_NOTEBOOK_TESTS"
 CHANGED_FILE_FIELDS = ("added", "modified")
@@ -162,6 +164,7 @@ def trigger_pipeline(
     target_branch: str,
     compare_branch: str,
     extra_variables: dict[str, str] | None = None,
+    correlation_id: str = "",
 ) -> dict[str, Any]:
     payload = pipeline_request_data(
         ref=ref,
@@ -170,6 +173,7 @@ def trigger_pipeline(
         target_branch=target_branch,
         compare_branch=compare_branch,
         extra_variables=extra_variables,
+        correlation_id=correlation_id,
     )
     response = request_json(
         "Pipeline trigger",
@@ -191,6 +195,7 @@ def pipeline_request_data(
     target_branch: str,
     compare_branch: str,
     extra_variables: dict[str, str] | None = None,
+    correlation_id: str = "",
 ) -> bytes:
     payload_pairs: list[tuple[str, str]] = [
         ("ref", ref),
@@ -201,6 +206,13 @@ def pipeline_request_data(
         ("variables[][key]", "VSS_COMPARE_BRANCH"),
         ("variables[][value]", compare_branch),
     ]
+    if correlation_id:
+        payload_pairs.extend(
+            [
+                ("variables[][key]", CORRELATION_VARIABLE),
+                ("variables[][value]", correlation_id),
+            ]
+        )
     for key, value in (extra_variables or {}).items():
         payload_pairs.extend(
             [
@@ -397,6 +409,13 @@ def write_output(key: str, value: str) -> None:
 DEFAULT_HANDOFF_PATH = ".ci/downstream-pipeline.json"
 
 
+def new_correlation_id() -> str:
+    """One-off token identifying a single trigger attempt."""
+    run_id = os.environ.get("GITHUB_RUN_ID", "local").strip() or "local"
+    attempt = os.environ.get("GITHUB_RUN_ATTEMPT", "1").strip() or "1"
+    return f"gh-{run_id}-{attempt}-{uuid.uuid4().hex}"
+
+
 def handoff_path() -> str:
     return os.environ.get("DOWNSTREAM_HANDOFF_PATH", DEFAULT_HANDOFF_PATH).strip() or (
         DEFAULT_HANDOFF_PATH
@@ -459,6 +478,7 @@ def extra_pipeline_variables() -> dict[str, str]:
         ),
         "VSS_TARGET_BRANCH",
         "VSS_COMPARE_BRANCH",
+        CORRELATION_VARIABLE,
     }
     overlap = reserved.intersection(payload)
     if overlap:
@@ -527,11 +547,16 @@ def main() -> int:
             return 0
 
         project_id = fetch_project_id(base_url, token, project_path)
+        # Identifies this trigger attempt alone, so a cancel that races the
+        # POST response cannot match a concurrent run's pipeline on the same
+        # ref and submodule SHA.
+        correlation_id = new_correlation_id()
         persist_handoff(
             project_id=project_id,
             ref=ref,
             commit_sha=commit_sha,
             variable_name=variable_name,
+            correlation_id=correlation_id,
             trigger_started_at=datetime.now(timezone.utc).strftime(
                 "%Y-%m-%dT%H:%M:%SZ"
             ),
@@ -546,6 +571,7 @@ def main() -> int:
             target_branch,
             compare_branch,
             extra_variables,
+            correlation_id,
         )
 
         pipeline_iid = str(pipeline.get("iid") or pipeline.get("id") or "")

--- a/.github/scripts/trigger_downstream_pipeline.py
+++ b/.github/scripts/trigger_downstream_pipeline.py
@@ -181,9 +181,6 @@ def trigger_pipeline(
         token,
         data=payload,
     )
-    pipeline_id = str(response.get("id") or "")
-    if pipeline_id:
-        persist_handoff(pipeline_id=pipeline_id)
     return response
 
 
@@ -417,9 +414,15 @@ def new_correlation_id() -> str:
 
 
 def handoff_path() -> str:
-    return os.environ.get("DOWNSTREAM_HANDOFF_PATH", DEFAULT_HANDOFF_PATH).strip() or (
-        DEFAULT_HANDOFF_PATH
-    )
+    override = os.environ.get("DOWNSTREAM_HANDOFF_PATH", "").strip()
+    if override:
+        return override
+    run_id = os.environ.get("GITHUB_RUN_ID", "").strip()
+    attempt = os.environ.get("GITHUB_RUN_ATTEMPT", "").strip()
+    if run_id:
+        suffix = f"{run_id}-{attempt}" if attempt else run_id
+        return f".ci/downstream-pipeline-{suffix}.json"
+    return DEFAULT_HANDOFF_PATH
 
 
 def persist_handoff(**fields: object) -> None:

--- a/.github/scripts/trigger_downstream_pipeline.py
+++ b/.github/scripts/trigger_downstream_pipeline.py
@@ -8,6 +8,7 @@ import re
 import socket
 import ssl
 import sys
+from pathlib import Path
 from typing import Any
 from urllib.error import ContentTooShortError
 from urllib.error import HTTPError
@@ -378,6 +379,52 @@ def write_output(key: str, value: str) -> None:
         return
     with open(output_path, "a", encoding="utf-8") as output_file:
         output_file.write(f"{key}={value}\n")
+        output_file.flush()
+        os.fsync(output_file.fileno())
+
+
+DEFAULT_HANDOFF_PATH = ".ci/downstream-pipeline.json"
+
+
+def handoff_path() -> str:
+    return os.environ.get("DOWNSTREAM_HANDOFF_PATH", DEFAULT_HANDOFF_PATH).strip() or (
+        DEFAULT_HANDOFF_PATH
+    )
+
+
+def persist_handoff(*, project_id: str | int = "", pipeline_id: str | int = "") -> None:
+    """Record GitLab ids on disk so a cancelled trigger step can still cancel.
+
+    GitHub only publishes ``GITHUB_OUTPUT`` when the step finishes. A cancel
+    between ``POST /pipeline`` and step completion would otherwise lose the
+    new pipeline id.
+    """
+    path = Path(handoff_path())
+    payload: dict[str, str] = {}
+    if path.is_file():
+        try:
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            loaded = {}
+        if isinstance(loaded, dict):
+            for key in ("project_id", "pipeline_id"):
+                value = loaded.get(key)
+                if isinstance(value, (str, int)) and str(value):
+                    payload[key] = str(value)
+    if project_id:
+        payload["project_id"] = str(project_id)
+    if pipeline_id:
+        payload["pipeline_id"] = str(pipeline_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    tmp = path.with_name(path.name + ".tmp")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+    try:
+        os.write(fd, encoded)
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    os.replace(tmp, path)
 
 
 def extra_pipeline_variables() -> dict[str, str]:
@@ -469,6 +516,7 @@ def main() -> int:
             return 0
 
         project_id = fetch_project_id(base_url, token, project_path)
+        persist_handoff(project_id=project_id)
         pipeline = trigger_pipeline(
             base_url,
             token,
@@ -483,6 +531,10 @@ def main() -> int:
 
         pipeline_iid = str(pipeline.get("iid") or pipeline.get("id") or "")
         pipeline_id = str(pipeline.get("id") or "")
+        persist_handoff(project_id=project_id, pipeline_id=pipeline_id)
+        write_output("pipeline_id", pipeline_id)
+        write_output("project_id", str(project_id))
+        write_output("pipeline_iid", pipeline_iid)
         pipeline_sha = str(pipeline.get("sha") or "")
         pipeline_url = str(pipeline.get("web_url") or "")
         pipeline_created_at = str(pipeline.get("created_at") or "")
@@ -525,14 +577,11 @@ def main() -> int:
             summary_lines.append(f"- **Created at:** {pipeline_created_at}")
         write_summary("\n".join(summary_lines))
 
-        # Expose identifiers to the poll step in the same job. Do NOT
-        # write the pipeline URL here - it is a secret and would appear
-        # in any caller that echoes the output.
-        write_output("pipeline_iid", pipeline_iid)
-        write_output("pipeline_id", pipeline_id)
+        # Remaining identifiers for the poll step. pipeline_id / project_id
+        # were already flushed above, immediately after GitLab created the
+        # pipeline, so a cancel during this summary still has a handoff file.
         write_output("pipeline_sha", pipeline_sha)
         write_output("pipeline_created_at", pipeline_created_at)
-        write_output("project_id", str(project_id))
         return 0
     except SystemExit:
         raise

--- a/.github/workflows/cancel-stale-pr-ci.yml
+++ b/.github/workflows/cancel-stale-pr-ci.yml
@@ -8,15 +8,20 @@
 # abandon) cancels leftover PR runs, including non-required jobs, but
 # not `develop`/`main` delivery CI.
 #
-# This workflow is cancel-only. It does not start CI and does not execute
-# PR code: `pull_request_target` with a base-ref checkout (the default SHA)
-# and no credentials.
+# `pull_request` (not `pull_request_target`): this repo has never fired a
+# pull_request_target run from develop, while pull_request registers on
+# both develop and main. PRs are branched in-repo, not from forks, so
+# GITHUB_TOKEN still has actions: write. The job is cancel-only and does
+# not start CI. `branches` is the PR base, so only PRs into main/develop.
 
 name: Cancel Stale PR CI
 
 on:
-  pull_request_target:
+  pull_request:
     types: [synchronize, closed]
+    branches:
+      - main
+      - develop
 
 permissions:
   actions: write
@@ -33,7 +38,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      # Base/default SHA of this trusted workflow — never the PR head.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           persist-credentials: false

--- a/.github/workflows/cancel-stale-pr-ci.yml
+++ b/.github/workflows/cancel-stale-pr-ci.yml
@@ -3,8 +3,10 @@
 #
 # PR CI runs on copy-pr-bot `pull-request/<N>` pushes, not on the source PR
 # event. Concurrency in those workflows only fires when the *mirror* moves.
-# A rebase of the source PR otherwise leaves the previous mirror SHA running
-# until the next `/ok to test`.
+# A rebase or new commit on the source PR otherwise leaves the previous
+# mirror SHA running until the next `/ok to test`. Close (merge or
+# abandon) cancels leftover PR runs, including non-required jobs, but
+# not `develop`/`main` delivery CI.
 #
 # This workflow is cancel-only. It does not start CI and does not execute
 # PR code: `pull_request_target` with a base-ref checkout (the default SHA)

--- a/.github/workflows/cancel-stale-pr-ci.yml
+++ b/.github/workflows/cancel-stale-pr-ci.yml
@@ -44,5 +44,6 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           SOURCE_SHA: ${{ github.event.pull_request.head.sha }}
+          SOURCE_BRANCH: ${{ github.event.pull_request.head.ref }}
           PR_CLOSED: ${{ github.event.action == 'closed' }}
         run: python3 .github/scripts/cancel_stale_pr_ci.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1488,6 +1488,7 @@ jobs:
           python3 .github/scripts/test_advance_ghcr_alias.py
           python3 .github/scripts/test_cleanup_pr_tags.py
           python3 .github/scripts/test_cancel_stale_pr_ci.py
+          python3 .github/scripts/test_cancel_downstream_pipeline.py
 
       - name: Unit-test the GHCR immutability/provenance guard
         run: python3 .github/scripts/test_ghcr_image_guard.py
@@ -1641,3 +1642,10 @@ jobs:
           POLL_INTERVAL_SECONDS: "120"
           MAX_POLL_DURATION_SECONDS: "14400"  # 4 hours
         run: python3 .github/scripts/poll-downstream-pipeline.py
+
+      - name: Cancel downstream if this GitHub job was cancelled
+        if: cancelled() && steps.trigger.outputs.pipeline_id != ''
+        env:
+          DOWNSTREAM_PIPELINE_ID: ${{ steps.trigger.outputs.pipeline_id }}
+          DOWNSTREAM_PROJECT_ID: ${{ steps.trigger.outputs.project_id }}
+        run: python3 .github/scripts/cancel_downstream_pipeline.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1644,7 +1644,7 @@ jobs:
         run: python3 .github/scripts/poll-downstream-pipeline.py
 
       - name: Cancel downstream if this GitHub job was cancelled
-        if: cancelled() && steps.trigger.outputs.pipeline_id != ''
+        if: cancelled()
         env:
           DOWNSTREAM_PIPELINE_ID: ${{ steps.trigger.outputs.pipeline_id }}
           DOWNSTREAM_PROJECT_ID: ${{ steps.trigger.outputs.project_id }}

--- a/.github/workflows/osrb-review.yml
+++ b/.github/workflows/osrb-review.yml
@@ -138,7 +138,7 @@ jobs:
         run: python3 .github/scripts/poll-downstream-pipeline.py
 
       - name: Cancel downstream if this GitHub job was cancelled
-        if: cancelled() && steps.pr.outputs.skip != 'true' && steps.trigger.outputs.pipeline_id != ''
+        if: cancelled() && steps.pr.outputs.skip != 'true'
         env:
           DOWNSTREAM_PIPELINE_ID: ${{ steps.trigger.outputs.pipeline_id }}
           DOWNSTREAM_PROJECT_ID: ${{ steps.trigger.outputs.project_id }}

--- a/.github/workflows/osrb-review.yml
+++ b/.github/workflows/osrb-review.yml
@@ -137,6 +137,13 @@ jobs:
           MAX_POLL_DURATION_SECONDS: "2400"
         run: python3 .github/scripts/poll-downstream-pipeline.py
 
+      - name: Cancel downstream if this GitHub job was cancelled
+        if: cancelled() && steps.pr.outputs.skip != 'true' && steps.trigger.outputs.pipeline_id != ''
+        env:
+          DOWNSTREAM_PIPELINE_ID: ${{ steps.trigger.outputs.pipeline_id }}
+          DOWNSTREAM_PROJECT_ID: ${{ steps.trigger.outputs.project_id }}
+        run: python3 .github/scripts/cancel_downstream_pipeline.py
+
       # Unconditional, so every path that created the check also resolves it.
       - name: Complete OSRB check
         if: always()

--- a/.github/workflows/spatialai-data-utils.yml
+++ b/.github/workflows/spatialai-data-utils.yml
@@ -282,3 +282,10 @@ jobs:
           POLL_INTERVAL_SECONDS: "30"
           MAX_POLL_DURATION_SECONDS: "2400"
         run: python3 .github/scripts/poll-downstream-pipeline.py
+
+      - name: Cancel downstream if this GitHub job was cancelled
+        if: cancelled() && steps.trigger.outputs.pipeline_id != ''
+        env:
+          DOWNSTREAM_PIPELINE_ID: ${{ steps.trigger.outputs.pipeline_id }}
+          DOWNSTREAM_PROJECT_ID: ${{ steps.trigger.outputs.project_id }}
+        run: python3 .github/scripts/cancel_downstream_pipeline.py

--- a/.github/workflows/spatialai-data-utils.yml
+++ b/.github/workflows/spatialai-data-utils.yml
@@ -284,7 +284,7 @@ jobs:
         run: python3 .github/scripts/poll-downstream-pipeline.py
 
       - name: Cancel downstream if this GitHub job was cancelled
-        if: cancelled() && steps.trigger.outputs.pipeline_id != ''
+        if: cancelled()
         env:
           DOWNSTREAM_PIPELINE_ID: ${{ steps.trigger.outputs.pipeline_id }}
           DOWNSTREAM_PROJECT_ID: ${{ steps.trigger.outputs.project_id }}


### PR DESCRIPTION
Closing a PR (merge or abandon) now cancels remaining GitHub PR checks, including optional ones like SonarQube, without touching develop/main. When the GitHub trigger job itself is cancelled, it also cancels the GitLab pipeline it already started.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
