### PR TITLE
fix(ci): make the detect-secrets scan actually scan tracked files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,7 @@ jobs:
     name: Security Scan (detect-secrets)
     needs: prepare-source
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 40
     defaults:
       run:
         working-directory: services/agent
@@ -277,10 +277,25 @@ jobs:
 
       - name: detect-secrets
         run: |
+          mapfile -t TRACKED_FILES < "$GITHUB_WORKSPACE/.ci/tracked-files.txt"
+
+          if [ "${#TRACKED_FILES[@]}" -eq 0 ]; then
+            echo "tracked-files.txt is empty; refusing to run an empty security scan."
+            exit 1
+          fi
+
+          for file in "${TRACKED_FILES[@]}"; do
+            if [ ! -f "$GITHUB_WORKSPACE/$file" ]; then
+              echo "Tracked file does not resolve from repository root: $file"
+              exit 1
+            fi
+          done
+
+          cd "$GITHUB_WORKSPACE"
           detect-secrets-hook --no-verify \
             --exclude-files '(gitleaks-baseline\.json|^deploy/docker/MANIFEST$)' \
             --exclude-files '(\.secrets\.baseline|gitleaks-baseline\.json|^deployments/MANIFEST$)' \
-            $(cat "$GITHUB_WORKSPACE/.ci/tracked-files.txt")
+            "${TRACKED_FILES[@]}"
 
   # ---------------------------------------------------------------------------
   # Job 5: Frontend lint + typecheck


### PR DESCRIPTION
## Summary

`Security Scan (detect-secrets)` has been passing without scanning anything.

The job runs with `working-directory: services/agent`, but the file list it is handed comes from `.ci/tracked-files.txt`, generated by `git ls-files` at the repo root in `prepare-source`. Every path therefore resolved to `services/agent/services/agent/...` and did not exist. `detect-secrets-hook` skips missing paths silently, so the step exited 0 having read nothing.

## Plan

This implements the patch @nv-support posted on #1897. The approach and the code are theirs; I verified it and carried it into a PR. Happy to close this if you would rather land it yourself.

Beyond running from the repo root, it fails loudly when the manifest is empty or when any listed path does not resolve, so the job cannot quietly regress to scanning nothing again, and it quotes the expansion so paths containing spaces survive. `timeout-minutes` goes to 40 because the previous 10 was measured against a job that never scanned the tree.

## Related Issue

Closes #1897

## Changes

`.github/workflows/ci.yml`, 17 insertions, 2 deletions, confined to the `security` job.

**Evidence.** Ran the new step body as a shell function against the pinned `detect-secrets==1.5.0`, with a planted AWS key and a manifest in the shape `git ls-files` produces:

| case | exit | result |
| --- | --- | --- |
| current shape: cwd `services/agent`, root-relative paths | 0 | 0 bytes stdout, 0 bytes stderr. Silent. |
| empty manifest | 1 | `tracked-files.txt is empty; refusing to run an empty security scan.` |
| path that does not resolve | 1 | `Tracked file does not resolve from repository root: <path>` |
| valid paths, planted secret | 1 | flags it as AWS Access Key |
| valid paths, no secret | 0 | silent, correctly |
| filename containing a space | 0 | resolves as one path rather than word-splitting |

`actionlint` reports one finding on this file, the pre-existing unknown `downstream-pipeline` self-hosted label. It is present identically on the parent commit at line 729 and appears at 744 here, matching the 15 inserted lines. No new findings.

**Expect a red run before a green one.** This scan has never executed for real, so the first failure is likely to come from pre-existing content rather than from this change. A subset run over `services/agent` flagged two hits in `services/agent/tests/unit_test/knowledge_retrieval/test_langchain_adapter.py` (lines 132 and 144) that I did not plant and have not triaged. They look like test fixtures. A `.secrets.baseline` refresh may be wanted alongside this.

**Could not verify.** I did not run the scan against the full tracked-file list: my machine's argument-length limit stops it well short of the ~25k entries. Linux runners have a far higher `ARG_MAX`, but since the command still passes every path as an argument, that limit is worth a thought at this repo's scale. I have not triaged the two pre-existing findings above.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.
