### PR TITLE
[6704636] fix(deploy): select SBSA RT-VLM via VSS_RT_VLM_TAG on GB300

### DIFF
--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -485,21 +485,6 @@ function get_rtvi_vlm_max_model_len() {
   esac
 }
 
-# Compose interpolates ${VSS_RT_VLM_IMAGE}:${VSS_RT_VLM_TAG}. Reuse an already
-# selected SBSA tag when present; otherwise append -sbsa to the managed channel.
-function resolve_sbsa_image_tag() {
-  local _current="${1}"
-  local _fallback="${2:-develop-latest}"
-  local _base
-  if [[ "${_current}" == *sbsa* ]]; then
-    echo "${_current}"
-    return
-  fi
-  _base="${_current:-${_fallback}}"
-  _base="${_base%-sbsa}"
-  echo "${_base}-sbsa"
-}
-
 # Apply VSS kernel settings (IPv6 disable, TCP buffer sizes). Persistent across reboots via /etc/sysctl.d/99-vss.conf.
 function set_vss_linux_kernel_settings() {
   local _sudo=""
@@ -1669,15 +1654,6 @@ function state_up() {
       echo "[INFO] Swapped to SBSA (${hardware_profile}): ${_key}"
     done < <(grep -E '^#[[:space:]]*[A-Za-z0-9_]+=.*sbsa' "${_generated_env}" 2>/dev/null | sed -nE 's/^#[[:space:]]*([A-Za-z0-9_]+)=.*/\1/p' | sort -u)
   fi
-  # rtvi-vlm-docker-compose.yml reads VSS_RT_VLM_TAG. LVS has no commented SBSA
-  # line for that key, so the swap above is not enough on GB300. Write the
-  # managed SBSA tag into generated.env so Compose interpolation wins.
-  if [[ "${hardware_profile}" == "DGX-SPARK" || "${hardware_profile}" == "GB300" ]]; then
-    local _rt_vlm_tag
-    _rt_vlm_tag="$(resolve_sbsa_image_tag "$(get_env_value "${_generated_env}" "VSS_RT_VLM_TAG")" "${VSS_CONTAINER_TAG:-develop-latest}")"
-    set_env_var "VSS_RT_VLM_TAG" "${_rt_vlm_tag}"
-    echo "[INFO] Selected SBSA RT-VLM image for ${hardware_profile}: ${_rt_vlm_tag}"
-  fi
 
   echo "[INFO] Generated environment file: ${_generated_env}"
 
@@ -1745,6 +1721,17 @@ function state_up() {
   # shellcheck disable=SC1091
   source "${deployment_directory}/containers.env"
   set +a
+
+  # rtvi-vlm-docker-compose.yml resolves ${VSS_RT_VLM_IMAGE}:${VSS_RT_VLM_TAG}, and
+  # Compose ranks the exported shell value above every --env-file, so the SBSA
+  # variant has to be selected here, once containers.env has resolved the channel.
+  # GB300 needs it because the generic ARM64 image omits the DeepStream runtime.
+  if [[ "${hardware_profile}" == "GB300" ]] && [[ "${VSS_RT_VLM_TAG}" != *sbsa* ]]; then
+    export VSS_RT_VLM_TAG="${VSS_RT_VLM_TAG}-sbsa"
+    set_env_var "VSS_RT_VLM_TAG" "${VSS_RT_VLM_TAG}"
+    echo "[INFO] Selected SBSA RT-VLM image for GB300: ${VSS_RT_VLM_TAG}"
+  fi
+
   # -f disables Compose's default file discovery, so the base file must be named
   # explicitly alongside any overlay.
   local compose_files=(-f compose.yml)

--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -1726,10 +1726,13 @@ function state_up() {
   # Compose ranks the exported shell value above every --env-file, so the SBSA
   # variant has to be selected here, once containers.env has resolved the channel.
   # GB300 needs it because the generic ARM64 image omits the DeepStream runtime.
+  # VSS_RT_VLM_SBSA_TAG pins a specific build, e.g. 3.3.0-26.08.2-sbsa; that one
+  # is an NGC coordinate, so pin VSS_RT_VLM_IMAGE to the NGC repository with it
+  # rather than leaving the image on the GHCR default, which has no such tag.
   if [[ "${hardware_profile}" == "GB300" ]] && [[ "${VSS_RT_VLM_TAG}" != *sbsa* ]]; then
-    export VSS_RT_VLM_TAG="${VSS_RT_VLM_TAG}-sbsa"
+    export VSS_RT_VLM_TAG="${VSS_RT_VLM_SBSA_TAG:-${VSS_RT_VLM_TAG}-sbsa}"
     set_env_var "VSS_RT_VLM_TAG" "${VSS_RT_VLM_TAG}"
-    echo "[INFO] Selected SBSA RT-VLM image for GB300: ${VSS_RT_VLM_TAG}"
+    echo "[INFO] Selected SBSA RT-VLM image for GB300: ${VSS_RT_VLM_IMAGE}:${VSS_RT_VLM_TAG}"
   fi
 
   # -f disables Compose's default file discovery, so the base file must be named

--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -485,6 +485,21 @@ function get_rtvi_vlm_max_model_len() {
   esac
 }
 
+# Compose interpolates ${VSS_RT_VLM_IMAGE}:${VSS_RT_VLM_TAG}. Reuse an already
+# selected SBSA tag when present; otherwise append -sbsa to the managed channel.
+function resolve_sbsa_image_tag() {
+  local _current="${1}"
+  local _fallback="${2:-develop-latest}"
+  local _base
+  if [[ "${_current}" == *sbsa* ]]; then
+    echo "${_current}"
+    return
+  fi
+  _base="${_current:-${_fallback}}"
+  _base="${_base%-sbsa}"
+  echo "${_base}-sbsa"
+}
+
 # Apply VSS kernel settings (IPv6 disable, TCP buffer sizes). Persistent across reboots via /etc/sysctl.d/99-vss.conf.
 function set_vss_linux_kernel_settings() {
   local _sudo=""
@@ -1654,11 +1669,14 @@ function state_up() {
       echo "[INFO] Swapped to SBSA (${hardware_profile}): ${_key}"
     done < <(grep -E '^#[[:space:]]*[A-Za-z0-9_]+=.*sbsa' "${_generated_env}" 2>/dev/null | sed -nE 's/^#[[:space:]]*([A-Za-z0-9_]+)=.*/\1/p' | sort -u)
   fi
-  # LVS keeps RTVI_VLM_IMAGE_TAG in its static .env, so write the ARM64
-  # override into generated.env where it wins during Compose interpolation.
-  if [[ "${hardware_profile}" == "GB300" ]]; then
-    set_env_var "RTVI_VLM_IMAGE_TAG" "3.3.0-26.08.2-sbsa"
-    echo "[INFO] Selected SBSA RT-VLM image for GB300"
+  # rtvi-vlm-docker-compose.yml reads VSS_RT_VLM_TAG. LVS has no commented SBSA
+  # line for that key, so the swap above is not enough on GB300. Write the
+  # managed SBSA tag into generated.env so Compose interpolation wins.
+  if [[ "${hardware_profile}" == "DGX-SPARK" || "${hardware_profile}" == "GB300" ]]; then
+    local _rt_vlm_tag
+    _rt_vlm_tag="$(resolve_sbsa_image_tag "$(get_env_value "${_generated_env}" "VSS_RT_VLM_TAG")" "${VSS_CONTAINER_TAG:-develop-latest}")"
+    set_env_var "VSS_RT_VLM_TAG" "${_rt_vlm_tag}"
+    echo "[INFO] Selected SBSA RT-VLM image for ${hardware_profile}: ${_rt_vlm_tag}"
   fi
 
   echo "[INFO] Generated environment file: ${_generated_env}"

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -1553,7 +1553,8 @@ run_dry_run_up_and_check_generated_env "generated.env LVS defaults to Nemotron 3
  -i 127.0.0.1 -H GB300 -d -- \
   "HARDWARE_PROFILE" "GB300" \
   "LLM_NAME" "nvidia/nemotron-3.5-lightning-30b-a3b" \
-  "LLM_NAME_SLUG" "nemotron-3.5-lightning-30b-a3b"
+  "LLM_NAME_SLUG" "nemotron-3.5-lightning-30b-a3b" \
+  "VSS_RT_VLM_TAG" "develop-latest-sbsa"
 
 run_dry_run_up_and_check_generated_env "generated.env Search defaults to Nemotron 3.5 Lightning on H100" "search" \
  -i 127.0.0.1 -H H100 -d -- \
@@ -1566,7 +1567,7 @@ run_dry_run_up_and_check_generated_env "generated.env Base GB300 overlay selects
   "HARDWARE_PROFILE" "GB300" \
   "LLM_NAME" "nvidia/nemotron-3.5-lightning-30b-a3b" \
   "LLM_NAME_SLUG" "nemotron-3.5-lightning-30b-a3b" \
-  "RTVI_VLM_IMAGE_TAG" "3.3.0-26.08.2-sbsa"
+  "VSS_RT_VLM_TAG" "develop-latest-sbsa"
 
 run_dry_run_up_and_check_generated_env "generated.env Base defaults to Nemotron 3.5 Lightning on H100" "base" \
  -i 127.0.0.1 -H H100 -d -- \

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -1556,6 +1556,11 @@ run_dry_run_up_and_check_generated_env "generated.env LVS defaults to Nemotron 3
   "LLM_NAME_SLUG" "nemotron-3.5-lightning-30b-a3b" \
   "VSS_RT_VLM_TAG" "develop-latest-sbsa"
 
+run_dry_run_up_and_check_generated_env "generated.env alerts GB300 selects SBSA RT-VLM" "alerts" \
+ -i 127.0.0.1 -H GB300 -m real-time -d -- \
+  "HARDWARE_PROFILE" "GB300" \
+  "VSS_RT_VLM_TAG" "develop-latest-sbsa"
+
 run_dry_run_up_and_check_generated_env "generated.env Search defaults to Nemotron 3.5 Lightning on H100" "search" \
  -i 127.0.0.1 -H H100 -d -- \
   "HARDWARE_PROFILE" "H100" \


### PR DESCRIPTION
## Summary
Fixes NVBug [6704636](https://nvbugspro.nvidia.com/bug/6704636). On GB300, `dev-profile.sh` logged `Selected SBSA RT-VLM image for GB300` while Compose started the generic `vss-rt-vlm:develop-latest`, which lacks the SBSA DeepStream runtime and exits with:

```
ImportError: libnvbufsurface.so.1.0.0: cannot open shared object file
```

RT-VLM never became healthy, so Alert Bridge stayed `Created` and Realtime Alerts could not be validated.

## Root cause (two layers)
1. **Wrong variable.** The GB300 branch wrote `RTVI_VLM_IMAGE_TAG=3.3.0-26.08.2-sbsa`, a leftover from the retired compose contract. `rtvi-vlm-docker-compose.yml` resolves `${VSS_RT_VLM_IMAGE}:${VSS_RT_VLM_TAG}`, so the write had no effect and the tag fell through `VSS_CONTAINER_TAG` to `develop-latest`.
2. **Wrong precedence.** Writing `VSS_RT_VLM_TAG` into `generated.env` is *also* not sufficient. `state_up` runs `set -a; source containers.env; set +a` before `docker compose up`, which exports `VSS_RT_VLM_TAG=develop-latest`, and Compose ranks the shell environment above every `--env-file`. Verified with `docker compose config --images`:

```
generated.env only (no shell var)        -> repo/vss-rt-vlm:develop-latest-sbsa
shell var exported (what state_up does)  -> repo/vss-rt-vlm:develop-latest   <-- wins
```

## Fix
Select the SBSA variant **after** `containers.env` resolves the managed channel, then export it and mirror it into `generated.env`:

```bash
if [[ "${hardware_profile}" == "GB300" ]] && [[ "${VSS_RT_VLM_TAG}" != *sbsa* ]]; then
  export VSS_RT_VLM_TAG="${VSS_RT_VLM_SBSA_TAG:-${VSS_RT_VLM_TAG}-sbsa}"
  set_env_var "VSS_RT_VLM_TAG" "${VSS_RT_VLM_TAG}"
  echo "[INFO] Selected SBSA RT-VLM image for GB300: ${VSS_RT_VLM_IMAGE}:${VSS_RT_VLM_TAG}"
fi
```

| `VSS_RT_VLM_TAG` (channel) | `VSS_RT_VLM_SBSA_TAG` (pin) | Result |
|---|---|---|
| `develop-latest` | unset | `develop-latest-sbsa` |
| `develop-latest` | `3.3.0-26.08.2-sbsa` | `3.3.0-26.08.2-sbsa` |
| `3.4.0-rc1` (QA override) | unset | `3.4.0-rc1-sbsa` |
| `develop-latest-sbsa` | unset | unchanged (idempotent) |

- **Pinning is supported** through `VSS_RT_VLM_SBSA_TAG`, so an exact build such as `3.3.0-26.08.2-sbsa` can be locked in when needed.
- The **default follows the managed channel**, because `3.3.0-26.08.2-sbsa` is an NGC coordinate and is not published on the GHCR repository the image default resolves to. Anonymous registry check against `ghcr.io/nvidia-ai-blueprints/vss/vss-rt-vlm`:

```
3.3.0-26.08.2-sbsa  -> HTTP 404
develop-latest-sbsa -> HTTP 200
```

  Shipping that pin as the default would swap a missing-library failure for a missing-manifest pull failure, so the comment ties the pin to a matching `VSS_RT_VLM_IMAGE`. This is the same hazard `containers.env` already documents for RT-CV ("pinning an NGC-style tag would combine with the GHCR image default and resolve to a nonexistent coordinate").
- Also covers LVS on GB300, which has no commented `VSS_RT_VLM_TAG=...-sbsa` line for the existing swap loop to activate.
- The log line now prints the full image reference, so the misleading "selected SBSA" message from the bug report can no longer disagree with the container that actually starts.

## Scope / non-goals
- **GB300 only.** DGX-SPARK is deliberately untouched: its `base`/`alerts` `overrides.env` already carry the commented `#VSS_RT_VLM_TAG="develop-latest-sbsa"` line that the existing swap loop activates, and rewriting it would change the quoted value `run_spark_test_for_profile` asserts.
- The shell-precedence issue in layer 2 applies to every `-sbsa` key selected only through `generated.env` (for example `VSS_RT_CV_TAG` on DGX-SPARK). That is pre-existing and left for a separate change rather than widened here.
- `RTVI_VLM_IMAGE_TAG` remains in the profile env files and in the override-key contract tests; only the ineffective GB300 write is removed.
- No change to `containers.env`, so the container-coordinates golden test is unaffected.

## Test plan
- [x] `bash -n` on `dev-profile.sh` and `test-dev-profile.sh`
- [x] Compose interpolation precedence verified with `docker compose config --images` (shell vs `--env-file`)
- [x] Tag resolution matrix verified for channel default, explicit pin, QA channel override, and already `-sbsa` input
- [x] GHCR tag availability checked for the default and the pinned coordinate
- [ ] `deploy/docker/test-scripts/test-dev-profile.sh` on CI (updated GB300 base/LVS assertions, new alerts GB300 case)
- [x] On GB300, deploy Realtime Alerts and confirm:
  - `[INFO] Selected SBSA RT-VLM image for GB300: .../vss-rt-vlm:develop-latest-sbsa`
  - `docker inspect -f '{{.Config.Image}}' vss-rtvi-vlm` reports the `-sbsa` image
  - RT-VLM becomes healthy and Alert Bridge starts
- [ ] Confirm DGX-SPARK alerts/base still resolve the `-sbsa` RT-VLM tag (unchanged path)
