### PR TITLE
feat(vios): complete the package-prebake loop — NVStreamer, nightly, and per-leg observability

### DIFF
--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -765,6 +765,39 @@ echo "synced $REPO to $(git rev-parse --short HEAD)"
             self._instance_name, (result.stdout or "").strip().splitlines()[-1] if result.stdout else "<no output>",
         )
 
+    async def _probe_vios_ready(self, label: str) -> None:
+        """Record what the VIOS container cost to start, into the trial artifact.
+
+        Prebake (#1798) moves a 224-package apt install out of container start.
+        Enabling it was one variable; seeing whether it did anything was not,
+        because the deploy runs here and none of its output reaches the job log
+        or the artifact. This writes the container's own verdict and timing to
+        /logs/artifacts/vios-ready.log, which harbor already collects.
+
+        NEVER raises: a probe fault must not perturb the trial it observes.
+        """
+        try:
+            try:
+                from envs import vios_probe  # normal harbor import path
+            except ImportError:
+                import vios_probe  # PYTHONPATH=.github/skill-eval fallback
+            result = await _run_brev_exec(
+                self._instance_name, vios_probe.build_probe_command(label),
+                timeout=90,
+            )
+            lines = vios_probe.parse_probe_lines(result.stdout or "")
+            if not lines:
+                logger.warning(
+                    "[vios-probe] %s: no VIOSPROBE output (rc=%s) stderr=%s",
+                    label, result.return_code, (result.stderr or "")[-200:],
+                )
+                return
+            for d in lines:
+                logger.info("[vios-probe] %s",
+                            " ".join(f"{k}={v}" for k, v in d.items()))
+        except Exception as exc:  # noqa: BLE001 — diagnostic must never fail the trial
+            logger.warning("[vios-probe] %s: probe failed: %s", label, exc)
+
     async def _probe_bind_mount(self, label: str) -> None:
         """Non-fatal guardrail: record the liveness of every discovered VIOS
         bind mount on the box. Proves/guards against the step-2 data-dir
@@ -954,6 +987,13 @@ echo "synced $REPO to $(git rev-parse --short HEAD)"
             ) from exc
 
     async def download_dir(self, source_dir: str, target_dir: Path | str) -> None:
+        # Write the VIOS readiness probe immediately before /logs/artifacts is
+        # collected. Hooking stop() would be too late: harbor pulls artifacts
+        # first, so the file would never reach the tarball. This is the one
+        # point where the directory is known to be about to be read.
+        if str(source_dir).rstrip("/").endswith("/logs/artifacts"):
+            await self._probe_vios_ready("at-collect")
+
         # Retry the pull: a transient stall — or a prior attempt whose ssh
         # child was killed (now reaped via _run_brev_exec's process-group
         # kill, so it can't wedge the box) — usually clears on a fresh

--- a/.github/skill-eval/envs/tests/test_vios_probe.py
+++ b/.github/skill-eval/envs/tests/test_vios_probe.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""The probe is the only evidence prebake produces, so it gets tested.
+
+Prebake was enabled and then invisible for a day: the deploy runs on the box
+and nothing published its output. If this probe silently emits nothing, that
+state returns and looks identical to "prebake did not help".
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import vios_probe  # noqa: E402
+
+
+class BuildProbeCommand(unittest.TestCase):
+    def test_writes_where_harbor_collects(self):
+        """Anything not under /logs/artifacts never reaches the tarball."""
+        self.assertIn("/logs/artifacts/vios-ready.log",
+                      vios_probe.build_probe_command("step-1"))
+
+    def test_sink_is_overridable_for_local_testing(self):
+        self.assertIn("VIOSPROBE_SINK", vios_probe.build_probe_command("x"))
+
+    def test_never_exits_non_zero(self):
+        """A diagnostic that fails the trial it observes is worse than none."""
+        cmd = vios_probe.build_probe_command("x")
+        self.assertIn("set +e", cmd)
+        self.assertTrue(cmd.rstrip().endswith("exit 0"))
+
+    def test_label_is_quoted(self):
+        self.assertIn("'weird label; rm -rf /'",
+                      vios_probe.build_probe_command("weird label; rm -rf /"))
+
+    def test_absent_container_is_stated_not_silent(self):
+        """A profile without VIOS says nothing about prebake and must not read
+        as a zero, but must still leave a trace that the probe ran."""
+        cmd = vios_probe.build_probe_command("x")
+        self.assertIn("container=absent", cmd)
+        self.assertIn("scan=complete", cmd)
+
+    def test_verdict_covers_the_unreadable_case(self):
+        """Counting only 'skipping APT' would report an unreadable log as if
+        the install had run. Both are counted and neither means unknown."""
+        cmd = vios_probe.build_probe_command("x")
+        for token in ("verdict=prebaked", "verdict=installed-at-start",
+                      "verdict=unknown"):
+            self.assertIn(token, cmd)
+
+
+class ParseProbeLines(unittest.TestCase):
+    def test_parses_a_full_line(self):
+        got = vios_probe.parse_probe_lines(
+            "VIOSPROBE step-1 container=present verdict=prebaked "
+            "image_prebaked=yes health=healthy started=2026-08-29T00:00:00Z")
+        self.assertEqual(got[0]["verdict"], "prebaked")
+        self.assertEqual(got[0]["label"], "step-1")
+
+    def test_ignores_surrounding_noise(self):
+        got = vios_probe.parse_probe_lines(
+            "docker: some warning\nVIOSPROBE a container=absent\nbye")
+        self.assertEqual(len(got), 1)
+        self.assertEqual(got[0]["container"], "absent")
+
+    def test_empty_input_is_empty_not_an_exception(self):
+        self.assertEqual(vios_probe.parse_probe_lines(""), [])
+        self.assertEqual(vios_probe.parse_probe_lines(None), [])

--- a/.github/skill-eval/envs/vios_probe.py
+++ b/.github/skill-eval/envs/vios_probe.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Box-side probe recording what the VIOS streamprocessing container cost to start.
+
+Prebake (#1798) moves a 224-package apt install out of container start and into
+image build. Turning it on was easy; proving it did anything was not, because
+the deploy runs on the box and none of its output reaches the CI job log or the
+trial artifact. Measured on an L40 the install takes 116.3 s and the prebaked
+path takes 0.17 s, so the effect is large and was still invisible.
+
+This closes that. It reads the numbers off the container itself, writes them
+where harbor already collects, and emits both the timing and the container's own
+verdict, so a reader never has to infer whether prebake was active.
+"""
+
+from __future__ import annotations
+
+import shlex
+
+SINK_DEFAULT = "/logs/artifacts/vios-ready.log"
+CONTAINER = "vss-vios-streamprocessing"
+
+
+def build_probe_command(label: str, container: str = CONTAINER) -> str:
+    """POSIX-sh emitting one `VIOSPROBE <label> ...` line, then `scan=complete`.
+
+    The trailing line always prints, so "the probe did not run" is
+    distinguishable from "the container was not there" -- a profile that never
+    activates VIOS is silent about prebake and must not read as a zero.
+
+    Output is tee'd to stdout and to a durable sink, because brev_env's Python
+    logging is swallowed by harbor. The default sink is collected into
+    `<trial>/artifacts/logs/artifacts/vios-ready.log`.
+    """
+    lbl, cnt = shlex.quote(label), shlex.quote(container)
+    return f"""set +e
+SINK="${{VIOSPROBE_SINK:-{SINK_DEFAULT}}}"
+mkdir -p "$(dirname "$SINK")" 2>/dev/null
+LABEL={lbl}
+CNT={cnt}
+{{
+if docker inspect "$CNT" >/dev/null 2>&1; then
+  started=$(docker inspect -f '{{{{.State.StartedAt}}}}' "$CNT" 2>/dev/null)
+  image=$(docker inspect -f '{{{{.Config.Image}}}}' "$CNT" 2>/dev/null)
+  health=$(docker inspect -f '{{{{if .State.Health}}}}{{{{.State.Health.Status}}}}{{{{else}}}}none{{{{end}}}}' "$CNT" 2>/dev/null)
+  # The container's own words. "skipping APT" is the prebaked path; "Installation
+  # completed" is the install actually running. Counting both means a log we
+  # failed to read is reported as unknown rather than as either verdict.
+  logs=$(docker logs "$CNT" 2>&1 | head -400)
+  skipped=$(printf '%s' "$logs" | grep -ci 'already installed; skipping APT')
+  installed=$(printf '%s' "$logs" | grep -ci 'Installation completed successfully')
+  if [ "$skipped" -gt 0 ]; then verdict=prebaked
+  elif [ "$installed" -gt 0 ]; then verdict=installed-at-start
+  else verdict=unknown; fi
+  case "$image" in *prebaked*) tagged=yes ;; *) tagged=no ;; esac
+  echo "VIOSPROBE $LABEL container=present verdict=$verdict image_prebaked=$tagged health=$health started=$started"
+else
+  echo "VIOSPROBE $LABEL container=absent"
+fi
+echo "VIOSPROBE $LABEL scan=complete"
+}} 2>&1 | tee -a "$SINK"
+exit 0
+"""
+
+
+def parse_probe_lines(stdout: str) -> list[dict]:
+    """`VIOSPROBE` lines -> dicts. Ignores everything else on the stream."""
+    out = []
+    for line in (stdout or "").splitlines():
+        line = line.strip()
+        if not line.startswith("VIOSPROBE "):
+            continue
+        parts = line.split()[1:]
+        d = {"label": parts[0]} if parts else {}
+        for kv in parts[1:]:
+            if "=" in kv:
+                k, _, v = kv.partition("=")
+                d[k] = v
+        if len(d) > 1:
+            out.append(d)
+    return out

