### PR TITLE
fix(skill-eval): redact secrets from everything the harness posts to GitHub

### DIFF
--- a/.github/skill-eval/leg_report.py
+++ b/.github/skill-eval/leg_report.py
@@ -34,6 +34,8 @@ import math
 import os
 import re
 import sys
+
+import redact_secrets
 from pathlib import Path
 
 TRACE_URLS_NAME = "trace-urls.tsv"
@@ -650,6 +652,14 @@ def main(argv: list[str] | None = None) -> int:
                          "use instead of parsing the rendered Markdown")
     args = ap.parse_args(argv)
 
+    # Redact the tree BEFORE reading it: this render is what the PR comment
+    # is posted from, during the agent step — the workflow's pack-step scan
+    # runs later and cannot protect the comment. Scanner failure propagates:
+    # skills_eval_agent fail-closes a leg whose report crashes, and an
+    # unscanned tree must read as BLOCKED, not as green.
+    for line in redact_secrets.redact_tree(args.results_root):
+        print(f"redact_secrets: {line}", file=sys.stderr)
+
     leg = collect_leg(args.results_root)
     if not leg["trials"]:
         print("no trials under results root", file=sys.stderr)
@@ -667,11 +677,19 @@ def main(argv: list[str] | None = None) -> int:
     body = render_comment(leg, spec_path=args.spec_path, platform=args.platform,
                           head_sha=args.head_sha, spec_sha=args.spec_sha,
                           declared=declared)
+    # Both writes leave the runner for GitHub (comment body, artifact
+    # summary). The results tree was already TruffleHog-redacted above; this
+    # covers what rendering itself could reintroduce. The summary is scrubbed
+    # as a STRUCTURE before serialization — json.dumps escapes quotes,
+    # backslashes and non-ASCII, after which an env value no longer occurs
+    # literally in the document and substring replacement would miss it.
+    body = redact_secrets.redact_text(body)
     if args.summary_json:
         args.summary_json.parent.mkdir(parents=True, exist_ok=True)
         args.summary_json.write_text(json.dumps(
-            leg_summary(leg, declared=declared, spec_path=args.spec_path,
-                        platform=args.platform), indent=2, default=str))
+            redact_secrets.redact_obj(
+                leg_summary(leg, declared=declared, spec_path=args.spec_path,
+                            platform=args.platform)), indent=2, default=str))
     if args.out:
         args.out.parent.mkdir(parents=True, exist_ok=True)
         args.out.write_text(body)

--- a/.github/skill-eval/redact_secrets.py
+++ b/.github/skill-eval/redact_secrets.py
@@ -180,6 +180,28 @@ def _finding_file(finding: dict, target: Path) -> Path:
     return resolved
 
 
+def _neutralize_symlinks(root: Path) -> list[str]:
+    """Replace every symlink in the tree with a stub, links first.
+
+    The rewriter and the quarantine both write through paths; a symlink would
+    make this security gate mutate a file elsewhere on the runner, a
+    directory symlink would let rglob edit files outside the tree, and the
+    link target string itself is archive metadata that can carry a secret no
+    content scan sees. Depth-first so a link inside a linked directory is
+    never traversed.
+    """
+    lines = []
+    links = sorted((p for p in root.rglob("*") if p.is_symlink()),
+                   key=lambda p: len(p.parts), reverse=True)
+    for link in links:
+        link.unlink()
+        link.write_text(
+            "[REDACTED: symlink removed by redact_secrets.py -- targets are "
+            "not part of the published tree]\n", encoding="utf-8")
+        lines.append(f"symlink removed: {link.relative_to(root)}")
+    return lines
+
+
 def redact_text(text: str, extra_secrets: list[str] | None = None) -> str:
     """Mask known secret values and secret-shaped tokens in one string."""
     for value in (extra_secrets or []):
@@ -225,6 +247,8 @@ def _replace_literals(root: Path, secrets: list[str]) -> tuple[list[str], set[st
     lines: list[str] = []
     replaced: set[str] = set()
     for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        if path.is_symlink():  # pre-pass removes these; never write through one
+            continue
         try:
             original = path.read_text(encoding="utf-8")
         except (UnicodeDecodeError, OSError):
@@ -278,30 +302,41 @@ def redact_tree(root: Path) -> list[str]:
     and detectors, never secret values.
     """
     root = Path(root)
+    summary = _neutralize_symlinks(root)
     findings = _scan(root)
+    # Every finding is pinned to a file inside the tree BEFORE any rewrite:
+    # replacement can blind the rescan, after which a finding with missing
+    # or escaping metadata would never be checked at all.
+    located = [(f, _finding_file(f, root)) for f in findings]
     secrets = sorted(
         {s for f in findings for s in (f.get("Raw"), f.get("RawV2"))
          if isinstance(s, str) and len(s) >= _MIN_SECRET_LEN},
         key=len, reverse=True)
-    summary = [f"trufflehog: {len(findings)} finding(s), "
-               f"{len(secrets)} distinct value(s)"]
+    summary.insert(len(summary), f"trufflehog: {len(findings)} finding(s), "
+                                 f"{len(secrets)} distinct value(s)")
     lines, replaced = _replace_literals(root, secrets)
     summary += lines
     if not findings:
-        if len(summary) == 1:
+        if len(summary) <= 1:
             summary.append("clean: no redactions needed")
         return summary
 
-    # Multipart guard: a finding whose values never matched literally hides
-    # its secret half from the rescan once the identifier half is gone, so
-    # the source file is quarantined on the initial finding's evidence.
-    for f in findings:
-        values = [s for s in (f.get("Raw"), f.get("RawV2"))
-                  if isinstance(s, str) and len(s) >= _MIN_SECRET_LEN]
-        if values and not any(v in replaced for v in values):
-            path = _finding_file(f, root)
+    # Multipart guard, judged per finding on its COMPLETE representation.
+    # TruffleHog's Raw is often only the identifier half of a credential and
+    # RawV2 the identifier+secret composite (AWS: `id` vs `id:secret`). When
+    # the halves sit on different lines, replacing the identifier blinds the
+    # rescan while the secret half survives — so replacing only Raw is not
+    # enough: the finding counts as neutralized only if its RawV2 (when it
+    # has one) was itself replaced somewhere.
+    for f, path in located:
+        raw, rawv2 = f.get("Raw"), f.get("RawV2")
+        required = next(
+            (v for v in (rawv2, raw)
+             if isinstance(v, str) and len(v) >= _MIN_SECRET_LEN), None)
+        if required is not None and required not in replaced:
             summary.append(_quarantine(
-                path, root, [f"{f.get('DetectorName') or 'unknown'} (unmatched)"]))
+                path, root,
+                [f"{f.get('DetectorName') or 'unknown'} (incomplete match)"]))
 
     # Rescan: representations the literal pass cannot reach.
     survivors: dict[Path, list[str]] = {}

--- a/.github/skill-eval/redact_secrets.py
+++ b/.github/skill-eval/redact_secrets.py
@@ -13,22 +13,33 @@ artifact and, for six days, in the PR comment). The tarball already excludes
 the verifier files and rendered reports that stayed in.
 
 The scanner is TruffleHog — the same tool the repo's pre-commit hook trusts —
-run with `--no-verification`: verification would send candidate secrets to
-their providers, which is itself exfiltration, and a candidate is worth
-masking whether or not it still works. The tree pass is scan -> replace ->
-rescan: findings whose raw value is a literal substring are replaced in
-place; files still flagged on the rescan (encoded, composite, or binary
-representations the literal pass cannot reach) are quarantined -- their
-content replaced by a stub -- and a final scan must come back empty.
+run with `--no-verification` (verification would send candidate secrets to
+their providers, which is itself exfiltration) and `--fail-on-scan-errors`
+(an ordinary scan error otherwise exits 0, and an unscanned file must not
+read as a clean one). The pinned-image docker path is preferred over
+whatever `trufflehog` happens to be on PATH, so the publish gate does not
+drift with the host.
+
+The tree pass is scan -> replace -> verify -> quarantine -> verify:
+
+* literal `Raw`/`RawV2` values are replaced wherever they appear;
+* a finding whose values never matched literally anywhere is quarantined at
+  the source file — TruffleHog's `Raw` is often only the identifier half of
+  a multipart credential (AWS id vs `id:secret` in `RawV2`), and replacing
+  the identifier blinds the rescan while the secret half survives;
+* files still flagged on the rescan (encoded, composite, or binary
+  representations) are quarantined — content replaced by a stub;
+* a rescan finding that cannot be mapped to a file inside the tree is fatal,
+  and the final scan must come back empty, or the publish refuses.
 
 At a public-output boundary the scanner failing means the publish fails:
 `redact_tree` raises on a missing scanner, timeout, or scan error, and its
 callers (leg_report before it reads anything, the workflow pack step before
 `tar`) let that propagate. `skills_eval_agent.py` already fail-closes a leg
 whose report crashes, so a scanner outage reads as BLOCKED, not as green.
-Builtin layers (the `nvapi-` NGC shape; exact values of secret-named env
-vars) run unconditionally on top -- TruffleHog's NGC detector exists, but a
-shape guard costs nothing and catches truncated quotes.
+Builtin layers (the `nvapi-` NGC shape — as bytes too, so a binary carrying
+an ASCII token is quarantined even when the scanner misses it; exact values
+of secret-named env vars) run unconditionally on top.
 """
 
 from __future__ import annotations
@@ -39,11 +50,13 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 MARKER = "[REDACTED]"
 #: Keep the prefix so a rationale still says what kind of secret it saw.
 NVAPI = re.compile(r"nvapi-[A-Za-z0-9_-]{16,}")
+_NVAPI_BYTES = re.compile(rb"nvapi-[A-Za-z0-9_-]{16,}")
 #: Component match, not substring: NGC_CLI_API_KEY yes, KEYCLOAK_URL no.
 _SECRET_NAME = re.compile(
     r"(^|_)(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|CREDENTIALS)(_|$)", re.IGNORECASE)
@@ -55,6 +68,8 @@ _MIN_SECRET_LEN = 8
 #: Match the pre-commit hook's pinned rev — `latest` would make the publish
 #: gate drift under us.
 _TRUFFLEHOG_IMAGE = "trufflesecurity/trufflehog:3.94.2"
+_TRUFFLEHOG_ARGS = ["filesystem", "--json", "--no-update", "--no-verification",
+                    "--fail-on-scan-errors"]
 _TRUFFLEHOG_TIMEOUT_S = 300
 
 
@@ -64,59 +79,105 @@ class ScannerUnavailable(RuntimeError):
 
 def _env_secret_values() -> list[str]:
     values = [v for k, v in os.environ.items()
-              if _SECRET_NAME.search(k) and v and len(v) >= _MIN_SECRET_LEN]
+              if _SECRET_NAME.search(k) and v and len(v) >= _MIN_SECRET_LEN
+              # A value that is a substring of the marker (e.g. TOKEN=REDACTED)
+              # would grow "[REDACTED]" on every pass; masking it is a no-op
+              # security-wise and breaks idempotency.
+              and v not in MARKER]
     # Longest first, so a secret containing another leaves no usable tail.
     return sorted(set(values), key=len, reverse=True)
 
 
-def _trufflehog_cmd(target: Path) -> list[str]:
-    if shutil.which("trufflehog"):
-        return ["trufflehog", "filesystem", "--json", "--no-update",
-                "--no-verification", str(target)]
+def _run_scanner(target: Path) -> subprocess.CompletedProcess:
+    """One scanner invocation; docker-pinned preferred over PATH drift."""
     if shutil.which("docker"):
-        return ["docker", "run", "--rm", "-v", f"{target}:/scan:ro",
-                _TRUFFLEHOG_IMAGE, "filesystem", "--json",
-                "--no-update", "--no-verification", "/scan"]
-    raise ScannerUnavailable("trufflehog: no binary on PATH and no docker")
+        with tempfile.NamedTemporaryFile(suffix=".cid") as cid:
+            cmd = ["docker", "run", "--rm", "--network", "none",
+                   f"--cidfile={cid.name}.live",
+                   "-v", f"{target}:/scan:ro", _TRUFFLEHOG_IMAGE,
+                   *_TRUFFLEHOG_ARGS, "/scan"]
+            try:
+                return subprocess.run(cmd, capture_output=True, text=True,
+                                      timeout=_TRUFFLEHOG_TIMEOUT_S)
+            except subprocess.TimeoutExpired:
+                # Killing the docker CLI does not kill the container.
+                try:
+                    container = Path(f"{cid.name}.live").read_text().strip()
+                    if container:
+                        subprocess.run(["docker", "rm", "-f", container],
+                                       capture_output=True, timeout=30)
+                except (OSError, subprocess.TimeoutExpired):
+                    pass
+                raise
+            finally:
+                Path(f"{cid.name}.live").unlink(missing_ok=True)
+    if shutil.which("trufflehog"):
+        version = subprocess.run(["trufflehog", "--version"], capture_output=True,
+                                 text=True, timeout=30)
+        print(f"redact_secrets: docker unavailable, using PATH scanner "
+              f"({(version.stdout or version.stderr).strip()})", file=sys.stderr)
+        return subprocess.run(["trufflehog", *_TRUFFLEHOG_ARGS, str(target)],
+                              capture_output=True, text=True,
+                              timeout=_TRUFFLEHOG_TIMEOUT_S)
+    raise ScannerUnavailable("trufflehog: no docker and no binary on PATH")
 
 
 def _scan(target: Path) -> list[dict]:
     """One TruffleHog pass; findings as dicts. Raises rather than degrades."""
-    cmd = _trufflehog_cmd(target)
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True,
-                              timeout=_TRUFFLEHOG_TIMEOUT_S)
+        proc = _run_scanner(target)
     except subprocess.TimeoutExpired as exc:
         raise ScannerUnavailable(
             f"trufflehog: timed out after {_TRUFFLEHOG_TIMEOUT_S}s") from exc
