### PR TITLE
chore: add nv-amkale as PR vetter

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -35,6 +35,7 @@ additional_vetters:
   - munjalp6
   - nathankw
   - nikunj-jesadiya
+  - nv-amkale
   - nv-mpandele
   - nv-pnikam
   - nv-vankit


### PR DESCRIPTION
## Summary

- add `nv-amkale` to the copy-PR bot's `additional_vetters` list
- keep the list sorted

This enables `nv-amkale` to issue `/ok to test <sha>` for VSS pull requests.

## Validation

- parsed `.github/copy-pr-bot.yaml` successfully
- verified the vetter list is sorted and contains no duplicates
- `git diff --check` passed