### PR TITLE
fix(rt-vlm): select the SBSA V4L2 decoder shim

### DIFF
--- a/services/rtvi/rt-vlm/docker/Dockerfile
+++ b/services/rtvi/rt-vlm/docker/Dockerfile
@@ -155,12 +155,19 @@ RUN rm -rf /usr/lib/*-linux-gnu/gstreamer-1.0/libgstaudioparsers.so \
 
 # The SBSA DeepStream image supplies its native hardware decoder as a system
 # GStreamer plugin rather than under /opt. Preserve it after the shared media
-# cleanup so H.264 decoding does not depend on the proprietary codec overlay.
+# cleanup and select its V4L2 shim so H.264 decoding does not depend on the
+# proprietary codec overlay.
 RUN --mount=from=sbsa-media-runtime,source=/,target=/tmp/sbsa-root,readonly \
     if [ "$TARGETARCH" = "arm64" ] && [ "$ARM_PLATFORM" = "sbsa" ]; then \
         source_plugin=/tmp/sbsa-root/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstnvvideo4linux2.so; \
+        source_v4l2_shim=/tmp/sbsa-root/usr/lib/aarch64-linux-gnu/tegra/libnvv4l2.so; \
+        source_v4l_plugins=/tmp/sbsa-root/usr/lib/aarch64-linux-gnu/libv4l/plugins/nv; \
         test -s "$source_plugin"; \
+        test -s "$source_v4l2_shim"; \
+        test -d "$source_v4l_plugins"; \
         install -Dm755 "$source_plugin" /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstnvvideo4linux2.so; \
+        mkdir -p /usr/lib/aarch64-linux-gnu/libv4l/plugins; \
+        cp -a "$source_v4l_plugins" /usr/lib/aarch64-linux-gnu/libv4l/plugins/nv; \
     fi
 # Mount Triton's CUDA targets instead of copying the whole tree into an image
 # layer. Only NPP and NVJPEG are needed at runtime; a COPY followed by rm would
@@ -375,6 +382,16 @@ RUN cd /usr && find . \( -name 'libavcodec*' -o -name 'libavfilter*' -o -name 'l
     && find /opt/tritonserver/backends/dali \( -name 'libavcodec*' -o -name 'libavformat*' \
         -o -name 'libavfilter*' -o -name 'libavutil*' -o -name 'libavdevice*' \
         -o -name 'libswresample*' -o -name 'libswscale*' \) -type f -delete 2>/dev/null || true
+
+# A runtime dependency can restore the generic libv4l2 dispatch link. Select
+# DeepStream's SBSA shim after all package installation and media cleanup.
+RUN if [ "$TARGETARCH" = "arm64" ] && [ "$ARM_PLATFORM" = "sbsa" ]; then \
+        test -s /usr/lib/aarch64-linux-gnu/tegra/libnvv4l2.so; \
+        ln -sfn /usr/lib/aarch64-linux-gnu/tegra/libnvv4l2.so /usr/lib/aarch64-linux-gnu/libv4l2.so.0.0.999999; \
+        ln -sfn libv4l2.so.0.0.999999 /usr/lib/aarch64-linux-gnu/libv4l2.so.0; \
+        ln -sfn libv4l2.so.0 /usr/lib/aarch64-linux-gnu/libv4l2.so; \
+    fi
+
 # Create user with UID/GID 1001 for non-root execution and set permissions.
 # install_codecs_nonroot.sh runs apt-get update at startup using user-owned state dirs,
 # so build-time apt lists are not needed and are cleaned up to keep the image smaller.

--- a/services/rtvi/rt-vlm/tests/test_sbsa_decoder_bridge.py
+++ b/services/rtvi/rt-vlm/tests/test_sbsa_decoder_bridge.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+
+def test_sbsa_uses_the_deepstream_v4l2_shim():
+    dockerfile = (Path(__file__).parents[1] / "docker" / "Dockerfile").read_text()
+
+    assert "source_v4l2_shim=/tmp/sbsa-root/usr/lib/aarch64-linux-gnu/tegra/libnvv4l2.so" in dockerfile
+    assert "source_v4l_plugins=/tmp/sbsa-root/usr/lib/aarch64-linux-gnu/libv4l/plugins/nv" in dockerfile
+    assert 'cp -a "$source_v4l_plugins" /usr/lib/aarch64-linux-gnu/libv4l/plugins/nv' in dockerfile
+    shim_link = "ln -sfn /usr/lib/aarch64-linux-gnu/tegra/libnvv4l2.so /usr/lib/aarch64-linux-gnu/libv4l2.so.0.0.999999"
+    dispatch_link = "ln -sfn libv4l2.so.0.0.999999 /usr/lib/aarch64-linux-gnu/libv4l2.so.0"
+    unversioned_link = "ln -sfn libv4l2.so.0 /usr/lib/aarch64-linux-gnu/libv4l2.so"
+    assert shim_link in dockerfile
+    assert dispatch_link in dockerfile
+    assert unversioned_link in dockerfile
+    assert dockerfile.rindex(dispatch_link) > dockerfile.index("RUN cd /usr && find .")
+    assert "/usr/lib/*-linux-gnu/gstreamer-1.0/libgstnvcodec.so" in dockerfile
+    assert "/usr/lib/*-linux-gnu/libavcodec*" in dockerfile


### PR DESCRIPTION
## Summary
- Restore the DeepStream SBSA V4L2 plugin bridge used by libnvv4l2.so.
- Preserve the SBSA system decoder shim after cleanup; do not restore libgstnvcodec or software codecs.

## Validation
- Static SBSA decoder-bridge regression check passes.
- Spark SBSA image sha256:0dd6b466a3e1d441429460e0137f65cba0c616f553c88b414703fa3d0078ebe2: Compose-equivalent UID 1001 H.264 nvv4l2decoder sample reached EOS.
- Verified no libgstnvcodec.so or libavcodec* in the image.