### PR TITLE
fix(CI): Fix python licenses CI check

### DIFF
--- a/.github/scripts/check_python_licenses.sh
+++ b/.github/scripts/check_python_licenses.sh
@@ -38,7 +38,7 @@ trap 'rm -rf "$uv_env"' EXIT
 export UV_PROJECT_ENVIRONMENT="$uv_env"
 
 uv sync --frozen --no-default-groups --extra agent --quiet
-uv pip install --python "$UV_PROJECT_ENVIRONMENT/bin/python" --quiet pip-licenses
+uv pip install --python "$UV_PROJECT_ENVIRONMENT/bin/python" --quiet "pip-licenses==5.5.5"
 
 # Both halves of the pipe run inside the agent's uv venv: pip-licenses needs
 # the venv to enumerate installed packages, and check_python_licenses.py needs


### PR DESCRIPTION
## Summary
CI check for python licenses failing in https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/1874 
Issue seems to be due to pip-licenses not being pinned and the latest 6.0.0 doesn't have the piplicenses module

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
