### PR TITLE
fix(skill-eval): isolate runtime and artifact checks

### DIFF
--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -399,10 +399,13 @@ The canonical harbor command is in § Harbor invocation.
    **The box's docker runtime is reset for you at the *start* of each spec,
    not on exit.** On a spec's first trial — a single-step spec, or `step-1`
    of a multi-step one — `BrevEnvironment.start()` (the env provider, before
-   the agent runs) wipes the docker runtime to a clean slate: it force-removes
+   the agent runs) wipes the docker runtime before repo cleanup, then repeats
+   the verified reset, host-data purge, and repo sync at agent handoff. It
+   force-removes
    **all** containers, **all** user-defined networks, and **all** volumes
    (images are preserved — re-pulling them is slow). So a spec always begins
-   from a deterministic, leak-free runtime regardless of what the previous
+   from a deterministic, leak-free runtime even if a cancelled predecessor
+   recreates containers during repo sync, and regardless of what the previous
    spec left — a leftover container from a *different* compose project used to
    port-conflict the new deploy (observed: a stuck `phoenix` + missing init
    containers because a prior base-profile deploy still held the ports).

--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -399,8 +399,9 @@ The canonical harbor command is in § Harbor invocation.
    **The box's docker runtime is reset for you at the *start* of each spec,
    not on exit.** On a spec's first trial — a single-step spec, or `step-1`
    of a multi-step one — `BrevEnvironment.start()` (the env provider, before
-   the agent runs) wipes the docker runtime before repo cleanup, then repeats
-   the verified reset, host-data purge, and repo sync at agent handoff. It
+   the agent runs) wipes the docker runtime before repo cleanup, then reaps
+   surviving agents and repeats the verified reset, host-data purge, and repo
+   sync at agent handoff. It
    force-removes
    **all** containers, **all** user-defined networks, and **all** volumes
    (images are preserved — re-pulling them is slow). So a spec always begins

--- a/.github/skill-eval/README.md
+++ b/.github/skill-eval/README.md
@@ -176,7 +176,9 @@ python3 .github/skill-eval/adapters/vss-manage-video-io-storage/generate.py \
 #    (or let the skills-eval agent select one).
 #
 # ⚠️ On a spec's first trial the env provider WIPES the box's docker runtime
-#    (all containers, user-defined networks, and volumes; images are kept).
+#    before repo cleanup, then repeats reset, host purge, and repo sync at
+#    agent handoff (all containers, user-defined networks, and volumes;
+#    images are kept).
 #    NEVER point a manual run at a box a CI run currently holds — it will
 #    `docker rm -f` that run's deployment mid-trial. Use run_leg.py so the
 #    same per-box lock contract applies to manual runs.

--- a/.github/skill-eval/README.md
+++ b/.github/skill-eval/README.md
@@ -176,9 +176,9 @@ python3 .github/skill-eval/adapters/vss-manage-video-io-storage/generate.py \
 #    (or let the skills-eval agent select one).
 #
 # ⚠️ On a spec's first trial the env provider WIPES the box's docker runtime
-#    before repo cleanup, then repeats reset, host purge, and repo sync at
-#    agent handoff (all containers, user-defined networks, and volumes;
-#    images are kept).
+#    before repo cleanup, then reaps surviving agents and repeats reset, host
+#    purge, and repo sync at agent handoff (all containers, user-defined
+#    networks, and volumes; images are kept).
 #    NEVER point a manual run at a box a CI run currently holds — it will
 #    `docker rm -f` that run's deployment mid-trial. Use run_leg.py so the
 #    same per-box lock contract applies to manual runs.

--- a/.github/skill-eval/adapters/vss-build-vision-ai/generate.py
+++ b/.github/skill-eval/adapters/vss-build-vision-ai/generate.py
@@ -105,6 +105,9 @@ PREAMBLE = (
 )
 
 GENERIC_JUDGE = Path(__file__).resolve().parents[2] / "verifiers" / "generic_judge.py"
