### PR TITLE
feat(rt-embed): add MIG deployment support

### DIFF
--- a/deploy/docker/services/rtvi/rtvi-embed/.env
+++ b/deploy/docker/services/rtvi/rtvi-embed/.env
@@ -32,6 +32,11 @@ RTVI_EMBED_KAFKA_BOOTSTRAP_SERVERS=
 RTVI_EMBED_IPC_FRAME_COPY=false
 RTVI_EMBED_IPC_SOCKET_HOST_DIR=
 
+# GPU configuration
+# Default preserves existing full-GPU behavior. For MIG, set both this and
+# RT_EMBED_DEVICE_ID to the same MIG-... or MIG-GPU-... UUID in your deployment override.
+RTVI_EMBED_NVIDIA_VISIBLE_DEVICES=all
+
 # Set the Huggingface token
 #HF_TOKEN=
 

--- a/deploy/docker/services/rtvi/rtvi-embed/rtvi-embed-docker-compose.yml
+++ b/deploy/docker/services/rtvi/rtvi-embed/rtvi-embed-docker-compose.yml
@@ -31,6 +31,8 @@ services:
             - gpu
             driver: nvidia
             device_ids:
+            # Accepts a GPU index, GPU UUID, or MIG UUID (MIG-... or MIG-GPU-...).
+            # The NVIDIA Container Toolkit exposes only this device to RTVI-Embed.
             - "${RT_EMBED_DEVICE_ID:-0}"
     ports:
       - "${RTVI_EMBED_PORT?}:8000"
@@ -46,6 +48,9 @@ services:
       REMOTE_EMBED_ENDPOINT_BATCH_SIZE: "${REMOTE_EMBED_ENDPOINT_BATCH_SIZE:-64}"
       NGC_API_KEY: "${NGC_API_KEY:-}"
       NVIDIA_API_KEY: "${NVIDIA_API_KEY:-NOAPIKEYSET}"
+      # Default is intentionally "all" for compatibility with existing deployments.
+      # For MIG, set both RT_EMBED_DEVICE_ID and RTVI_EMBED_NVIDIA_VISIBLE_DEVICES
+      # to the same MIG-... or MIG-GPU-... UUID; the slice appears as logical CUDA device 0.
       NVIDIA_VISIBLE_DEVICES: "${RTVI_EMBED_NVIDIA_VISIBLE_DEVICES:-all}"
       NUM_VLM_PROCS: "${RTVI_EMBED_NUM_VLM_PROCS:-}"
       VLM_BATCH_SIZE: "${VLM_BATCH_SIZE:-}"

--- a/deploy/helm/services/rtvi/charts/rtvi-embed/README-standalone.md
+++ b/deploy/helm/services/rtvi/charts/rtvi-embed/README-standalone.md
@@ -151,6 +151,7 @@ helm upgrade --install "${RELEASE}" . \
 Notes:
 
 - Ensure **`hf-token-secret`** exists in **`${NAMESPACE}`** (the umbrella install does not create secrets). Configure `imagePullSecrets` only if you override the public GHCR image with a private registry image.
+- **MIG:** add `--set vss-rtvi-embed.gpuResourceName=nvidia.com/mig-<profile>` to the umbrella command, replacing `<profile>` with a resource advertised by the NVIDIA device plugin. Do not set a MIG UUID in `vss-rtvi-embed.gpuDeviceId`; the device plugin injects the allocated slice. This replaces the child chart's default `nvidia.com/gpu: 1` request and limit.
 - **`messageBusTopic`** defaults to **`mdx-embed`** in `values.yaml`; standalone overrides keep the same topic for later Kafka integration.
 - Output and error publishing are controlled by **`MESSAGE_BUS`**, **`MESSAGE_BUS_TOPIC`**, and **`ERROR_BUS`**.
 - First startup can take **many minutes** (HF model download + Triton model repo; `startupProbe` in `values.yaml` allows a long initial delay).

--- a/deploy/helm/services/rtvi/charts/rtvi-embed/README-standalone.md
+++ b/deploy/helm/services/rtvi/charts/rtvi-embed/README-standalone.md
@@ -8,7 +8,7 @@ For chart internals (templates, values), see `charts/rtvi-embed/`.
 
 ## Prerequisites
 
