### PR TITLE
fix(alerts): request category+info for incidents and stop the agent refusing on absent fields

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/config.yml
@@ -315,8 +315,18 @@ workflow:
 
     Optional parameters for filtering:
       - start_time, end_time: ISO 8601 format (e.g., "2026-01-06T00:00:00.000Z")
-      - incident_type: filter by type (e.g., "collision")
       - max_count: number of incidents to return (default 10)
+
+    Each incident always carries Id, timestamp (start), end and sensorId. It also
+    carries category and info (info.verdict, info.triggerPhrase, info.vlm_response)
+    when the producer set them. Everything beyond Id/timestamp/end/sensorId is
+    OPTIONAL and is often absent.
+
+    RENDERING (CRITICAL): Build your answer from the fields the tool actually
+    returned - derive table columns from the keys present in the response. A missing
+    optional field is normal, NOT an error: never refuse to answer, never report the
+    response as invalid, and never ask the user for a field the tool does not return.
+    If the user asked for a table, always produce the table.
 
     WORKFLOW 5: Generate Incident Report (Detailed Analysis)
     User: "Generate a report for the last incident from Montague-2-HO-6"
@@ -420,8 +430,8 @@ workflow:
          * action="get_sensor_uuid": Get UUID for a sensor name (required before incident_report_agent)
        - For get_incidents, optional parameters:
          * start_time, end_time: ISO 8601 format
-         * incident_type: filter by type (e.g., "collision")
          * max_count: number of incidents (default 10)
+       - Returns: Id, timestamp, end, sensorId, plus category and info when present
        - Use when: User asks "show alerts", "list incidents", "start/stop monitoring"
 
     6. report_agent (for UPLOADED video reports):

--- a/deploy/helm/developer-profiles/dev-profile-alerts/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/configs/vss-agent/config.yml
@@ -316,8 +316,18 @@ workflow:
 
     Optional parameters for filtering:
       - start_time, end_time: ISO 8601 format (e.g., "2026-01-06T00:00:00.000Z")
-      - incident_type: filter by type (e.g., "collision")
       - max_count: number of incidents to return (default 10)
+
+    Each incident always carries Id, timestamp (start), end and sensorId. It also
+    carries category and info (info.verdict, info.triggerPhrase, info.vlm_response)
+    when the producer set them. Everything beyond Id/timestamp/end/sensorId is
+    OPTIONAL and is often absent.
+
+    RENDERING (CRITICAL): Build your answer from the fields the tool actually
+    returned - derive table columns from the keys present in the response. A missing
+    optional field is normal, NOT an error: never refuse to answer, never report the
+    response as invalid, and never ask the user for a field the tool does not return.
+    If the user asked for a table, always produce the table.
 
     WORKFLOW 5: Generate Incident Report (Detailed Analysis)
     User: "Generate a report for the last incident from Montague-2-HO-6"
@@ -421,8 +431,8 @@ workflow:
          * action="get_sensor_uuid": Get UUID for a sensor name (required before incident_report_agent)
        - For get_incidents, optional parameters:
          * start_time, end_time: ISO 8601 format
-         * incident_type: filter by type (e.g., "collision")
          * max_count: number of incidents (default 10)
+       - Returns: Id, timestamp, end, sensorId, plus category and info when present
        - Use when: User asks "show alerts", "list incidents", "start/stop monitoring"
 
     6. report_agent (for UPLOADED video reports):

--- a/deploy/helm/industry-profiles/warehouse-operations/warehouse-2d-app/configs/vss-agent/config.yml
+++ b/deploy/helm/industry-profiles/warehouse-operations/warehouse-2d-app/configs/vss-agent/config.yml
@@ -316,8 +316,18 @@ workflow:
 
     Optional parameters for filtering:
       - start_time, end_time: ISO 8601 format (e.g., "2026-01-06T00:00:00.000Z")
-      - incident_type: filter by type (e.g., "collision")
       - max_count: number of incidents to return (default 10)
+
+    Each incident always carries Id, timestamp (start), end and sensorId. It also
+    carries category and info (info.verdict, info.triggerPhrase, info.vlm_response)
+    when the producer set them. Everything beyond Id/timestamp/end/sensorId is
+    OPTIONAL and is often absent.
+
+    RENDERING (CRITICAL): Build your answer from the fields the tool actually
+    returned - derive table columns from the keys present in the response. A missing
+    optional field is normal, NOT an error: never refuse to answer, never report the
+    response as invalid, and never ask the user for a field the tool does not return.
+    If the user asked for a table, always produce the table.
 
     WORKFLOW 5: Generate Incident Report (Detailed Analysis)
     User: "Generate a report for the last incident from Montague-2-HO-6"
@@ -421,8 +431,8 @@ workflow:
          * action="get_sensor_uuid": Get UUID for a sensor name (required before incident_report_agent)
        - For get_incidents, optional parameters:
          * start_time, end_time: ISO 8601 format