--- a/.github/skill-eval/tests/test_eval_env_forwarding.py
+++ b/.github/skill-eval/tests/test_eval_env_forwarding.py
@@ -17,12 +17,16 @@ import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[3]
-WORKFLOW = ROOT / ".github" / "workflows" / "skills-eval.yml"
+# Both workflows, because they are separate files with separate env blocks.
+# The nightly sweep is where the GPU-heavy specs actually run, so wiring only
+# the PR workflow leaves the population that matters untouched.
+WORKFLOWS = (ROOT / ".github" / "workflows" / "skills-eval.yml",
+             ROOT / ".github" / "workflows" / "skills-eval-daily.yml")
 BREV_ENV = ROOT / ".github" / "skill-eval" / "envs" / "brev_env.py"
 
 
-def _workflow_env_keys() -> set[str]:
-    """Keys of the workflow's top-level `env:` mapping.
+def _workflow_env_keys(path: Path) -> set[str]:
+    """Keys of one workflow's top-level `env:` mapping.
 
     Scanned rather than parsed with PyYAML: this runs in the harness-contracts
     step, whose uvx environment carries pytest and nothing else. The block is a
@@ -31,7 +35,7 @@ def _workflow_env_keys() -> set[str]:
     """
     keys: set[str] = set()
     inside = False
-    for line in WORKFLOW.read_text().splitlines():
+    for line in path.read_text().splitlines():
         if not inside:
             inside = line.rstrip() == "env:"
             continue
@@ -40,7 +44,7 @@ def _workflow_env_keys() -> set[str]:
         m = re.match(r"^  ([A-Za-z_][A-Za-z0-9_]*):", line)
         if m:
             keys.add(m.group(1))
-    assert keys, "no top-level env: block found in skills-eval.yml"
+    assert keys, f"no top-level env: block found in {path.name}"
     return keys
 
 
@@ -65,18 +69,32 @@ def _forwarded_keys() -> set[str]:
 
 
 def test_vss_workflow_env_is_forwarded_to_the_instance():
-    """A VSS_* knob set in the workflow must reach the box that deploys."""
-    missing = sorted(
-        k for k in _workflow_env_keys()
-        if k.startswith("VSS_") and k not in _forwarded_keys()
-    )
-    assert not missing, (
-        "set in skills-eval.yml but not forwarded by brev_env.py, so the deploy "
-        f"will silently keep its default: {missing}"
+    """A VSS_* knob set in a workflow must reach the box that deploys."""
+    forwarded = _forwarded_keys()
+    for path in WORKFLOWS:
+        missing = sorted(k for k in _workflow_env_keys(path)
+                         if k.startswith("VSS_") and k not in forwarded)
+        assert not missing, (
+            f"set in {path.name} but not forwarded by brev_env.py, so the deploy "
+            f"will silently keep its default: {missing}"
+        )
+
+
+def test_every_workflow_declares_the_same_vss_knobs():
+    """A knob in one workflow and not the other silently skips a population.
+
+    The PR sweep and the nightly sweep are separate files. Wiring only the PR
+    one left the nightly, where the GPU-heavy specs run, on the old path.
+    """
+    per_file = {p.name: {k for k in _workflow_env_keys(p) if k.startswith("VSS_")}
+                for p in WORKFLOWS}
+    assert len(set(map(frozenset, per_file.values()))) == 1, (
+        f"VSS_* env differs between the workflows: {per_file}"
     )
 
 
 def test_prebake_flag_is_wired_end_to_end():
-    """The specific knob this test file was added for, asserted both sides."""
-    assert "VSS_VIOS_PREBAKE_PACKAGES" in _workflow_env_keys()
+    """The specific knob this test file was added for, asserted on every hop."""
+    for path in WORKFLOWS:
+        assert "VSS_VIOS_PREBAKE_PACKAGES" in _workflow_env_keys(path), path.name
     assert "VSS_VIOS_PREBAKE_PACKAGES" in _forwarded_keys()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,6 +485,7 @@ jobs:
             .github/skill-eval/tests/test_python_runtime_contract.py \
             .github/skill-eval/tests/test_skills_eval_agent_protocol.py \
             .github/skill-eval/envs/tests/test_cancellation_recovery.py \
+            .github/skill-eval/envs/tests/test_vios_probe.py \
             .github/skill-eval/tests/test_run_leg.py::HarborCommand \
             .github/skill-eval/tests/test_run_leg.py::PhaseBudgets \
             .github/skill-eval/tests/test_run_leg.py::HarborEnvironment \

--- a/.github/workflows/skills-eval-daily.yml
+++ b/.github/workflows/skills-eval-daily.yml
@@ -66,6 +66,9 @@ env:
   # Match the PR workflow: every coordinator-side Python process, including
   # Harbor's uvx environment, runs on one declared minor version.
   SKILL_EVAL_PYTHON_VERSION: "3.12"
+  # Prebaked VIOS runtime-media packages (#1798). Same repository variable
+  # the PR workflow reads; unset is not forwarded, so the default stands.
+  VSS_VIOS_PREBAKE_PACKAGES: ${{ vars.VSS_VIOS_PREBAKE_PACKAGES }}
 
 jobs:
   # ---------------------------------------------------------------------

--- a/deploy/docker/scripts/blueprint-deploy.sh
+++ b/deploy/docker/scripts/blueprint-deploy.sh
@@ -1000,6 +1000,14 @@ function state_up() {
   chmod -R 777 "${data_directory}/data_log" 2>/dev/null || true
 
   local _compose_file_args=(-f compose.yml -f services/infra/compose-no-turn-tcp-relay.yml)
+  # Same opt-in dev-profile.sh honors. Read from the environment only: this
+  # script has no flag surface, and CI reaches it through two containers where
+  # only environment survives.
+  if [[ "${VSS_VIOS_PREBAKE_PACKAGES:-false}" == "true" ]]; then
+    _compose_file_args+=(-f services/vios/streamprocessing/docker-compose.prebaked.yaml)
+    _compose_file_args+=(-f services/nvstreamer/docker-compose.prebaked.yaml)
+    echo "[INFO] Prebaking VIOS runtime-media packages into a local image."
+  fi
   local _compose_file_args_text=" ${_compose_file_args[*]}"
   echo "[INFO] TURN TCP relay host-port publishing disabled for blueprint-deploy.sh"
 

--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -1707,6 +1707,7 @@ function state_up() {
   local compose_files=(-f compose.yml)
   if [[ "${prebake_vios_packages}" == "true" ]]; then
     compose_files+=(-f services/vios/streamprocessing/docker-compose.prebaked.yaml)
+    compose_files+=(-f services/nvstreamer/docker-compose.prebaked.yaml)
     echo "[INFO] Prebaking VIOS runtime-media packages into a local image."
   fi
 

--- a/deploy/docker/services/nvstreamer/docker-compose.prebaked.yaml
+++ b/deploy/docker/services/nvstreamer/docker-compose.prebaked.yaml
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NVStreamer counterpart of streamprocessing/docker-compose.prebaked.yaml:
+# moves the same runtime-media apt install from container start to image
+# build. Opt in with `dev-profile.sh up --prebake-vios-packages`, which applies
+# both overlays together.
+#
+# Same load-bearing constraints as over there: paths resolve against the
+# project dir; `build:` rather than a prebuilt tag because the deploy pulls
+# with `--pull always`; the image name stays off the first-party registry.
+#
+# EVERY variant is listed, not just nvstreamer-base. Compose resolves
+# `extends` when it loads a file, before overlays merge, so overriding only
+# the base would leave each variant on the registry image. The entrypoint's
+# install branch needs no change: the baked marker makes the script skip.
+# Profiles are inherited from the merged base definitions, so nothing here
+# changes which services start.
+
+services:
+  nvstreamer-base:
+    image: vss-vios-nvstreamer-prebaked:${VSS_NVSTREAMER_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
+    build:
+      context: ./services/vios
+      dockerfile: streamprocessing/Dockerfile.prebaked
+      args:
+        VSS_VIOS_PREBAKE_BASE: ${VSS_NVSTREAMER_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-nvstreamer}:${VSS_NVSTREAMER_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
+
+  nvstreamer:
+    image: vss-vios-nvstreamer-prebaked:${VSS_NVSTREAMER_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
+    build:
+      context: ./services/vios
+      dockerfile: streamprocessing/Dockerfile.prebaked
+      args:
+        VSS_VIOS_PREBAKE_BASE: ${VSS_NVSTREAMER_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-nvstreamer}:${VSS_NVSTREAMER_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
+
+  nvstreamer-2d:
+    image: vss-vios-nvstreamer-prebaked:${VSS_NVSTREAMER_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
+    build:
+      context: ./services/vios
+      dockerfile: streamprocessing/Dockerfile.prebaked
+      args:
+        VSS_VIOS_PREBAKE_BASE: ${VSS_NVSTREAMER_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-nvstreamer}:${VSS_NVSTREAMER_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
+
+  nvstreamer-3d:
+    image: vss-vios-nvstreamer-prebaked:${VSS_NVSTREAMER_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
+    build:
+      context: ./services/vios
+      dockerfile: streamprocessing/Dockerfile.prebaked
+      args:
+        VSS_VIOS_PREBAKE_BASE: ${VSS_NVSTREAMER_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-nvstreamer}:${VSS_NVSTREAMER_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
+
+  nvstreamer-mv3dt:
+    image: vss-vios-nvstreamer-prebaked:${VSS_NVSTREAMER_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
+    build:
+      context: ./services/vios
+      dockerfile: streamprocessing/Dockerfile.prebaked
+      args:
+        VSS_VIOS_PREBAKE_BASE: ${VSS_NVSTREAMER_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-nvstreamer}:${VSS_NVSTREAMER_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
+
+  nvstreamer-amc:
+    image: vss-vios-nvstreamer-prebaked:${VSS_NVSTREAMER_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
+    build:
+      context: ./services/vios
+      dockerfile: streamprocessing/Dockerfile.prebaked
+      args:
+        VSS_VIOS_PREBAKE_BASE: ${VSS_NVSTREAMER_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-nvstreamer}:${VSS_NVSTREAMER_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
+
+  nvstreamer-alerts:
+    image: vss-vios-nvstreamer-prebaked:${VSS_NVSTREAMER_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
+    build:
+      context: ./services/vios
+      dockerfile: streamprocessing/Dockerfile.prebaked
+      args:
+        VSS_VIOS_PREBAKE_BASE: ${VSS_NVSTREAMER_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-nvstreamer}:${VSS_NVSTREAMER_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
+
+  nvstreamer-lvs:
+    image: vss-vios-nvstreamer-prebaked:${VSS_NVSTREAMER_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
+    build:
+      context: ./services/vios
+      dockerfile: streamprocessing/Dockerfile.prebaked
+      args:
+        VSS_VIOS_PREBAKE_BASE: ${VSS_NVSTREAMER_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-nvstreamer}:${VSS_NVSTREAMER_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
+
+  nvstreamer-2d-fusion:
+    image: vss-vios-nvstreamer-prebaked:${VSS_NVSTREAMER_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
+    build:
+      context: ./services/vios
+      dockerfile: streamprocessing/Dockerfile.prebaked
+      args:
+        VSS_VIOS_PREBAKE_BASE: ${VSS_NVSTREAMER_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-nvstreamer}:${VSS_NVSTREAMER_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}

--- a/deploy/docker/services/vios/streamprocessing/Dockerfile.prebaked
+++ b/deploy/docker/services/vios/streamprocessing/Dockerfile.prebaked
@@ -19,8 +19,8 @@
 #
 # Locally built images only. Never pushed.
 
-ARG VSS_VIOS_STREAMPROCESSING_BASE
-FROM ${VSS_VIOS_STREAMPROCESSING_BASE}
+ARG VSS_VIOS_PREBAKE_BASE
+FROM ${VSS_VIOS_PREBAKE_BASE}
 
 USER 0:0
 COPY scripts/user_additional_install.sh /home/vst/vst_release/tools/user_additional_install.sh

--- a/deploy/docker/services/vios/streamprocessing/docker-compose.prebaked.yaml
+++ b/deploy/docker/services/vios/streamprocessing/docker-compose.prebaked.yaml
@@ -22,8 +22,9 @@
 #     on an image that exists only locally
 #   - the image name must stay off the first-party registry, or release-set
 #     assembly sees two tags for one image name and fails
-#   - `vios-apt-cache-init` stays enabled: NVStreamer shares that cache and is
-#     not prebaked here
+#   - `vios-apt-cache-init` stays enabled: it also serves deployments that run
+#     only one of the two prebake overlays, and is a no-op when nothing needs
+#     the cache
 #
 # The derived image is local only and never pushed.
 
@@ -34,7 +35,7 @@ services:
       context: ./services/vios
       dockerfile: streamprocessing/Dockerfile.prebaked
       args:
-        VSS_VIOS_STREAMPROCESSING_BASE: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
+        VSS_VIOS_PREBAKE_BASE: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
 
   streamprocessing-ms-2d:
     image: vss-vios-streamprocessing-prebaked:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
@@ -42,7 +43,7 @@ services:
       context: ./services/vios
       dockerfile: streamprocessing/Dockerfile.prebaked
       args:
-        VSS_VIOS_STREAMPROCESSING_BASE: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
+        VSS_VIOS_PREBAKE_BASE: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
 
   streamprocessing-ms-3d:
     image: vss-vios-streamprocessing-prebaked:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
@@ -50,7 +51,7 @@ services:
       context: ./services/vios
       dockerfile: streamprocessing/Dockerfile.prebaked
       args:
-        VSS_VIOS_STREAMPROCESSING_BASE: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
+        VSS_VIOS_PREBAKE_BASE: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
 
   streamprocessing-ms-mv3dt:
     image: vss-vios-streamprocessing-prebaked:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
@@ -58,4 +59,4 @@ services:
       context: ./services/vios
       dockerfile: streamprocessing/Dockerfile.prebaked
       args:
-        VSS_VIOS_STREAMPROCESSING_BASE: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
+        VSS_VIOS_PREBAKE_BASE: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}

--- a/deploy/docker/test-scripts/compose-images.golden
+++ b/deploy/docker/test-scripts/compose-images.golden
@@ -60,6 +60,15 @@ deploy/docker/services/nim/nvidia-nemotron-nano-9b-v2/compose.yml nvcr.io/nim/nv
 deploy/docker/services/nim/qwen3-vl-8b-instruct/compose.yml nvcr.io/nvidia/vllm:25.12.post1-py3
 deploy/docker/services/nim/qwen3-vl-8b-instruct/compose.yml nvcr.io/nvidia/vllm:25.12.post1-py3
 deploy/docker/services/nvstreamer/base.yml ghcr.io/nvidia-ai-blueprints/vss/vss-vios-nvstreamer:develop-latest
+deploy/docker/services/nvstreamer/docker-compose.prebaked.yaml vss-vios-nvstreamer-prebaked:develop-latest
+deploy/docker/services/nvstreamer/docker-compose.prebaked.yaml vss-vios-nvstreamer-prebaked:develop-latest
+deploy/docker/services/nvstreamer/docker-compose.prebaked.yaml vss-vios-nvstreamer-prebaked:develop-latest
+deploy/docker/services/nvstreamer/docker-compose.prebaked.yaml vss-vios-nvstreamer-prebaked:develop-latest
+deploy/docker/services/nvstreamer/docker-compose.prebaked.yaml vss-vios-nvstreamer-prebaked:develop-latest
+deploy/docker/services/nvstreamer/docker-compose.prebaked.yaml vss-vios-nvstreamer-prebaked:develop-latest
+deploy/docker/services/nvstreamer/docker-compose.prebaked.yaml vss-vios-nvstreamer-prebaked:develop-latest
+deploy/docker/services/nvstreamer/docker-compose.prebaked.yaml vss-vios-nvstreamer-prebaked:develop-latest
+deploy/docker/services/nvstreamer/docker-compose.prebaked.yaml vss-vios-nvstreamer-prebaked:develop-latest
 deploy/docker/services/rtvi/rtvi-cv/compose.yaml ghcr.io/nvidia-ai-blueprints/vss/vss-rt-cv:develop-latest
 deploy/docker/services/rtvi/rtvi-cv/rtvi-cv-mv3dt/compose.yaml ghcr.io/nvidia-ai-blueprints/vss/vss-rt-cv-mv3dt-bev-fusion:develop-latest
 deploy/docker/services/rtvi/rtvi-cv/rtvi-cv-mv3dt/compose.yaml ghcr.io/nvidia-ai-blueprints/vss/vss-rt-cv-mv3dt-config-init:develop-latest


### PR DESCRIPTION
## Description

Rounds out [#1798](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/1798) so `--prebake-vios-packages` covers everything that installs the runtime-media packages at container start, and so the effect is observable where it runs. Measured on an L40, per container start:

| container | install at start | prebaked |
|---|---|---|
| vss-vios-streamprocessing | 116.3 s | 0.17 s |
| vss-vios-nvstreamer | 144.2 s | 0.15 s |

Confirmed on live CI (GitLab pipeline 65243977, the first run where the flag reached `dev-profile.sh`): `test-search`'s container went Started→healthy in **2 s against a 30 s baseline** built from 74 prior jobs.

### NVStreamer prebake
A counterpart overlay to the streamprocessing one resolves `nvstreamer-base` **and every variant** to a local prebaked image — every variant, because compose resolves `extends` at file load, before overlays merge, so overriding only the base leaves the variants on the registry image. The entrypoint needs no change: the baked marker makes its install branch skip. The Dockerfile's base ARG becomes `VSS_VIOS_PREBAKE_BASE` now that it bakes more than one image. Golden image refs regenerated for the new overlay.

Verified by resolving the full compose model with and without the overlays: with them, `nvstreamer` and `streamprocessing-ms` land on the `-prebaked` images while `vios-apt-cache-init` stays on the registry image; without them, byte-identical to today.

### Warehouse path
`blueprint-deploy.sh` assembles its own compose file list, so the warehouse eval never saw the flag regardless of settings. It now applies the same two overlays under the same environment opt-in (it has no flag surface, and CI reaches it through two containers where only environment survives). This is the heaviest deploy in CI — its container-readiness baseline is 247 s.

### Nightly sweep
`skills-eval-daily.yml` is a separate workflow with its own `env:` block, so #1915 left the sweep where the VIOS specs actually run on the old path. Same repository variable; a parity test asserts both workflows declare the same `VSS_*` knobs and fails when either side is removed.

### Per-leg observability
A leg's deploy runs on the Brev instance and none of its output reaches the job log or artifact, so the flag was enabled on GitHub and unverifiable. `vios_probe.py` records the container's own verdict (`prebaked` / `installed-at-start` / `unknown`, read from its logs) and timing to `/logs/artifacts/vios-ready.log`, written at collection time so it cannot land after its own pickup, and never exits non-zero so a diagnostic cannot fail the trial it observes.

Nothing changes until the repository variable is set; unset is not forwarded and every default stands.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally.
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.