-- Kubernetes cluster with **NVIDIA GPU** nodes and the NVIDIA device plugin (workload requests `nvidia.com/gpu: 1`).
+- Kubernetes cluster with **NVIDIA GPU** nodes and the NVIDIA device plugin (workload requests `nvidia.com/gpu: 1` by default, or one configured `nvidia.com/mig-*` resource for MIG).
 - **`helm`** (v3) with network access to pull images from `ghcr.io`.
 - **Hugging Face token** in a Secret (default name/key below) for [nvidia/Cosmos-Embed1-448p](https://huggingface.co/nvidia/Cosmos-Embed1-448p). The chart **`modelPath`** value is `git:https://huggingface.co/nvidia/Cosmos-Embed1-448p` (runtime download specifier for the embed service—not a URL to open in a browser).
 - A **StorageClass** for RWO volumes (or leave `persistence.storageClass` empty to use the cluster default).
@@ -102,6 +102,26 @@ helm upgrade --install "${RELEASE}" . \
   -f overrides_rtvi_embed.yaml \
   --wait --timeout 45m
 ```
+
+### 3.2 Install on a MIG slice (optional)
+
+Configure MIG and the NVIDIA device plugin on the cluster first. Set
+`gpuResourceName` to the resource advertised by the plugin; do not set a MIG
+UUID in `NVIDIA_VISIBLE_DEVICES`, because the device plugin injects the selected
+slice. The supplied example uses `nvidia.com/mig-3g.40gb` and must be changed if
+your cluster advertises a different resource:
+
+```bash
+helm upgrade --install "${RELEASE}" . \
+  --namespace "${NAMESPACE}" \
+  --create-namespace \
+  -f overrides_rtvi_embed.yaml \
+  -f overrides_rtvi_embed_mig.yaml \
+  --wait --timeout 45m
+```
+
+The MIG resource replaces the default `nvidia.com/gpu: 1` in both requests and
+limits; the chart never requests a full GPU and a MIG slice together.
 
 ---
 
@@ -243,7 +263,7 @@ kubectl delete namespace "${NAMESPACE}"
 
 ## 8. Troubleshooting
 
-- **Pod `Pending`**: insufficient **`nvidia.com/gpu`** or missing device plugin — `kubectl describe pod -n "${NAMESPACE}"`.
+- **Pod `Pending`**: insufficient **`nvidia.com/gpu`** (or configured `nvidia.com/mig-*`) or missing device plugin — `kubectl describe pod -n "${NAMESPACE}"`.
 - **`ImagePullBackOff`**: check the image repository/tag, registry reachability, and `imagePullSecrets` when using a private registry override.
 - **Stuck in init `wait-for-kafka`**: use **`overrides_rtvi_embed.yaml`** or set **`waitForKafka.enabled: false`**.
 - **HF / model errors**: verify **`hf-token-secret`** / **`HF_TOKEN`**; check pod logs during Cosmos-Embed1 download.

--- a/deploy/helm/services/rtvi/charts/rtvi-embed/overrides_rtvi_embed_mig.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-embed/overrides_rtvi_embed_mig.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Example override for an RTVI-Embed pod on one MIG slice. Apply this together
+# with overrides_rtvi_embed.yaml, changing the resource name to one advertised
+# by the NVIDIA Kubernetes device plugin on the target cluster:
+#
+#   helm upgrade --install vss-rtvi-embed . -n <ns> \
+#     -f overrides_rtvi_embed.yaml -f overrides_rtvi_embed_mig.yaml
+#
+# This chart deliberately does not set NVIDIA_VISIBLE_DEVICES. The Kubernetes
+# NVIDIA device plugin injects the allocated full GPU or MIG device. RTVI-Embed
+# then uses it as logical CUDA device 0.
+
+gpuResourceName: "nvidia.com/mig-3g.40gb"

--- a/deploy/helm/services/rtvi/charts/rtvi-embed/templates/deployment.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-embed/templates/deployment.yaml
@@ -13,6 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- $resources := deepCopy (.Values.resources | default dict) }}
+{{- $gpuResourceName := trim (.Values.gpuResourceName | default "") }}
+{{- if $gpuResourceName }}
+{{- $limits := $resources.limits | default dict }}
+{{- $requests := $resources.requests | default dict }}
+{{- $_ := unset $limits "nvidia.com/gpu" }}
+{{- $_ := unset $requests "nvidia.com/gpu" }}
+{{- $_ := set $limits $gpuResourceName 1 }}
+{{- $_ := set $requests $gpuResourceName 1 }}
+{{- $_ := set $resources "limits" $limits }}
+{{- $_ := set $resources "requests" $requests }}
+{{- end }}
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -152,14 +165,14 @@ spec:
               protocol: TCP
           env:
             {{- /*
-              NVIDIA_VISIBLE_DEVICES is only emitted when gpuDeviceId is set,
-              so the empty chart default leaves the container's runtime default
-              intact (whichever GPUs the pod's resource request exposed).
-              Set .Values.gpuDeviceId to e.g. "1" to pin a specific device.
+              NVIDIA_VISIBLE_DEVICES is emitted only when gpuDeviceId is set
+              and no gpuResourceName is configured. A MIG resource is assigned
+              by the NVIDIA device plugin, which injects the allocated device.
+              Otherwise, the empty default leaves the runtime setting intact.
             */}}
-            {{- with .Values.gpuDeviceId }}
+            {{- if and (eq $gpuResourceName "") .Values.gpuDeviceId }}
             - name: NVIDIA_VISIBLE_DEVICES
-              value: {{ . | quote }}
+              value: {{ .Values.gpuDeviceId | quote }}
             {{- end }}
             - name: LOG_LEVEL
               value: {{ .Values.logLevel | quote }}
@@ -307,7 +320,7 @@ spec:
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml $resources | nindent 12 }}
           volumeMounts:
             - name: ngc-model-cache
               mountPath: /opt/nvidia/rtvi/.rtvi/ngc_model_cache

--- a/deploy/helm/services/rtvi/charts/rtvi-embed/values.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-embed/values.yaml
@@ -35,6 +35,12 @@ service:
 # pod's resource request exposed (runtime default).
 gpuDeviceId: ""
 
+# Optional Kubernetes MIG resource replacement. Set this to the resource name
+# advertised by the NVIDIA device plugin (for example, nvidia.com/mig-3g.40gb).
+# The default remains one nvidia.com/gpu. A MIG deployment requests one slice
+# per pod and relies on the device plugin to set NVIDIA_VISIBLE_DEVICES.
+# gpuResourceName: "nvidia.com/mig-3g.40gb"
+
 # Stream-affinity routing via a HAProxy stick table keyed on an HTTP header.
 # When enabled, the rendered Service carries `haproxy.org/*` annotations
 # that ask a HAProxy Ingress controller to record, on the first request for
@@ -159,6 +165,9 @@ hfTokenSecret:
   name: ""
   key: "HF_TOKEN"
 resources:
+  # gpuResourceName replaces the default GPU resource in both limits and
+  # requests while preserving any CPU or memory resources set here. See
+  # overrides_rtvi_embed_mig.yaml for a complete MIG example.
   limits:
     nvidia.com/gpu: 1
 podSecurityContext:

--- a/services/rtvi/rt-embed/README.md
+++ b/services/rtvi/rt-embed/README.md
@@ -102,6 +102,75 @@ curl -fsS "http://localhost:${BACKEND_PORT}/v1/ready" && echo "Service is ready"
 
 The APIs are available at `http://<host_ip>:<BACKEND_PORT>/docs`.
 
+## Optional: Run RT-Embed on an NVIDIA MIG slice
+
+MIG is optional. Existing Docker Compose and Helm deployments continue to use their
+default full-GPU configuration without changes. Before using MIG, configure the
+GPU and NVIDIA Container Toolkit or Kubernetes device plugin on the host, then
+obtain the slice UUID or resource name from `nvidia-smi -L` or `kubectl describe
+node <node-name>`. The selected slice must have sufficient memory for the model.
+
+MIG availability, the supported profile geometries, and valid co-placement
+combinations are defined by the GPU and its driver. Consult NVIDIA's
+[Supported MIG Profiles](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/supported-mig-profiles.html)
+before partitioning a GPU; do not infer a profile name or instance count from a
+different platform.
+
+### VSS Docker Compose profiles
+
+For the VSS deployment Compose manifest at
+`deploy/docker/services/rtvi/rtvi-embed/rtvi-embed-docker-compose.yml`, set both
+variables to the same MIG UUID reported by `nvidia-smi -L` in the active
+deployment override or shell environment. Current drivers may report a compact
+`MIG-<uuid>` value; older drivers report `MIG-GPU-<gpu-uuid>/<gi>/<ci>`.
+
+```bash
+RT_EMBED_DEVICE_ID="MIG-<uuid-from-nvidia-smi-L>"
+RTVI_EMBED_NVIDIA_VISIBLE_DEVICES="MIG-<uuid-from-nvidia-smi-L>"
+```
+
+`RT_EMBED_DEVICE_ID` assigns the MIG device to the container.
+`RTVI_EMBED_NVIDIA_VISIBLE_DEVICES` exposes that same device to CUDA and the
+embedding service. Inside the container it is CUDA device `0`. Do not set these
+MIG values for a normal full-GPU deployment.
+
+For a multi-instance deployment, run isolated Compose projects or service
+instances and give each service a different MIG UUID. Do not assign multiple MIG
+UUIDs to one single-GPU RT-Embed service.
+
+### Standalone Docker Compose
+
+The standalone Compose file under `services/rtvi/rt-embed/docker/` uses its
+existing `NVIDIA_VISIBLE_DEVICES` setting. Set it to the MIG UUID in that stack's
+`.env` file:
+
+```bash
+NVIDIA_VISIBLE_DEVICES="MIG-<uuid-from-nvidia-smi-L>"
+```
+
+### Standalone Helm chart
+
+The Kubernetes NVIDIA device plugin assigns the device. Do not set a MIG UUID in
+`NVIDIA_VISIBLE_DEVICES`. Configure the resource name advertised by the plugin
+instead. For a device plugin using the `mixed` MIG strategy, an example is:
+
+```yaml
+gpuResourceName: "nvidia.com/mig-3g.40gb"
+```
+
+The repository provides `overrides_rtvi_embed_mig.yaml` as a complete example.
+Install it after the normal standalone override:
+
+```bash
+helm upgrade --install vss-rtvi-embed . \
+  -n vss-rtvi \
+  -f overrides_rtvi_embed.yaml \
+  -f overrides_rtvi_embed_mig.yaml
+```
+
+The MIG resource replaces the chart's default `nvidia.com/gpu: 1` request; the
+chart does not request a full GPU and a MIG slice together.
+
 ### 3. (Optional) Enable monitoring
 
 To start the Prometheus + Jaeger + OpenTelemetry stack alongside the service, set `ENABLE_OTEL_MONITORING=true` in your `.env` and run:
@@ -412,7 +481,7 @@ ASSET_STORAGE_DIR=/path/to/assets           # Host path for uploaded files
 EXAMPLE_STREAMS_DIR=/path/to/sample-videos  # Host path for example streams
 
 # GPU Configuration
-NVIDIA_VISIBLE_DEVICES=0                    # Use specific GPUs (default: all)
+NVIDIA_VISIBLE_DEVICES=0                    # GPU index, UUID, or MIG UUID (default: all)
 VLM_BATCH_SIZE=128                          # Override automatic batch size
 
 # Logging
@@ -497,7 +566,7 @@ Use the /v1/models API to get the name of the model once the server is up.
 | `VLM_BATCH_SIZE` | Inference batch size | Auto-calculated | No |
 | `NUM_VLM_PROCS` | Number of inference processes | `10` | No |
 | `NUM_GPUS` | Number of GPUs to use | Auto-detected | No |
-| `NVIDIA_VISIBLE_DEVICES` | GPU device IDs | `all` | No |
+| `NVIDIA_VISIBLE_DEVICES` | GPU index, UUID, or MIG UUID exposed to the container | `all` | No |
 | `MODEL_PATH` | Model source: `ngc:<org/team/model:ver>`, `git:<hf-url>`, or local path | `git:https://huggingface.co/nvidia/Cosmos-Embed1-448p` | No |
 | `MODEL_IMPLEMENTATION_PATH` | Implementation code path for the model | `/opt/nvidia/rtvi/rtvi/models/custom/samples/cosmos-embed1` | No |
 | `REMOTE_EMBED_ENDPOINT` | Optional CE1 NIM endpoint URL. When set, startup switches to the CE1 NIM backend and uses the remote endpoint instead of the local Cosmos-Embed1 model. | - | No |


### PR DESCRIPTION
## Summary
      Add opt-in NVIDIA MIG support for the RT-Embed service across Docker Compose and Helm, matching the existing RT-VLM deployment model. Full-GPU deployments retain their current defaults.

## Plan

## Related Issue

## Changes

  - Docker Compose:
      - Support MIG UUIDs in RT_EMBED_DEVICE_ID.
      - Add RTVI_EMBED_NVIDIA_VISIBLE_DEVICES guidance; both variables use the same MIG UUID.

  - Helm:
      - Add optional gpuResourceName to request one device-plugin MIG resource instead of nvidia.com/gpu.
      - Remove explicit NVIDIA_VISIBLE_DEVICES when a MIG resource is selected, allowing the NVIDIA device plugin to inject the allocated device.
      - Add overrides_rtvi_embed_mig.yaml with an editable nvidia.com/mig-3g.40gb example.

  - Documentation:
      - Document RT-Embed MIG deployment for VSS Compose, standalone Compose, and standalone Helm.
      - Update RT-Embed chart prerequisites and troubleshooting for MIG resources.

## Checklist
- [ ✅] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ✅] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ✅] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ✅] New or existing tests cover these changes.
- [ ✅] The documentation is up to date with these changes.
- [ ✅] No secrets, API keys, or credentials committed.