-         * incident_type: filter by type (e.g., "collision")
          * max_count: number of incidents (default 10)
+       - Returns: Id, timestamp, end, sensorId, plus category and info when present
        - Use when: User asks "show alerts", "list incidents", "start/stop monitoring"
 
     6. report_agent (for UPLOADED video reports):

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/rtvi_vlm_alert.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/rtvi_vlm_alert.py
@@ -106,10 +106,6 @@ class RTVIVLMAlertInput(BaseModel):
         10,
         description="Maximum number of incidents to return. Only for 'get_incidents' action.",
     )
-    incident_type: str | None = Field(
-        None,
-        description="Filter by incident type (e.g., 'collision'). Only for 'get_incidents' action.",
-    )
 
 
 class RTVIVLMAlertOutput(BaseModel):
@@ -198,10 +194,15 @@ async def rtvi_vlm_alert(config: RTVIVLMAlertConfig, builder: Builder) -> AsyncG
 
                 # Build input for VA tool - use sensor_name directly as source
                 # When sensor_name is provided to RTVI-VLM, it's used as sensor_id in Kafka messages
+                # VA projects only Id/timestamp/end/sensorId unless extra fields are
+                # requested via `includes`. RT-VLM incidents carry their kind in
+                # `category` and the verification result in `info` (verdict,
+                # triggerPhrase, vlm_response), so ask for both.
                 va_input = {
                     "source": sensor_name,
                     "source_type": "sensor",
                     "max_count": input_data.max_count,
+                    "includes": ["category", "info"],
                 }
 
                 # Add time range if provided (VA tool requires both start and end)

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_rtvi_vlm_alert.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_rtvi_vlm_alert.py
@@ -93,11 +93,9 @@ class TestRTVIVLMAlertInput:
             start_time="2026-01-06T00:00:00.000Z",
             end_time="2026-01-07T00:00:00.000Z",
             max_count=5,
-            incident_type="collision",
         )
         assert inp.action == "get_incidents"
         assert inp.max_count == 5
-        assert inp.incident_type == "collision"
 
     def test_defaults(self):
         inp = RTVIVLMAlertInput(action="start")
@@ -108,7 +106,6 @@ class TestRTVIVLMAlertInput:
         assert inp.start_time is None
         assert inp.end_time is None
         assert inp.max_count == 10
-        assert inp.incident_type is None
 
     def test_invalid_action_raises(self):
         with pytest.raises(ValidationError):

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_rtvi_vlm_alert_inner.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_rtvi_vlm_alert_inner.py
@@ -85,6 +85,11 @@ class TestRTVIVLMAlertInner:
         assert result.success is True
         assert result.total_count == 1
 
