### PR TITLE
Added VLM incident verification tests in video analytics api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -608,6 +608,7 @@ jobs:
     name: Test (behavior analytics)
     needs: prepare-source
     runs-on: ubuntu-latest
+    if: needs.prepare-source.outputs.build-behavior-analytics == 'true' || needs.prepare-source.outputs.unit-test-workflow-changed == 'true'
     timeout-minutes: 30
     defaults:
       run:
@@ -658,6 +659,7 @@ jobs:
     name: Test (video analytics API)
     needs: prepare-source
     runs-on: ubuntu-latest
+    if: needs.prepare-source.outputs.build-video-analytics-api == 'true' || needs.prepare-source.outputs.unit-test-workflow-changed == 'true'
     timeout-minutes: 30
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -919,6 +919,7 @@ jobs:
     name: Integration (video analytics API)
     needs: prepare-source
     runs-on: ubuntu-latest
+    if: needs.prepare-source.outputs.build-video-analytics-api == 'true' || needs.prepare-source.outputs.unit-test-workflow-changed == 'true'
     timeout-minutes: 150
     env:
       COMPOSE_TIMEOUT: "300"

--- a/deploy/docker/industry-profiles/warehouse-operations/overrides.env
+++ b/deploy/docker/industry-profiles/warehouse-operations/overrides.env
@@ -297,7 +297,8 @@ COMPOSE_PROFILES_PLAYBACK_REDIS_MV3DT=redis,broker-health-check,vss-behavior-ana
 
 # Active profile. Set this to one of the accepted warehouse or playback variants:
 # - COMPOSE_PROFILES_WH_2D for MODE=2d with BP_PROFILE=bp_wh.
-# - COMPOSE_PROFILES_WH_{KAFKA,REDIS,AUTO_CALIB}_{2D,3D,MV3DT} for matching BP_PROFILE/MODE pairs.
+# - COMPOSE_PROFILES_WH_{KAFKA,REDIS}_{2D,3D,MV3DT} for matching BP_PROFILE/MODE pairs.
 # - COMPOSE_PROFILES_WH_{KAFKA,REDIS}_{2D,3D,MV3DT}_MINIMAL for minimal Kafka/Redis deployments.
 # - COMPOSE_PROFILES_PLAYBACK_{KAFKA,REDIS}_{2D,3D,MV3DT} for playback-only deployments.
+# - COMPOSE_PROFILES_WH_AUTO_CALIB for auto-calibration deployments.
 COMPOSE_PROFILES=${COMPOSE_PROFILES_WH_2D}

--- a/services/analytics/video-analytics-api/test/integration-test/elasticsearch_data_dump/mdx-vlm-incidents.json
+++ b/services/analytics/video-analytics-api/test/integration-test/elasticsearch_data_dump/mdx-vlm-incidents.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea3f87119e979fd8fa13fc83c9ae6a65b33aa6021956782c881289ee6717cf18
+size 996

--- a/services/analytics/video-analytics-api/test/integration-test/elasticsearch_data_dump/mdx-vlm-incidents.json
+++ b/services/analytics/video-analytics-api/test/integration-test/elasticsearch_data_dump/mdx-vlm-incidents.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ea3f87119e979fd8fa13fc83c9ae6a65b33aa6021956782c881289ee6717cf18
-size 996
+oid sha256:bcbeea1dfc93651d3a40ccb613a80cd04542ea25b4f32d460cd82702eaba65d4
+size 1333

--- a/services/analytics/video-analytics-api/test/integration-test/elasticsearch_data_dump/mdx-vlm-incidents.json
+++ b/services/analytics/video-analytics-api/test/integration-test/elasticsearch_data_dump/mdx-vlm-incidents.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bcbeea1dfc93651d3a40ccb613a80cd04542ea25b4f32d460cd82702eaba65d4
-size 1333
+oid sha256:7f4c6bb180348185d71fd8423037340abfe453dd1c059b2cc85a4592abe6afe4
+size 3294

