### PR TITLE
fix(ci): pin pip-licenses to 5.5.5 in the Python licence check

### DIFF
--- a/.github/scripts/check_python_licenses.sh
+++ b/.github/scripts/check_python_licenses.sh
@@ -38,7 +38,12 @@ trap 'rm -rf "$uv_env"' EXIT
 export UV_PROJECT_ENVIRONMENT="$uv_env"
 
 uv sync --frozen --no-default-groups --extra agent --quiet
-uv pip install --python "$UV_PROJECT_ENVIRONMENT/bin/python" --quiet pip-licenses
+# Pin pip-licenses: an unpinned install resolved to a 6.0.0 pre-release whose
+# console script does `from piplicenses.__main__ import main`, and that module
+# is absent -> ModuleNotFoundError, then "pip-licenses CSV had no header". 5.5.5
+# is the latest stable (6.x is pre-release only) and a compliance check wants a
+# deterministic tool version anyway.
+uv pip install --python "$UV_PROJECT_ENVIRONMENT/bin/python" --quiet "pip-licenses==5.5.5"
 
 # Both halves of the pipe run inside the agent's uv venv: pip-licenses needs
 # the venv to enumerate installed packages, and check_python_licenses.py needs


### PR DESCRIPTION
## Summary

`License Check (Python)` fails on `develop`:

```
File ".../bin/pip-licenses", line 6, in <module>
    from piplicenses.__main__ import main
ModuleNotFoundError: No module named 'piplicenses'
ERROR: pip-licenses CSV had no header.
```

The install in `check_python_licenses.sh` was unpinned (`uv pip install pip-licenses`) and
resolved to a **6.0.0 pre-release** whose console script imports `piplicenses.__main__` — a
module that isn't present — so the tool exits before printing any CSV and the check then reads
an empty header.

## Fix

Pin to `pip-licenses==5.5.5`. It's the latest **stable** release (6.x is pre-release only,
there is no 6.0.0 final on PyPI), uses the single-module layout the console entry point
expects, and a licence-audit check wants a deterministic tool version regardless.

One line. No behaviour change beyond restoring a working `pip-licenses`.

## Note

This is the same fix as #1938 (`pip-licenses==5.5.5`), which already passes
`License Check (Python)`. Raised as a standalone short PR so the fix can land quickly and
independently; close whichever of the two you don't take.

## Test plan
- [x] `bash -n .github/scripts/check_python_licenses.sh` — syntax OK
- [x] 5.5.5 confirmed on PyPI: stable, not yanked, `requires-python >=3.9`
- [ ] `License Check (Python)` green on this PR

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] Every commit is DCO sign-off'd.
- [x] No secrets committed.
