### PR TITLE
feat: add OrcaRouter as a named NEMOCLAW_PROVIDER

### DIFF
--- a/deploy/docker/scripts/deploy_nemoclaw_vss.ipynb
+++ b/deploy/docker/scripts/deploy_nemoclaw_vss.ipynb
@@ -74,11 +74,13 @@
     "NGC_CLI_API_KEY = \"\"               # NVIDIA Legacy API key — used to pull VSS artifacts from nvcr.io\n",
     "HARDWARE_PROFILE = \"RTXPRO6000BW\"  # DGX-SPARK | RTXPRO6000BW | H100 | L40S | OTHER\n",
     "\n",
-    "# ================== Shared OpenClaw model vars (overridden by ONE of (a)/(b)/(c) in 1.2) ==================\n",
+    "# ================== Shared OpenClaw model vars (overridden by ONE of (a)/(b)/(c)/(d) in 1.2) ==================\n",
     "NVIDIA_API_KEY = \"\"\n",
     "NEMOCLAW_ENDPOINT_URL = \"\"\n",
     "NEMOCLAW_MODEL = \"\"\n",
-    "COMPATIBLE_API_KEY = \"\"\n"
+    "COMPATIBLE_API_KEY = \"\"\n",
+    "ORCAROUTER_API_KEY = \"\"\n",
+    "ORCAROUTER_BASE_URL = \"\"   # default https://api.orcarouter.ai/v1 when blank\n"
    ]
   },
   {
@@ -94,7 +96,8 @@
     "|---|---|---|\n",
     "| **(a) SOTA cloud model** | Best agent quality (Claude Opus, GPT-5, …) via any OpenAI-compatible cloud API. | `NEMOCLAW_ENDPOINT_URL`, `NEMOCLAW_MODEL`, `COMPATIBLE_API_KEY` |\n",
     "| **(b) Local OpenAI-compatible model** | Self-hosted on this box or LAN | `NEMOCLAW_ENDPOINT_URL`, `NEMOCLAW_MODEL`, `COMPATIBLE_API_KEY` |\n",
-    "| **(c) build.nvidia.com NVIDIA-hosted model** | Default path — uses NVIDIA's hosted Nemotron via `integrate.api.nvidia.com`. | `NVIDIA_API_KEY`, optionally `NEMOCLAW_MODEL` |\n"
+    "| **(c) build.nvidia.com NVIDIA-hosted model** | Default path — uses NVIDIA's hosted Nemotron via `integrate.api.nvidia.com`. | `NVIDIA_API_KEY`, optionally `NEMOCLAW_MODEL` |\n",
+    "| **(d) OrcaRouter gateway** | [OrcaRouter](https://www.orcarouter.ai) — OpenAI-compatible AI gateway exposing a provider/model namespace with adaptive routing, failover, guardrails, and agent-tool governance on one endpoint. | `ORCAROUTER_API_KEY`, optionally `NEMOCLAW_MODEL` (default `orcarouter/auto`) |\n"
    ]
   },
   {
@@ -174,6 +177,31 @@
   },
   {
    "cell_type": "markdown",
+   "id": "orcarouter-md",
+   "metadata": {},
+   "source": [
+    "#### (d) OrcaRouter gateway — *OpenAI-compatible AI gateway*\n",
+    "\n",
+    "Uses the [OrcaRouter](https://www.orcarouter.ai) gateway at `api.orcarouter.ai/v1`. Only `ORCAROUTER_API_KEY` is required; `NEMOCLAW_MODEL` defaults to `orcarouter/auto` for adaptive routing.\n",
+    "\n",
+    "> Get a key at <https://www.orcarouter.ai>. The gateway exposes the same OpenAI-compatible `/v1` surface as NVIDIA Endpoints, so NemoClaw is configured exactly like the `custom` provider under the hood — but the script wires the OrcaRouter base URL and key for you."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "orcarouter-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# (d) OrcaRouter gateway — set ORCAROUTER_API_KEY; leave NEMOCLAW_ENDPOINT_URL blank so the installer picks NEMOCLAW_PROVIDER=orcarouter.\n",
+    "ORCAROUTER_API_KEY = \"\"  # from https://www.orcarouter.ai\n",
+    "ORCAROUTER_BASE_URL = \"\"  # optional; default https://api.orcarouter.ai/v1\n",
+    "NEMOCLAW_MODEL = \"orcarouter/auto\"  # optional; default orcarouter/auto"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "a32154bc",
    "metadata": {},
    "source": [
@@ -232,7 +260,9 @@
     "NEMOCLAW_REPO_DIR = Path(os.environ.get(\"NEMOCLAW_REPO_DIR\", HOME_DIR / \"NemoClaw\")).resolve()\n",
     "DEPLOY_SCRIPTS_DIR = VSS_REPO_DIR / \"deploy\" / \"docker\" / \"scripts\"\n",
     "NEMOCLAW_INIT_SCRIPT_PATH = DEPLOY_SCRIPTS_DIR / \"nemoclaw\" / \"init_nemoclaw.sh\"\n",
-    "NEMOCLAW_PROVIDER = \"custom\" if NEMOCLAW_ENDPOINT_URL else \"build\"\n",
+    "ORCAROUTER_API_KEY = (ORCAROUTER_API_KEY or os.environ.get(\"ORCAROUTER_API_KEY\", \"\")).strip()\n",
+    "ORCAROUTER_BASE_URL = (ORCAROUTER_BASE_URL or os.environ.get(\"ORCAROUTER_BASE_URL\", \"\")).strip() or \"https://api.orcarouter.ai/v1\"\n",
+    "NEMOCLAW_PROVIDER = \"orcarouter\" if ORCAROUTER_API_KEY else (\"custom\" if NEMOCLAW_ENDPOINT_URL else \"build\")\n",
     "POLICY_PATH = VSS_REPO_DIR / \"assets\" / \"vss_nemoclaw_policy.yaml\"\n",
     "OPENCLAW_CONFIG_UPDATE_SCRIPT = DEPLOY_SCRIPTS_DIR / \"nemoclaw\" / \"update_openclaw_config.py\"\n",
     "SKILLS_DIR = VSS_REPO_DIR / \"skills\"\n",
@@ -284,6 +314,10 @@
     "    print(\"NEMOCLAW_ENDPOINT_URL:\", NEMOCLAW_ENDPOINT_URL)\n",
     "    print(\"NEMOCLAW_MODEL:\", NEMOCLAW_MODEL)\n",
     "    print(\"COMPATIBLE_API_KEY set:\", bool(COMPATIBLE_API_KEY))\n",
+    "if NEMOCLAW_PROVIDER == \"orcarouter\":\n",
+    "    print(\"NEMOCLAW_ENDPOINT_URL:\", ORCAROUTER_BASE_URL)\n",
+    "    print(\"NEMOCLAW_MODEL:\", NEMOCLAW_MODEL)\n",
+    "    print(\"ORCAROUTER_API_KEY set:\", bool(ORCAROUTER_API_KEY))\n",
     "if VSS_LLM_ENDPOINT_URL:\n",
     "    print(\"VSS_LLM_NAME:\", VSS_LLM_NAME)\n",
     "    print(\"VSS_LLM_ENDPOINT_URL:\", VSS_LLM_ENDPOINT_URL)\n",
@@ -522,6 +556,11 @@
     "        \"NEMOCLAW_MODEL is required when NEMOCLAW_ENDPOINT_URL is set. \"\n",
     "        \"If you ran more than one of (a)/(b)/(c), re-run just the (a) or (b) cell you want to use.\"\n",
     "    )\n",
+    "if NEMOCLAW_PROVIDER == \"orcarouter\" and not ORCAROUTER_API_KEY:\n",
+    "    raise RuntimeError(\n",
+    "        \"ORCAROUTER_API_KEY is required for the OrcaRouter gateway provider (option d). \"\n",
+    "        \"Set it in the (d) cell.\"\n",
+    "    )\n",
     "\n",
     "if not POLICY_PATH.is_file():\n",
     "    raise FileNotFoundError(f\"Missing policy file: {POLICY_PATH}\")\n",
@@ -553,6 +592,10 @@
     "    env[\"NEMOCLAW_ENDPOINT_URL\"] = NEMOCLAW_ENDPOINT_URL\n",
     "    env[\"COMPATIBLE_API_KEY\"] = COMPATIBLE_API_KEY\n",
     "    print(f\"[{HARDWARE_PROFILE}] Local OpenAI-compatible provider: {NEMOCLAW_ENDPOINT_URL} model={NEMOCLAW_MODEL} key set={bool(COMPATIBLE_API_KEY)}\")\n",
+    "if NEMOCLAW_PROVIDER == \"orcarouter\":\n",
+    "    env[\"ORCAROUTER_API_KEY\"] = ORCAROUTER_API_KEY\n",
+    "    env[\"ORCAROUTER_BASE_URL\"] = ORCAROUTER_BASE_URL\n",
+    "    print(f\"[{HARDWARE_PROFILE}] OrcaRouter gateway provider: {ORCAROUTER_BASE_URL} model={NEMOCLAW_MODEL} key set={bool(ORCAROUTER_API_KEY)}\")\n",
     "\n",
     "timeout_sec = 3600\n",
     "\n",

--- a/deploy/docker/scripts/nemoclaw/README.md
+++ b/deploy/docker/scripts/nemoclaw/README.md
@@ -1,11 +1,12 @@
 # NemoClaw VSS Installer
 
-`init_nemoclaw.sh` bootstraps a NemoClaw sandbox on a Brev instance, configures its NVIDIA-hosted model provider, uploads the repository `skills/`, and updates OpenClaw allowed origins.
+`init_nemoclaw.sh` bootstraps a NemoClaw sandbox on a Brev instance, configures its model provider, uploads the repository `skills/`, and updates OpenClaw allowed origins.
 
-It supports two onboard providers, selected via the **required** `NEMOCLAW_PROVIDER` env var:
+It supports three onboard providers, selected via the **required** `NEMOCLAW_PROVIDER` env var:
 
 - `build` — NVIDIA Endpoints (`integrate.api.nvidia.com`), authenticated with `NVIDIA_API_KEY`.
 - `custom` — any OpenAI-compatible endpoint (e.g. a local vLLM), configured with `NEMOCLAW_ENDPOINT_URL` and `COMPATIBLE_API_KEY`.
+- `orcarouter` — the [OrcaRouter](https://www.orcarouter.ai) OpenAI-compatible AI gateway (`api.orcarouter.ai`), authenticated with `ORCAROUTER_API_KEY`. Exposes the same provider/model namespace as OpenRouter plus adaptive routing, failover, guardrails, and agent-tool governance on the same endpoint.
 
 ## What It Does
 
@@ -81,6 +82,26 @@ NEMOCLAW_PROVIDER=custom \
     --nvidia-api-key "$NVIDIA_API_KEY"
 ```
 
+### `orcarouter` provider (OrcaRouter gateway)
+
+`ORCAROUTER_API_KEY` is required when `NEMOCLAW_PROVIDER=orcarouter`. `NEMOCLAW_MODEL` defaults to `orcarouter/auto` for adaptive routing across the gateway's model namespace:
+
+```bash
+NEMOCLAW_PROVIDER=orcarouter \
+ORCAROUTER_API_KEY="$ORCAROUTER_API_KEY" \
+  bash deploy/docker/scripts/nemoclaw/init_nemoclaw.sh demo
+```
+
+Equivalent with CLI flags:
+
+```bash
+NEMOCLAW_PROVIDER=orcarouter \
+  bash deploy/docker/scripts/nemoclaw/init_nemoclaw.sh \
+    --sandbox-name demo \
+    --model orcarouter/auto \
+    --orcarouter-api-key "$ORCAROUTER_API_KEY"
+```
+
 ### Background run on a Brev instance
 
 ```bash
@@ -94,11 +115,12 @@ nohup env NEMOCLAW_PROVIDER=build NVIDIA_API_KEY="$NVIDIA_API_KEY" \
 | Option | Description | Default |
 |---|---|---|
 | `--sandbox-name NAME` | Target sandbox name | `demo` |
-| `--model NAME` | NemoClaw inference model | `nvidia/nemotron-3-super-120b-a12b` |
+| `--model NAME` | NemoClaw inference model | `orcarouter/auto` (`orcarouter` provider) / `nvidia/nemotron-3-super-120b-a12b` (otherwise) |
 | `--nvidia-base-url URL` | NVIDIA API base URL for the `build` provider | `https://integrate.api.nvidia.com/v1` |
 | `--nvidia-api-key KEY` | API key for the `build` provider | `NVIDIA_API_KEY` env fallback |
 | `--endpoint-url URL` | OpenAI-compatible endpoint URL (required when `NEMOCLAW_PROVIDER=custom`) | — |
 | `--compatible-api-key KEY` | API key for the OpenAI-compatible endpoint (required when `NEMOCLAW_PROVIDER=custom`) | — |
+| `--orcarouter-api-key KEY` | API key for the OrcaRouter gateway (required when `NEMOCLAW_PROVIDER=orcarouter`) | `ORCAROUTER_API_KEY` env fallback |
 | `--openclaw-config-script PATH` | Path to `update_openclaw_config.py` | `deploy/docker/scripts/nemoclaw/update_openclaw_config.py` |
 | `--policy-file PATH` | Custom sandbox policy file | `assets/vss_nemoclaw_policy.yaml` |
 | `--help` | Show usage help | n/a |
@@ -109,9 +131,11 @@ The script also honors these environment variables:
 
 - `VSS_REPO_DIR`: repo root used to resolve plugin assets and the default policy file
 - `NEMOCLAW_SANDBOX_NAME`
-- `NEMOCLAW_PROVIDER` (**required**) — `build` or `custom`
+- `NEMOCLAW_PROVIDER` (**required**) — `build`, `custom`, or `orcarouter`
 - `NEMOCLAW_ENDPOINT_URL` — OpenAI-compatible endpoint URL; required when `NEMOCLAW_PROVIDER=custom`
 - `COMPATIBLE_API_KEY` — API key for the OpenAI-compatible endpoint; required when `NEMOCLAW_PROVIDER=custom`
+- `ORCAROUTER_API_KEY` — API key for the OrcaRouter gateway; required when `NEMOCLAW_PROVIDER=orcarouter`
+- `ORCAROUTER_BASE_URL` — OrcaRouter gateway base URL (default `https://api.orcarouter.ai/v1`)
 - `OPENSHELL_PROVIDER_NAME`
 - `NEMOCLAW_MODEL`
 - `NVIDIA_BASE_URL`
@@ -144,8 +168,9 @@ If the config update succeeds, the helper also prints:
 
 ## Troubleshooting
 
-- Verify `NEMOCLAW_PROVIDER` is set (`build` or `custom`) — the script exits immediately if it is unset.
+- Verify `NEMOCLAW_PROVIDER` is set (`build`, `custom`, or `orcarouter`) — the script exits immediately if it is unset.
 - For `NEMOCLAW_PROVIDER=custom`, verify both `NEMOCLAW_ENDPOINT_URL` and `COMPATIBLE_API_KEY` are set (or pass `--endpoint-url` / `--compatible-api-key`).
+- For `NEMOCLAW_PROVIDER=orcarouter`, verify `ORCAROUTER_API_KEY` is set (or pass `--orcarouter-api-key`).
 - Verify `NVIDIA_API_KEY` is set before running the installer.
 - If NemoClaw onboarding fails, verify `nemoclaw` is resolvable or that `/home/ubuntu/NemoClaw/install.sh` exists and is executable.
 - If the custom policy is skipped, confirm `assets/vss_nemoclaw_policy.yaml` exists or pass `--policy-file`.

--- a/deploy/docker/scripts/nemoclaw/init_nemoclaw.sh
+++ b/deploy/docker/scripts/nemoclaw/init_nemoclaw.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-# Configures NemoClaw to use either NVIDIA's hosted Nemotron model (NEMOCLAW_PROVIDER=build)
-# or an OpenAI-compatible endpoint (NEMOCLAW_PROVIDER=custom).
+# Configures NemoClaw to use NVIDIA's hosted Nemotron model (NEMOCLAW_PROVIDER=build),
+# an OpenAI-compatible endpoint (NEMOCLAW_PROVIDER=custom), or the OrcaRouter
+# OpenAI-compatible AI gateway (NEMOCLAW_PROVIDER=orcarouter).
 # For "build": requires NVIDIA_API_KEY (via --nvidia-api-key, env var, or interactive prompt).
 # For "custom": requires NEMOCLAW_ENDPOINT_URL and COMPATIBLE_API_KEY; NVIDIA_API_KEY is unused.
+# For "orcarouter": requires ORCAROUTER_API_KEY; NVIDIA_API_KEY is unused.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
@@ -10,15 +12,22 @@ VSS_REPO_DIR="${VSS_REPO_DIR:-$(cd "${SCRIPT_DIR}/../../../.." && pwd)}"
 NEMOCLAW_REPO_DIR="${NEMOCLAW_REPO_DIR:-${HOME}/NemoClaw}"
 NEMOCLAW_SANDBOX_NAME="${NEMOCLAW_SANDBOX_NAME:-demo}"
 # NEMOCLAW_PROVIDER selects the Nemoclaw onboard/install provider. Required — no default.
-# Accepted values: "build" (NVIDIA Endpoints / integrate.api.nvidia.com) or "custom" (OpenAI-compatible endpoint).
+# Accepted values: "build" (NVIDIA Endpoints / integrate.api.nvidia.com), "custom" (OpenAI-compatible endpoint),
+# or "orcarouter" (OrcaRouter gateway / api.orcarouter.ai).
 NEMOCLAW_PROVIDER="${NEMOCLAW_PROVIDER:?NEMOCLAW_PROVIDER is required}"
 # Custom-provider settings — required when NEMOCLAW_PROVIDER=custom (OpenAI-compatible endpoint).
 NEMOCLAW_ENDPOINT_URL="${NEMOCLAW_ENDPOINT_URL:-}"
 COMPATIBLE_API_KEY="${COMPATIBLE_API_KEY:-}"
+# OrcaRouter-provider settings — required when NEMOCLAW_PROVIDER=orcarouter (OrcaRouter gateway).
+ORCAROUTER_API_KEY="${ORCAROUTER_API_KEY:-}"
+ORCAROUTER_BASE_URL="${ORCAROUTER_BASE_URL:-https://api.orcarouter.ai/v1}"
 # OpenShell provider display name (separate from Nemoclaw's NEMOCLAW_PROVIDER for onboard).
 OPENCLAW_PLUGIN_VARIANT="${OPENCLAW_PLUGIN_VARIANT:-}"
 OPENSHELL_PROVIDER_NAME="${OPENSHELL_PROVIDER_NAME:-nvidia}"
-NEMOCLAW_MODEL="${NEMOCLAW_MODEL:-nvidia/nemotron-3-super-120b-a12b}"
+# NEMOCLAW_MODEL defaults per provider; resolved in parse_args() because the
+# default depends on NEMOCLAW_PROVIDER. orcarouter/auto for the OrcaRouter gateway
+# (adaptive routing), nvidia/nemotron-3-super-120b-a12b otherwise.
+NEMOCLAW_MODEL="${NEMOCLAW_MODEL:-}"
 NEMOCLAW_NON_INTERACTIVE=1
 NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1
 NVIDIA_API_KEY="${NVIDIA_API_KEY:-}"
@@ -47,17 +56,19 @@ usage() {
 Usage:
   bash init_nemoclaw.sh [--nvidia-api-key <KEY>] [options]
   NVIDIA_API_KEY=<key> bash init_nemoclaw.sh [options]
+  ORCAROUTER_API_KEY=<key> bash init_nemoclaw.sh [options]
 
   When NEMOCLAW_PROVIDER=build, the NVIDIA API key is resolved in this order:
     1. --nvidia-api-key flag (overrides env)
     2. NVIDIA_API_KEY environment variable
     3. Interactive prompt (if neither is set)
   When NEMOCLAW_PROVIDER=custom, NVIDIA_API_KEY is ignored — use --endpoint-url and --compatible-api-key.
+  When NEMOCLAW_PROVIDER=orcarouter, ORCAROUTER_API_KEY is used with the OrcaRouter gateway (api.orcarouter.ai).
 
 Options:
-  --nvidia-api-key KEY        NVIDIA API key (required when NEMOCLAW_PROVIDER=build; ignored for "custom")
+  --nvidia-api-key KEY        NVIDIA API key (required when NEMOCLAW_PROVIDER=build; ignored for "custom"/"orcarouter")
   --sandbox-name NAME         Sandbox name (default: demo)
-  --model NAME                NVIDIA model ID (default: nvidia/nemotron-3-super-120b-a12b)
+  --model NAME                Model ID (default: orcarouter/auto for "orcarouter"; nvidia/nemotron-3-super-120b-a12b otherwise)
   --nvidia-base-url URL       NVIDIA API base URL (default: https://integrate.api.nvidia.com/v1)
   --endpoint-url URL          OpenAI-compatible endpoint URL (REQUIRED when --provider=custom)
   --compatible-api-key KEY    API key for the OpenAI-compatible endpoint (REQUIRED when --provider=custom)
@@ -68,9 +79,11 @@ Options:
   --help                      Show this help
 
 Environment (non-interactive Nemoclaw / OpenShell):
-  NEMOCLAW_PROVIDER           Nemoclaw onboard/install provider (REQUIRED; must be "build" = NVIDIA Endpoints / integrate.api.nvidia.com, or "custom" = OpenAI-compatible)
+  NEMOCLAW_PROVIDER           Nemoclaw onboard/install provider (REQUIRED; must be "build" = NVIDIA Endpoints / integrate.api.nvidia.com, "custom" = OpenAI-compatible, or "orcarouter" = OrcaRouter gateway)
   NEMOCLAW_ENDPOINT_URL       OpenAI-compatible endpoint URL (REQUIRED when NEMOCLAW_PROVIDER=custom)
   COMPATIBLE_API_KEY          API key for the OpenAI-compatible endpoint (REQUIRED when NEMOCLAW_PROVIDER=custom)
+  ORCAROUTER_API_KEY          API key for the OrcaRouter gateway (REQUIRED when NEMOCLAW_PROVIDER=orcarouter)
+  ORCAROUTER_BASE_URL         OrcaRouter gateway base URL (default: https://api.orcarouter.ai/v1)
   OPENSHELL_PROVIDER_NAME     Name for openshell OpenAI-compatible provider (default: nvidia)
   OPENCLAW_PLUGIN_DIR              Path to the OpenClaw plugin source to pack and install
                               (default: <VSS_REPO_DIR>/.openclaw)
@@ -104,6 +117,10 @@ parse_args() {
         ;;
       --compatible-api-key)
         COMPATIBLE_API_KEY="$2"
+        shift 2
+        ;;
+      --orcarouter-api-key)
+        ORCAROUTER_API_KEY="$2"
         shift 2
         ;;
       --nemoclaw-repo-dir)
@@ -146,12 +163,23 @@ parse_args() {
   # NVIDIA_API_KEY is only required for the "build" provider (NVIDIA Endpoints).
   # In "custom" mode the OpenAI-compatible endpoint uses COMPATIBLE_API_KEY instead,
   # which is validated separately in validate_custom_provider_settings().
+  # In "orcarouter" mode the OrcaRouter gateway uses ORCAROUTER_API_KEY instead.
   if [ "${NEMOCLAW_PROVIDER}" = "build" ] && [ -z "${NVIDIA_API_KEY:-}" ]; then
     read -rsp "Enter your NVIDIA API key: " NVIDIA_API_KEY
     printf '\n'
     if [ -z "${NVIDIA_API_KEY:-}" ]; then
       log "ERROR: NVIDIA API key is required when NEMOCLAW_PROVIDER=build."
       exit 1
+    fi
+  fi
+
+  # Provider-specific default model: the OrcaRouter gateway defaults to its
+  # adaptive-routing model id; the other providers keep the NVIDIA Nemotron default.
+  if [ -z "${NEMOCLAW_MODEL:-}" ]; then
+    if [ "${NEMOCLAW_PROVIDER}" = "orcarouter" ]; then
+      NEMOCLAW_MODEL="orcarouter/auto"
+    else
+      NEMOCLAW_MODEL="nvidia/nemotron-3-super-120b-a12b"
     fi
   fi
 }
@@ -222,7 +250,8 @@ configure_openshell_provider() {
   fi
 
   # Pick endpoint + key based on NEMOCLAW_PROVIDER. "build" uses NVIDIA Endpoints;
-  # "custom" uses the user-supplied OpenAI-compatible endpoint (e.g. a local vLLM).
+  # "custom" uses the user-supplied OpenAI-compatible endpoint (e.g. a local vLLM);
+  # "orcarouter" uses the OrcaRouter gateway base URL with the ORCAROUTER_API_KEY.
   local openai_base_url openai_api_key
   case "${NEMOCLAW_PROVIDER}" in
     build)
@@ -233,8 +262,12 @@ configure_openshell_provider() {
       openai_base_url="${NEMOCLAW_ENDPOINT_URL}"
       openai_api_key="${COMPATIBLE_API_KEY}"
       ;;
+    orcarouter)
+      openai_base_url="${ORCAROUTER_BASE_URL}"
+      openai_api_key="${ORCAROUTER_API_KEY}"
+      ;;
     *)
-      log "ERROR: NEMOCLAW_PROVIDER=${NEMOCLAW_PROVIDER} is not supported by configure_openshell_provider (expected 'build' or 'custom')."
+      log "ERROR: NEMOCLAW_PROVIDER=${NEMOCLAW_PROVIDER} is not supported by configure_openshell_provider (expected 'build', 'custom', or 'orcarouter')."
       return 1
       ;;
   esac
@@ -515,16 +548,31 @@ validate_custom_provider() {
   fi
 }
 
-export_provider_env() {
-  export NEMOCLAW_PROVIDER
+validate_orcarouter_provider() {
+  if [ "${NEMOCLAW_PROVIDER}" != "orcarouter" ]; then
+    return 0
+  fi
+  if [ -z "${ORCAROUTER_API_KEY}" ]; then
+    log "ERROR: NEMOCLAW_PROVIDER=orcarouter requires ORCAROUTER_API_KEY (or --orcarouter-api-key)."
+    exit 1
+  fi
+}
+
+# NemoClaw's onboard/install flow only understands "build" (NVIDIA Endpoints) and
+# "custom" (OpenAI-compatible endpoint). OrcaRouter is a first-class OpenShell
+# provider in this script, but NemoClaw itself sees it as a custom OpenAI-compatible
+# endpoint — so downgrade the provider value and derive the custom-endpoint vars
+# from the OrcaRouter settings before invoking the NemoClaw installer.
+export_installer_provider_env() {
+  if [ "${NEMOCLAW_PROVIDER}" = "orcarouter" ]; then
+    export NEMOCLAW_PROVIDER="custom"
+    export NEMOCLAW_ENDPOINT_URL="${ORCAROUTER_BASE_URL}"
+    export COMPATIBLE_API_KEY="${ORCAROUTER_API_KEY}"
+  fi
   export NEMOCLAW_MODEL
   export NEMOCLAW_NON_INTERACTIVE
   export NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE
   export NVIDIA_API_KEY
-  if [ "${NEMOCLAW_PROVIDER}" = "custom" ]; then
-    export NEMOCLAW_ENDPOINT_URL
-    export COMPATIBLE_API_KEY
-  fi
 }
 
 run_onboard() {
@@ -535,8 +583,10 @@ run_onboard() {
   }
 
   log "Running nemoclaw onboard (NEMOCLAW_PROVIDER=${NEMOCLAW_PROVIDER})"
-  export_provider_env
-  "$nemoclaw_cmd" onboard --non-interactive
+  (
+    export_installer_provider_env
+    "$nemoclaw_cmd" onboard --non-interactive
+  )
 }
 
 run_install() {
@@ -549,7 +599,7 @@ run_install() {
 
   log "Running NemoClaw installer (NEMOCLAW_PROVIDER=${NEMOCLAW_PROVIDER})"
   (
-    export_provider_env
+    export_installer_provider_env
     export NEMOCLAW_SANDBOX_NAME
     cd "$NEMOCLAW_REPO_DIR" && ./install.sh --non-interactive
   )
@@ -629,8 +679,10 @@ main() {
 
 parse_args "$@"
 validate_custom_provider
+validate_orcarouter_provider
 export NEMOCLAW_SANDBOX_NAME NEMOCLAW_PROVIDER OPENSHELL_PROVIDER_NAME NEMOCLAW_MODEL NEMOCLAW_NON_INTERACTIVE NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE
 export NEMOCLAW_ENDPOINT_URL COMPATIBLE_API_KEY
+export ORCAROUTER_API_KEY ORCAROUTER_BASE_URL
 export NEMOCLAW_REPO_DIR OPENCLAW_CONFIG_UPDATE_SCRIPT NEMOCLAW_POLICY_FILE
 
 main


### PR DESCRIPTION
## Summary

This PR adds **OrcaRouter** as a first-class `NEMOCLAW_PROVIDER` for the NemoClaw onboarding path of the Video Search and Summarization (VSS) blueprint. Until now `init_nemoclaw.sh` only offered `build` (NVIDIA Endpoints) and `custom` (any OpenAI-compatible endpoint). OrcaRouter is an OpenAI-compatible AI gateway — like OpenRouter it exposes a provider/model namespace across many models, but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding it as a named provider means VSS users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Plan

- Extend the `NEMOCLAW_PROVIDER` enum in `deploy/docker/scripts/nemoclaw/init_nemoclaw.sh` from `build|custom` to `build|custom|orcarouter`.
- Mirror the existing `build` provider shape (a hard-coded named endpoint) for `orcarouter`: `ORCAROUTER_BASE_URL` defaults to `https://api.orcarouter.ai/v1`, authenticated via `ORCAROUTER_API_KEY`, with `NEMOCLAW_MODEL` defaulting to `orcarouter/auto` for adaptive routing.
- Keep NemoClaw's own onboard/install flow unchanged: because NemoClaw only understands `build`/`custom`, the installer step downgrades `orcarouter` to its `custom` shape (endpoint + key derived from the OrcaRouter vars), while the OpenShell provider config still wires the named OrcaRouter endpoint.
- Document the new provider in the NemoClaw installer README and add a `(d) OrcaRouter gateway` option cell to the `deploy_nemoclaw_vss.ipynb` Brev notebook, matching the existing `(a)/(b)/(c)` provider-choice pattern.

## Changes

- `deploy/docker/scripts/nemoclaw/init_nemoclaw.sh` — `orcarouter` case in `configure_openshell_provider`, provider-specific model default, `ORCAROUTER_API_KEY`/`ORCAROUTER_BASE_URL` plumbing, validation, usage/help text.
- `deploy/docker/scripts/nemoclaw/README.md` — new `orcarouter` provider section, options/env tables, troubleshooting.
- `deploy/docker/scripts/deploy_nemoclaw_vss.ipynb` — shared provider vars, table row, new `(d)` cell, derived `NEMOCLAW_PROVIDER` logic, env plumbing.

## Verification

- `bash -n` syntax check passes on the modified script.
- Function-level tests (mocked `openshell`/`nemoclaw`) confirm `configure_openshell_provider` wires `OPENAI_BASE_URL=https://api.orcarouter.ai/v1` with `NEMOCLAW_MODEL=orcarouter/auto`, the installer downgrade to the `custom` shape carries the OrcaRouter endpoint/key, and empty `ORCAROUTER_API_KEY` is rejected.
- Provider-specific default model resolution verified: `build`/`custom` keep `nvidia/nemotron-3-super-120b-a12b`, `orcarouter` gets `orcarouter/auto`.
- All notebook code cells parse; repo copyright-header check passes.
- Live check against `https://api.orcarouter.ai/v1` with an OrcaRouter key returned HTTP 200 for both `GET /models` (204 models) and a `POST /chat/completions` completion.

## Related Issue

N/A

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.

---

I'm an engineer on the OrcaRouter team. Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
