### PR TITLE
fix(agent): route RTVI-CV ingest through the internal VST endpoint

### DIFF
--- a/services/agent/packages/vss_agents/src/vss_agents/api/video_ingest.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/api/video_ingest.py
@@ -58,7 +58,7 @@ from pydantic import Field
 from vss_agents.tools.vst.timeline import get_timeline
 from vss_agents.tools.vst.utils import VSTError
 from vss_agents.utils.time_measure import TimeMeasure
-from vss_agents.utils.url_translation import rewrite_url_host
+from vss_agents.utils.url_translation import rewrite_to_internal_vst_url
 
 logger = logging.getLogger(__name__)
 
@@ -388,7 +388,6 @@ async def _run_rtvi_embedding(
     *,
     rtvi_embed_base_url: str,
     sensor_id: str,
-    vst_url: str,
     vst_file_path: str,
     rtvi_embed_model: str,
     rtvi_embed_chunk_duration: int,
@@ -403,14 +402,9 @@ async def _run_rtvi_embedding(
     """
     rtvi_embed_url = rtvi_embed_base_url.rstrip("/")
     embedding_url = f"{rtvi_embed_url}/v1/generate_video_embeddings"
-    parsed_vst = urllib.parse.urlparse(f"http://{vst_url}" if "://" not in vst_url else vst_url)
-    if not parsed_vst.hostname:
-        raise HTTPException(status_code=500, detail=f"Invalid vst_url format: {vst_url}")
-    translated_video_url = rewrite_url_host(vst_file_path, parsed_vst.hostname)
-    logger.info(f"Using internal VST URL for RTVI: {translated_video_url}")
 
     embed_request = {
-        "url": translated_video_url,
+        "url": vst_file_path,
         "id": sensor_id,
         "model": rtvi_embed_model,
         "creation_time": start_timestamp,
@@ -524,7 +518,16 @@ async def _run_post_upload_processing(
             logger.error(error_msg)
             raise HTTPException(status_code=502, detail=f"Storage API response invalid: {error_msg}")
 
-        logger.info(f"VST video URL obtained: {vst_file_path}")
+    # Translate the VST storage URL to the internal VST endpoint once, so both
+    # RTVI-CV and RTVI-Embed can fetch the video directly without hitting a
+    # reverse proxy / external host that may be unreachable from in-cluster.
+    # rewrite_to_internal_vst_url replaces the proxy base (host + port) with the
+    # configured internal VST base, so an explicit port on the external URL
+    # is not carried over to the internal endpoint.
+    if not vst_url:
+        raise HTTPException(status_code=500, detail=f"Invalid vst_url format: {vst_url}")
+    internal_video_url = rewrite_to_internal_vst_url(vst_file_path, vst_url)
+    logger.info(f"Using internal VST URL for RTVI services: {internal_video_url}")
 
     # Register with RTVI-CV and trigger embedding generation concurrently.
     # The two services are independent — they both consume the VST storage URL
@@ -545,7 +548,7 @@ async def _run_post_upload_processing(
                     rtvi_cv_base_url=rtvi_cv_base_url,
                     sensor_id=sensor_id,
                     camera_name=camera_name,
-                    vst_file_path=vst_file_path,
+                    vst_file_path=internal_video_url,
                     start_timestamp=start_timestamp,
                     timeout_seconds=rtvi_cv_timeout_seconds,
                 ),
@@ -562,8 +565,7 @@ async def _run_post_upload_processing(
                 _run_rtvi_embedding(
                     rtvi_embed_base_url=rtvi_embed_base_url,
                     sensor_id=sensor_id,
-                    vst_url=vst_url,
-                    vst_file_path=vst_file_path,
+                    vst_file_path=internal_video_url,
                     rtvi_embed_model=rtvi_embed_model,
                     rtvi_embed_chunk_duration=rtvi_embed_chunk_duration,
                     start_timestamp=start_timestamp,

--- a/services/agent/packages/vss_agents/tests/unit_test/api/test_video_ingest.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/api/test_video_ingest.py
@@ -317,6 +317,74 @@ class TestRunPostUploadProcessing:
         assert "embeddings generated" in result.message
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("raw_video_url", "expected"),
+        [
+            (
+                "http://vst.example-nip.io/vst/storage/temp_files/clip.mp4",
+                "http://vst-internal:30888/vst/storage/temp_files/clip.mp4",
+            ),
+            # Explicit external port must NOT carry over to the internal endpoint.
+            (
+                "http://vst.example-nip.io:8080/vst/storage/temp_files/clip.mp4",
+                "http://vst-internal:30888/vst/storage/temp_files/clip.mp4",
+            ),
+        ],
+    )
+    async def test_rtvi_cv_and_embed_receive_internal_vst_url(self, raw_video_url, expected):
+        """Both RTVI-CV and RTVI-Embed must receive the VST storage URL rewritten
+        to the internal VST endpoint, not the raw external ``videoUrl`` from VST
+        storage. Guards: (1) in-cluster RTVI-CV failing to fetch clips when the
+        VST ingress endpoint is an external host unreachable from the pod,
+        and (2) an explicit external port on the storage URL not being carried
+        over to the internal endpoint.
+        """
+        from vss_agents.utils.url_translation import rewrite_to_internal_vst_url
+
+        vst_internal = "http://vst-internal:30888"
+        assert rewrite_to_internal_vst_url(raw_video_url, vst_internal) == expected
+
+        storage_resp = self._mock_response(200, {"videoUrl": raw_video_url})
+        cv_resp = self._mock_response(200, {"ok": True})
+        embed_resp = self._mock_response(200, {"usage": {"total_chunks_processed": 7}})
+
+        posted: dict[str, dict] = {}
+
+        def _dispatch(url, *args, **kwargs):
+            if "/api/v1/stream/add" in url:
+                posted["cv"] = kwargs.get("json")
+                return cv_resp
+            if "/v1/generate_video_embeddings" in url:
+                posted["embed"] = kwargs.get("json")
+                return embed_resp
+            raise AssertionError(f"unexpected POST URL: {url}")
+
+        client = MagicMock()
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=None)
+        client.get = AsyncMock(return_value=storage_resp)
+        client.post = AsyncMock(side_effect=_dispatch)
+
+        with self._timeline_patch(), patch("vss_agents.api.video_ingest.httpx.AsyncClient", return_value=client):
+            await _run_post_upload_processing(
+                camera_name="clip",
+                sensor_id="sensor-abc",
+                filename="clip.mp4",
+                vst_url=vst_internal,
+                rtvi_embed_base_url="http://rtvi-embed:8017",
+                rtvi_cv_base_url="http://rtvi-cv:9000",
+            )
+
+        # Both consumers must receive the internal VST endpoint.
+        assert posted["cv"]["value"]["camera_url"] == expected
+        assert posted["embed"]["url"] == expected
+        # Neither consumer should carry the raw external host or its explicit port.
+        assert "example-nip.io" not in posted["cv"]["value"]["camera_url"]
+        assert "example-nip.io" not in posted["embed"]["url"]
+        assert ":8080" not in posted["cv"]["value"]["camera_url"]
+        assert ":8080" not in posted["embed"]["url"]
+
+    @pytest.mark.asyncio
     async def test_rtvi_cv_unreachable_is_skipped_not_fatal(self):
         import httpx
 


### PR DESCRIPTION
## Summary

 Video-file ingest handed RTVI-CV the raw external VST URL while RTVI-Embed rewrote it to internal. When the external VST ingress was unreachable from in-cluster,
 RTVI-CV got no source → no behavior docs → attribute_search 404'd ("0 results"). Translate the VST URL to internal once; pass the same internal URL to both
 RTVI-CV and RTVI-Embed.

## Plan

 - Translate vst_file_path → internal_video_url once in _run_post_upload_processing; pass to both _register_with_rtvi_cv and _run_rtvi_embedding.
 - Drop the now-redundant rewrite + vst_url param from _run_rtvi_embedding.
 - pytest test_video_ingest.py → 82 passed; new test fails on pre-fix code (stash-verified).

## Related Issue

 VIA-2744

## Changes

 - video_ingest.py: translate to internal_video_url once in _run_post_upload_processing; pass to both RTVI-CV and RTVI-Embed.
 - video_ingest.py: drop vst_url param + internal rewrite_url_host from _run_rtvi_embedding.
 - test_video_ingest.py: add test_rtvi_cv_and_embed_receive_internal_vst_url asserting both consumers get the internal URL.
 - Scope: nvidia-vss-agents only; RTSP path and vss-core/cli unaffected.
 
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.