+BUILD_ARTIFACT_INSPECTOR = (
+    Path(__file__).resolve().parents[2] / "verifiers" / "build_artifact_inspector.py"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -143,7 +146,7 @@ def _substitute_spec(spec: dict, platform: str) -> dict:
 # Per-file generators
 # ---------------------------------------------------------------------------
 
-def generate_test_script(step: int, spec_name: str) -> str:
+def generate_test_script(step: int, spec_name: str, build_profile: str) -> str:
     """Shell wrapper invoking the generic LLM-as-judge verifier for one step.
     Harbor reads /logs/verifier/reward.txt."""
     return (
@@ -152,6 +155,11 @@ def generate_test_script(step: int, spec_name: str) -> str:
         "set -uo pipefail\n"
         "\n"
         'TEST_DIR="$(cd "$(dirname "$0")" && pwd)"\n'
+        'REPO_ROOT="${HOME}/video-search-and-summarization"\n'
+        'python3 "$TEST_DIR/build_artifact_inspector.py" \\\n'
+        '    --repo-root "$REPO_ROOT" \\\n'
+        f'    --build-dir "$REPO_ROOT/_builds/{build_profile}" \\\n'
+        '    --out /logs/verifier/build-artifacts.json\n'
         "python3 -m pip install --quiet 'anthropic>=0.40.0' >/dev/null 2>&1 || true\n"
         "\n"
         'python3 "$TEST_DIR/generic_judge.py" \\\n'
@@ -324,9 +332,16 @@ def generate_task(
         # ---- tests/ --------------------------------------------------------
         tests_dir = step_dir / "tests"
         tests_dir.mkdir(exist_ok=True)
-        (tests_dir / "test.sh").write_text(generate_test_script(idx, spec_name))
+        (tests_dir / "test.sh").write_text(
+            generate_test_script(idx, spec_name, build_profile)
+        )
         if GENERIC_JUDGE.exists():
             shutil.copy(GENERIC_JUDGE, tests_dir / "generic_judge.py")
+        if BUILD_ARTIFACT_INSPECTOR.exists():
+            shutil.copy(
+                BUILD_ARTIFACT_INSPECTOR,
+                tests_dir / "build_artifact_inspector.py",
+            )
         # Ship the rendered spec so the verifier's judge sees substituted paths
         (tests_dir / spec_name).write_text(json.dumps(rendered_spec, indent=2))
 

--- a/.github/skill-eval/adapters/vss-build-vision-ai/generate.py
+++ b/.github/skill-eval/adapters/vss-build-vision-ai/generate.py
@@ -108,6 +108,10 @@ GENERIC_JUDGE = Path(__file__).resolve().parents[2] / "verifiers" / "generic_jud
 BUILD_ARTIFACT_INSPECTOR = (
     Path(__file__).resolve().parents[2] / "verifiers" / "build_artifact_inspector.py"
 )
+BUILD_ARTIFACT_EVIDENCE_HINT = (
+    "For build-artifact claims, read `/logs/verifier/build-artifacts.json` and "
+    "prefer that deterministic evidence over trajectory or prose inspection."
+)
 
 
 # ---------------------------------------------------------------------------
@@ -152,7 +156,7 @@ def generate_test_script(step: int, spec_name: str, build_profile: str) -> str:
     return (
         "#!/bin/bash\n"
         f"# vss-build-vision-ai verifier (step {step}): delegates to generic_judge.\n"
-        "set -uo pipefail\n"
+        "set -euo pipefail\n"
         "\n"
         'TEST_DIR="$(cd "$(dirname "$0")" && pwd)"\n'
         'REPO_ROOT="${HOME}/video-search-and-summarization"\n'
@@ -240,6 +244,11 @@ def generate_task(
         build_profile = Path(spec_name).stem  # fallback to spec filename stem
 
     rendered_spec = _substitute_spec(spec, platform)
+    for rendered_expect in rendered_spec.get("expects") or []:
+        rendered_expect["checks"] = [
+            f"{check}\n\n{BUILD_ARTIFACT_EVIDENCE_HINT}"
+            for check in rendered_expect.get("checks") or []
+        ]
     runtime_deploy = bool(spec.get("runtime_deploy", True))
     judge_max_turns = int(spec.get("judge_max_turns", 60))
 

--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -520,6 +520,14 @@ class BrevEnvironment(BaseEnvironment):
         await self._probe_bind_mount(f"{task_dir_name}:before-sync")
         if is_first_trial:
             await self._sync_repo_to_pr_head()
+            # A cancelled predecessor can have an on-box child that survives
+            # the initial reap long enough to recreate containers or files
+            # while the repository is syncing. Repeat the same verified prep
+            # at the final handoff boundary so the agent inherits neither
+            # runtime nor filesystem state from that race.
+            await self._reset_docker_runtime()
+            await self._purge_host_data_dirs()
+            await self._sync_repo_to_pr_head()
         await self._probe_bind_mount(f"{task_dir_name}:after-sync")
 
         # The harness intentionally does NOT pre-deploy any VSS profile
@@ -557,13 +565,13 @@ class BrevEnvironment(BaseEnvironment):
         NOTE: wiping all volumes also drops the model-weight caches
         (`rtvi-hf-cache`, `rtvi-ngc-model-cache`), so the next deploy pays the
         full cold model-weight download (~20 min vs ~55 s warm). The caller
-        gates this to a spec's first trial only (single-step, or step-1 of a
-        multi-step spec — later steps reuse step-1's deployment), so under the
-        canonical `-n 1 --max-retries 0` invocation (one trial per spec) the
-        cost is paid once per spec, not once per step. An `-n>1` rollout, a
-        harbor retry, or a repeated manual run on the same warm box each
-        re-wipes the caches and re-pays the cold start. The per-trial harbor
-        timeout already budgets for a cold deploy.
+        gates both pre-agent reset passes to a spec's first trial only
+        (single-step, or step-1 of a multi-step spec — later steps reuse
+        step-1's deployment). Both passes happen before deployment, so the
+        cold-download cost is still paid once per spec, not once per step. An
+        `-n>1` rollout, a harbor retry, or a repeated manual run on the same
+        warm box each re-wipes the caches and re-pays the cold start. The
+        per-trial harbor timeout already budgets for a cold deploy.
 
         Runs as the normal (docker-group) user — the same identity the
         trial's deploy uses; no sudo. `network prune` leaves the built-in

--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -237,21 +237,7 @@ class BrevEnvironment(BaseEnvironment):
         # wipe (suspected in PR #1281's base/search legs losing SSH
         # mid-deploy on vss-eval-rtx-2g-2, minutes after a cancelled run's
         # legs died there). Must run before the /logs wipe and docker reset.
-        reap_result = await _run_brev_exec(
-            self._instance_name,
-            _stray_agent_reap_command(),
-            timeout=30,
-        )
-        if reap_result.return_code != 0:
-            tail = (reap_result.stderr or reap_result.stdout or "")[-500:]
-            raise RuntimeError(
-                f"stray-agent reap failed on {self._instance_name}: "
-                f"exit {reap_result.return_code}; tail:\n{tail}"
-            )
-        logger.info(
-            "Stray-agent reap on %s: %s",
-            self._instance_name, (reap_result.stdout or "").strip(),
-        )
+        await self._reap_stray_agents()
 
         # Pre-create harbor's expected directories with correct ownership
         # so that agent and verifier processes can write to them.
@@ -522,9 +508,10 @@ class BrevEnvironment(BaseEnvironment):
             await self._sync_repo_to_pr_head()
             # A cancelled predecessor can have an on-box child that survives
             # the initial reap long enough to recreate containers or files
-            # while the repository is syncing. Repeat the same verified prep
-            # at the final handoff boundary so the agent inherits neither
-            # runtime nor filesystem state from that race.
+            # while the repository is syncing. Reap again, then repeat the
+            # verified prep at the final handoff boundary so the agent inherits
+            # neither runtime nor filesystem state from that race.
+            await self._reap_stray_agents()
             await self._reset_docker_runtime()
             await self._purge_host_data_dirs()
             await self._sync_repo_to_pr_head()
@@ -540,6 +527,25 @@ class BrevEnvironment(BaseEnvironment):
 
         self._started = True
         logger.info("Brev instance %s is reachable", self._instance_name)
+
+    async def _reap_stray_agents(self) -> None:
+        """Fail closed after killing marked agent processes on the eval box."""
+        result = await _run_brev_exec(
+            self._instance_name,
+            _stray_agent_reap_command(),
+            timeout=30,
+        )
+        if result.return_code != 0:
+            tail = (result.stderr or result.stdout or "")[-500:]
+            raise RuntimeError(
+                f"stray-agent reap failed on {self._instance_name}: "
+                f"exit {result.return_code}; tail:\n{tail}"
+            )
+        logger.info(
+            "Stray-agent reap on %s: %s",
+            self._instance_name,
+            (result.stdout or "").strip(),
+        )
 
     async def _reset_docker_runtime(self) -> None:
         """Wipe the warm-pool box's docker runtime before the trial.

--- a/.github/skill-eval/envs/tests/test_step_gate.py
+++ b/.github/skill-eval/envs/tests/test_step_gate.py
@@ -73,9 +73,10 @@ class StepGateTest(unittest.IsolatedAsyncioTestCase):
         env.environment_dir = env_dir
         env._instance_name = "vss-eval-test"
 
-        reset = mock.AsyncMock()
-        purge = mock.AsyncMock()
-        sync = mock.AsyncMock()
+        calls: list[str] = []
+        reset = mock.AsyncMock(side_effect=lambda: calls.append("reset"))
+        purge = mock.AsyncMock(side_effect=lambda: calls.append("purge"))
+        sync = mock.AsyncMock(side_effect=lambda: calls.append("sync"))
 
         with mock.patch.object(env, "_resolve_instance_name", return_value="vss-eval-test"), \
              mock.patch.object(env, "_reset_docker_runtime", new=reset), \
@@ -91,38 +92,31 @@ class StepGateTest(unittest.IsolatedAsyncioTestCase):
                                new=mock.AsyncMock(side_effect=_async_ok)):
             await env.start(force_build=False)
 
-        calls: set[str] = set()
-        if reset.await_count:
-            calls.add("reset")
-        if purge.await_count:
-            calls.add("purge")
-        if sync.await_count:
-            calls.add("sync")
         return calls
 
     async def test_step1_runs_all_prep(self):
         calls = await self._run_start_for("step-1")
-        self.assertEqual(calls, {"reset", "purge", "sync"},
-                         "step-1 must reset, purge, and sync (clean slate)")
+        self.assertEqual(calls, ["reset", "purge", "sync"] * 2,
+                         "step-1 must repeat all prep at handoff")
 
     async def test_single_step_runs_all_prep(self):
         # Single-step spec: task dir is the platform, not `step-N`.
         calls = await self._run_start_for("rtxpro6000bw")
-        self.assertEqual(calls, {"reset", "purge", "sync"},
-                         "single-step spec must reset, purge, and sync")
+        self.assertEqual(calls, ["reset", "purge", "sync"] * 2,
+                         "single-step spec must repeat all prep at handoff")
 
     async def test_step2_skips_all_prep(self):
         calls = await self._run_start_for("step-2")
         self.assertNotIn("sync", calls,
                          "step-2 must NOT re-sync: git clean would delete the "
                          "live deploy/docker/data-dir bind mounts")
-        self.assertEqual(calls, set(),
+        self.assertEqual(calls, [],
                          "step-2 must skip reset, purge, AND sync")
 
     async def test_step10_skips_all_prep(self):
         # Guard the string compare: `step-10` must not be mistaken for step-1.
         calls = await self._run_start_for("step-10")
-        self.assertEqual(calls, set(), "step-10 must skip all destructive prep")
+        self.assertEqual(calls, [], "step-10 must skip all destructive prep")
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/skill-eval/envs/tests/test_step_gate.py
+++ b/.github/skill-eval/envs/tests/test_step_gate.py
@@ -63,7 +63,7 @@ def _async_ok(*_a, **_kw):
 class StepGateTest(unittest.IsolatedAsyncioTestCase):
     async def _run_start_for(self, task_dir_name: str):
         """Drive start() for a task dir named `task_dir_name`, with every
-        box-side coroutine stubbed, and return the set of gated helpers that
+        box-side coroutine stubbed, and return the ordered gated helpers that
         were awaited."""
         tmp = Path(tempfile.mkdtemp())
         env_dir = tmp / task_dir_name / "environment"
@@ -78,6 +78,11 @@ class StepGateTest(unittest.IsolatedAsyncioTestCase):
         purge = mock.AsyncMock(side_effect=lambda: calls.append("purge"))
         sync = mock.AsyncMock(side_effect=lambda: calls.append("sync"))
 
+        async def run_brev_exec(*args, **_kwargs):
+            if "[stray-agent-reap]" in args[1]:
+                calls.append("reap")
+            return _async_ok()
+
         with mock.patch.object(env, "_resolve_instance_name", return_value="vss-eval-test"), \
              mock.patch.object(env, "_reset_docker_runtime", new=reset), \
              mock.patch.object(env, "_purge_host_data_dirs", new=purge), \
@@ -89,20 +94,20 @@ class StepGateTest(unittest.IsolatedAsyncioTestCase):
              mock.patch.object(brev_env, "_check_live_resources",
                                new=mock.AsyncMock(return_value=None)), \
              mock.patch.object(brev_env, "_run_brev_exec",
-                               new=mock.AsyncMock(side_effect=_async_ok)):
+                               new=mock.AsyncMock(side_effect=run_brev_exec)):
             await env.start(force_build=False)
 
         return calls
 
     async def test_step1_runs_all_prep(self):
         calls = await self._run_start_for("step-1")
-        self.assertEqual(calls, ["reset", "purge", "sync"] * 2,
+        self.assertEqual(calls, ["reap", "reset", "purge", "sync"] * 2,
                          "step-1 must repeat all prep at handoff")
 
     async def test_single_step_runs_all_prep(self):
         # Single-step spec: task dir is the platform, not `step-N`.
         calls = await self._run_start_for("rtxpro6000bw")
-        self.assertEqual(calls, ["reset", "purge", "sync"] * 2,
+        self.assertEqual(calls, ["reap", "reset", "purge", "sync"] * 2,
                          "single-step spec must repeat all prep at handoff")
 
     async def test_step2_skips_all_prep(self):
@@ -110,13 +115,13 @@ class StepGateTest(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("sync", calls,
                          "step-2 must NOT re-sync: git clean would delete the "
                          "live deploy/docker/data-dir bind mounts")
-        self.assertEqual(calls, [],
+        self.assertEqual(calls, ["reap"],
                          "step-2 must skip reset, purge, AND sync")
 
     async def test_step10_skips_all_prep(self):
         # Guard the string compare: `step-10` must not be mistaken for step-1.
         calls = await self._run_start_for("step-10")
-        self.assertEqual(calls, [], "step-10 must skip all destructive prep")
+        self.assertEqual(calls, ["reap"], "step-10 must skip all destructive prep")
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/skill-eval/tests/test_build_artifact_inspector.py
+++ b/.github/skill-eval/tests/test_build_artifact_inspector.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+INSPECTOR = ROOT / ".github/skill-eval/verifiers/build_artifact_inspector.py"
+ADAPTER = ROOT / ".github/skill-eval/adapters/vss-build-vision-ai/generate.py"
+
+
+def _load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_inspector_parses_assignments_and_ignores_comments(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    build = repo / "_builds/test"
+    build.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    (build / "override.env").write_text(
+        "# FOUNDATION=wrong\nFOUNDATION=lvs\n"
+        "# COMPOSE_PROFILES=wrong\nexport COMPOSE_PROFILES='kafka,rtvi-vlm'\n"
+    )
+    (build / "compose.yml").write_text("services: {}\n")
+    protected = repo / "deploy/docker/generated.txt"
+    protected.parent.mkdir(parents=True)
+    protected.write_text("stale\n")
+
+    evidence = _load(INSPECTOR, "build_artifact_inspector").inspect(repo, build)
+
+    assert evidence["foundation"] == "lvs"
+    assert evidence["compose_profiles"] == ["kafka", "rtvi-vlm"]
+    assert evidence["deploy_docker_changes"] == ["?? deploy/docker/generated.txt"]
+    assert evidence["artifacts"] == {
+        "override.env": True,
+        "compose.yml": True,
+        "resolved.yml": False,
+    }
+
+
+def test_adapter_bundles_and_invokes_inspector(tmp_path: Path) -> None:
+    adapter = _load(ADAPTER, "vss_build_vision_ai_adapter")
+    spec = {
+        "_source_path": "example.json",
+        "profile": "in-1",
+        "resources": {"platforms": {"RTXPRO6000BW": {}}},
+        "expects": [{"query": "Build it", "checks": []}],
+    }
+    skill = tmp_path / "skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("test\n")
+
+    adapter.generate_task(
+        "RTXPRO6000BW",
+        spec,
+        tmp_path / "out",
+        skill,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+
+    tests = tmp_path / "out/example/rtxpro6000bw/tests"
+    assert (tests / "build_artifact_inspector.py").is_file()
+    script = (tests / "test.sh").read_text()
+    assert '--build-dir "$REPO_ROOT/_builds/in-1"' in script
+    assert "--out /logs/verifier/build-artifacts.json" in script

--- a/.github/skill-eval/tests/test_build_artifact_inspector.py
+++ b/.github/skill-eval/tests/test_build_artifact_inspector.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import importlib.util
+import json
+import os
 import subprocess
 from pathlib import Path
 
@@ -53,7 +55,7 @@ def test_adapter_bundles_and_invokes_inspector(tmp_path: Path) -> None:
         "_source_path": "example.json",
         "profile": "in-1",
         "resources": {"platforms": {"RTXPRO6000BW": {}}},
-        "expects": [{"query": "Build it", "checks": []}],
+        "expects": [{"query": "Build it", "checks": ["Build artifacts exist"]}],
     }
     skill = tmp_path / "skill"
     skill.mkdir()
@@ -74,5 +76,33 @@ def test_adapter_bundles_and_invokes_inspector(tmp_path: Path) -> None:
     tests = tmp_path / "out/example/rtxpro6000bw/tests"
     assert (tests / "build_artifact_inspector.py").is_file()
     script = (tests / "test.sh").read_text()
+    rendered_spec = json.loads((tests / "example.json").read_text())
+    rendered_check = rendered_spec["expects"][0]["checks"][0]
+
+    assert "set -euo pipefail" in script
     assert '--build-dir "$REPO_ROOT/_builds/in-1"' in script
     assert "--out /logs/verifier/build-artifacts.json" in script
+    assert "/logs/verifier/build-artifacts.json" in rendered_check
+    assert "deterministic evidence" in rendered_check
+
+
+def test_generated_verifier_stops_when_inspector_fails(tmp_path: Path) -> None:
+    adapter = _load(ADAPTER, "vss_build_vision_ai_fail_fast")
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    marker = tmp_path / "judge-ran"
+    script = tests / "test.sh"
+    script.write_text(adapter.generate_test_script(1, "example.json", "in-1"))
+    (tests / "build_artifact_inspector.py").write_text("raise SystemExit(42)\n")
+    (tests / "generic_judge.py").write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).touch()\n"
+    )
+
+    result = subprocess.run(
+        ["bash", str(script)],
+        check=False,
+        env={**os.environ, "HOME": str(tmp_path)},
+    )
+
+    assert result.returncode == 42
+    assert not marker.exists()

--- a/.github/skill-eval/verifiers/build_artifact_inspector.py
+++ b/.github/skill-eval/verifiers/build_artifact_inspector.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Emit deterministic, non-secret evidence for build-artifact checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+
+def _env_value(path: Path, key: str) -> str | None:
+    if not path.is_file():
+        return None
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[7:].lstrip()
+        name, separator, value = line.partition("=")
+        if separator and name.strip() == key:
+            value = value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+                value = value[1:-1]
+            return value
+    return None
+
+
+def _run(*args: str, cwd: Path) -> tuple[int, list[str]]:
+    try:
+        result = subprocess.run(
+            args, cwd=cwd, capture_output=True, text=True, check=False
+        )
+    except OSError as exc:
+        return 127, [str(exc)]
+    output = result.stdout if result.returncode == 0 else result.stderr
+    return result.returncode, [line for line in output.splitlines() if line]
+
+
+def inspect(repo_root: Path, build_dir: Path) -> dict:
+    override = build_dir / "override.env"
+    profiles = _env_value(override, "COMPOSE_PROFILES")
+    resolved = build_dir / "resolved.yml"
+    compose_rc, services = (
+        _run(
+            "docker",
+            "compose",
+            "-f",
+            str(resolved),
+            "config",
+            "--services",
+            cwd=repo_root,
+        )
+        if resolved.is_file()
+        else (None, [])
+    )
+    status_rc, protected_changes = _run(
+        "git",
+        "status",
+        "--short",
+        "--untracked-files=all",
+        "--",
+        "deploy/docker",
+        cwd=repo_root,
+    )
+    return {
+        "schema": 1,
+        "build_dir": str(build_dir),
+        "artifacts": {
+            name: (build_dir / name).is_file()
+            for name in ("override.env", "compose.yml", "resolved.yml")
+        },
+        "foundation": _env_value(override, "FOUNDATION"),
+        "compose_profiles": sorted(
+            token.strip() for token in (profiles or "").split(",") if token.strip()
+        ),
+        "resolved_config_valid": compose_rc == 0,
+        "resolved_services": sorted(services) if compose_rc == 0 else [],
+        "deploy_docker_status_valid": status_rc == 0,
+        "deploy_docker_changes": protected_changes,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, required=True)
+    parser.add_argument("--build-dir", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    evidence = inspect(args.repo_root.resolve(), args.build_dir.resolve())
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(evidence, indent=2) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skill-eval/verifiers/generic_judge.py
+++ b/.github/skill-eval/verifiers/generic_judge.py
@@ -88,10 +88,6 @@ You have read-only access to the trial artifacts via tools:
 - The agent's trajectory is on disk at one of /logs/agent/trajectory.json, /logs/agent/trajectory.jsonl, /logs/agent/claude-code.txt, /logs/agent/agent.log.
 - The live deployed system is reachable through Bash — you can `docker ps`, `curl http://localhost:...`, `cat /some/file`, etc. Use this to independently verify response-structure claims against the live endpoint, not just transcript pattern-matching.
 - The trial's `/tests/` dir has the task spec and verifier helpers if you need them.
-- Build-vision trials write `/logs/verifier/build-artifacts.json`. Prefer this
-  deterministic structural evidence for artifact presence, parsed FOUNDATION,
-  parsed COMPOSE_PROFILES, resolved services, and deploy/docker git status.
-  It ignores comments and metadata prose; do not replace it with raw grep.
 
 # ⚠️ Trajectory size — never load the whole file into context
 

--- a/.github/skill-eval/verifiers/generic_judge.py
+++ b/.github/skill-eval/verifiers/generic_judge.py
@@ -88,6 +88,10 @@ You have read-only access to the trial artifacts via tools:
 - The agent's trajectory is on disk at one of /logs/agent/trajectory.json, /logs/agent/trajectory.jsonl, /logs/agent/claude-code.txt, /logs/agent/agent.log.
 - The live deployed system is reachable through Bash — you can `docker ps`, `curl http://localhost:...`, `cat /some/file`, etc. Use this to independently verify response-structure claims against the live endpoint, not just transcript pattern-matching.
 - The trial's `/tests/` dir has the task spec and verifier helpers if you need them.
+- Build-vision trials write `/logs/verifier/build-artifacts.json`. Prefer this
+  deterministic structural evidence for artifact presence, parsed FOUNDATION,
+  parsed COMPOSE_PROFILES, resolved services, and deploy/docker git status.
+  It ignores comments and metadata prose; do not replace it with raw grep.
 
 # ⚠️ Trajectory size — never load the whole file into context
 


### PR DESCRIPTION
## Summary

- repeat the verified Docker reset, host-data purge, and repo sync at the final agent handoff boundary to prevent cancelled-run state from resurfacing during setup
- emit deterministic, non-secret build artifact evidence for Foundation, COMPOSE_PROFILES, resolved services, and deploy/docker changes
- direct the generic judge to prefer structural evidence over comment/prose grep for build-vision checks

This is a separate harness-reliability follow-up to the nondeterministic Skills Eval failures observed on #1913. It does not modify that PR.

## Validation

- 12 focused harness tests passed on Python 3.13
- generated an IN-1 dataset and verified the inspector is bundled and invoked
- copyright-header check passed for all 8517 tracked files
- git diff --check passed
- staged credential-pattern scan passed

The full local harness suite reached 299 passed and 3 skipped. Six unrelated existing tests remained unavailable or inconsistent locally: three leg-report cases require TruffleHog or Docker, and three RTX 4090 routing tests expect routing tables that are disabled on current develop.