-    # 183 is "findings present" under --fail; without it success is 0. Any
-    # other exit is a scan error, and an unscanned tree must not publish.
+    # 183 is "findings present" under --fail; success without it is 0. Any
+    # other exit — including --fail-on-scan-errors firing — means part of
+    # the tree went unscanned, and an unscanned tree must not publish.
     if proc.returncode not in (0, 183):
         raise ScannerUnavailable(
             f"trufflehog: exit {proc.returncode}: {proc.stderr.strip()[:300]}")
     findings = []
     for line in proc.stdout.splitlines():
+        if not line.strip():
+            continue
         try:
             obj = json.loads(line)
         except json.JSONDecodeError:
-            continue
+            # --json output is NDJSON findings only; anything else on stdout
+            # means we are not parsing what we think we are.
+            raise ScannerUnavailable(
+                f"trufflehog: unparseable stdout line: {line[:120]!r}")
         if isinstance(obj, dict) and (obj.get("Raw") or obj.get("RawV2")):
             findings.append(obj)
     return findings
 
 
-def _finding_file(finding: dict, target: Path) -> Path | None:
-    """The file a finding points at, mapped back from the docker mount."""
+def _finding_file(finding: dict, target: Path) -> Path:
+    """The file a finding points at, proven to live inside the tree.
+
+    A finding that cannot be pinned to a file under the target cannot be
+    redacted or quarantined, so it is fatal — returning None here would
+    let the publish proceed with a known live finding.
+    """
     meta = finding.get("SourceMetadata") or {}
-    data = meta.get("Data") or {}
-    fs = data.get("Filesystem") or {}
+    fs = (meta.get("Data") or {}).get("Filesystem") or {}
     raw_path = fs.get("file")
     if not raw_path:
-        return None
+        raise RuntimeError(
+            f"redact_secrets: finding without a file path "
+            f"(detector {finding.get('DetectorName')!r}); refusing to publish")
     path = Path(raw_path)
     if path.parts[:2] == ("/", "scan"):  # docker mount prefix
         path = target / Path(*path.parts[2:])
-    return path
+    resolved = path.resolve()
+    if not resolved.is_relative_to(target.resolve()):
+        raise RuntimeError(
+            f"redact_secrets: finding path {raw_path!r} escapes the tree; "
+            f"refusing to publish")
+    if not resolved.is_file():
+        raise RuntimeError(
+            f"redact_secrets: finding path {raw_path!r} does not exist; "
+            f"refusing to publish")
+    return resolved
 
 
 def redact_text(text: str, extra_secrets: list[str] | None = None) -> str:
@@ -147,18 +208,46 @@ def redact_obj(obj, extra_secrets: list[str] | None = None):
     return obj
 
 
-def _replace_literals(root: Path, secrets: list[str]) -> list[str]:
-    changed = []
+def _binary_has_builtin_hit(data: bytes, secrets: list[str]) -> bool:
+    if _NVAPI_BYTES.search(data):
+        return True
+    return any(s.encode("utf-8", "ignore") in data
+               for s in [*secrets, *_env_secret_values()])
+
+
+def _replace_literals(root: Path, secrets: list[str]) -> tuple[list[str], set[str]]:
+    """Rewrite text files in place; quarantine binaries with builtin hits.
+
+    Returns (summary lines, the secret values that were actually found and
+    replaced somewhere). A value never seen literally is the multipart /
+    encoded case the caller must quarantine at the finding's source file.
+    """
+    lines: list[str] = []
+    replaced: set[str] = set()
     for path in sorted(p for p in root.rglob("*") if p.is_file()):
         try:
             original = path.read_text(encoding="utf-8")
         except (UnicodeDecodeError, OSError):
+            # The builtin layers still apply to binaries: an ASCII nvapi-
+            # token inside a non-UTF-8 file leaks exactly the same, and a
+            # byte-level rewrite would corrupt the file, so quarantine it.
+            try:
+                data = path.read_bytes()
+            except OSError:
+                continue
+            if _binary_has_builtin_hit(data, secrets):
+                lines.append(_quarantine(path, root, ["builtin-binary"]))
             continue
-        cleaned = redact_text(original, extra_secrets=secrets)
+        cleaned = original
+        for value in secrets:
+            if value in cleaned:
+                cleaned = cleaned.replace(value, MARKER)
+                replaced.add(value)
+        cleaned = redact_text(cleaned)
         if cleaned != original:
             path.write_text(cleaned, encoding="utf-8")
-            changed.append(f"redacted: {path.relative_to(root)}")
-    return changed
+            lines.append(f"redacted: {path.relative_to(root)}")
+    return lines, replaced
 
 
 def _quarantine(path: Path, root: Path, detectors: list[str]) -> str:
