### PR TITLE
fix(agent-ui): drop icons from Manage Alerts kind tab titles

### DIFF
--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/components/CreateAlertRulesView.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/components/CreateAlertRulesView.tsx
@@ -19,8 +19,6 @@ import {
   IconArrowsUpDown,
   IconArrowUp,
   IconArrowDown,
-  IconBolt,
-  IconShieldCheck,
   IconDeviceFloppy,
   IconAlertCircle,
   IconLoader2,
@@ -58,14 +56,9 @@ type SortDirection = 'asc' | 'desc' | null;
 const KIND_TABS: Array<{
   id: AlertRulesType;
   label: string;
-  icon: React.ReactNode;
 }> = [
-  { id: 'real-time', label: 'Real-time Alerts', icon: <IconBolt size={14} /> },
-  {
-    id: 'verification',
-    label: 'CV Alerts Verification',
-    icon: <IconShieldCheck size={14} />,
-  },
+  { id: 'real-time', label: 'Real-time Alerts' },
+  { id: 'verification', label: 'CV Alerts Verification' },
 ];
 
 const generateDraftId = () =>
@@ -112,7 +105,7 @@ export const CreateAlertRulesView: React.FC<CreateAlertRulesViewProps> = ({
       <div role="tablist" aria-label="Alert kind" className="flex items-end gap-1">
         {enabledKindTabs.map((tab) => {
           const isSelected = activeKind === tab.id;
-          const baseClass = 'flex items-center gap-2 px-4 py-2 text-sm border-b-2 -mb-px';
+          const baseClass = 'flex items-center px-4 py-2 text-sm border-b-2 -mb-px';
           return (
             <button
               key={tab.id}
@@ -131,7 +124,6 @@ export const CreateAlertRulesView: React.FC<CreateAlertRulesViewProps> = ({
                     (isDark ? 'text-neutral-400' : 'text-gray-500')
               }`}
             >
-              {tab.icon}
               {tab.label}
             </button>
           );


### PR DESCRIPTION
Keep Real-time Alerts and CV Alerts Verification as text-only labels so the tab titles are cleaner and consistent.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