--- a/services/analytics/video-analytics-api/test/integration-test/elasticsearch_data_dump/mdx-vlm-incidents.json
+++ b/services/analytics/video-analytics-api/test/integration-test/elasticsearch_data_dump/mdx-vlm-incidents.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7f4c6bb180348185d71fd8423037340abfe453dd1c059b2cc85a4592abe6afe4
-size 3294
+oid sha256:01ab6b0f620cfb90f1ed668012b6de21e056c82445cf6e3716269dc538dc6d2d
+size 2997

--- a/services/analytics/video-analytics-api/test/integration-test/scripts/controllers/rest-apis/incidents.js
+++ b/services/analytics/video-analytics-api/test/integration-test/scripts/controllers/rest-apis/incidents.js
@@ -28,6 +28,7 @@ function getTests(c) {
     const F = c.FROM_TS;
     const T = c.TO_TS;
     const expectedVlmAlertTypes = new Set([
+        'Load Quality Violation',
         'Near Miss Violation',
         'Pathway Obstruction Violation',
         'PPE Violation'
@@ -47,7 +48,7 @@ function getTests(c) {
                 if (!Array.isArray(incidents)) return 'missing incidents array';
                 const alertTypes = new Set(incidents.map(({ info }) => info && info.alertCategory));
                 if (alertTypes.has(undefined)) return 'missing info.alertCategory';
-                if (alertTypes.size !== 3) return `expected 3 unique alert types, got ${alertTypes.size}`;
+                if (alertTypes.size !== 4) return `expected 4 unique alert types, got ${alertTypes.size}`;
                 const unexpectedAlertTypes = [...alertTypes].filter((alertType) => !expectedVlmAlertTypes.has(alertType));
                 if (unexpectedAlertTypes.length > 0) return `unexpected alert types: ${unexpectedAlertTypes.join(', ')}`;
                 const missingAlertTypes = [...expectedVlmAlertTypes].filter((alertType) => !alertTypes.has(alertType));

--- a/services/analytics/video-analytics-api/test/integration-test/scripts/controllers/rest-apis/incidents.js
+++ b/services/analytics/video-analytics-api/test/integration-test/scripts/controllers/rest-apis/incidents.js
@@ -46,8 +46,7 @@ function getTests(c) {
             validate: (b) => {
                 const { incidents } = JSON.parse(b);
                 if (!Array.isArray(incidents)) return 'missing incidents array';
-                const alertTypes = new Set(incidents.map(({ info }) => info && info.alertCategory));
-                if (alertTypes.has(undefined)) return 'missing info.alertCategory';
+                const alertTypes = new Set(incidents.map(({ category, info }) => (info && info.alertCategory) || category));
                 if (alertTypes.size !== 4) return `expected 4 unique alert types, got ${alertTypes.size}`;
                 const unexpectedAlertTypes = [...alertTypes].filter((alertType) => !expectedVlmAlertTypes.has(alertType));
                 if (unexpectedAlertTypes.length > 0) return `unexpected alert types: ${unexpectedAlertTypes.join(', ')}`;

--- a/services/analytics/video-analytics-api/test/integration-test/scripts/controllers/rest-apis/incidents.js
+++ b/services/analytics/video-analytics-api/test/integration-test/scripts/controllers/rest-apis/incidents.js
@@ -40,7 +40,7 @@ function getTests(c) {
         { name: 'GET /incidents (no sensorId/place) returns 200', path: `/incidents?${qs({ fromTimestamp: F, toTimestamp: T })}`, method: 'GET', expectedStatus: 200, validate: (b) => (Array.isArray(JSON.parse(b).incidents) ? null : 'missing incidents array') },
         {
             name: 'GET /incidents (VLM verified alert types)',
-            path: `/incidents?${qs({ vlmVerified: true, maxResultSize: 10000 })}`,
+            path: `/incidents?${qs({ place: P, fromTimestamp: F, toTimestamp: T, vlmVerified: true, maxResultSize: 10000 })}`,
             method: 'GET',
             expectedStatus: 200,
             validate: (b) => {

--- a/services/analytics/video-analytics-api/test/integration-test/scripts/controllers/rest-apis/incidents.js
+++ b/services/analytics/video-analytics-api/test/integration-test/scripts/controllers/rest-apis/incidents.js
@@ -27,11 +27,33 @@ function getTests(c) {
     const P = c.PLACE;
     const F = c.FROM_TS;
     const T = c.TO_TS;
+    const expectedVlmAlertTypes = new Set([
+        'Near Miss Violation',
+        'Pathway Obstruction Violation',
+        'PPE Violation'
+    ]);
 
     return [
         { name: 'GET /incidents (sensorId+timestamps)', path: `/incidents?${qs({ sensorId: S, fromTimestamp: F, toTimestamp: T })}`, method: 'GET', expectedStatus: 200, validate: (b) => (Array.isArray(JSON.parse(b).incidents) ? null : 'missing incidents array') },
         { name: 'GET /incidents (place only)', path: `/incidents?${qs({ place: P })}`, method: 'GET', expectedStatus: 200 },
         { name: 'GET /incidents (no sensorId/place) returns 200', path: `/incidents?${qs({ fromTimestamp: F, toTimestamp: T })}`, method: 'GET', expectedStatus: 200, validate: (b) => (Array.isArray(JSON.parse(b).incidents) ? null : 'missing incidents array') },
+        {
+            name: 'GET /incidents (VLM verified alert types)',
+            path: `/incidents?${qs({ vlmVerified: true, maxResultSize: 10000 })}`,
+            method: 'GET',
+            expectedStatus: 200,
+            validate: (b) => {
+                const { incidents } = JSON.parse(b);
+                if (!Array.isArray(incidents)) return 'missing incidents array';
+                const alertTypes = new Set(incidents.map(({ info }) => info && info.alertCategory));
+                if (alertTypes.has(undefined)) return 'missing info.alertCategory';
+                if (alertTypes.size !== 3) return `expected 3 unique alert types, got ${alertTypes.size}`;
+                const unexpectedAlertTypes = [...alertTypes].filter((alertType) => !expectedVlmAlertTypes.has(alertType));
+                if (unexpectedAlertTypes.length > 0) return `unexpected alert types: ${unexpectedAlertTypes.join(', ')}`;
+                const missingAlertTypes = [...expectedVlmAlertTypes].filter((alertType) => !alertTypes.has(alertType));
+                return missingAlertTypes.length === 0 ? null : `missing alert types: ${missingAlertTypes.join(', ')}`;
+            },
+        },
         { name: 'GET /incidents/severe (sensorId+timestamps)', path: `/incidents/severe?${qs({ sensorId: S, fromTimestamp: F, toTimestamp: T })}`, method: 'GET', expectedStatus: 200, skipOpenApiValidation: true },
         { name: 'GET /incidents/severe (no sensorId/place) -> 400', path: '/incidents/severe', method: 'GET', expectedStatus: 400 },
     ];

--- a/services/analytics/video-analytics-api/test/unit-test/web-api-core/Services/Incidents.test.js
+++ b/services/analytics/video-analytics-api/test/unit-test/web-api-core/Services/Incidents.test.js
@@ -169,6 +169,7 @@ describe('Incident', () => {
                     hits: {
                         hits: [
                             { _source: { info: { alertCategory: 'Near Miss Violation' } } },
+                            { _source: { info: { alertCategory: 'Load Quality Violation' } } },
                             { _source: { info: { alertCategory: 'Pathway Obstruction Violation' } } },
                             { _source: { info: { alertCategory: 'PPE Violation' } } },
                             { _source: { info: { alertCategory: 'PPE Violation' } } }
@@ -181,12 +182,13 @@ describe('Incident', () => {
 
             const alertTypes = new Set(result.incidents.map(({ info }) => info.alertCategory));
             const expectedAlertTypes = new Set([
+                'Load Quality Violation',
                 'Near Miss Violation',
                 'Pathway Obstruction Violation',
                 'PPE Violation'
             ]);
 
-            expect(alertTypes.size).to.equal(3);
+            expect(alertTypes.size).to.equal(4);
             expect([...alertTypes].filter((alertType) => !expectedAlertTypes.has(alertType))).to.be.empty;
             expect([...expectedAlertTypes].filter((alertType) => !alertTypes.has(alertType))).to.be.empty;
             expect(searchStub.firstCall.args[1].index).to.equal('mdx-vlm-incidents-*');

--- a/services/analytics/video-analytics-api/test/unit-test/web-api-core/Services/Incidents.test.js
+++ b/services/analytics/video-analytics-api/test/unit-test/web-api-core/Services/Incidents.test.js
@@ -158,25 +158,38 @@ describe('Incident', () => {
 
         it('should return VLM verified incidents', async () => {
             const input = {
-                sensorId: 'sensor123',
                 vlmVerified: true,
-                vlmVerdict: 'confirmed',
-                fromTimestamp: '2023-01-12T11:20:10.000Z',
-                toTimestamp: '2023-01-12T14:20:10.000Z'
+                vlmVerdict: 'all',
+                maxResultSize: 10000
             };
 
             searchStub.resolves({
                 indexAbsent: false,
                 body: {
                     hits: {
-                        hits: []
+                        hits: [
+                            { _source: { info: { alertCategory: 'Near Miss Violation' } } },
+                            { _source: { info: { alertCategory: 'Pathway Obstruction Violation' } } },
+                            { _source: { info: { alertCategory: 'PPE Violation' } } },
+                            { _source: { info: { alertCategory: 'PPE Violation' } } }
+                        ]
                     }
                 }
             });
 
             const result = await incident.getIncidents(elasticDb, input);
 
-            expect(result).to.have.property('incidents');
+            const alertTypes = new Set(result.incidents.map(({ info }) => info.alertCategory));
+            const expectedAlertTypes = new Set([
+                'Near Miss Violation',
+                'Pathway Obstruction Violation',
+                'PPE Violation'
+            ]);
+
+            expect(alertTypes.size).to.equal(3);
+            expect([...alertTypes].filter((alertType) => !expectedAlertTypes.has(alertType))).to.be.empty;
+            expect([...expectedAlertTypes].filter((alertType) => !alertTypes.has(alertType))).to.be.empty;
+            expect(searchStub.firstCall.args[1].index).to.equal('mdx-vlm-incidents-*');
         });
 
         it('should return VLM incidents with not-confirmed verdict', async () => {

--- a/services/analytics/video-analytics-api/test/unit-test/web-api-core/Services/Incidents.test.js
+++ b/services/analytics/video-analytics-api/test/unit-test/web-api-core/Services/Incidents.test.js
@@ -168,7 +168,7 @@ describe('Incident', () => {
                 body: {
                     hits: {
                         hits: [
-                            { _source: { info: { alertCategory: 'Near Miss Violation' } } },
+                            { _source: { category: 'Near Miss Violation', info: {} } },
                             { _source: { info: { alertCategory: 'Load Quality Violation' } } },
                             { _source: { info: { alertCategory: 'Pathway Obstruction Violation' } } },
                             { _source: { info: { alertCategory: 'PPE Violation' } } },
@@ -180,7 +180,7 @@ describe('Incident', () => {
 
             const result = await incident.getIncidents(elasticDb, input);
 
-            const alertTypes = new Set(result.incidents.map(({ info }) => info.alertCategory));
+            const alertTypes = new Set(result.incidents.map(({ category, info }) => info.alertCategory || category));
             const expectedAlertTypes = new Set([
                 'Load Quality Violation',
                 'Near Miss Violation',


### PR DESCRIPTION
- Introduced a new JSON data dump for VLM incidents to support testing.
- Enhanced the integration tests for the `/incidents` endpoint to validate VLM verified alert types, ensuring the response contains the expected unique alert categories.
- Updated unit tests to verify the correct handling of VLM verified incidents, including checks for expected alert types and their uniqueness.

These changes improve the robustness of incident verification in the video analytics API.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