@@ -166,22 +255,27 @@ def _quarantine(path: Path, root: Path, detectors: list[str]) -> str:
 
     Encoded (base64/UTF-16), composite (RawV2 joins fields that sit on
     different lines), and binary representations all defeat substring
-    replacement; the only safe artifact is no artifact.
+    replacement; the only safe artifact is no artifact. `.json` files get a
+    JSON stub so downstream readers (collect_leg, row_state) parse a
+    document that says what happened instead of crashing on prose.
     """
     names = ", ".join(sorted(set(detectors))) or "unknown"
-    path.write_text(
-        f"[REDACTED: quarantined by redact_secrets.py -- trufflehog "
-        f"detector(s) {names} still matched after literal redaction]\n",
-        encoding="utf-8")
+    message = (f"quarantined by redact_secrets.py -- trufflehog detector(s) "
+               f"{names} still matched after literal redaction")
+    if path.suffix == ".json":
+        path.write_text(json.dumps({"redacted": message}) + "\n", encoding="utf-8")
+    else:
+        path.write_text(f"[REDACTED: {message}]\n", encoding="utf-8")
     return f"quarantined: {path.relative_to(root)} ({names})"
 
 
 def redact_tree(root: Path) -> list[str]:
-    """Scan -> replace -> rescan -> quarantine -> verify; summary lines back.
+    """Scan -> replace -> verify -> quarantine -> verify; summary lines back.
 
     Raises ScannerUnavailable if TruffleHog cannot run, and RuntimeError if
-    findings survive quarantine — in both cases the caller must not publish
-    the tree. Summary lines name files and detectors, never secret values.
+    a finding cannot be pinned to a file in the tree or survives quarantine —
+    in every such case the caller must not publish. Summary lines name files
+    and detectors, never secret values.
     """
     root = Path(root)
     findings = _scan(root)
@@ -191,27 +285,38 @@ def redact_tree(root: Path) -> list[str]:
         key=len, reverse=True)
     summary = [f"trufflehog: {len(findings)} finding(s), "
                f"{len(secrets)} distinct value(s)"]
-    summary += _replace_literals(root, secrets)
+    lines, replaced = _replace_literals(root, secrets)
+    summary += lines
+    if not findings:
+        if len(summary) == 1:
+            summary.append("clean: no redactions needed")
+        return summary
 
-    if findings:
-        survivors: dict[Path, list[str]] = {}
-        for f in _scan(root):
+    # Multipart guard: a finding whose values never matched literally hides
+    # its secret half from the rescan once the identifier half is gone, so
+    # the source file is quarantined on the initial finding's evidence.
+    for f in findings:
+        values = [s for s in (f.get("Raw"), f.get("RawV2"))
+                  if isinstance(s, str) and len(s) >= _MIN_SECRET_LEN]
+        if values and not any(v in replaced for v in values):
             path = _finding_file(f, root)
-            detector = str(f.get("DetectorName") or "unknown")
-            if path is not None and path.is_file():
-                survivors.setdefault(path, []).append(detector)
-        for path, detectors in sorted(survivors.items()):
-            summary.append(_quarantine(path, root, detectors))
-        if survivors and (final := _scan(root)):
-            raise RuntimeError(
-                f"redact_secrets: {len(final)} finding(s) survived quarantine; "
-                f"refusing to publish {root}")
-    else:
-        # No scanner findings — still run the builtin layers over the tree.
-        summary += _replace_literals(root, [])
+            summary.append(_quarantine(
+                path, root, [f"{f.get('DetectorName') or 'unknown'} (unmatched)"]))
 
-    if len(summary) == 1:
-        summary.append("clean: no redactions needed")
+    # Rescan: representations the literal pass cannot reach.
+    survivors: dict[Path, list[str]] = {}
+    for f in _scan(root):
+        path = _finding_file(f, root)  # unmappable or escaping paths raise
+        survivors.setdefault(path, []).append(str(f.get("DetectorName") or "unknown"))
+    for path, detectors in sorted(survivors.items()):
+        summary.append(_quarantine(path, root, detectors))
+
+    # Final verification is unconditional once findings existed: the publish
+    # only proceeds over a tree the scanner can no longer flag.
+    if final := _scan(root):
+        raise RuntimeError(
+            f"redact_secrets: {len(final)} finding(s) survived quarantine; "
+            f"refusing to publish {root}")
     return summary
 
 

