### PR TITLE
fix(rt-embed): reuse camera IDs as stream IDs

### DIFF
--- a/services/rtvi/rt-embed/src/api_models/live_stream.py
+++ b/services/rtvi/rt-embed/src/api_models/live_stream.py
@@ -189,7 +189,7 @@ class AddLiveStreamsResponse(CommonBaseModel):
 class DeleteLiveStreamsRequest(CommonBaseModel):
     """Request schema for batch delete live streams API."""
 
-    stream_ids: list[UUID] = Field(
+    stream_ids: list[str] = Field(
         description="List of stream identifiers to delete",
         min_length=1,
         max_length=256,
@@ -219,7 +219,7 @@ class DeleteLiveStreamsRequest(CommonBaseModel):
 class DeleteLiveStreamsResponse(CommonBaseModel):
     """Response schema for the batch delete live streams API."""
 
-    deleted: list[UUID] = Field(
+    deleted: list[str] = Field(
         description="List of successfully deleted stream identifiers",
         min_length=0,
         max_length=256,

--- a/services/rtvi/rt-embed/src/server/rtvi_embed_server.py
+++ b/services/rtvi/rt-embed/src/server/rtvi_embed_server.py
@@ -530,6 +530,7 @@ class RTVIServer:
                 purpose="vision",
                 media_type="video",
                 creation_time=value.creation_time,
+                file_id=value.camera_id,
                 sensor_name=value.camera_id,
                 camera_id=value.camera_id,
             )
@@ -545,7 +546,7 @@ class RTVIServer:
                 purpose="vision",
                 media_type="video",
                 creation_time=value.creation_time,
-                file_id=None,
+                file_id=value.camera_id,
                 url_headers=url_headers,
                 sensor_name=value.camera_id,
                 camera_id=value.camera_id,
@@ -1277,10 +1278,9 @@ class RTVIServer:
         )
         async def delete_live_stream(
             stream_id: Annotated[
-                UUID, Path(description="Unique identifier for the live stream to be deleted.")
+                str, Path(description="Unique identifier for the live stream to be deleted.")
             ],
         ):
-            stream_id = str(stream_id)
             logger.info("Received delete live stream request for %s", stream_id)
 
             try:
@@ -1476,12 +1476,14 @@ class RTVIServer:
                     video_id,
                 )
             else:
-                # Add stream via existing asset manager with camera_id tracking
+                # Reuse camera_id as the internal stream/asset id so downstream
+                # correlation stays consistent with the caller-supplied id.
                 video_id = self._asset_manager.add_live_stream(
                     url=value.camera_url,
                     description=value.camera_name or value.camera_id,
                     camera_id=value.camera_id,
                     sensor_name=value.camera_id,
+                    stream_id=value.camera_id,
                 )
 
                 logger.info(
@@ -2318,14 +2320,13 @@ class RTVIServer:
         )
         async def stop_live_stream(
             stream_id: Annotated[
-                UUID,
+                str,
                 Path(
                     description="Unique identifier for the live stream for"
                     " which video embeddings generation is to be stopped."
                 ),
             ],
         ):
-            stream_id = str(stream_id)
             logger.info(
                 "Received stop live stream video embeddings generation request for %s", stream_id
             )

--- a/services/rtvi/rt-embed/tests/rtvi_embed/test_rtvi_embed_integration.py
+++ b/services/rtvi/rt-embed/tests/rtvi_embed/test_rtvi_embed_integration.py
@@ -406,6 +406,8 @@ class TestCvStreamApiIntegration:
         add_data = resp.json()
         assert add_data["camera_id"] == camera_id
         assert "asset_id" in add_data
+        # asset_id is reused from camera_id, not a server-generated UUID.
+        assert add_data["asset_id"] == camera_id
         assert add_data["status"] in ("added", "processing")
         assert isinstance(add_data["inference"], bool)
         asset_id = add_data["asset_id"]

--- a/services/rtvi/rt-embed/tests/rtvi_embed/test_rtvi_embed_server.py
+++ b/services/rtvi/rt-embed/tests/rtvi_embed/test_rtvi_embed_server.py
@@ -557,7 +557,7 @@ class TestLiveStreamEndpoints:
 
     def test_delete_live_streams_batch(self, test_client):
         """Test batch deleting live streams"""
-        fake_ids = [str(uuid.uuid4()), str(uuid.uuid4())]
+        fake_ids = [str(uuid.uuid4()), "my-camera-batch-123"]
         response = test_client.request(
             "DELETE", f"{API_PREFIX}/streams/delete-batch", json={"stream_ids": fake_ids}
         )

--- a/services/rtvi/rt-embed/tests/rtvi_embed/test_rtvi_embed_server.py
+++ b/services/rtvi/rt-embed/tests/rtvi_embed/test_rtvi_embed_server.py
@@ -550,6 +550,11 @@ class TestLiveStreamEndpoints:
         response = test_client.delete(f"{API_PREFIX}/streams/delete/{fake_id}")
         assert response.status_code == 400
 
+    def test_delete_live_stream_accepts_non_uuid_stream_id(self, test_client):
+        """Delete-by-id accepts camera-id-derived stream IDs, not only UUIDs."""
+        response = test_client.delete(f"{API_PREFIX}/streams/delete/my-camera-123")
+        assert response.status_code == 400
+
     def test_delete_live_streams_batch(self, test_client):
         """Test batch deleting live streams"""
         fake_ids = [str(uuid.uuid4()), str(uuid.uuid4())]
@@ -639,6 +644,11 @@ class TestVideoEmbeddingsGeneration:
         response = test_client.delete(f"{API_PREFIX}/generate_video_embeddings/{fake_id}")
         assert response.status_code == 400
 
+    def test_stop_live_stream_embeddings_accepts_non_uuid_stream_id(self, test_client):
+        """Stop-by-id accepts camera-id-derived stream IDs, not only UUIDs."""
+        response = test_client.delete(f"{API_PREFIX}/generate_video_embeddings/my-camera-123")
+        assert response.status_code == 400
+
 
 class TestStreamingConstraints:
     """Test streaming implementation constraints"""
@@ -714,7 +724,7 @@ class TestCVStreamEndpoints:
         assert response.status_code == 200
         data = response.json()
         assert data["camera_id"] == camera_id
-        assert data["asset_id"]
+        assert data["asset_id"] == camera_id
         asset = rtvi_server._asset_manager.get_asset(data["asset_id"])
         assert asset.path == str(file_path)
         assert asset.is_live is False
@@ -743,7 +753,6 @@ class TestCVStreamEndpoints:
     def test_stream_add_downloads_vios_https_file_sensor(self, mock_args):
         """VIOS HTTPS camera URL is downloaded as a file asset with request headers."""
         camera_id = f"vios-http-file-{uuid.uuid4()}"
-        asset_id = str(uuid.uuid4())
         url_headers = {"Authorization": "Bearer test-token"}
         remote_url = (
             "https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/360/"
@@ -758,7 +767,7 @@ class TestCVStreamEndpoints:
 
                 rtvi_server = RTVIServer(mock_args)
                 test_client = TestClient(rtvi_server._app)
-                download_file = AsyncMock(return_value=asset_id)
+                download_file = AsyncMock(return_value=camera_id)
                 add_live_stream = MagicMock()
                 rtvi_server._asset_manager.download_file = download_file
                 rtvi_server._asset_manager.add_live_stream = add_live_stream
@@ -785,7 +794,7 @@ class TestCVStreamEndpoints:
                         rtvi_server._stream_handler.stop()
 
         assert response.status_code == 200
-        assert response.json()["asset_id"] == asset_id
+        assert response.json()["asset_id"] == camera_id
         add_live_stream.assert_not_called()
         download_file.assert_awaited_once_with(
             url=remote_url,
@@ -793,10 +802,55 @@ class TestCVStreamEndpoints:
             purpose="vision",
             media_type="video",
             creation_time="2026-07-09T14:58:40.000Z",
-            file_id=None,
+            file_id=camera_id,
             url_headers=url_headers,
             sensor_name=camera_id,
             camera_id=camera_id,
+        )
+
+    def test_stream_add_rtsp_uses_camera_id_as_stream_id(self, mock_args):
+        """CV-compatible /v1/stream/add reuses camera_id as the internal stream/asset id."""
+        camera_id = f"cam-{uuid.uuid4()}"
+        rtsp_url = "rtsp://127.0.0.1:8554/live/video"
+
+        with TempEnv({"SKIP_PIPELINE_WARMUP": "1", "MESSAGE_BUS": ""}):
+            with patch("server.rtvi_stream_handler.VlmPipeline") as mock_vlm_pipeline_class:
+                mock_pipeline = MagicMock()
+                mock_pipeline.get_health_status.return_value = []
+                mock_vlm_pipeline_class.return_value = mock_pipeline
+
+                rtvi_server = RTVIServer(mock_args)
+                test_client = TestClient(rtvi_server._app)
+                add_live_stream = MagicMock(return_value=camera_id)
+                rtvi_server._asset_manager.add_live_stream = add_live_stream
+
+                try:
+                    response = test_client.post(
+                        f"{API_PREFIX}/stream/add",
+                        json={
+                            "key": "sensor",
+                            "value": {
+                                "camera_id": camera_id,
+                                "camera_name": "front_door",
+                                "camera_url": rtsp_url,
+                                "change": "camera_add",
+                            },
+                        },
+                    )
+                finally:
+                    if hasattr(rtvi_server, "_stream_handler") and rtvi_server._stream_handler:
+                        rtvi_server._stream_handler.stop()
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["camera_id"] == camera_id
+        assert data["asset_id"] == camera_id
+        add_live_stream.assert_called_once_with(
+            url=rtsp_url,
+            description="front_door",
+            camera_id=camera_id,
+            sensor_name=camera_id,
+            stream_id=camera_id,
         )
 
     def test_stream_remove_accepts_vios_registration_without_asset(self, mock_args):

--- a/services/rtvi/rt-embed/tests/rtvi_embed/test_stream_cv_api.py
+++ b/services/rtvi/rt-embed/tests/rtvi_embed/test_stream_cv_api.py
@@ -36,6 +36,8 @@ StreamMetadata = live_stream.StreamMetadata
 MAX_GENERATION_TOKENS = live_stream.MAX_GENERATION_TOKENS
 StreamAddRequest = live_stream.StreamAddRequest
 StreamAddResponse = live_stream.StreamAddResponse
+DeleteLiveStreamsRequest = live_stream.DeleteLiveStreamsRequest
+DeleteLiveStreamsResponse = live_stream.DeleteLiveStreamsResponse
 StreamRemoveValue = live_stream.StreamRemoveValue
 StreamRemoveRequest = live_stream.StreamRemoveRequest
 StreamRemoveResponse = live_stream.StreamRemoveResponse
@@ -397,6 +399,23 @@ class TestStreamRemoveRequest:
             headers={"source": "vios", "created_at": "2025-01-01T00:00:00Z"},
         )
         assert req.headers.source == "vios"
+
+
+# =============================================================================
+# DeleteLiveStreamsRequest / DeleteLiveStreamsResponse
+# =============================================================================
+
+
+class TestDeleteLiveStreamsRequest:
+    """Test batch delete stream model construction."""
+
+    def test_accepts_camera_id_stream_ids(self):
+        req = DeleteLiveStreamsRequest(stream_ids=["my-camera-123"])
+        assert req.stream_ids == ["my-camera-123"]
+
+    def test_response_accepts_camera_id_stream_ids(self):
+        resp = DeleteLiveStreamsResponse(deleted=["my-camera-123"])
+        assert resp.deleted == ["my-camera-123"]
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Align `services/rtvi/rt-embed` with RTVI Embed MR !621 behavior by reusing `camera_id` as the internal stream/asset id for CV and VIOS stream-add requests.
- Relax live-stream delete/stop path parameters to accept non-UUID camera-id-derived stream IDs.
- Add focused tests for RTSP, VIOS file-sensor, VIOS HTTP file-sensor, and non-UUID delete/stop endpoints.

## Test plan
- `git diff --check`
- `python3 -m py_compile services/rtvi/rt-embed/src/server/rtvi_embed_server.py services/rtvi/rt-embed/tests/rtvi_embed/test_rtvi_embed_server.py`
- RTX Pro container validation with `nvcr.io/nvstaging/vss-core/vss-rt-embed:3.3.0-26.08.1`:
  - `test_stream_add_rtsp_uses_camera_id_as_stream_id`
  - `test_stream_add_accepts_vios_camera_streaming_file_sensor`
  - `test_stream_add_downloads_vios_https_file_sensor`
  - `test_delete_live_stream_accepts_non_uuid_stream_id`
  - `test_stop_live_stream_embeddings_accepts_non_uuid_stream_id`