### PR TITLE
docs: retire the removed LLMs from the product docs

### DIFF
--- a/.github/skill-eval/README.md
+++ b/.github/skill-eval/README.md
@@ -46,7 +46,7 @@ Per-CI-run hygiene is the trial's own responsibility: each spec's first agent tu
 | `NGC_CLI_API_KEY` | Pull VSS NIM containers from `nvcr.io` |
 | `LLM_REMOTE_URL` / `LLM_REMOTE_MODEL` | Remote-LLM endpoint used by `remote-*` deploy modes |
 | `VLM_REMOTE_URL` / `VLM_REMOTE_MODEL` | Remote-VLM endpoint used by `remote-*` deploy modes |
-| `HF_TOKEN` | Required by the Edge 4B vLLM on SPARK / Thor `shared` mode |
+| `HF_TOKEN` | Required by RT-VLM / RT-Embed when loading Hugging Face checkpoints |
 | `GITHUB_TOKEN` | Issued to `gh pr comment` when the agent posts results |
 | `BREV_REGISTERED_POOL` | Comma/space-separated registered-node names approved for automatic pool selection |
 | `BREV_RTX4090_POOL` | Registered RTX 4090 workers; routed only to the proven tests in `run_leg.py::RTX4090_TESTS` / `RTX4090_ALL_TESTS` |

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ We provide multiple reference [Agent Workflows](https://docs.nvidia.com/vss/late
 1. **NIM microservices**: Here are models used in this blueprint:
 
     - [Cosmos3 Nano Reasoner](https://build.nvidia.com/nvidia/cosmos3-nano-reasoner)
-    - [NVIDIA Nemotron-Nano-9B-v2](https://build.nvidia.com/nvidia/nvidia-nemotron-nano-9b-v2)
+    - [NVIDIA Nemotron 3.5 Lightning 30B A3B](https://build.nvidia.com/nvidia/nemotron-3.5-lightning-30b-a3b)
 
 2. **Real-time video intelligence**: The Real-Time Video Intelligence layer extracts rich visual features, semantic embeddings, and contextual understanding from video data in real-time, publishing results to a message broker for downstream analytics and agentic workflows. It provides three core microservices for processing video streams.
 

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -221,7 +221,7 @@ Default LVS model wiring:
 
 | Component | Local Compose behavior | Default model name |
 |-----------|------------------------|--------------------|
-| LLM | Starts the **`nvidia-nemotron-nano-9b-v2`** NIM container on **`LLM_PORT=30081`** when `LLM_MODE` is `local` or `local_shared`. | `nvidia/nvidia-nemotron-nano-9b-v2` |
+| LLM | Starts the **`nemotron-3.5-lightning-30b-a3b`** NIM container on **`LLM_PORT=30081`** when `LLM_MODE` is `local` or `local_shared`. | `nvidia/nemotron-3.5-lightning-30b-a3b` |
 | VLM / RT-VLM | Starts **`rtvi-vlm`** on **`RTVI_VLM_PORT=8018`**. The LVS profile sets **`VLM_NAME_SLUG=none`**, so Compose does not start a separate Cosmos VLM NIM by default; RT-VLM loads the integrated checkpoint. | `nim_nvidia_cosmos3-nano-reasoner_bf16-final` |
 
 For external endpoints, use the helper flags instead of editing Compose files directly:
@@ -235,7 +235,7 @@ export VLM_ENDPOINT_URL='<REMOTE VLM SERVICE ROOT, no trailing /v1>'
   --hardware-profile H100 \
   --use-remote-llm \
   --use-remote-vlm \
-  --llm nvidia/nvidia-nemotron-nano-9b-v2 \
+  --llm nvidia/nemotron-3.5-lightning-30b-a3b \
   --vlm nim_nvidia_cosmos3-nano-reasoner_bf16-final
 ```
 

--- a/deploy/docker/services/video-summarization/README.md
+++ b/deploy/docker/services/video-summarization/README.md
@@ -41,7 +41,7 @@ ES_PORT=9200
 LVS_DATABASE_BACKEND=vector_db
 
 # LLM Configuration
-LVS_LLM_MODEL_NAME=meta/llama-3.1-70b-instruct
+LVS_LLM_MODEL_NAME=nvidia/nemotron-3.5-lightning-30b-a3b
 LVS_LLM_BASE_URL=http://localhost:9233/v1
 NVIDIA_API_KEY=nvapi-xxxxx
 

--- a/deploy/helm/developer-profiles/dev-profile-alerts/README.md
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/README.md
@@ -57,7 +57,7 @@ With default **`values.yaml`** and the mode values files, the stack requests **4
 | `vss-rtvi-cv` | 1 |
 | `vss-rtvi-vlm` | 1 |
 | `vss-vios-streamprocessing` | 1 |
-| `nvidia-nemotron-nano-9b-v2` (NIM) | 1 |
+| `nemotron-35-lightning-30b-a3b` (NIM) | 1 |
 | **Total** | **4** |
 
 ### Alert real-time (`values-realtime.yaml`)
@@ -66,7 +66,7 @@ With default **`values.yaml`** and the mode values files, the stack requests **4
 |----------|-----|
 | `vss-vios-streamprocessing` | 1 |
 | `vss-rtvi-vlm` | 1 |
-| `nvidia-nemotron-nano-9b-v2` (NIM) | 1 |
+| `nemotron-35-lightning-30b-a3b` (NIM) | 1 |
 | **Total** | **3** |
 
 
@@ -120,7 +120,7 @@ Edit **`values-verification.yaml`** or **`values-realtime.yaml`** (use **one** *
 | **`global.externalHost`** | Hostname or IP the browser uses (e.g. `vss-alerts.YOUR_IP.nip.io`). Required for a typical external install when subchart URL fields are omitted. |
 | **`global.externalPort`** | Port segment in generated URLs; use **`""`** so URLs omit **`:port`** when using default 80/443. Set only for non-default ports (e.g. **`8080`**). |
 | **`global.kibanaPublicUrl`** | Full public Kibana base URL (no `/kibana` suffix). Used for the Dashboard tab and Kibana `SERVER_PUBLICBASEURL` when **`infra.kibana.kibanaPublicUrl`** is empty. |
-| **`nims`** | **`nims.enabled`**: umbrella for all NIM subcharts. Use **`nims.gpuType`** to select model tuning from **`gpuProfiles`** and **`nims.nemotron.enabled`** / **`nims.cosmos.enabled`** to choose the models to deploy. Set **`nims.enabled`** to **`false`** when using [remote LLM/VLM](#remote-llm-and-vlm) only. |
+| **`nims`** | **`nims.enabled`**: umbrella for all NIM subcharts. Use **`nims.gpuType`** to select model tuning from **`gpuProfiles`** and **`nims.nemotron35.enabled`** / **`nims.cosmos.enabled`** to choose the models to deploy. Set **`nims.enabled`** to **`false`** when using [remote LLM/VLM](#remote-llm-and-vlm) only. |
 | **`global.llmBaseUrl`** / **`global.vlmBaseUrl`** (remote) | HTTP(S) base URLs when LLM/VLM are **not** deployed in-cluster; use with **`nims.enabled: false`**. Must be reachable from **vss-agent** (and **vss-alert-bridge** / **vss-rtvi-vlm** as applicable). Align **`global.llmName`** / **`global.vlmName`** with remote endpoints. |
 | **`global.llmName`** / **`global.vlmName`** (remote) | Model identifiers for **vss-agent** and related services; must match remote APIs. |
 | **`vssIngress`** (optional) | Set **`vssIngress.enabled`** to **`true`** to create a Kubernetes **`Ingress`** for UI, agent, VST, **video-analytics-api**, **vss-alert-bridge**, **vss-va-mcp**, and optional **Kibana** / **Phoenix** / **NVStreamer** hosts. Requires an existing **IngressClass** (see [VSS Ingress (`vssIngress`)](#vss-ingress-vssingress)). **`global.externalHost`** must be set unless **`vssIngress.host`** is set. Mode sample files enable this by default. |
@@ -151,7 +151,7 @@ In **Description**, **Real-time (`values-realtime.yaml`)** notes which subcharts
 | **`global.storageClass`** | unset in repo **`values.yaml`** | Set in **`values-verification.yaml`** or **`values-realtime.yaml`**; used to create PVC. |
 | **`global.llmBaseUrl`** | **`""`** | Remote LLM base URL for **vss-agent** when models are not in-cluster (use with **`nims.enabled: false`**). Must be reachable from pods in the release namespace. |
 | **`global.vlmBaseUrl`** | **`""`** | Remote VLM base URL; same constraints. **vss-alert-bridge** and **vss-rtvi-vlm** may use separate overrides when enabled. |
-| **`global.llmName`** | e.g. **`nvidia/nvidia-nemotron-nano-9b-v2`** | Catalog-style model id for **vss-agent**; align with **`global.llmBaseUrl`** when remote. |
+| **`global.llmName`** | e.g. **`nvidia/nemotron-3.5-lightning-30b-a3b`** | Catalog-style model id for **vss-agent**; align with **`global.llmBaseUrl`** when remote. |
 | **`global.vlmName`** | e.g. **`nim_nvidia_cosmos3-nano-reasoner_bf16-final`** | Model id for VLM calls. For integrated RT-VLM, this must match the id advertised by **`/v1/models`**. |
 | **`vios.vstStorage.createSharedPvcs`** | **`true`** | **`true`:** the **`vios`** umbrella creates **PersistentVolumeClaims** so **sensor** and **streamprocessing** share on-disk folders for VST data and video; data survives pod restarts but your cluster must have a working **StorageClass** (see **`global.storageClass`**). **`false`:** no shared PVCs from **`vios`**; behavior depends on **`vios.vss-vios-*`** persistence settings. |
 | **`vios.vstStorage.accessMode`** | **`ReadWriteOnce`** | Access mode for the three shared VST PVCs (see **`helm/services/vios/templates/vst-storage-pvc.yaml`**). |
@@ -192,7 +192,7 @@ In **Description**, **Real-time (`values-realtime.yaml`)** notes which subcharts
 | **`agent.vss-agent.enabled`** | **`true`** | Set **`false`** to disable the **vss-agent** deployment only. |
 | **`agent.vss-agent.profile`** | **`alerts`** | Passed to the **vss-agent** subchart so it mounts **report-templates** and sets template env for the **alerts** UX. ConfigMap data is read from **`configs/vss-agent/config.yml`** (and **`incident_report_template.md`**) in this chart — flat paths, no profile subfolders. |
 | **`agent.vss-agent.mountEvalOutput`** | **`false`** | Shared **vss-agent** chart defaults **`mountEvalOutput: true`** (eval **emptyDir**); alerts sets **`false`** because this profile does not use the eval-output volume. |
-| **`agent.vss-agent.llmName`** | NGC model id (e.g. **`nvidia/nvidia-nemotron-nano-9b-v2`**) | NGC catalog id for the LLM; must match the model deployed under **`nims`**. |
+| **`agent.vss-agent.llmName`** | NGC model id (e.g. **`nvidia/nemotron-3.5-lightning-30b-a3b`**) | NGC catalog id for the LLM; must match the model deployed under **`nims`**. |
 | **`agent.vss-agent.vlmName`** | NGC model id (e.g. **`nim_nvidia_cosmos3-nano-reasoner_bf16-final`**) | NGC catalog id for the RTVI-VLM; must match the model deployed with rtvi-vlm. |
 | **`agent.vss-agent.evalLlmJudgeName`** | **`""`** | Optional eval judge model id. When empty, the **vss-agent** subchart defaults to **`llmName`**. |
 | **`agent.vss-agent.evalLlmJudgeBaseUrl`** | **`""`** | Optional base URL for the eval judge endpoint. When empty, the subchart defaults alongside **`llmBaseUrl`**. |
@@ -324,7 +324,7 @@ helm upgrade --install vss-alerts ./dev-profile-alerts \
   --set global.storageClass="$STORAGE_CLASS" \
   --set-string global.llmBaseUrl="$LLM_BASE_URL" \
   --set-string global.vlmBaseUrl="$VLM_BASE_URL" \
-  --set-string global.llmName="nvidia/nvidia-nemotron-nano-9b-v2" \
+  --set-string global.llmName="nvidia/nemotron-3.5-lightning-30b-a3b" \
   --set-string global.vlmName="$VLM_NAME"
 
 ```
@@ -366,7 +366,7 @@ helm upgrade --install vss-alerts ./dev-profile-alerts \
   --set global.storageClass="$STORAGE_CLASS" \
   --set-string global.llmBaseUrl="$LLM_BASE_URL" \
   --set-string global.vlmBaseUrl="$VLM_BASE_URL" \
-  --set-string global.llmName="nvidia/nvidia-nemotron-nano-9b-v2" \
+  --set-string global.llmName="nvidia/nemotron-3.5-lightning-30b-a3b" \
   --set-string global.vlmName="$VLM_NAME"
 ```
 

--- a/deploy/helm/developer-profiles/dev-profile-base/README.md
+++ b/deploy/helm/developer-profiles/dev-profile-base/README.md
@@ -149,7 +149,7 @@ Use the table below when you want to change behavior beyond the minimal **`value
 | **`vssIngress.phoenixPort`** | `6006` | Backend **`Service`** port for Phoenix when the Phoenix subchart is enabled. |
 | **`agent.enabled`** | `true` | Set **`false`** to skip the **`agent`** umbrella (**`deploy/helm/services/agent`**). |
 | **`agent.vss-agent.enabled`** | `true` | Set **`false`** to disable the **vss-agent** deployment only. |
-| **`agent.vss-agent.mountConfigEdge`** / **`mountEvalOutput`** | `true` / `true` | Parent **ConfigMap** includes **`config_edge.yml`** when the file exists; **`/vss-agent/eval-output`** emptyDir when **`mountEvalOutput`** is **`true`**. Agent YAML lives at **`configs/vss-agent/config.yml`** (flat path, no profile subfolders). |
+| **`agent.vss-agent.mountConfigEdge`** / **`mountEvalOutput`** | `false` / `true` | Parent **ConfigMap** includes **`config_edge.yml`** when the file exists; **`/vss-agent/eval-output`** emptyDir when **`mountEvalOutput`** is **`true`**. Agent YAML lives at **`configs/vss-agent/config.yml`** (flat path, no profile subfolders). |
 | **`agent.vss-agent.llmName`** | NGC model id (e.g. **`nvidia/nvidia-nemotron-nano-9b-v2`**) | NGC catalog id for the LLM; must match the model deployed under **`nims`**. |
 | **`agent.vss-agent.vlmName`** | RT-VLM model id (e.g. **`nim_nvidia_cosmos3-nano-reasoner_bf16-final`**) | Must match the model advertised by **`vss-rtvi-vlm`** `/v1/models`. |
 | **`agent.vss-agent.evalLlmJudgeName`** | `""` | Optional eval judge model id. When empty, the **vss-agent** subchart defaults to **`llmName`**. |

--- a/deploy/helm/developer-profiles/dev-profile-lvs/README.md
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/README.md
@@ -32,7 +32,7 @@ Switch to **external-service mode** only when the model endpoints already run ou
 
 ## Performance profile (`values-perf.yaml`, opt-in)
 
-`values-perf.yaml` runs the LVS profile with its highest-performance model configuration for dedicated-GPU deployments: the `nemotron-3-nano` (30B) LLM with reasoning disabled and the integrated Cosmos VLM quantized to the precision that matches the GPU (FP8 or NVFP4). Apply it explicitly on top of the base values:
+`values-perf.yaml` runs the LVS profile with its highest-performance model configuration for dedicated-GPU deployments: the `nemotron-35-lightning-30b-a3b` (30B) LLM with reasoning disabled and the integrated Cosmos VLM quantized to the precision that matches the GPU (FP8 or NVFP4). Apply it explicitly on top of the base values:
 
 ```bash
 helm upgrade --install vss . -f values-lvs.yaml -f values-perf.yaml -n vss --create-namespace
@@ -42,17 +42,15 @@ The overlay switches the LVS profile to:
 
 | Component | With `values-perf.yaml` |
 |-----------|--------------------------|
-| LLM | **`nemotron-3-nano`** (30B), reasoning disabled (`NIM_PASSTHROUGH_ARGS=--default-chat-template-kwargs {"enable_thinking":false}`); auto-sizes its own KV/concurrency per GPU. The NIMCache pins one profile — `nims.nemotron3.modelPrecision`, TP = the requested GPU count — so only that profile is cached, not every precision variant. |
+| LLM | **`nemotron-35-lightning-30b-a3b`** (30B), reasoning disabled (`NIM_PASSTHROUGH_ARGS=--default-chat-template-kwargs {"enable_thinking":false}`); auto-sizes its own KV/concurrency per GPU. The engine profile is pinned per platform by `nims.gpuType` (`NIM_MODEL_PROFILE`: INT4 on H100/L40S, NVFP4 on Blackwell), so only that profile is served. |
 | VLM | integrated Cosmos Reason3 Nano, precision selected by `nims.gpuType`: **FP8** on `H100`/`L40S`, **NVFP4** on `RTXPRO6000BW` |
 
-The overlay defaults to `nims.gpuType: H100` with **FP8** for both the LLM (`nims.nemotron3.modelPrecision`) and VLM. For **Blackwell (`RTXPRO6000BW`)**, override the platform, the LLM precision, and the VLM precision strings to **NVFP4** — the render-time guard (`templates/validate-vlm-precision.yaml`) fails `helm template`/`install` if any of them disagree with `nims.gpuType`:
+The overlay defaults to `nims.gpuType: H100`. The LLM engine profile follows `nims.gpuType` automatically; only the VLM precision strings need overriding. For **Blackwell (`RTXPRO6000BW`)**, set the platform and the VLM precision strings to **NVFP4** — the render-time guard (`templates/validate-vlm-precision.yaml`) fails `helm template`/`install` if they disagree with `nims.gpuType`:
 
 ```yaml
 # values-perf-blackwell.yaml — apply after values-perf.yaml
 nims:
   gpuType: RTXPRO6000BW
-  nemotron3:
-    modelPrecision: "nvfp4"
 global:
   vlmName: "nim_nvidia_cosmos3-nano-reasoner_modelopt-nvfp4-full-quantize-final_format_fix"
 rtvi:
@@ -275,7 +273,7 @@ Use the table below for additional keys. Order follows **`values.yaml`**. **`ngc
 | **`vss-summarization.enabled`** | **`true`** | Set **`false`** to disable the **LVS** summarization service. |
 | **`vss-summarization.elasticsearchHost`** | **`""`** | Elasticsearch hostname for **vss-summarization** **`ES_HOST`**. When empty, defaults to **`<release>-elasticsearch`**. |
 | **`vss-summarization.elasticsearchPort`** | **`9200`** | Elasticsearch HTTP port (**`ES_PORT`**). |
-| **`vss-summarization.llmService`** | **`nemotron-3.5-lightning-30b-a3b`** | NIM subchart **name segment** used to build **`LVS_LLM_BASE_URL`** as **`http://<release>-<value>:8000/v1`** when **`global.llmBaseUrl`** and **`vss-summarization.llmBaseUrl`** are empty. Keep it aligned with the enabled LLM NIM. |
+| **`vss-summarization.llmService`** | **`nemotron-35-lightning-30b-a3b`** | NIM subchart **name segment** used to build **`LVS_LLM_BASE_URL`** as **`http://<release>-<value>:8000/v1`** when **`global.llmBaseUrl`** and **`vss-summarization.llmBaseUrl`** are empty. Keep it aligned with the enabled LLM NIM. |
 | **`vss-summarization.vlmService`** | **`vss-rtvi-vlm`** | Service segment used to build **`VIA_VLM_ENDPOINT`** when **`global.vlmBaseUrl`** and **`vss-summarization.vlmBaseUrl`** are empty. Default LVS points this at RT-VLM, not a Cosmos NIM service. |
 | **`vss-summarization.llmBaseUrl`** | **`""`** | Optional **LVS-only** override of **`global.llmBaseUrl`**. |
 | **`vss-summarization.vlmBaseUrl`** | **`""`** | Optional **LVS-only** override of **`global.vlmBaseUrl`**. |
@@ -390,7 +388,7 @@ Run the port-forwards in separate terminals:
 ```bash
 kubectl port-forward -n <NAMESPACE> svc/vss-summarization 38111:38111
 kubectl port-forward -n <NAMESPACE> svc/vss-rtvi-vlm 8018:8000
-kubectl port-forward -n <NAMESPACE> svc/nemotron-3.5-lightning-30b-a3b 30081:8000
+kubectl port-forward -n <NAMESPACE> svc/nemotron-35-lightning-30b-a3b 30081:8000
 ```
 
 Then validate:

--- a/docs/VSS-Agents.mdx
+++ b/docs/VSS-Agents.mdx
@@ -15,7 +15,7 @@ Above shows Agents deployed with the 2D Vision AI with Agents Profile.
 
 ## Components
 
-- **LLM** ([Nemotron-Nano-9B-v2](https://build.nvidia.com/nvidia/nvidia-nemotron-nano-9b-v2/modelcard)): Reasoning and report generation
+- **LLM** ([Nemotron-3.5-Lightning-30B-A3B](https://build.nvidia.com/nvidia/nemotron-3.5-lightning-30b-a3b)): Reasoning and report generation
 - **VLM** ([Cosmos3 Nano Reasoner](https://build.nvidia.com/nvidia/cosmos3-nano-reasoner)): Video understanding
 - **VSS Agent**: Orchestrates LLM/VLM to process events and generate reports
 - **Reference UI**: Browser-based chat interface using [NeMo Agent Toolkit (NAT)](https://docs.nvidia.com/nemo/agent-toolkit/1.3/) API

--- a/docs/agent-workflow-alert-verification.mdx
+++ b/docs/agent-workflow-alert-verification.mdx
@@ -608,7 +608,7 @@ your network speed, this may take a few minutes.
 **This deployment uses the following defaults:**
 
 
-- LLM model: nvidia/nvidia-nemotron-nano-9b-v2
+- LLM model: nvidia/nemotron-3.5-lightning-30b-a3b
 - VLM model: cosmos-reason3 (served via RTVI VLM container)
 
 <Note>

--- a/docs/agent-workflow-lvs.mdx
+++ b/docs/agent-workflow-lvs.mdx
@@ -581,7 +581,7 @@ your network speed, this may take a few minutes.
 **This deployment uses the following defaults:**
 
 
-- LLM model: nvidia/nvidia-nemotron-nano-9b-v2
+- LLM model: nvidia/nemotron-3.5-lightning-30b-a3b
 - VLM model: nvidia/cosmos3-nano-reasoner
 
 <Note>

--- a/docs/agent-workflow-rt-alert.mdx
+++ b/docs/agent-workflow-rt-alert.mdx
@@ -585,7 +585,7 @@ your network speed, this may take a few minutes.
 **This deployment uses the following defaults:**
 
 
-- LLM model: nvidia/nvidia-nemotron-nano-9b-v2
+- LLM model: nvidia/nemotron-3.5-lightning-30b-a3b
 - VLM model: cosmos-reason3 (served via RTVI VLM container)
 
 <Note>

--- a/docs/assets/static/default_models.csv
+++ b/docs/assets/static/default_models.csv
@@ -1,3 +1,3 @@
 Model,Purpose
-"`Nemotron-Nano-9B-v2 <https://build.nvidia.com/nvidia/nvidia-nemotron-nano-9b-v2>`_","LLM for reasoning and report generation"
+"`Nemotron-3.5-Lightning-30B-A3B <https://build.nvidia.com/nvidia/nemotron-3.5-lightning-30b-a3b>`_","LLM for reasoning and report generation"
 "`Cosmos3-Nano-Reasoner <https://build.nvidia.com/nvidia/cosmos3-nano-reasoner>`_","VLM for video understanding"

--- a/docs/assets/static/llm_params.csv
+++ b/docs/assets/static/llm_params.csv
@@ -1,6 +1,6 @@
 Parameter,Type,Description
 _type,string,LLM provider type (e.g. ``nim`` for NVIDIA NIM)
-model_name,string,Model identifier (e.g. ``nvidia/nvidia-nemotron-nano-9b-v2``)
+model_name,string,Model identifier (e.g. ``nvidia/nemotron-3.5-lightning-30b-a3b``)
 base_url,string,API endpoint URL with ``/v1`` suffix
 max_tokens,int,Maximum tokens to generate
 temperature,float,Sampling temperature (0.0 = deterministic)

--- a/docs/edge-deployment.mdx
+++ b/docs/edge-deployment.mdx
@@ -3,18 +3,24 @@ title: "Edge Deployment"
 description: ""
 position: 2
 ---
-This guide covers deploying the base vision agent with **NVIDIA Nemotron 3 Nano 4B** or **NVIDIA Nemotron Nano 9B v2 FP8** as the
-LLM on edge platforms (DGX Spark, IGX Thor, AGX Thor).
+This guide covers deploying the base vision agent on edge platforms (DGX Spark, IGX Thor, AGX Thor).
 
-For small models like **NVIDIA Nemotron 3 Nano 4B**, a dedicated configuration file (`config_edge.yml`) is provided.
-It inherits all settings from the standard `config.yml` and overrides only the planning prompt with a simplified
-version optimized for smaller models.
+The LLM is the blueprint default, **`nvidia/nemotron-3.5-lightning-30b-a3b`** — the same model as
+on every other platform. Each edge profile ships its own sizing file
+(`deploy/docker/services/nim/nemotron-3.5-lightning-30b-a3b/hw-<HARDWARE_PROFILE>*.env`), which pins
+the INT4 engine profile and caps the NIM at 30% of the device's unified memory so it coexists with
+the VLM. The LLM deploys as a normal Compose service; no standalone container is needed and no
+Hugging Face token is involved.
 
 <Note>
-The edge configuration does not encourage clarifying questions from the agent prompt. Hence, in ambiguous situations,
-the agent with `config_edge.yml` may tend to not request more context from the user.
-If this behavior is not desired, use a larger model like **NVIDIA Nemotron Nano 9B v2 FP8** which will ask clarifying questions
-when the user's request does not contain enough context.
+Two alternatives when the default does not fit:
+
+- **`nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8`** (11.7 GB) — a smaller in-tree build for GPUs that
+  cannot host the default. Select it by setting `LLM_NAME` and `LLM_NAME_SLUG` in the overlay, as
+  shown in the commented lines below.
+- **A remote endpoint** — best latency on edge. Set `LLM_MODE=remote`, `LLM_NAME_SLUG=none`,
+  `LLM_BASE_URL` to an OpenAI-compatible endpoint (for example `https://integrate.api.nvidia.com`),
+  `LLM_NAME` to a model the endpoint serves, and `LLM_MODEL_TYPE` (`nim` or `openai`).
 </Note>
 
 ## Prerequisites
@@ -25,8 +31,7 @@ Also ensure to reboot the system and free up the GPU completely before deploying
 You will also need:
 
 - **NGC CLI API Key** — for pulling container images
-- **HF Token** — for pulling model weights from Hugging Face
-- **NVIDIA Nemotron 3 Nano 4B** running locally or on a reachable endpoint (e.g. via vLLM on port 30081)
+- **HF Token** — optional; not needed by the default edge deployment
 
 For more details on VSS configurations and how to get API tokens, refer to:
 
@@ -88,52 +93,11 @@ docker compose -f compose.yml \
 
 ## DGX Spark
 
-1. Start the Nemotron 3 Nano 4B model. For example, using vLLM:
-
-   ```bash
-   export HF_TOKEN=$HF_TOKEN
-   
-   docker run --gpus all -d --name nemotron-edge -p 30081:8000 \
-       -e HF_TOKEN=$HF_TOKEN \
-       nvcr.io/nvidia/vllm:26.02-py3 \
-       python3 -m vllm.entrypoints.openai.api_server \
-       --model nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8 \
-       --trust-remote-code \
-       --gpu-memory-utilization 0.25 \
-       --enable-auto-tool-choice \
-       --tool-call-parser qwen3_coder \
-       --port 8000
-   ```
-
-2. Deploy the agent workflow:
-
-   ```ini
-   # developer-profiles/dev-profile-base/user-overrides.env
-   HARDWARE_PROFILE=DGX-SPARK
-   VSS_RT_VLM_TAG=develop-latest-sbsa
-   VLM_DEVICE_ID=0
-   RT_VLM_DEVICE_ID=0
-   RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.7
-   LLM_MODE=remote
-   LLM_NAME_SLUG=none
-   LLM_BASE_URL=http://<HOST_IP>:30081
-   LLM_NAME=nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8
-   LLM_MODEL_TYPE=openai
-   VSS_AGENT_CONFIG_FILE=/vss-agent/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config_edge.yml
-   VLM_ENV_FILE=services/nim/cosmos3-reasoner/hw-DGX-SPARK-shared.env
-   ```
-
-   The configured `VLM_ENV_FILE` limits the VLM KV-cache (`NIM_KVCACHE_PERCENT=0.4`) so both
-   models fit in GPU memory.
-
-<Note>
-If you prefer the agent to handle ambiguous or incomplete user queries better with clarifying questions, use the **Nemotron Nano 9B v2 FP8** model.
-This larger model should also be able to handle more complex user queries and situations.
-In this case, you can skip running the vLLM container entirely, as the blueprint deploys both the LLM and the VLM itself. On edge hardware profiles the deploy script already selects `nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8`, so `--llm` is optional:
+Add the platform values to `deploy/docker/developer-profiles/dev-profile-base/user-overrides.env`,
+then run the `docker compose config --quiet` / `up -d` commands above:
 
 ```ini
-# Free up GPU for a full blueprint deployment first:
-# docker stop nemotron-edge && docker rm nemotron-edge
+# developer-profiles/dev-profile-base/user-overrides.env
 HARDWARE_PROFILE=DGX-SPARK
 VSS_RT_VLM_TAG=develop-latest-sbsa
 LLM_DEVICE_ID=0
@@ -146,70 +110,33 @@ LLM_MODE=local
 # LLM_NAME_SLUG=nvidia-nemotron-nano-9b-v2-fp8
 ```
 
-This uses the standard `config.yml` (no `config_edge.yml` override needed) since
-the 9B model handles complex and ambiguous queries better.
-</Note>
+`HARDWARE_PROFILE=DGX-SPARK` selects the Spark sizing files for both models: the LLM's
+`hw-DGX-SPARK*.env` (30% of unified memory, 64K context) and the VLM's Spark-shared limits, so the
+two fit together in the 128 GB pool. The `-sbsa` image tag is required on Spark — the default tag
+pulls the Tegra build, which crash-loops on missing GB10 libraries.
 
 ## AGX Thor / IGX Thor
 
-On AGX Thor and IGX Thor, the Nemotron 3 Nano 4B LLM runs locally alongside `rtvi-vlm` (the VLM
-used by the blueprint on Thor). Both models share the same GPU, so their memory budgets
-must be tuned to coexist.
-
-1. Start the Nemotron 3 Nano 4B model on the device:
-
-   ```bash
-   export HF_TOKEN=$HF_TOKEN
-   
-   docker run --gpus all -d --name nemotron-edge -p 30081:8000 \
-       --runtime=nvidia \
-       -e NVIDIA_VISIBLE_DEVICES=0 \
-       -e HF_TOKEN=$HF_TOKEN \
-       ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
-       python3 -m vllm.entrypoints.openai.api_server \
-       --model nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8 \
-       --trust-remote-code \
-       --gpu-memory-utilization 0.25 \
-       --enable-auto-tool-choice \
-       --tool-call-parser qwen3_coder \
-       --port 8000
-   ```
-
-2. Deploy the agent workflow:
-
-   ```ini
-   # developer-profiles/dev-profile-base/user-overrides.env
-   HARDWARE_PROFILE=AGX-THOR # Set IGX-THOR on IGX hardware.
-   VLM_DEVICE_ID=0 # Adjust to the Thor GPU ID reported by nvidia-smi.
-   RT_VLM_DEVICE_ID=0 # Adjust to the Thor GPU ID reported by nvidia-smi.
-   RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.35
-   LLM_MODE=remote
-   LLM_NAME_SLUG=none
-   LLM_BASE_URL=http://<HOST_IP>:30081
-   LLM_NAME=nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8
-   LLM_MODEL_TYPE=openai
-   VSS_AGENT_CONFIG_FILE=/vss-agent/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config_edge.yml
-   # Uses the default GPU memory utilization of 0.35 for rtvi-vlm.
-   ```
-
-<Note>
-If you prefer the agent to handle ambiguous or incomplete user queries better with clarifying questions, use the **Nemotron Nano 9B v2 FP8** model.
-This larger model should also be able to handle more complex user queries and situations.
-In this case, you can skip running the vLLM container entirely, as the blueprint deploys both the LLM and the VLM itself. On edge hardware profiles the deploy script already selects `nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8`, so `--llm` is optional:
+On Thor the LLM shares the GPU with `rtvi-vlm` (the VLM used by the blueprint on Thor), so both
+memory budgets are set by the checked-in sizing files. Add the platform values to
+`user-overrides.env`, then run the same `docker compose` commands:
 
 ```ini
-# Free up GPU for a full blueprint deployment first:
-# docker stop nemotron-edge && docker rm nemotron-edge
+# developer-profiles/dev-profile-base/user-overrides.env
 HARDWARE_PROFILE=AGX-THOR # Set IGX-THOR on IGX hardware.
 LLM_DEVICE_ID=0 # Adjust to the Thor GPU ID reported by nvidia-smi.
 VLM_DEVICE_ID=0 # Adjust to the Thor GPU ID reported by nvidia-smi.
 RT_VLM_DEVICE_ID=0 # Adjust to the Thor GPU ID reported by nvidia-smi.
-# To choose a local model, set LLM_NAME and LLM_NAME_SLUG in this file.
+RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.35
+LLM_MODE=local
+# The default LLM (nvidia/nemotron-3.5-lightning-30b-a3b) applies; to use the
+# smaller FP8 build instead, uncomment both lines:
+# LLM_NAME=nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8
+# LLM_NAME_SLUG=nvidia-nemotron-nano-9b-v2-fp8
 ```
 
-This uses the standard `config.yml` (no `config_edge.yml` override needed) since
-the 9B model handles complex and ambiguous queries better.
-</Note>
+The LLM's `hw-AGX-THOR*.env` / `hw-IGX-THOR*.env` cap it at 30% of unified memory alongside
+RT-VLM's 35%, keeping the co-resident total under the 80% edge ceiling.
 
 <Note>
 For IGX Thor, set `HARDWARE_PROFILE=IGX-THOR` in the profile settings above.

--- a/docs/edge-deployment.mdx
+++ b/docs/edge-deployment.mdx
@@ -3,7 +3,7 @@ title: "Edge Deployment"
 description: ""
 position: 2
 ---
-This guide covers deploying the base vision agent with **NVIDIA Nemotron 3 Nano 4B** or **NVIDIA Nemotron Nano 9B v2** as the
+This guide covers deploying the base vision agent with **NVIDIA Nemotron 3 Nano 4B** or **NVIDIA Nemotron Nano 9B v2 FP8** as the
 LLM on edge platforms (DGX Spark, IGX Thor, AGX Thor).
 
 For small models like **NVIDIA Nemotron 3 Nano 4B**, a dedicated configuration file (`config_edge.yml`) is provided.
@@ -13,7 +13,7 @@ version optimized for smaller models.
 <Note>
 The edge configuration does not encourage clarifying questions from the agent prompt. Hence, in ambiguous situations,
 the agent with `config_edge.yml` may tend to not request more context from the user.
-If this behavior is not desired, use a larger model like **NVIDIA Nemotron Nano 9B v2** which will ask clarifying questions
+If this behavior is not desired, use a larger model like **NVIDIA Nemotron Nano 9B v2 FP8** which will ask clarifying questions
 when the user's request does not contain enough context.
 </Note>
 
@@ -127,9 +127,9 @@ docker compose -f compose.yml \
    models fit in GPU memory.
 
 <Note>
-If you prefer the agent to handle ambiguous or incomplete user queries better with clarifying questions, use the **Nemotron Nano 9B** model.
+If you prefer the agent to handle ambiguous or incomplete user queries better with clarifying questions, use the **Nemotron Nano 9B v2 FP8** model.
 This larger model should also be able to handle more complex user queries and situations.
-In this case, you can skip running the vLLM container entirely, as the blueprint will deploy both the LLM and VLM as NIM containers.
+In this case, you can skip running the vLLM container entirely, as the blueprint deploys both the LLM and the VLM itself. On edge hardware profiles the deploy script already selects `nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8`, so `--llm` is optional:
 
 ```ini
 # Free up GPU for a full blueprint deployment first:
@@ -140,8 +140,10 @@ LLM_DEVICE_ID=0
 VLM_DEVICE_ID=0
 RT_VLM_DEVICE_ID=0
 LLM_MODE=local
-LLM_NAME=nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8
-LLM_NAME_SLUG=nemotron-nano
+# The default LLM (nvidia/nemotron-3.5-lightning-30b-a3b) applies; to use the
+# smaller FP8 build instead, uncomment both lines:
+# LLM_NAME=nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8
+# LLM_NAME_SLUG=nvidia-nemotron-nano-9b-v2-fp8
 ```
 
 This uses the standard `config.yml` (no `config_edge.yml` override needed) since
@@ -191,9 +193,9 @@ must be tuned to coexist.
    ```
 
 <Note>
-If you prefer the agent to handle ambiguous or incomplete user queries better with clarifying questions, use the **Nemotron Nano 9B** model.
+If you prefer the agent to handle ambiguous or incomplete user queries better with clarifying questions, use the **Nemotron Nano 9B v2 FP8** model.
 This larger model should also be able to handle more complex user queries and situations.
-In this case, you can skip running the vLLM container entirely, as the blueprint will deploy both the LLM and VLM as NIM containers.
+In this case, you can skip running the vLLM container entirely, as the blueprint deploys both the LLM and the VLM itself. On edge hardware profiles the deploy script already selects `nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8`, so `--llm` is optional:
 
 ```ini
 # Free up GPU for a full blueprint deployment first:

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -235,9 +235,11 @@ Supported values are `video/mp4` and `video/x-matroska`.
 
 #### Can I run local LLM and VLM on NVIDIA A100 80 GB GPUs?
 
-Yes. The default models (`nvidia/nvidia-nemotron-nano-9b-v2` for LLM and `nvidia/cosmos3-nano-reasoner`
-for VLM) have been verified to work on dedicated A100 (80 GB) GPUs each with no environment overrides. There
-are no tested overrides to make these defaults work on a shared GPU.
+A100 (80 GB) maps to the `OTHER` hardware profile, and the default models
+(`nvidia/nemotron-3.5-lightning-30b-a3b` for LLM and `nvidia/cosmos3-nano-reasoner` for VLM) ship an `OTHER`
+configuration intended for a dedicated GPU each. The LLM default is a 30B-A3B model and has not been
+validated on A100; check the engine profiles the NIM advertises for your GPU before relying on it.
+There are no tested overrides to make these defaults work on a shared GPU.
 
 ### NVIDIA H200
 

--- a/docs/long-video-summarization.mdx
+++ b/docs/long-video-summarization.mdx
@@ -181,7 +181,7 @@ ES_PORT=9200
 # LLM (external NIM)
 LVS_LLM_HOST=<llm-nim-host-ip>
 LVS_LLM_PORT=8002
-LVS_LLM_MODEL_NAME=openai/gpt-oss-20b
+LVS_LLM_MODEL_NAME=nvidia/nemotron-3.5-lightning-30b-a3b
 LVS_DATABASE_BACKEND=elasticsearch_db
 
 # RTVI-VLM Integration
@@ -430,7 +430,7 @@ VSS_LOG_LEVEL=DEBUG
 
 # LLM Configuration
 # Update these to point to your external LLM NIM services
-LVS_LLM_MODEL_NAME=openai/gpt-oss-20b
+LVS_LLM_MODEL_NAME=nvidia/nemotron-3.5-lightning-30b-a3b
 LVS_LLM_BASE_URL=http://<llm-nim-host-ip>:8002/v1
 
 # Database Selection
@@ -1183,7 +1183,7 @@ Complete list of available environment variables:
 **LLM Configuration**
 
 * `LVS_LLM_HOST`, `LVS_LLM_PORT`: LLM NIM host and port
-* `LVS_LLM_MODEL_NAME`: LLM model name (e.g., `openai/gpt-oss-20b`)
+* `LVS_LLM_MODEL_NAME`: LLM model name (e.g., `nvidia/nemotron-3.5-lightning-30b-a3b`)
 * `LVS_LLM_BASE_URL`: LLM API base URL
 * `LVS_ENABLE_LLM_MERGE`: Use the LLM to merge adjacent duplicate events into natural text (default: false). See [Event Merging](/vss/system-components/vision-microservices/video-summarization#event-merging) for details and examples.
 

--- a/docs/publicsafety-docs/Agents.mdx
+++ b/docs/publicsafety-docs/Agents.mdx
@@ -6,7 +6,7 @@ description: ""
 
 The Public Safety Blueprint incorporates an agentic AI system that provides natural language interaction capabilities for querying unauthorized entry and tailgating incidents, generating reports, and retrieving visual information from security cameras.
 
-The agent uses NVIDIA Nemotron Nano 9B v2 (`nvidia/nvidia-nemotron-nano-9b-v2`) for natural language understanding and query routing, and NVIDIA Cosmos3 Nano Reasoner (`nvidia/cosmos3-nano-reasoner`) for video understanding and analyzing security incidents.
+The agent uses NVIDIA Nemotron 3.5 Lightning 30B A3B (`nvidia/nemotron-3.5-lightning-30b-a3b`) for natural language understanding and query routing, and NVIDIA Cosmos3 Nano Reasoner (`nvidia/cosmos3-nano-reasoner`) for video understanding and analyzing security incidents.
 
 ## Sub-Agents
 
@@ -75,7 +75,7 @@ The configuration file defines key settings such as service endpoints, environme
 * **General**: Frontend settings (FastAPI), object stores, telemetry, and health endpoints
 * **Function Groups**: MCP client connections to Video Analytics and Video Storage microservices
 * **Functions**: Individual tool definitions for video understanding, report generation, chart creation, sensor operations, and sub-agents
-* **LLMs**: Configuration for primary reasoning LLM (NVIDIA Nemotron Nano 9B v2) and VLM (NVIDIA Cosmos3 Nano Reasoner)
+* **LLMs**: Configuration for primary reasoning LLM (NVIDIA Nemotron 3.5 Lightning 30B A3B) and VLM (NVIDIA Cosmos3 Nano Reasoner)
 * **Workflow**: Top-level agent orchestration with routing logic, retry settings, and iteration limits
 
 The configuration file can be found in the deployment directory. For the complete explanation of the agent configuration YAML file and environment variables, please refer to the VSS Agent Configuration documentation.

--- a/docs/publicsafety-docs/Blueprint-deep-dive.mdx
+++ b/docs/publicsafety-docs/Blueprint-deep-dive.mdx
@@ -137,7 +137,7 @@ The agent is configured through a YAML file that defines the general settings, f
 
 **Models Used**
 
-* **Primary LLM**: NVIDIA Nemotron Nano 9B v2 (`nvidia/nvidia-nemotron-nano-9b-v2`) - Used for natural language understanding, query routing, and orchestrating sub-agents
+* **Primary LLM**: NVIDIA Nemotron 3.5 Lightning 30B A3B (`nvidia/nemotron-3.5-lightning-30b-a3b`) - Used for natural language understanding, query routing, and orchestrating sub-agents
 
 * **Vision Language Model (VLM)**: NVIDIA Cosmos3 Nano Reasoner (`nvidia/cosmos3-nano-reasoner`) - Used for video understanding and analyzing security incidents from video segments
 

--- a/docs/publicsafety-docs/Introduction.mdx
+++ b/docs/publicsafety-docs/Introduction.mdx
@@ -22,7 +22,7 @@ At a high level, the blueprint includes the following components:
 * **Perception and Video Analytics** – filter and analyze video content to identify events relevant for VLM review.
 * **Alerts Microservice** – connect filtered content from the perception pipeline with the VLM for validation.
 * **Video Storage Toolkit (VST)** – use as a Video Management System (VMS) or interface with third‑party VMS solutions.
-* **Agent** – powered by Nemotron Nano 9B v2 for natural language interaction, enabling queries, report generation and incident lookup.
+* **Agent** – powered by Nemotron 3.5 Lightning 30B A3B for natural language interaction, enabling queries, report generation and incident lookup.
 * **Scalable Deployment** – deploy the solution at scale across multiple cameras and locations.
 
 ## Architecture Overview
@@ -45,7 +45,7 @@ All components communicate via a Message Bus, with alerts and CV metadata stored
 
 **Agent Pipeline (Right)**
 
-Users interact with the system through an AI Agent powered by Nemotron Nano 9B v2. The Agent connects to various tools via MCP (Model Context Protocol):
+Users interact with the system through an AI Agent powered by Nemotron 3.5 Lightning 30B A3B. The Agent connects to various tools via MCP (Model Context Protocol):
 
 - **Video IO & Storage** – Access to VST/VMS for video retrieval
 - **Video Analytics Tool** – Query incident data from Video Analytics Storage
@@ -53,7 +53,7 @@ Users interact with the system through an AI Agent powered by Nemotron Nano 9B v
 
 **Inference Microservices** provide the underlying AI capabilities:
 
-- nvidia-nemotron-nano-9bv2 – Agent reasoning and natural language understanding
+- nemotron-3.5-lightning-30b-a3b – Agent reasoning and natural language understanding
 - cosmos3-nano-reasoner – Alert verification and report generation
 - RT‑DETR detector (Real‑Time Detection Transformer) – Object detection and tracking
 

--- a/docs/publicsafety-docs/Quickstart-Guide.mdx
+++ b/docs/publicsafety-docs/Quickstart-Guide.mdx
@@ -20,7 +20,7 @@ The deployment includes:
 
 - CV perception pipeline for tailgating detection
 - Cosmos3 Nano Reasoner for VLM-based verification of alerts
-- Nemotron Nano 9B v2 for Agent natural language interaction
+- Nemotron 3.5 Lightning 30B A3B for Agent natural language interaction
 - API access
 - Kibana dashboard
 - Kafka event streams
@@ -203,10 +203,8 @@ To use remote NIM endpoints, modify the `public-safety/.env` file:
 # Set VLM_BASE_URL=http://<remote-host>:<vlm-port>
 #
 # Set LLM_NAME based on the provided remote LLM endpoint to any of
-# - LLM_NAME=nvidia/nvidia-nemotron-nano-9b-v2
-# - LLM_NAME=nvidia/nemotron-3-nano
-# - LLM_NAME=nvidia/llama-3.3-nemotron-super-49b-v1.5
-# - LLM_NAME=openai/gpt-oss-20b
+# - LLM_NAME=nvidia/nemotron-3.5-lightning-30b-a3b
+# - LLM_NAME=nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8
 #
 # Set VLM_NAME based on the provided remote VLM endpoint to any of
 # - VLM_NAME=nvidia/cosmos3-nano-reasoner

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -29,7 +29,7 @@ The following diagram illustrates a conceptual architecture of the base vision a
 
 ## What's being deployed
 
-- **VSS Agent:** Agent service that uses a configured LLM endpoint to route requests and orchestrate tool calls to VSS microservices and model endpoints (LLM/VLM NIMs) to answer questions and generate outputs. The recommended orchestrator model is NVIDIA Nemotron Nano 9B v2 (`nvidia/nvidia-nemotron-nano-9b-v2`), which handles query routing, reasoning, and report generation.
+- **VSS Agent:** Agent service that uses a configured LLM endpoint to route requests and orchestrate tool calls to VSS microservices and model endpoints (LLM/VLM NIMs) to answer questions and generate outputs. The recommended orchestrator model is NVIDIA Nemotron 3.5 Lightning 30B A3B (`nvidia/nemotron-3.5-lightning-30b-a3b`), which handles query routing, reasoning, and report generation.
 - **VSS Agent UI:** Web UI with chat, video upload, and different views
 - **VSS Video IO & Storage (VIOS):** Video ingestion, recording, and playback services used by the agent for video access and management
 - **Nemotron LLM (NIM):** LLM inference service used for reasoning, tool selection, and response generation
@@ -858,7 +858,7 @@ as documented in [Development Profile GPU Requirements](/vss/getting-started/pre
 8. Returns a browser-reachable ingress URL (for example
    `http://<HOST_IP>:7777/`) for opening the UI.
 
-The base defaults are the `nvidia/nvidia-nemotron-nano-9b-v2` LLM NIM (port
+The base defaults are the `nvidia/nemotron-3.5-lightning-30b-a3b` LLM NIM (port
 `30081`) and the `nvidia/cosmos3-nano-reasoner` VLM NIM (port `30082`). To use
 a different model or a remote endpoint, name it in the prompt and the agent
 sets `LLM_MODE` / `VLM_MODE` accordingly.

--- a/docs/smartcity-docs/Blueprint-deep-dive.mdx
+++ b/docs/smartcity-docs/Blueprint-deep-dive.mdx
@@ -140,12 +140,12 @@ The agent is configured through a YAML file that defines the general settings, f
 * **General**: Frontend settings (FastAPI), object stores, telemetry, and health endpoints
 * **Function Groups**: MCP client connections to Video Analytics and Video Storage microservices
 * **Functions**: Individual tool definitions for video understanding, report generation, chart creation, sensor operations, and sub-agents
-* **LLMs**: Configuration for primary reasoning LLM (NVIDIA Nemotron Nano 9B v2 - `nvidia/nvidia-nemotron-nano-9b-v2`) and VLM (NVIDIA Cosmos3 Nano Reasoner - `nvidia/cosmos3-nano-reasoner`)
+* **LLMs**: Configuration for primary reasoning LLM (NVIDIA Nemotron 3.5 Lightning 30B A3B - `nvidia/nemotron-3.5-lightning-30b-a3b`) and VLM (NVIDIA Cosmos3 Nano Reasoner - `nvidia/cosmos3-nano-reasoner`)
 * **Workflow**: Top-level agent orchestration with routing logic, retry settings, and iteration limits
 
 **Models Used**
 
-* **Primary LLM**: NVIDIA Nemotron Nano 9B v2 (`nvidia/nvidia-nemotron-nano-9b-v2`) - Used for natural language understanding, query routing, and orchestrating sub-agents
+* **Primary LLM**: NVIDIA Nemotron 3.5 Lightning 30B A3B (`nvidia/nemotron-3.5-lightning-30b-a3b`) - Used for natural language understanding, query routing, and orchestrating sub-agents
 * **Vision Language Model (VLM)**: NVIDIA Cosmos3 Nano Reasoner (`nvidia/cosmos3-nano-reasoner`) - Used for video understanding and analyzing traffic incidents from video segments
 
 The configuration file can be found under `deployments/smartcities/vss-agent/configs/config.yml` once you download the resource from NGC.

--- a/docs/vss-agent/VSS-Agent-Configuration.mdx
+++ b/docs/vss-agent/VSS-Agent-Configuration.mdx
@@ -24,7 +24,7 @@ workflow:       # Top agent
 llms:
   nim_llm:
     _type: nim
-    model_name: nvidia/nvidia-nemotron-nano-9b-v2
+    model_name: nvidia/nemotron-3.5-lightning-30b-a3b
     base_url: ${LLM_BASE_URL}/v1
     max_tokens: 4096
     temperature: 0.0
@@ -353,7 +353,7 @@ VST_MCP_PORT=8001
 VST_MCP_URL=http://${HOST_IP}:${VST_MCP_PORT}
 
 # LLM Configuration
-LLM_NAME=nvidia/nvidia-nemotron-nano-9b-v2
+LLM_NAME=nvidia/nemotron-3.5-lightning-30b-a3b
 NEMOTRON_PORT=30081
 LLM_BASE_URL=http://${HOST_IP}:${NEMOTRON_PORT}
 

--- a/docs/vss-agent/configure-llm.mdx
+++ b/docs/vss-agent/configure-llm.mdx
@@ -11,7 +11,7 @@ For **remote** LLMs, as long as the API is [OpenAI compatible](https://platform.
 
 When deploying with a local LLM, the agent workflow uses a default NIM endpoint. You can customize it as follows:
 
-- **Default model:** The local default is profile-specific. The Base, Live Video Search, and Search profiles use `nvidia/nemotron-3.5-lightning-30b-a3b`; the Alerts profile uses `nvidia/nvidia-nemotron-nano-9b-v2`. Each profile's `overrides.env` includes the matching `LLM_NAME` and `LLM_NAME_SLUG`.
+- **Default model:** `nvidia/nemotron-3.5-lightning-30b-a3b` for every profile (configured as a local NIM endpoint; each profile's `overrides.env` carries the matching `LLM_NAME` and `LLM_NAME_SLUG`).
 
 - **Custom NIM env file:** Set `LLM_ENV_FILE` in the selected profile `user-overrides.env` to the path (absolute or relative to `deploy/docker`) of an env file that overrides NIM settings. See [NIM configuration settings](/vss/getting-started/prerequisites#nim-configuration-settings) in Prerequisites.
 
@@ -19,14 +19,10 @@ When deploying with a local LLM, the agent workflow uses a default NIM endpoint.
 
   | `LLM_NAME` | `LLM_NAME_SLUG` |
   | --- | --- |
-  | `nvidia/nvidia-nemotron-nano-9b-v2` | `nvidia-nemotron-nano-9b-v2` |
+  | `nvidia/nemotron-3.5-lightning-30b-a3b` (default) | `nemotron-3.5-lightning-30b-a3b` |
   | `nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8` | `nvidia-nemotron-nano-9b-v2-fp8` |
-  | `nvidia/nemotron-3-nano` | `nemotron-3-nano` |
-  | `nvidia/nemotron-3.5-lightning-30b-a3b` | `nemotron-3.5-lightning-30b-a3b` |
-  | `nvidia/llama-3.3-nemotron-super-49b-v1.5` | `llama-3.3-nemotron-super-49b-v1.5` |
-  | `openai/gpt-oss-20b` | `gpt-oss-20b` |
 
-- **Compatibility:** The profile defaults are the shipped local configurations. For another model, ensure GPU memory meets its requirements and refer to [LLM NIM documentation](https://docs.nvidia.com/nim/large-language-models/latest/supported-models.html).
+- **Supported models:** `nvidia/nemotron-3.5-lightning-30b-a3b` ships sizing for every accepted hardware profile, including the DGX-SPARK / AGX-THOR / IGX-THOR edge profiles. `nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8` (11.7 GB) is the alternative for GPUs too small for the default and is only used when passed explicitly via `--llm`. Serve any other model through a remote endpoint; ensure GPU memory meets requirements and refer to [LLM NIM documentation](https://docs.nvidia.com/nim/large-language-models/latest/supported-models.html).
 
 - **GPU assignment:** Set `LLM_DEVICE_ID` to pin the local LLM to a specific GPU (e.g. when sharing with a local VLM). See the quickstart deploy tab-set for examples.
 

--- a/docs/vss-agent/vss-agent-Observability.mdx
+++ b/docs/vss-agent/vss-agent-Observability.mdx
@@ -72,7 +72,7 @@ The trace begins with the **workflow** span, which orchestrates the entire agent
 
 The workflow includes:
 
-1. **LLM Call (nvidia/nvidia-nemotron-nano-9b-v2)**: The first LLM call processes the user query. Click on this span to view:
+1. **LLM Call (nvidia/nemotron-3.5-lightning-30b-a3b)**: The first LLM call processes the user query. Click on this span to view:
 
    - **Input**: The user's question and system prompt
    - **Output**: The LLM's reasoning and decision to call a tool
@@ -99,13 +99,13 @@ The trace view shows a hierarchical execution pattern typical of agent workflows
 
 ```text
 workflow
-├── LLM Call (nvidia/nvidia-nemotron-nano-9b-v2)  → Reasoning & tool selection
+├── LLM Call (nvidia/nemotron-3.5-lightning-30b-a3b)  → Reasoning & tool selection
 │   ├── Input: User query + system prompt
 │   └── Output: Decision to call vst_video_list
-├── Tool Call (vst_video_list)                    → Tool execution
+├── Tool Call (vst_video_list)                        → Tool execution
 │   ├── Input: Tool parameters
 │   └── Output: List of videos
-└── LLM Call (nvidia/nvidia-nemotron-nano-9b-v2)  → Final response generation
+└── LLM Call (nvidia/nemotron-3.5-lightning-30b-a3b)  → Final response generation
     ├── Input: Tool results + context
     └── Output: User-facing response
 ```

--- a/docs/vss-orchestrator-mcp.mdx
+++ b/docs/vss-orchestrator-mcp.mdx
@@ -174,7 +174,7 @@ Response:
   "external_ip": "10.0.0.10",
   "mode": "2d_cv",
   "llm_mode": "local",
-  "llm_name": "nvidia/nvidia-nemotron-nano-9b-v2",
+  "llm_name": "nvidia/nemotron-3.5-lightning-30b-a3b",
   "vlm_mode": "local",
   "vlm_name": "nvidia/cosmos3-nano-reasoner",
   "compose_profiles": "alerts_2d_cv,...",

--- a/docs/warehouse-docs/2D-profile-with-agents.mdx
+++ b/docs/warehouse-docs/2D-profile-with-agents.mdx
@@ -64,7 +64,7 @@ The diagram depicts **VSS Warehouse 2D Vision AI with Agents Profile**, emphasiz
 8. **LLM and VLM NIMs**:
 
    - **VLM NIM** (e.g., NVIDIA Cosmos3 Nano Reasoner): The vision-language model backend that powers alert verification, real-time alerts, and video understanding for the agent. Receives video frames plus prompts and returns structured predictions.
-   - **LLM NIM** (e.g., NVIDIA Nemotron Nano 9B v2): The language model that powers the agent's reasoning, query routing, and report generation.
+   - **LLM NIM** (e.g., NVIDIA Nemotron 3.5 Lightning 30B A3B): The language model that powers the agent's reasoning, query routing, and report generation.
 
 9. **Storage**
 
@@ -97,7 +97,7 @@ The diagram depicts **VSS Warehouse 2D Vision AI with Agents Profile**, emphasiz
 - **Microservices**: Components like NvStreamer, VIOS, DeepStream, Behavior Analytics, RTVI VLM, and the Alerting Service are modular, independently deployable microservices.
 - **RTSP**: Facilitates real-time video streaming between cameras, NvStreamer, VIOS, and RTVI VLM.
 - **Vision-Language Models (VLMs)**: NVIDIA Cosmos3 Nano Reasoner enables multi-step visual reasoning for alert verification, real-time anomaly detection, and video understanding.
-- **Large Language Models (LLMs)**: NVIDIA Nemotron Nano 9B v2 powers agent reasoning, query interpretation, and report generation.
+- **Large Language Models (LLMs)**: NVIDIA Nemotron 3.5 Lightning 30B A3B powers agent reasoning, query interpretation, and report generation.
 - **MCP (Model Context Protocol)**: A standardized tool interface that exposes microservice capabilities (analytics queries, alert management, video storage) to the LLM-powered agent.
 - **Protobuf**: Ensures efficient, compact data exchange across the CV pipeline.
 - **Kafka**: Manages data distribution and control messaging across all microservices.

--- a/docs/warehouse-docs/Troubleshooting-Guide.mdx
+++ b/docs/warehouse-docs/Troubleshooting-Guide.mdx
@@ -81,7 +81,7 @@ fcdbc01b99ee   nvcr.io/nvidia/vss-core/vss-vios-streamprocessing:3.2.1          
 f656d6a94dd0   docker.elastic.co/kibana/kibana:9.3.3                               "/bin/tini -- /usr/l…"    2 days ago   Up 2 days (healthy)                                                  kibana
 4504d14836f1   mdx-elasticsearch-init-container                                    "bash -c ' /opt/mdx/…"    2 days ago   Exited (0) 2 days ago                                                vss-elasticsearch-init
 ba933c9f035e   alpine:3.23.4                                                       "/bin/sh -c 'apk add…"    2 days ago   Exited (0) 2 days ago                                                sdrc-wdm-env-from-config
-8ac40145a98b   nvcr.io/nim/nvidia/nvidia-nemotron-nano-9b-v2:1                     "/opt/nvidia/nvidia_…"    2 days ago   Up 2 days (healthy)     0.0.0.0:30081->8000/tcp                      nvidia-nemotron-nano-9b-v2
+8ac40145a98b   nvcr.io/nim/nvidia/nemotron-3.5-lightning-30b-a3b:2.0.9-variant     "/opt/nvidia/nvidia_…"    2 days ago   Up 2 days (healthy)     0.0.0.0:30081->8000/tcp                      nemotron-3.5-lightning-30b-a3b
 cdd60a3e6d56   postgres:17.9-alpine                                                "docker-entrypoint.s…"    2 days ago   Up 2 days (healthy)                                                  vss-vios-postgres
 3d5c25a4637b   confluentinc/cp-kafka:8.2.0                                         "/bin/sh /usr/local/…"    2 days ago   Up 2 days (healthy)                                                  kafka
 a3f44e5fe8ad   quay.io/prometheus/prometheus:v3.11.3                               "/bin/prometheus --c…"    2 days ago   Up 2 days               0.0.0.0:9090->9090/tcp                       prometheus

--- a/docs/warehouse-docs/agents.mdx
+++ b/docs/warehouse-docs/agents.mdx
@@ -5,7 +5,7 @@ position: 4
 ---
 The Warehouse Blueprint incorporates an agentic AI system that provides natural language interaction capabilities for querying warehouse safety incidents, generating reports, and retrieving visual information from warehouse cameras.
 
-The suggested agent to use is NVIDIA Nemotron Nano 9B v2 (`nvidia/nvidia-nemotron-nano-9b-v2`) for natural language understanding and query routing, and NVIDIA Cosmos3 Nano Reasoner (`nvidia/cosmos3-nano-reasoner`) for video understanding and analyzing warehouse safety incidents.
+The suggested agent to use is NVIDIA Nemotron 3.5 Lightning 30B A3B (`nvidia/nemotron-3.5-lightning-30b-a3b`) for natural language understanding and query routing, and NVIDIA Cosmos3 Nano Reasoner (`nvidia/cosmos3-nano-reasoner`) for video understanding and analyzing warehouse safety incidents.
 
 For detailed information on all components, APIs, and customization options, refer to the [VSS Agents](/vss/vision-agent/vss-agents).
 
@@ -108,7 +108,7 @@ The warehouse agent configuration file is located at `deploy/docker/industry-pro
 
 | Model | Type | Purpose |
 | --- | --- | --- |
-| `nvidia/nvidia-nemotron-nano-9b-v2` | LLM | Query routing, reasoning, report generation |
+| `nvidia/nemotron-3.5-lightning-30b-a3b` | LLM | Query routing, reasoning, report generation |
 | `nvidia/cosmos3-nano-reasoner` | VLM | Video understanding and analysis |
 
 **Key Warehouse-Specific Settings**

--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -201,7 +201,7 @@ or are only needed for specific features.
 | `INTERNAL_IP` | yes | — | Internal IP (usually same as `HOST_IP`) |
 | `LLM_BASE_URL` | yes | — | LLM endpoint (e.g. `http://HOST:30081`) |
 | `VLM_BASE_URL` | yes | — | VLM endpoint (e.g. `http://HOST:30082`) |
-| `LLM_NAME` | yes | — | LLM model name (e.g. `nvidia/nvidia-nemotron-nano-9b-v2`) |
+| `LLM_NAME` | yes | — | LLM model name (e.g. `nvidia/nemotron-3.5-lightning-30b-a3b`) |
 | `VLM_NAME` | yes | — | VLM model name (e.g. `nvidia/cosmos-reason2-8b`) |
 | `LLM_MODEL_TYPE` | no | `nim` | LLM backend type: `nim`, `openai` |
 | `VLM_MODEL_TYPE` | no | `nim` | VLM backend type: `nim`, `openai`, `vllm`, `rtvi` |

--- a/services/agent/packages/vss_agents/src/vss_agents/orchestrator/README.md
+++ b/services/agent/packages/vss_agents/src/vss_agents/orchestrator/README.md
@@ -133,7 +133,7 @@ uv run nat mcp client tool call \
       "host_ip": "10.0.0.10",
       "external_ip": "10.0.0.10",
       "llm_mode": "local",
-      "llm_name": "nvidia/nvidia-nemotron-nano-9b-v2",
+      "llm_name": "nvidia/nemotron-3.5-lightning-30b-a3b",
       "vlm_mode": "local",
       "vlm_name": "nvidia/cosmos-reason2-8b",
       "compose_profiles": "search_local,...",

--- a/services/video-summarization/README.md
+++ b/services/video-summarization/README.md
@@ -29,7 +29,7 @@ Video Summarization is composed of the following services:
 |---------|------|
 | **lvs** | REST API server — orchestrates captioning, summarization, and streaming workflows |
 | **rt-vlm** | Real-Time VLM inference — downloads video, chunks frames, runs VLM, streams captions via SSE or Kafka |
-| **LLM NIM** (e.g. gpt-oss-20b) | Summarization LLM — aggregates captions into structured summaries via Context-Aware RAG |
+| **LLM NIM** (e.g. nemotron-3.5-lightning-30b-a3b) | Summarization LLM — aggregates captions into structured summaries via Context-Aware RAG |
 | **Elasticsearch** | Document store for captions and summaries |
 | **Kafka + Logstash** | (Optional, profile-gated) Streaming pipeline — RT-VLM publishes raw events to Kafka, Logstash writes to Elasticsearch |
 
@@ -90,28 +90,28 @@ endpoint must already be reachable before you run `docker compose up` for this
 project. If the endpoint is not ready (or `LVS_LLM_HOST` / `LVS_LLM_PORT` are unset),
 the `lvs` service will refuse to start.
 
-The recommended path is to deploy `gpt-oss-20b` locally using the repo-level NIM
-compose at `deploy/docker/services/nim/compose.yml` (which defines the
-`llm_local_gpt-oss-20b` profile). From the repo root:
+The recommended path is to deploy `nemotron-3.5-lightning-30b-a3b` locally using the
+repo-level NIM compose at `deploy/docker/services/nim/compose.yml` (which defines the
+`llm_local_nemotron-3.5-lightning-30b-a3b` profile). From the repo root:
 
 ```sh
 cd deploy/docker
 export VSS_APPS_DIR=$(pwd)            # absolute path to deploy/docker
-export HARDWARE_PROFILE=H100          # H100 | A100 | L40S | ...
+export HARDWARE_PROFILE=H100          # H100 | GB300 | L40S | RTXPRO4500BW | RTXPRO6000BW | OTHER
 export NGC_CLI_API_KEY=<nvapi-...>    # NGC credential used to pull the NIM image
 export LLM_PORT=9233                  # host port to expose the NIM on (any free port)
 export LLM_DEVICE_ID=1                # GPU index the NIM should use
 
 docker compose -f services/nim/compose.yml \
-  --profile llm_local_gpt-oss-20b \
-  up -d gpt-oss-20b
+  --profile llm_local_nemotron-3.5-lightning-30b-a3b \
+  up -d nemotron-3.5-lightning-30b-a3b
 ```
 
 Wait until the NIM reports ready before bringing up Video Summarization:
 
 ```sh
 until curl -sf http://localhost:${LLM_PORT}/v1/health/ready; do
-  echo "Waiting for gpt-oss-20b..."; sleep 5
+  echo "Waiting for nemotron-3.5-lightning-30b-a3b..."; sleep 5
 done
 echo "LLM ready on port ${LLM_PORT}."
 ```
@@ -119,8 +119,9 @@ echo "LLM ready on port ${LLM_PORT}."
 Then point Video Summarization at the LLM by setting `LVS_LLM_HOST`, `LVS_LLM_PORT`,
 and `LVS_LLM_MODEL_NAME` (see [Set environment variables](#set-environment-variables)).
 The NIM runs in a separate Docker Compose project, so reference it by the docker host
-IP (or another routable hostname), not by the `gpt-oss-20b` container name — the LVS
-stack's `app-network` cannot resolve container names across projects.
+IP (or another routable hostname), not by the `nemotron-3.5-lightning-30b-a3b`
+container name — the LVS stack's `app-network` cannot resolve container names
+across projects.
 
 Any OpenAI-compatible LLM endpoint (a remote NIM, NVIDIA-hosted endpoint, a vLLM
 server, etc.) can be substituted by pointing `LVS_LLM_HOST` / `LVS_LLM_PORT` /
@@ -163,9 +164,9 @@ export BACKEND_PORT=38111          # LVS REST API port
 # "Deploy the summarization LLM (prerequisite)" above. Use the docker
 # host IP (or a routable hostname) — the NIM runs in a separate compose
 # project, so its container name will not resolve from within this stack.
-export LVS_LLM_HOST=<>             # Hostname of the summarization LLM (e.g. gpt-oss-20b)
+export LVS_LLM_HOST=<>             # Hostname of the summarization LLM (e.g. the docker host IP)
 export LVS_LLM_PORT=<>             # Port of the summarization LLM (e.g. 9233)
-export LVS_LLM_MODEL_NAME=<>      # LLM model name (e.g. openai/gpt-oss-20b)
+export LVS_LLM_MODEL_NAME=<>      # LLM model name (e.g. nvidia/nemotron-3.5-lightning-30b-a3b)
 
 # Database Backend
 export LVS_DATABASE_BACKEND=elasticsearch_db      # Elasticsearch backend
@@ -258,7 +259,7 @@ BACKEND_PORT=38111
 
 LVS_LLM_HOST=<host-ip>
 LVS_LLM_PORT=9233
-LVS_LLM_MODEL_NAME=openai/gpt-oss-20b
+LVS_LLM_MODEL_NAME=nvidia/nemotron-3.5-lightning-30b-a3b
 
 # Database backend
 LVS_DATABASE_BACKEND=elasticsearch_db


### PR DESCRIPTION
## What

Retires the removed local LLMs from the product documentation.

**Split out of #1854** so that PR carries deploy config, scripts, tests and skills only.

#1854 reduces the bundled local LLM catalogue to `nvidia/nemotron-3.5-lightning-30b-a3b` — removing `nvidia-nemotron-nano-9b-v2`, `nemotron-3-nano`, `llama-3.3-nemotron-super-49b-v1.5` and `openai/gpt-oss-20b` — and makes Lightning the default on every hardware profile, including DGX Spark and AGX/IGX Thor. The Fern pages, the model tables and the profile READMEs still offered the removed models as selectable options.

## Scope

Documentation only — 38 files, +120/−105:

- `docs/**` — the Fern site (`.mdx`), including `edge-deployment`, `quickstart`, `configure-llm`, and the per-vertical doc sets
- `docs/assets/static/default_models.csv` and `llm_params.csv` — the generated model tables
- `README.md` files under `deploy/`, `services/` and `.github/skill-eval/`

No deploy config, script, test or skill changes ride along.

**License pages are excluded on purpose.** `docs/licenses.mdx` and all four `License-Information.mdx` pages still list the removed models; which models appear on a license page is a legal-review question, not a rename. They need a follow-up with OSRB/legal sign-off (also flagged as a known gap on #1854).

## Ordering

This can land before or after #1854. Until #1854 merges, these pages describe the intended end state rather than what is in `develop`, so the two are best landed together.

## Why the skills tree stayed in #1854

`skills/**` is not documentation in the CI sense. Its evals are **agentic** — they run an agent against the skill references and grade the answer — so an eval asserting Lightning-on-DGX-Spark only passes once the routing change is in the same tree. `skills-eval`, `skills-review` and `skills-signatures` all run per-PR, so splitting the two halves would fail whichever PR lacked the other.

## Note on the diff

The first push of this branch was built by checking the files out of the feature branch wholesale, which reverted four newer `develop` commits that touch the same pages — notably `b33c7634b docs: rewrite internal links to Fern slug URLs (#1917)`. It was rebuilt as a patch applied onto `develop`, and the Fern slug URLs are verified present. The corrected diff is +120/−105; the bad one was +369/−378.

🤖 Generated with [Claude Code](https://claude.com/claude-code)