--- a/.github/skill-eval/redact_secrets.py
+++ b/.github/skill-eval/redact_secrets.py
@@ -1,0 +1,237 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Redact secrets from everything the eval harness posts to GitHub.
+
+Two things leave the runner for a public surface: the results tree that the
+workflow tars into the run artifact, and the Markdown/JSON that leg_report.py
+renders into the PR comment and leg summary. A judge that proves "the agent
+printed NGC_CLI_API_KEY" by quoting the key publishes a live credential
+through both (PR #1647 run 32535909071 — full 70-char key in the public
+artifact and, for six days, in the PR comment). The tarball already excludes
+`agent/` trajectories for exactly this reason (PR #516); this module covers
+the verifier files and rendered reports that stayed in.
+
+The scanner is TruffleHog — the same tool the repo's pre-commit hook trusts —
+run with `--no-verification`: verification would send candidate secrets to
+their providers, which is itself exfiltration, and a candidate is worth
+masking whether or not it still works. The tree pass is scan -> replace ->
+rescan: findings whose raw value is a literal substring are replaced in
+place; files still flagged on the rescan (encoded, composite, or binary
+representations the literal pass cannot reach) are quarantined -- their
+content replaced by a stub -- and a final scan must come back empty.
+
+At a public-output boundary the scanner failing means the publish fails:
+`redact_tree` raises on a missing scanner, timeout, or scan error, and its
+callers (leg_report before it reads anything, the workflow pack step before
+`tar`) let that propagate. `skills_eval_agent.py` already fail-closes a leg
+whose report crashes, so a scanner outage reads as BLOCKED, not as green.
+Builtin layers (the `nvapi-` NGC shape; exact values of secret-named env
+vars) run unconditionally on top -- TruffleHog's NGC detector exists, but a
+shape guard costs nothing and catches truncated quotes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+MARKER = "[REDACTED]"
+#: Keep the prefix so a rationale still says what kind of secret it saw.
+NVAPI = re.compile(r"nvapi-[A-Za-z0-9_-]{16,}")
+#: Component match, not substring: NGC_CLI_API_KEY yes, KEYCLOAK_URL no.
+_SECRET_NAME = re.compile(
+    r"(^|_)(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|CREDENTIALS)(_|$)", re.IGNORECASE)
+#: Values shorter than this are config flags ("true", "1", a region name),
+#: not credentials; masking them would shred the evidence text. This is a
+#: high-entropy-token heuristic, not a guarantee for short passwords.
+_MIN_SECRET_LEN = 8
+
+#: Match the pre-commit hook's pinned rev — `latest` would make the publish
+#: gate drift under us.
+_TRUFFLEHOG_IMAGE = "trufflesecurity/trufflehog:3.94.2"
+_TRUFFLEHOG_TIMEOUT_S = 300
+
+
+class ScannerUnavailable(RuntimeError):
+    """TruffleHog could not run to completion; the publish must not proceed."""
+
+
+def _env_secret_values() -> list[str]:
+    values = [v for k, v in os.environ.items()
+              if _SECRET_NAME.search(k) and v and len(v) >= _MIN_SECRET_LEN]
+    # Longest first, so a secret containing another leaves no usable tail.
+    return sorted(set(values), key=len, reverse=True)
+
+
+def _trufflehog_cmd(target: Path) -> list[str]:
+    if shutil.which("trufflehog"):
+        return ["trufflehog", "filesystem", "--json", "--no-update",
+                "--no-verification", str(target)]
+    if shutil.which("docker"):
+        return ["docker", "run", "--rm", "-v", f"{target}:/scan:ro",
+                _TRUFFLEHOG_IMAGE, "filesystem", "--json",
+                "--no-update", "--no-verification", "/scan"]
+    raise ScannerUnavailable("trufflehog: no binary on PATH and no docker")
+
+
+def _scan(target: Path) -> list[dict]:
+    """One TruffleHog pass; findings as dicts. Raises rather than degrades."""
+    cmd = _trufflehog_cmd(target)
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True,
+                              timeout=_TRUFFLEHOG_TIMEOUT_S)
+    except subprocess.TimeoutExpired as exc:
+        raise ScannerUnavailable(
+            f"trufflehog: timed out after {_TRUFFLEHOG_TIMEOUT_S}s") from exc
+    # 183 is "findings present" under --fail; without it success is 0. Any
+    # other exit is a scan error, and an unscanned tree must not publish.
+    if proc.returncode not in (0, 183):
+        raise ScannerUnavailable(
+            f"trufflehog: exit {proc.returncode}: {proc.stderr.strip()[:300]}")
+    findings = []
+    for line in proc.stdout.splitlines():
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and (obj.get("Raw") or obj.get("RawV2")):
+            findings.append(obj)
+    return findings
+
+
+def _finding_file(finding: dict, target: Path) -> Path | None:
+    """The file a finding points at, mapped back from the docker mount."""
+    meta = finding.get("SourceMetadata") or {}
+    data = meta.get("Data") or {}
+    fs = data.get("Filesystem") or {}
+    raw_path = fs.get("file")
+    if not raw_path:
+        return None
+    path = Path(raw_path)
+    if path.parts[:2] == ("/", "scan"):  # docker mount prefix
+        path = target / Path(*path.parts[2:])
+    return path
+
+
+def redact_text(text: str, extra_secrets: list[str] | None = None) -> str:
+    """Mask known secret values and secret-shaped tokens in one string."""
+    for value in (extra_secrets or []):
+        if isinstance(value, str) and len(value) >= _MIN_SECRET_LEN and value in text:
+            text = text.replace(value, MARKER)
+    for value in _env_secret_values():
+        if value in text:
+            text = text.replace(value, MARKER)
+    return NVAPI.sub(f"nvapi-{MARKER}", text)
+
+
+def redact_obj(obj, extra_secrets: list[str] | None = None):
+    """`redact_text` over every string in a JSON-shaped structure.
+
+    Runs BEFORE serialization on purpose: `json.dumps` escapes quotes,
+    backslashes and non-ASCII, after which an env value no longer occurs
+    literally in the document and substring replacement misses it.
+    """
+    if isinstance(obj, str):
+        return redact_text(obj, extra_secrets)
+    if isinstance(obj, list):
+        return [redact_obj(x, extra_secrets) for x in obj]
+    if isinstance(obj, dict):
+        return {redact_obj(k, extra_secrets): redact_obj(v, extra_secrets)
+                for k, v in obj.items()}
+    return obj
+
+
+def _replace_literals(root: Path, secrets: list[str]) -> list[str]:
+    changed = []
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        try:
+            original = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        cleaned = redact_text(original, extra_secrets=secrets)
+        if cleaned != original:
+            path.write_text(cleaned, encoding="utf-8")
+            changed.append(f"redacted: {path.relative_to(root)}")
+    return changed
+
+
+def _quarantine(path: Path, root: Path, detectors: list[str]) -> str:
+    """Replace a file the literal pass could not clean with a stub.
+
+    Encoded (base64/UTF-16), composite (RawV2 joins fields that sit on
+    different lines), and binary representations all defeat substring
+    replacement; the only safe artifact is no artifact.
+    """
+    names = ", ".join(sorted(set(detectors))) or "unknown"
+    path.write_text(
+        f"[REDACTED: quarantined by redact_secrets.py -- trufflehog "
+        f"detector(s) {names} still matched after literal redaction]\n",
+        encoding="utf-8")
+    return f"quarantined: {path.relative_to(root)} ({names})"
+
+
+def redact_tree(root: Path) -> list[str]:
+    """Scan -> replace -> rescan -> quarantine -> verify; summary lines back.
+
+    Raises ScannerUnavailable if TruffleHog cannot run, and RuntimeError if
+    findings survive quarantine — in both cases the caller must not publish
+    the tree. Summary lines name files and detectors, never secret values.
+    """
+    root = Path(root)
+    findings = _scan(root)
+    secrets = sorted(
+        {s for f in findings for s in (f.get("Raw"), f.get("RawV2"))
+         if isinstance(s, str) and len(s) >= _MIN_SECRET_LEN},
+        key=len, reverse=True)
+    summary = [f"trufflehog: {len(findings)} finding(s), "
+               f"{len(secrets)} distinct value(s)"]
+    summary += _replace_literals(root, secrets)
+
+    if findings:
+        survivors: dict[Path, list[str]] = {}
+        for f in _scan(root):
+            path = _finding_file(f, root)
+            detector = str(f.get("DetectorName") or "unknown")
+            if path is not None and path.is_file():
+                survivors.setdefault(path, []).append(detector)
+        for path, detectors in sorted(survivors.items()):
+            summary.append(_quarantine(path, root, detectors))
+        if survivors and (final := _scan(root)):
+            raise RuntimeError(
+                f"redact_secrets: {len(final)} finding(s) survived quarantine; "
+                f"refusing to publish {root}")
+    else:
+        # No scanner findings — still run the builtin layers over the tree.
+        summary += _replace_literals(root, [])
+
+    if len(summary) == 1:
+        summary.append("clean: no redactions needed")
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--tree", type=Path, required=True,
+                    help="Directory to redact in place before it is packed/posted")
+    args = ap.parse_args(argv)
+    if not args.tree.is_dir():
+        print(f"redact_secrets: {args.tree} is not a directory", file=sys.stderr)
+        return 1
+    try:
+        for line in redact_tree(args.tree):
+            print(f"redact_secrets: {line}")
+    except (ScannerUnavailable, RuntimeError) as exc:
+        print(f"redact_secrets: FATAL: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skill-eval/tests/test_secret_redaction.py
+++ b/.github/skill-eval/tests/test_secret_redaction.py
@@ -90,7 +90,7 @@ class TestRedactObj:
 
 class TestRedactTree:
     def test_scanner_unavailable_fails_closed(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(redact_secrets.shutil, "which", lambda _: None)
+        monkeypatch.setattr(redact_secrets.shutil, "which", lambda name: None)
         (tmp_path / "x.txt").write_text("hello")
         with pytest.raises(redact_secrets.ScannerUnavailable):
             redact_secrets.redact_tree(tmp_path)
@@ -139,9 +139,18 @@ class TestRedactTree:
             redact_secrets.redact_tree(tmp_path)
 
     def test_docker_mount_path_mapped_back(self, tmp_path):
+        real = tmp_path / "step-1" / "verifier" / "judge.json"
+        real.parent.mkdir(parents=True)
+        real.write_text("{}")
         finding = _finding("/scan/step-1/verifier/judge.json", "x")
-        mapped = redact_secrets._finding_file(finding, tmp_path)
-        assert mapped == tmp_path / "step-1" / "verifier" / "judge.json"
+        assert redact_secrets._finding_file(finding, tmp_path) == real
+
+    def test_missing_file_is_fatal(self, tmp_path):
+        """A finding pointing at a path that is not there cannot be redacted
+        or quarantined, so it must refuse the publish, not pass silently."""
+        finding = _finding("/scan/gone.txt", "x")
+        with pytest.raises(RuntimeError, match="does not exist"):
+            redact_secrets._finding_file(finding, tmp_path)
 
 
 class TestJudgeEndToEnd:
@@ -211,3 +220,73 @@ class TestReportBoundary:
         monkeypatch.setattr(redact_secrets, "redact_tree", boom)
         with pytest.raises(redact_secrets.ScannerUnavailable):
             leg_report.main(["--results-root", str(tmp_path)])
+
+
+class TestRoundFourGuards:
+    def test_multipart_finding_quarantined_when_values_never_match(self, tmp_path, monkeypatch):
+        """AWS-style: Raw is the id, RawV2 is id:secret on separate lines.
+        Replacing the id blinds the rescan while the secret survives — the
+        source file must be quarantined on the initial finding's evidence."""
+        f = tmp_path / "trial.log"
+        f.write_text("id AKIAFAKEID0000\nsecret wJalrXUtnFAKESECRET\n")
+        composite = "AKIAFAKEID0000:wJalrXUtnFAKESECRET"
+        calls = {"n": 0}
+
+        def fake_scan(root):
+            calls["n"] += 1
+            # Initial scan reports only the composite; rescans see nothing
+            # because the id got replaced.
+            return [_finding(f, composite, "AWS")] if calls["n"] == 1 else []
+        monkeypatch.setattr(redact_secrets, "_scan", fake_scan)
+        lines = redact_secrets.redact_tree(tmp_path)
+        text = f.read_text()
+        assert "wJalrXUtnFAKESECRET" not in text and "quarantined" in text
+        assert any("unmatched" in l for l in lines)
+
+    def test_unmappable_finding_is_fatal(self, tmp_path, monkeypatch):
+        bad = {"Raw": "x" * 20, "DetectorName": "X", "SourceMetadata": {}}
+        f = tmp_path / "a.txt"; f.write_text("x" * 20)
+        monkeypatch.setattr(redact_secrets, "_scan", lambda root: [bad])
+        with pytest.raises(RuntimeError, match="without a file path"):
+            redact_secrets.redact_tree(tmp_path)
+
+    def test_path_escape_is_fatal(self, tmp_path):
+        finding = _finding("/scan/../../etc/passwd", "x" * 20)
+        with pytest.raises(RuntimeError, match="escapes the tree"):
+            redact_secrets._finding_file(finding, tmp_path)
+
+    def test_binary_nvapi_quarantined_without_scanner_finding(self, tmp_path, monkeypatch):
+        """The builtin layer must cover binaries: an ASCII token inside a
+        non-UTF-8 file leaks the same, even when TruffleHog misses it."""
+        blob = tmp_path / "frame.bin"
+        blob.write_bytes(b"\xff\xfe" + FAKE_KEY.encode() + b"\x00")
+        monkeypatch.setattr(redact_secrets, "_scan", lambda root: [])
+        lines = redact_secrets.redact_tree(tmp_path)
+        assert FAKE_KEY not in blob.read_text()
+        assert any("builtin-binary" in l for l in lines)
+
+    def test_json_quarantine_stub_parses(self, tmp_path):
+        f = tmp_path / "judge.json"
+        f.write_text("{}")
+        redact_secrets._quarantine(f, tmp_path, ["NGC"])
+        assert "redacted" in json.loads(f.read_text())
+
+    def test_marker_idempotent_with_redacted_env_value(self, monkeypatch):
+        """TOKEN=REDACTED must not grow [REDACTED] into [[REDACTED]]."""
+        monkeypatch.setenv("WEIRD_TOKEN", "REDACTED")
+        assert redact_secrets.redact_text("[REDACTED]") == "[REDACTED]"
+
+    def test_malformed_scanner_stdout_is_fatal(self, tmp_path, monkeypatch):
+        class P:
+            returncode = 0
+            stdout = "not json at all"
+            stderr = ""
+        monkeypatch.setattr(redact_secrets, "_run_scanner", lambda target: P())
+        with pytest.raises(redact_secrets.ScannerUnavailable, match="unparseable"):
+            redact_secrets._scan(tmp_path)
+
+    def test_scan_error_flag_present(self):
+        """--fail-on-scan-errors verified to exist in trufflehog 3.94.2;
+        without it a partly-unscanned tree exits 0 and publishes."""
+        assert "--fail-on-scan-errors" in redact_secrets._TRUFFLEHOG_ARGS
+        assert "--no-verification" in redact_secrets._TRUFFLEHOG_ARGS

--- a/.github/skill-eval/tests/test_secret_redaction.py
+++ b/.github/skill-eval/tests/test_secret_redaction.py
@@ -1,0 +1,213 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""No secret may leave the harness for GitHub.
+
+Boundaries under test: the judge's own outputs (stdout -> test-stdout.txt
+and judge.json, packed into the public artifact), the results tree
+(TruffleHog scan -> replace -> quarantine -> verify, fail-closed), and
+leg_report's rendered comment/summary. A judge that proved "the agent
+printed NGC_CLI_API_KEY" by quoting the key published a live credential
+through all of them (PR #1647 run 32535909071).
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+HARNESS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(HARNESS))  # leg_report imports redact_secrets as a sibling
+
+import redact_secrets  # noqa: E402
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+judge = _load("gj_scrub", HARNESS / "verifiers" / "generic_judge.py")
+leg_report = _load("lr_scrub", HARNESS / "leg_report.py")
+
+FAKE_KEY = "nvapi-" + "A1b2C3d4" * 8  # 70 chars, the real NGC shape
+
+
+def _finding(path, raw, detector="FakeDetector"):
+    return {"Raw": raw, "DetectorName": detector,
+            "SourceMetadata": {"Data": {"Filesystem": {"file": str(path)}}}}
+
+
+class TestRedactText:
+    def test_nvapi_shape_masked_alone(self, monkeypatch):
+        """Agent-side keys are known only by shape; that layer must fire alone."""
+        monkeypatch.delenv("NGC_CLI_API_KEY", raising=False)
+        out = redact_secrets.redact_text(f"The key {FAKE_KEY} was exposed.")
+        assert FAKE_KEY not in out and "nvapi-[REDACTED]" in out
+
+    def test_env_value_masked_by_component_name(self, monkeypatch):
+        monkeypatch.setenv("MY_SERVICE_TOKEN", "s3cr3t-no-prefix")
+        out = redact_secrets.redact_text("echoed s3cr3t-no-prefix here")
+        assert "s3cr3t-no-prefix" not in out and "[REDACTED]" in out
+
+    def test_component_match_not_substring(self, monkeypatch):
+        """KEYCLOAK_URL must not be treated as a secret name."""
+        monkeypatch.setenv("KEYCLOAK_URL", "https://keycloak.internal:8443")
+        assert "keycloak.internal" in redact_secrets.redact_text(
+            "auth via https://keycloak.internal:8443")
+
+    def test_short_values_left_alone(self, monkeypatch):
+        monkeypatch.setenv("ENABLE_KEY", "true")
+        assert redact_secrets.redact_text("the true rate") == "the true rate"
+
+    def test_marker_is_markdown_safe(self, monkeypatch):
+        """<redacted> would render as an HTML tag in a PR comment."""
+        monkeypatch.delenv("NGC_CLI_API_KEY", raising=False)
+        out = redact_secrets.redact_text(FAKE_KEY)
+        assert "<" not in out and ">" not in out
+
+
+class TestRedactObj:
+    def test_scrubs_before_serialization_beats_escaping(self, monkeypatch):
+        r"""A secret with a quote/backslash is changed by json.dumps, so
+        post-serialization substring replacement misses it. Pre-serialization
+        structure scrubbing must not."""
+        secret = 'pa"ss\\word-123456'
+        monkeypatch.setenv("SNEAKY_PASSWORD", secret)
+        doc = json.dumps(redact_secrets.redact_obj({"note": f"saw {secret}"}))
+        assert secret not in doc and json.dumps(secret)[1:-1] not in doc
+        assert "[REDACTED]" in doc
+
+    def test_dict_keys_scrubbed(self, monkeypatch):
+        monkeypatch.delenv("NGC_CLI_API_KEY", raising=False)
+        assert FAKE_KEY not in str(redact_secrets.redact_obj({FAKE_KEY: 1}))
+
+
+class TestRedactTree:
+    def test_scanner_unavailable_fails_closed(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(redact_secrets.shutil, "which", lambda _: None)
+        (tmp_path / "x.txt").write_text("hello")
+        with pytest.raises(redact_secrets.ScannerUnavailable):
+            redact_secrets.redact_tree(tmp_path)
+        # ...and the CLI turns that into a nonzero exit for the workflow gate.
+        assert redact_secrets.main(["--tree", str(tmp_path)]) == 2
+
+    def test_literal_findings_replaced(self, tmp_path, monkeypatch):
+        f = tmp_path / "verifier" / "judge.json"
+        f.parent.mkdir()
+        f.write_text(json.dumps({"rationale": f"saw {FAKE_KEY}"}))
+        calls = {"n": 0}
+
+        def fake_scan(root):
+            calls["n"] += 1
+            return [_finding(f, FAKE_KEY)] if calls["n"] == 1 else []
+        monkeypatch.setattr(redact_secrets, "_scan", fake_scan)
+        lines = redact_secrets.redact_tree(tmp_path)
+        assert FAKE_KEY not in f.read_text()
+        assert any(l.startswith("redacted:") for l in lines)
+
+    def test_survivor_files_quarantined_and_verified(self, tmp_path, monkeypatch):
+        """Encoded/composite/binary findings defeat literal replacement; the
+        file must be stubbed out and a final scan must come back empty."""
+        blob = tmp_path / "frame.bin"
+        blob.write_bytes(b"\x89PNG\x00" + FAKE_KEY.encode() + b"\xff")
+        calls = {"n": 0}
+
+        def fake_scan(root):
+            calls["n"] += 1
+            # finding on scans 1 and 2 (binary defeats the literal pass),
+            # gone on scan 3 (after quarantine).
+            return [_finding(blob, FAKE_KEY, "NGC")] if calls["n"] <= 2 else []
+        monkeypatch.setattr(redact_secrets, "_scan", fake_scan)
+        lines = redact_secrets.redact_tree(tmp_path)
+        text = blob.read_text()
+        assert FAKE_KEY not in text and "quarantined" in text
+        assert any(l.startswith("quarantined:") for l in lines)
+        assert calls["n"] == 3, "a final verify scan must run"
+
+    def test_findings_surviving_quarantine_refuse_publish(self, tmp_path, monkeypatch):
+        f = tmp_path / "weird.dat"
+        f.write_text("data")
+        monkeypatch.setattr(redact_secrets, "_scan",
+                            lambda root: [_finding(f, "some-secret-123")])
+        with pytest.raises(RuntimeError, match="refusing to publish"):
+            redact_secrets.redact_tree(tmp_path)
+
+    def test_docker_mount_path_mapped_back(self, tmp_path):
+        finding = _finding("/scan/step-1/verifier/judge.json", "x")
+        mapped = redact_secrets._finding_file(finding, tmp_path)
+        assert mapped == tmp_path / "step-1" / "verifier" / "judge.json"
+
+
+class TestJudgeEndToEnd:
+    def test_main_emits_no_secret_on_any_path(self, tmp_path, monkeypatch, capsys):
+        """Through main(): spec query, check text, rationale, matched — the
+        lot. Fails if any output path bypasses the scrub (the first version
+        of this fix scrubbed the results list but printed the raw query)."""
+        spec = tmp_path / "spec.json"
+        spec.write_text(json.dumps({"expects": [{
+            "query": f"never print the key (example leak: {FAKE_KEY})",
+            "checks": [f"agent must not echo {FAKE_KEY}"],
+        }]}))
+        monkeypatch.setattr(judge, "locate_trajectory", lambda: None)
+        monkeypatch.setattr(judge, "_run_checks", lambda checks, traj, timeout: [
+            {"pass": False,
+             "rationale": f"The key {FAKE_KEY} was exposed in the trajectory.",
+             "matched": {FAKE_KEY: [f"curl -H 'Bearer {FAKE_KEY}'"]}},
+        ])
+        monkeypatch.delenv("NGC_CLI_API_KEY", raising=False)
+        reward, details = tmp_path / "reward.txt", tmp_path / "judge.json"
+        monkeypatch.setattr(sys, "argv", [
+            "generic_judge.py", "--spec", str(spec), "--step", "1",
+            "--reward-file", str(reward), "--details-file", str(details)])
+        assert judge.main() == 0
+        stdout = capsys.readouterr().out
+        dumped = details.read_text()
+        assert FAKE_KEY not in stdout, "stdout becomes public test-stdout.txt"
+        assert FAKE_KEY not in dumped, "judge.json lands in the public artifact"
+        assert json.loads(dumped)["reward"] == 0.0
+        assert reward.read_text() == "0.0"
+
+
+class TestReportBoundary:
+    def test_tree_gated_before_read_and_writes_scrubbed(self, tmp_path, monkeypatch):
+        """The comment posts from this render during the agent step, before
+        the workflow pack step — the gate must run first, and both writes
+        must come out clean."""
+        gate = {"ran_before_read": None}
+        monkeypatch.setattr(redact_secrets, "redact_tree",
+                            lambda root: ["clean: no redactions needed"])
+
+        def fake_collect(root):
+            gate["ran_before_read"] = True
+            return {"trials": [{"checks": []}]}
+        monkeypatch.setattr(leg_report, "collect_leg", fake_collect)
+        monkeypatch.setattr(leg_report, "spec_steps", lambda f: 1)
+        monkeypatch.setattr(leg_report, "render_comment",
+                            lambda *a, **k: f"### report\nthe key {FAKE_KEY} leaked")
+        secret = 'qu"o\\te-secret-42'
+        monkeypatch.setenv("SUMMARY_TOKEN", secret)
+        monkeypatch.setattr(leg_report, "leg_summary",
+                            lambda *a, **k: {"note": f"saw {secret}"})
+        monkeypatch.delenv("NGC_CLI_API_KEY", raising=False)
+        out, summary = tmp_path / "body.md", tmp_path / "leg-summary.json"
+        rc = leg_report.main(["--results-root", str(tmp_path),
+                              "--out", str(out), "--summary-json", str(summary)])
+        assert rc == 0 and gate["ran_before_read"]
+        assert FAKE_KEY not in out.read_text()
+        assert "nvapi-[REDACTED]" in out.read_text()
+        s = summary.read_text()
+        assert secret not in s and json.dumps(secret)[1:-1] not in s
+
+    def test_scanner_failure_propagates(self, tmp_path, monkeypatch):
+        """An unscanned tree must read as BLOCKED, not render a comment."""
+        def boom(root):
+            raise redact_secrets.ScannerUnavailable("no scanner")
+        monkeypatch.setattr(redact_secrets, "redact_tree", boom)
+        with pytest.raises(redact_secrets.ScannerUnavailable):
+            leg_report.main(["--results-root", str(tmp_path)])

--- a/.github/skill-eval/tests/test_secret_redaction.py
+++ b/.github/skill-eval/tests/test_secret_redaction.py
@@ -188,12 +188,12 @@ class TestReportBoundary:
         """The comment posts from this render during the agent step, before
         the workflow pack step — the gate must run first, and both writes
         must come out clean."""
-        gate = {"ran_before_read": None}
+        order = []
         monkeypatch.setattr(redact_secrets, "redact_tree",
-                            lambda root: ["clean: no redactions needed"])
+                            lambda root: order.append("redact") or ["clean"])
 
         def fake_collect(root):
-            gate["ran_before_read"] = True
+            order.append("read")
             return {"trials": [{"checks": []}]}
         monkeypatch.setattr(leg_report, "collect_leg", fake_collect)
         monkeypatch.setattr(leg_report, "spec_steps", lambda f: 1)
@@ -207,7 +207,8 @@ class TestReportBoundary:
         out, summary = tmp_path / "body.md", tmp_path / "leg-summary.json"
         rc = leg_report.main(["--results-root", str(tmp_path),
                               "--out", str(out), "--summary-json", str(summary)])
-        assert rc == 0 and gate["ran_before_read"]
+        assert rc == 0 and order == ["redact", "read"], \
+            "the gate must run before anything reads the tree"
         assert FAKE_KEY not in out.read_text()
         assert "nvapi-[REDACTED]" in out.read_text()
         s = summary.read_text()
@@ -241,7 +242,7 @@ class TestRoundFourGuards:
         lines = redact_secrets.redact_tree(tmp_path)
         text = f.read_text()
         assert "wJalrXUtnFAKESECRET" not in text and "quarantined" in text
-        assert any("unmatched" in l for l in lines)
+        assert any("incomplete match" in l for l in lines)
 
     def test_unmappable_finding_is_fatal(self, tmp_path, monkeypatch):
         bad = {"Raw": "x" * 20, "DetectorName": "X", "SourceMetadata": {}}
@@ -290,3 +291,83 @@ class TestRoundFourGuards:
         without it a partly-unscanned tree exits 0 and publishes."""
         assert "--fail-on-scan-errors" in redact_secrets._TRUFFLEHOG_ARGS
         assert "--no-verification" in redact_secrets._TRUFFLEHOG_ARGS
+
+
+class TestRoundFiveGuards:
+    def test_partial_multipart_match_still_quarantines(self, tmp_path, monkeypatch):
+        """THE round-3/4 bug: Raw (the id) matches and is replaced, RawV2
+        (id:secret) does not because the halves sit on different lines.
+        Replacing the id blinds the rescan while the secret survives — the
+        finding is neutralized only if its COMPLETE representation (RawV2)
+        was replaced."""
+        f = tmp_path / "trial.log"
+        f.write_text("id AKIAFAKEID0000\nsecret wJalrXUtnFAKESECRET\n")
+        finding = _finding(f, "AKIAFAKEID0000", "AWS")
+        finding["RawV2"] = "AKIAFAKEID0000:wJalrXUtnFAKESECRET"
+        calls = {"n": 0}
+
+        def fake_scan(root):
+            calls["n"] += 1
+            return [finding] if calls["n"] == 1 else []
+        monkeypatch.setattr(redact_secrets, "_scan", fake_scan)
+        lines = redact_secrets.redact_tree(tmp_path)
+        text = f.read_text()
+        assert "wJalrXUtnFAKESECRET" not in text and "quarantined" in text
+        assert any("incomplete match" in l for l in lines)
+
+    def test_full_rawv2_match_is_not_quarantined(self, tmp_path, monkeypatch):
+        """When the composite itself occurs literally, replacement covers
+        both halves and quarantine would be a false positive."""
+        f = tmp_path / "trial.log"
+        f.write_text("cred AKIAFAKEID0000:wJalrXUtnFAKESECRET here\n")
+        finding = _finding(f, "AKIAFAKEID0000", "AWS")
+        finding["RawV2"] = "AKIAFAKEID0000:wJalrXUtnFAKESECRET"
+        calls = {"n": 0}
+
+        def fake_scan(root):
+            calls["n"] += 1
+            return [finding] if calls["n"] == 1 else []
+        monkeypatch.setattr(redact_secrets, "_scan", fake_scan)
+        lines = redact_secrets.redact_tree(tmp_path)
+        text = f.read_text()
+        assert "wJalrXUtnFAKESECRET" not in text and "quarantined" not in text
+        assert not any("quarantined:" in l for l in lines)
+
+    def test_bad_metadata_fatal_even_when_literal_replaced(self, tmp_path, monkeypatch):
+        """Findings are pinned to files BEFORE any rewrite: replacement can
+        blind the rescan, after which bad metadata would never be checked."""
+        f = tmp_path / "a.txt"
+        f.write_text("tok " + "x" * 20)
+        bad = {"Raw": "x" * 20, "DetectorName": "X", "SourceMetadata": {}}
+        monkeypatch.setattr(redact_secrets, "_scan", lambda root: [bad])
+        with pytest.raises(RuntimeError, match="without a file path"):
+            redact_secrets.redact_tree(tmp_path)
+        assert "x" * 20 in f.read_text(), "no rewrite before validation"
+
+    def test_file_symlink_replaced_not_followed(self, tmp_path, monkeypatch):
+        outside = tmp_path.parent / f"{tmp_path.name}-outside.txt"
+        outside.write_text(f"precious {FAKE_KEY}")
+        tree = tmp_path / "tree"; tree.mkdir()
+        (tree / "link.txt").symlink_to(outside)
+        monkeypatch.setattr(redact_secrets, "_scan", lambda root: [])
+        lines = redact_secrets.redact_tree(tree)
+        assert outside.read_text() == f"precious {FAKE_KEY}", \
+            "the gate must never write outside the tree"
+        assert not (tree / "link.txt").is_symlink()
+        assert "symlink removed" in (tree / "link.txt").read_text() + str(lines)
+
+    def test_dir_symlink_not_traversed(self, tmp_path, monkeypatch):
+        outside_dir = tmp_path.parent / f"{tmp_path.name}-outdir"
+        outside_dir.mkdir()
+        victim = outside_dir / "victim.txt"
+        victim.write_text(f"target {FAKE_KEY}")
+        tree = tmp_path / "tree"; tree.mkdir()
+        (tree / "sub").symlink_to(outside_dir)
+        monkeypatch.setattr(redact_secrets, "_scan", lambda root: [])
+        redact_secrets.redact_tree(tree)
+        assert victim.read_text() == f"target {FAKE_KEY}"
+        assert not (tree / "sub").is_symlink()
+
+    def test_judge_marker_idempotent(self, monkeypatch):
+        monkeypatch.setenv("WEIRD_TOKEN", "REDACTED")
+        assert judge._scrub_secrets("[REDACTED]") == "[REDACTED]"

--- a/.github/skill-eval/verifiers/generic_judge.py
+++ b/.github/skill-eval/verifiers/generic_judge.py
@@ -45,6 +45,7 @@ import argparse
 import asyncio
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -513,6 +514,62 @@ def _run_checks(checks: list[str], traj_path: str | None,
     return results
 
 
+# --- secret redaction -------------------------------------------------------
+#
+# Everything this process emits leaves the box: stdout is captured as
+# `verifier/test-stdout.txt`, the details file is `verifier/judge.json`, both
+# land in the public run artifact, and leg_report.py renders the details into
+# the PR comment. A judge that proved "the agent printed NGC_CLI_API_KEY" by
+# quoting the key published a live credential through all three (PR #1647 run
+# 32535909071). The runner-side redact_secrets.py guards those boundaries
+# with TruffleHog as well, but this copy runs inside the verifier container
+# where that module and scanner do not exist, so it stays self-contained.
+#
+# Two layers, because they fail differently:
+#  * the `nvapi-` token shape — the load-bearing layer here. Agent-side
+#    secrets are NOT in this container's env, so only their shape gives
+#    them away when the judge quotes trajectory text.
+#  * exact values of secret-named env vars — whatever this process itself
+#    holds (the verifier env carries the judge's own API key).
+
+_REDACTED = "[REDACTED]"
+_NVAPI = re.compile(r"nvapi-[A-Za-z0-9_-]{16,}")
+# Component match, not substring: NGC_CLI_API_KEY yes, KEYCLOAK_URL no.
+_SECRET_ENV_NAME = re.compile(
+    r"(^|_)(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|CREDENTIALS)(_|$)", re.IGNORECASE)
+# Below this length a value is a flag ("true", "1"), not a credential;
+# masking it would shred rationale text. Heuristic, not a guarantee.
+_MIN_SECRET_LEN = 8
+
+
+def _scrub_secrets(text: str) -> str:
+    """Mask secret values and secret-shaped tokens in judge-visible text."""
+    # Longest first, so a secret containing another leaves no usable tail.
+    values = sorted(
+        (v for k, v in os.environ.items()
+         if _SECRET_ENV_NAME.search(k) and v and len(v) >= _MIN_SECRET_LEN),
+        key=len, reverse=True)
+    for value in values:
+        if value in text:
+            text = text.replace(value, _REDACTED)
+    return _NVAPI.sub(f"nvapi-{_REDACTED}", text)
+
+
+def _scrub_tree(obj):
+    """Apply `_scrub_secrets` to every string — values AND dict keys.
+
+    Judge output is weakly typed; a structured `matched` value can carry a
+    credential anywhere, including as a key.
+    """
+    if isinstance(obj, str):
+        return _scrub_secrets(obj)
+    if isinstance(obj, list):
+        return [_scrub_tree(x) for x in obj]
+    if isinstance(obj, dict):
+        return {_scrub_tree(k): _scrub_tree(v) for k, v in obj.items()}
+    return obj
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--spec", required=True,
@@ -538,7 +595,7 @@ def main() -> int:
     checks = expect.get("checks") or []
     traj_path = locate_trajectory()
 
-    print(f"=== Step {args.step}/{len(expects)}: {expect.get('query', '')[:120]} ===")
+    print(_scrub_secrets(f"=== Step {args.step}/{len(expects)}: {expect.get('query', '')[:120]} ==="))
     if traj_path:
         print(f"(trajectory: {traj_path})")
     else:
@@ -550,9 +607,9 @@ def main() -> int:
     passed = 0
     for check, result in zip(checks, results):
         ok = bool(result["pass"])
-        print(f"{'PASS' if ok else 'FAIL'}: {check}")
+        print(_scrub_secrets(f"{'PASS' if ok else 'FAIL'}: {check}"))
         if result.get("rationale"):
-            print(f"  {result['rationale']}")
+            print(_scrub_secrets(f"  {result['rationale']}"))
         if ok:
             passed += 1
 
@@ -561,7 +618,10 @@ def main() -> int:
 
     Path(args.reward_file).parent.mkdir(parents=True, exist_ok=True)
     Path(args.reward_file).write_text(f"{reward}")
-    Path(args.details_file).write_text(json.dumps({
+    # Scrubbed as one object at the boundary: the query and check strings
+    # come from the spec, but specs quote command examples, and the checks
+    # list is judge-written free text either way.
+    Path(args.details_file).write_text(json.dumps(_scrub_tree({
         "spec": args.spec,
         "step": args.step,
         "query": expect.get("query"),
@@ -571,7 +631,7 @@ def main() -> int:
         "trajectory_path": traj_path,
         "trajectory_found": bool(traj_path),
         "checks": results,
-    }, indent=2))
+    }), indent=2))
 
     print(f"\n=== Results: {passed} passed, {total - passed} failed (of {total}) ===")
     return 0

--- a/.github/skill-eval/verifiers/generic_judge.py
+++ b/.github/skill-eval/verifiers/generic_judge.py
@@ -547,7 +547,11 @@ def _scrub_secrets(text: str) -> str:
     # Longest first, so a secret containing another leaves no usable tail.
     values = sorted(
         (v for k, v in os.environ.items()
-         if _SECRET_ENV_NAME.search(k) and v and len(v) >= _MIN_SECRET_LEN),
+         if _SECRET_ENV_NAME.search(k) and v and len(v) >= _MIN_SECRET_LEN
+         # A value that is a substring of the marker (e.g. TOKEN=REDACTED)
+         # would grow "[REDACTED]" on every pass; masking it is a no-op
+         # security-wise and breaks idempotency.
+         and v not in _REDACTED),
         key=len, reverse=True)
     for value in values:
         if value in text:

--- a/.github/workflows/skills-eval-daily.yml
+++ b/.github/workflows/skills-eval-daily.yml
@@ -306,6 +306,18 @@ jobs:
           # overwrite each other's archive before upload — each leg then
           # uploads whichever sibling wrote last. The slug makes the path
           # unique per (skill,spec,platform).
+          # Redact secrets from the tree before packing: TruffleHog
+          # (--no-verification, scan -> replace -> quarantine -> verify) plus
+          # builtin nvapi-/env-value layers (redact_secrets.py). The verifier
+          # files stay in the tarball because the report consumes them, and a
+          # judge explaining "the agent printed the key" by quoting it would
+          # otherwise ship the credential (PR #1647 run 32535909071), exactly
+          # as agent/ trajectories once did (PR #516). leg_report.py runs the
+          # same gate before the PR comment renders; this one covers the
+          # artifact for legs that never reached a report. Fail closed: a
+          # scanner failure exits nonzero, the step stops before tar, and
+          # the upload finds nothing — an unscanned tree does not publish.
+          python3 .github/skill-eval/redact_secrets.py --tree "$LEG_RESULTS"
           LEG_TARBALL="/tmp/skills-eval-daily-results-${EVAL_SLUG}-${GITHUB_RUN_ID}.tar.gz"
           RESULTS=$(find "$LEG_RESULTS" -maxdepth 3 -name "result.json" 2>/dev/null | head -50 || true)
           if [ -n "$RESULTS" ]; then

--- a/.github/workflows/skills-eval-daily.yml
+++ b/.github/workflows/skills-eval-daily.yml
@@ -307,18 +307,23 @@ jobs:
           # uploads whichever sibling wrote last. The slug makes the path
           # unique per (skill,spec,platform).
           # Redact secrets from the tree before packing: TruffleHog
-          # (--no-verification, scan -> replace -> quarantine -> verify) plus
-          # builtin nvapi-/env-value layers (redact_secrets.py). The verifier
-          # files stay in the tarball because the report consumes them, and a
-          # judge explaining "the agent printed the key" by quoting it would
-          # otherwise ship the credential (PR #1647 run 32535909071), exactly
-          # as agent/ trajectories once did (PR #516). leg_report.py runs the
-          # same gate before the PR comment renders; this one covers the
-          # artifact for legs that never reached a report. Fail closed: a
-          # scanner failure exits nonzero, the step stops before tar, and
-          # the upload finds nothing — an unscanned tree does not publish.
-          python3 .github/skill-eval/redact_secrets.py --tree "$LEG_RESULTS"
+          # (--no-verification --fail-on-scan-errors, scan -> replace ->
+          # quarantine -> verify) plus builtin nvapi-/env-value layers
+          # (redact_secrets.py). The verifier files stay in the tarball
+          # because the report consumes them, and a judge explaining "the
+          # agent printed the key" by quoting it would otherwise ship the
+          # credential (PR #1647 run 32535909071), exactly as agent/
+          # trajectories once did (PR #516). leg_report.py runs the same
+          # gate before the PR comment renders; this one covers the artifact
+          # for legs that never reached a report. Fail closed: a scanner
+          # failure exits nonzero and the step stops before tar. The tarball
+          # is removed FIRST — reruns reuse GITHUB_RUN_ID on the same
+          # self-hosted runner, and `if: always()` upload would otherwise
+          # ship a stale, unredacted archive from a previous attempt when
+          # this attempt's scan fails.
           LEG_TARBALL="/tmp/skills-eval-daily-results-${EVAL_SLUG}-${GITHUB_RUN_ID}.tar.gz"
+          rm -f "$LEG_TARBALL"
+          python3 .github/skill-eval/redact_secrets.py --tree "$LEG_RESULTS"
           RESULTS=$(find "$LEG_RESULTS" -maxdepth 3 -name "result.json" 2>/dev/null | head -50 || true)
           if [ -n "$RESULTS" ]; then
             tar czf "$LEG_TARBALL" \

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -323,6 +323,18 @@ jobs:
           # overwrite each other's archive before upload — each leg then
           # uploads whichever sibling wrote last. The slug makes the path
           # unique per (skill,spec,platform).
+          # Redact secrets from the tree before packing: TruffleHog
+          # (--no-verification, scan -> replace -> quarantine -> verify) plus
+          # builtin nvapi-/env-value layers (redact_secrets.py). The verifier
+          # files stay in the tarball because the report consumes them, and a
+          # judge explaining "the agent printed the key" by quoting it would
+          # otherwise ship the credential (PR #1647 run 32535909071), exactly
+          # as agent/ trajectories once did (PR #516). leg_report.py runs the
+          # same gate before the PR comment renders; this one covers the
+          # artifact for legs that never reached a report. Fail closed: a
+          # scanner failure exits nonzero, the step stops before tar, and
+          # the upload finds nothing — an unscanned tree does not publish.
+          python3 .github/skill-eval/redact_secrets.py --tree "$LEG_RESULTS"
           LEG_TARBALL="/tmp/skills-eval-results-${EVAL_SLUG}-${GITHUB_RUN_ID}.tar.gz"
           RESULTS=$(find "$LEG_RESULTS" -maxdepth 3 -name "result.json" 2>/dev/null | head -50 || true)
           if [ -n "$RESULTS" ]; then

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -324,18 +324,23 @@ jobs:
           # uploads whichever sibling wrote last. The slug makes the path
           # unique per (skill,spec,platform).
           # Redact secrets from the tree before packing: TruffleHog
-          # (--no-verification, scan -> replace -> quarantine -> verify) plus
-          # builtin nvapi-/env-value layers (redact_secrets.py). The verifier
-          # files stay in the tarball because the report consumes them, and a
-          # judge explaining "the agent printed the key" by quoting it would
-          # otherwise ship the credential (PR #1647 run 32535909071), exactly
-          # as agent/ trajectories once did (PR #516). leg_report.py runs the
-          # same gate before the PR comment renders; this one covers the
-          # artifact for legs that never reached a report. Fail closed: a
-          # scanner failure exits nonzero, the step stops before tar, and
-          # the upload finds nothing — an unscanned tree does not publish.
-          python3 .github/skill-eval/redact_secrets.py --tree "$LEG_RESULTS"
+          # (--no-verification --fail-on-scan-errors, scan -> replace ->
+          # quarantine -> verify) plus builtin nvapi-/env-value layers
+          # (redact_secrets.py). The verifier files stay in the tarball
+          # because the report consumes them, and a judge explaining "the
+          # agent printed the key" by quoting it would otherwise ship the
+          # credential (PR #1647 run 32535909071), exactly as agent/
+          # trajectories once did (PR #516). leg_report.py runs the same
+          # gate before the PR comment renders; this one covers the artifact
+          # for legs that never reached a report. Fail closed: a scanner
+          # failure exits nonzero and the step stops before tar. The tarball
+          # is removed FIRST — reruns reuse GITHUB_RUN_ID on the same
+          # self-hosted runner, and `if: always()` upload would otherwise
+          # ship a stale, unredacted archive from a previous attempt when
+          # this attempt's scan fails.
           LEG_TARBALL="/tmp/skills-eval-results-${EVAL_SLUG}-${GITHUB_RUN_ID}.tar.gz"
+          rm -f "$LEG_TARBALL"
+          python3 .github/skill-eval/redact_secrets.py --tree "$LEG_RESULTS"
           RESULTS=$(find "$LEG_RESULTS" -maxdepth 3 -name "result.json" 2>/dev/null | head -50 || true)
           if [ -n "$RESULTS" ]; then
             tar czf "$LEG_TARBALL" \


### PR DESCRIPTION
## Summary

A judge proved *"the agent printed NGC_CLI_API_KEY"* by quoting the key in its rationale, and the harness
shipped that rationale verbatim through every public surface: `verifier/judge.json` and
`verifier/test-stdout.txt` in the run artifact, and the PR comment `leg_report.py` renders from them.
**PR #1647 run 32535909071 published a full 70-char NGC key that way** — live in the public artifact, and in
the PR comment for six days until manually redacted. (Key rotation and artifact deletion are being handled
separately; this PR is prevention.) The tarball already excludes `agent/` trajectories for exactly this leak
class (PR #516) — the verifier files and rendered reports stayed in.

A sweep of all 292 live artifacts in the affected eval family found exactly one containing the full key and
one containing a 4-char prefix; 32 more contain only the harmless literal `nvapi-`.

## What this does

Gates every path from the harness to GitHub with TruffleHog (the same scanner the repo's pre-commit hook
already trusts) plus always-on builtin layers:

| Boundary | Gate |
|---|---|
| Results tree → PR comment | `leg_report.py` runs `redact_secrets.redact_tree()` **before reading anything** — the comment posts during the agent step, long before the workflow pack step, so gating only the tarball would leave the comment exposed |
| Results tree → run artifact | `skills-eval.yml` / `skills-eval-daily.yml` run the same CLI gate immediately before `tar czf`, covering legs that never reached a report |
| Rendered comment + leg summary | body shape-scrubbed; summary scrubbed **as a structure before serialization** (`json.dumps` escaping defeats substring replacement afterwards) |
| Judge's own outputs | self-contained scrub in `generic_judge.py` (the verifier container has neither the module nor a scanner): stdout header, per-check prints, and the whole `judge.json` object at serialization |

`redact_secrets.py` semantics:

- **`--no-verification`**: verification would send candidate secrets to their providers — itself exfiltration — and a candidate is worth masking whether or not it still works.
- **scan → replace literals → rescan → quarantine → verify**: findings that survive literal replacement (base64/UTF-16-encoded, composite `RawV2`, binary) get their file stubbed out, and a final scan must come back empty or the publish refuses.
- **Fail closed**: no scanner, timeout, scan error, or surviving findings → nonzero exit. The workflow step stops before `tar` (the upload finds nothing), and `skills_eval_agent.py` already fail-closes a leg whose report crashes, so a scanner outage reads as BLOCKED, not green.
- Builtin layers run unconditionally: the `nvapi-` token shape, and exact values of env vars whose underscore-delimited name contains KEY/TOKEN/SECRET/PASSWORD/CREDENTIAL (≥8 chars; component match, so `KEYCLOAK_URL` is not a secret).
- Docker fallback pins `trufflesecurity/trufflehog:3.94.2` — the pre-commit rev — not `latest`.
- Markers are `[REDACTED]` / `nvapi-[REDACTED]`; `<redacted>` would parse as an HTML tag in a PR comment.

## Verification

- The real leaked `judge.json` from run 32535909071, planted in a tree and run through the CLI with
  TruffleHog via docker: scanner finds the key, both occurrences replaced, zero `nvapi-` tokens remain, exit 0.
- 15 new tests (`test_secret_redaction.py`) cover each boundary end to end: judge `main()` with a
  secret-bearing spec asserting captured stdout + `judge.json` + reward; quarantine convergence with a
  binary survivor and the mandatory final verify scan; refuse-to-publish when findings survive quarantine;
  fail-closed CLI exit; the report gate running before `collect_leg`; pre-serialization structure scrubbing
  beating JSON escaping; docker mount path mapping; `KEYCLOAK_URL` not treated as a secret.
- Full harness suite: 242 pass; the 3 failures in `test_run_leg.py::PoolCandidates` pre-exist on pristine
  `origin/develop` (they are #1878's unmerged fixes — verified by stash/run/pop).

## Review

Reviewed twice by the OpenAI Codex CLI before posting, told the diff was Claude-generated; both rounds
reshaped it. Round 1 found the first version scrubbed the results list but still printed the raw query and
dumped it into `judge.json`, missed dict keys, used a substring env-name match (`KEYCLOAK_URL` would have
been masked), and used an HTML-swallowed marker. Round 2 found the structural bypass (comment posts before
the pack step), that `--results=verified,unknown` excludes unverified candidates, that scanner failures were
converted into success, that TruffleHog `Raw`/`RawV2` values are not necessarily literal substrings (hence
quarantine + verify), that binary findings were deliberately shipped, and that post-serialization scrubbing
misses JSON-escaped values. All addressed as described above.

## Follow-ups (not in this PR)

- Enable GitHub secret scanning on the repo — it is currently disabled, so no partner auto-revocation fired
  on the leaked NGC key.
- The Harbor viewer on eval boxes serves `/tmp/skill-eval/results/` unauthenticated to the public internet;
  `leg_report`'s tree mutation covers what it serves after a report runs, but trajectories under `agent/`
  remain exposed there while a box lives.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally.
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d.
- [x] New or existing tests cover these changes — 15 new boundary tests; full harness suite passes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