+        # VA projects only Id/timestamp/end/sensorId unless `includes` asks for more;
+        # the alerts path needs category and info to render an incident table.
+        va_input = mock_va_tool.ainvoke.call_args.kwargs["input"]
+        assert va_input["includes"] == ["category", "info"]
+
     @pytest.mark.asyncio
     async def test_get_incidents_string_result(self, mock_builder):
         config = RTVIVLMAlertConfig(


### PR DESCRIPTION
## Summary

**NVBug 6654364** (P0) — in the Alerts Real-Time profile, *"Show me the 5 most recent incidents from `warehouse_sample` as a table"* intermittently fails. `rtvi_vlm_alert` returns five valid incidents, but the agent refuses to render the table and reports that `Type` and `Description` are missing. Repro 2/3; not reproduced on a second host.

Two distinct causes, neither of them a regression in the alerts code:

1. **`category` and `info` were unreachable.** `video_analytics.get_incidents` deliberately projects a minimal ES `_source` — `["Id", "id", "timestamp", "end", "sensorId"]` — and its docstring says everything else must be requested via `includes`. `rtvi_vlm_alert` never passed `includes`, and `RTVIVLMAlertInput` had no such parameter, so the optional fields could not be requested from the alerts path at all. `video_analytics__get_incidents` (which *does* expose `includes`) is imported by the MCP client but is not in the top_agent's `tool_names`, so the model never sees it either.
2. **The prompt promised a filter that did nothing.** `RTVIVLMAlertInput.incident_type` was declared but never read — it was never forwarded to `va_input`. The top_agent prompt advertised it twice as a working filter, priming the model to expect a `Type` on every incident that the response never carried.

Field naming, for the record:

| Reported as | Actually | Where |
|---|---|---|
| `Type` | **`category`** | behavior-analytics writes the incident kind here — `anomaly_action_detection.py:180` does `category=incident_type` |
| `Description` | **`info.vlm_response`** | there is no `description` field on an incident; `description` belongs to the alert *rule* (`realtime/schemas/alert_config.py`, `rtvi_client.py`) |

Nothing in the prompt makes `Type`/`Description` mandatory columns — the refusal is the model's own inference. At `temperature: 0.0`, the intermittency is LLM-backend nondeterminism, not sampling.

### Not the cause: the `develop-latest` image move

The bug's regression analysis proposes source/runtime skew from the agent image moving to a moving tag. That move is **real** and worth its own bug:

| | agent image |
|---|---|
| `dev-26.07.2` | `nvcr.io/nvstaging/vss-core/vss-agent:${VSS_AGENT_VERSION}`, alerts `.env` pinning `3.2.1-26.07.1-e33af13d2f59` |
| `dev-26.08.2` | `…:${VSS_CONTAINER_TAG:-${VSS_AGENT_VERSION:-develop-latest}}`, alerts `.env` no longer sets `VSS_AGENT_VERSION`, `containers.env` sets `VSS_CONTAINER_TAG:-develop-latest` |

But it cannot explain this symptom: `git diff dev-26.08.2..origin/develop` over `video_analytics/`, `tools/rtvi_vlm_alert.py` and `dev-profile-alerts/vss-agent/` is **empty**, and the profile config is bind-mounted (`${VSS_APPS_DIR}:/vss-agent/deploy/docker:ro`) so the prompt always comes from the host checkout at the tag, never from the image. `incident_fields` itself has not changed since May 2026 (`f1a07f912`).

## Plan

Two decisions were put to the reviewer, each with a recommendation:

**1. Where should `category` + `info` be added — narrowly on the alerts path, or in the shared VA-MCP default?**

| Option | |
|---|---|
| **Pass `includes` in `rtvi_vlm_alert`** | *Recommended.* Alerts-only. Uses the `includes` mechanism that exists for exactly this, and leaves the documented VA-MCP contract intact for base/search/smartcities/warehouse. |
| Change the VA default projection | Every `get_incidents` caller starts receiving `category`+`info`; the tool docstring and its unit tests would have to change too. |
| Both | Redundant. |

→ **Answer: pass `includes` in `rtvi_vlm_alert`.** Implemented as such; `video_analytics/tools.py` is untouched.

**2. What should the PR do with the dead `incident_type` parameter?**

| Option | |
|---|---|
| **Remove param + both prompt mentions** | *Recommended.* Zero behavior lost — it never worked. Stops the prompt promising a filter that does nothing and priming the model to expect a `Type`. |
| Wire it up as a category filter | VA's `get_incidents` has no type/category filter today; adding one is a feature well beyond this bug. |
| Leave it alone | The two misleading prompt lines stay. |

→ **Answer: remove it.** Implemented as such.

## Related Issue

NVBug 6654364 — `[VSS 3.3.0 dev-26.08.2][DevX Alerts Real-Time] Agent refuses to display recent incidents as a table when Type and Description are absent`

## Changes

`services/agent/packages/vss_agents/src/vss_agents/tools/rtvi_vlm_alert.py`
- Pass `includes=["category", "info"]` to the VA `get_incidents` tool.
- Drop the dead `incident_type` field from `RTVIVLMAlertInput`.

Prompts — `deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/config.yml`, `deploy/helm/developer-profiles/dev-profile-alerts/configs/vss-agent/config.yml`, `deploy/helm/industry-profiles/warehouse-operations/warehouse-2d-app/configs/vss-agent/config.yml` (all three configs that wire `rtvi_vlm_alert`)
- Remove both `incident_type` mentions.
- State which incident fields are guaranteed and which are optional.
- Add a rendering rule: derive table columns from the keys actually present in the response; a missing optional field is normal, not an error; never refuse, never report the response as invalid, never ask the user for a field the tool does not return.

Tests
- `test_rtvi_vlm_alert.py`: drop `incident_type` assertions.
- `test_rtvi_vlm_alert_inner.py`: assert `va_input["includes"] == ["category", "info"]`.

**Not changed:** `video_analytics/tools.py`, the VA-MCP `get_incidents` schema/contract, and the warehouse `incident_report_template.md` `{incident_type}` placeholder (an unrelated `template_report_gen` substitution).

## Verification

```
uv run pytest packages/vss_agents/tests/unit_test/tools \
              packages/vss_agents/tests/unit_test/video_analytics \
              -m "not slow and not integration"
→ 1239 passed in 154.54s

ruff check      → All checks passed!
ruff format     → 3 files already formatted
mypy            → Success: no issues found in 1 source file
pre-commit      → TruffleHog / ruff / SPDX / LFS / DCO all Passed
```

The new assertion was mutation-checked: removing the `includes` line makes `test_get_incidents_with_va_tool` fail with `KeyError: 'includes'`, so it is not vacuous.

**Not verified:** no end-to-end run against a live Alerts Real-Time deployment. The rendering-rule prompt change in particular is an LLM-behavior fix — it should be confirmed on the failing repro (Jenkins #934) before this bug is closed.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally.
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d.
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes. — no user-facing doc describes the incident field set.
- [x] No secrets, API keys, or credentials committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
