### PR TITLE
feat(unified-memory): support embeddings for memory retrieval

### DIFF
--- a/services/agent/packages/vss_cli/AGENTS.md
+++ b/services/agent/packages/vss_cli/AGENTS.md
@@ -103,6 +103,27 @@ Elasticsearch, the embedding NIM, or the agent API directly — a hand-built que
 that returns *something* is worse than a clean failure, because nothing
 downstream can tell it was improvised.
 
+## `vss memory` — recall
+
+```bash
+vss memory query --query "..." [--mode keyword|semantic|hybrid]
+vss memory introspect --query "..." --sensor NAME
+vss memory embeddings backfill [--dry-run]
+```
+
+Text queries use the configured retrieval mode — `hybrid` whenever embeddings
+are enabled, fusing the keyword and semantic rankings client-side. Asking for a
+semantic mode with embeddings disabled warns on stderr and answers from keyword
+retrieval rather than failing. Lookups by identity embed nothing and stay
+deterministic: `get`, a `query` with no `--query`, and an introspection scoped
+by `--job-id` or `--record-id`.
+
+Canonical Elasticsearch memory remains authoritative. Vectors live in a
+versioned companion index, and authoritative records carry only
+`output.embedding` references to it. The CLI runs no model — the embedding
+endpoint's deployment decides CPU or GPU. Policy, defaults, and the backfill
+contract are in [MEMORY.md](MEMORY.md).
+
 ## Rules
 
 The seven that govern every group — configure once, branch on the exit code, an

--- a/services/agent/packages/vss_cli/AGENTS.md
+++ b/services/agent/packages/vss_cli/AGENTS.md
@@ -99,7 +99,7 @@ vss vlm get --job-id <id>
 ```
 
 If a preflight fails, report its error and stop. Do not fall back to calling
-Elasticsearch, the embedding NIM, or the agent API directly — a hand-built query
+Elasticsearch, the embedding service, or the agent API directly — a hand-built query
 that returns *something* is worse than a clean failure, because nothing
 downstream can tell it was improvised.
 
@@ -120,9 +120,10 @@ by `--job-id` or `--record-id`.
 
 Canonical Elasticsearch memory remains authoritative. Vectors live in a
 versioned companion index, and authoritative records carry only
-`output.embedding` references to it. The CLI runs no model — the embedding
-endpoint's deployment decides CPU or GPU. Policy, defaults, and the backfill
-contract are in [MEMORY.md](MEMORY.md).
+`output.embedding` references to it. The CLI runs no model — by default it
+reuses the OpenClaw Gateway's `openclaw/default` target, while an explicitly
+configured OpenAI-compatible service can be used instead. Policy, prerequisites,
+and the backfill contract are in [MEMORY.md](MEMORY.md).
 
 ## Rules
 

--- a/services/agent/packages/vss_cli/MEMORY.md
+++ b/services/agent/packages/vss_cli/MEMORY.md
@@ -90,6 +90,7 @@ vss memory get --job-id <job-id>
 vss memory query --job-id <job-id>
 vss memory events --asset-id <sensor-or-video-id>
 vss memory introspect --query "What happened?" --sensor <sensor-name>
+vss memory embeddings backfill --dry-run
 ```
 
 Use `get` for an exact parent or child identity, `query` for filtered or text
@@ -131,6 +132,102 @@ There is no `lookup` or `retrieve` command. The schema has no slug or
 `memory_id`. `events --window` is deferred until duration and boundary
 semantics are defined; use `--start-time` and `--end-time`.
 
+## Derived embeddings and hybrid recall
+
+The canonical `nv.vss.memory/1.0` documents in Elasticsearch stay
+authoritative. Vectors live in a separate versioned companion index. An
+authoritative record gains only `output.embedding` references — companion
+index, document id, model, dimensions, and content hash — never vector values.
+Markdown notes are untouched by this: they carry no vectors and no embedding
+references.
+
+Enable the capability once:
+
+```console
+vss configure memory \
+  --enable \
+  --backend elasticsearch \
+  --index vss-memory \
+  --embeddings \
+  --embedding-provider openai_compatible \
+  --embedding-endpoint http://embedding-service:8000/v1 \
+  --embedding-model nvidia/llama-nemotron-embed-300m-v2 \
+  --embedding-dimensions 768 \
+  --embedding-index vss-memory-embeddings-v1 \
+  --embedding-timeout 30 \
+  --embedding-batch-size 16 \
+  --retrieval-mode hybrid \
+  --semantic-candidate-count 50 \
+  --rrf-rank-constant 60
+```
+
+Only the endpoint has to be given: the model, dimensions, companion index, and
+retrieval mode shown above are the defaults. The endpoint is required whenever
+embeddings are enabled and must carry no credentials — name an environment
+variable holding a Bearer token with `--embedding-api-key-env`. The companion
+index must differ from the authoritative one. `--embedding-timeout` (30
+seconds), `--embedding-batch-size` (16), `--semantic-candidate-count` (50), and
+`--rrf-rank-constant` (60) complete the static policy.
+
+The CLI never loads an embedding model. It posts to an OpenAI-compatible
+`/embeddings` endpoint, so CPU or GPU execution is a property of that
+endpoint's deployment and not a CLI flag or a host requirement.
+
+Validate the wiring without writing records:
+
+```console
+vss configure memory check
+```
+
+With embeddings enabled this also embeds one probe string, reports the model
+and the dimensions actually returned, and inspects the companion mapping. A
+missing companion index is reported as missing — it is created lazily on the
+first embedding write or backfill. An incompatible one is a configuration
+error.
+
+Retrieval mode applies only to text queries:
+
+```console
+vss memory query --query "forklift near the loading dock" --mode hybrid
+```
+
+`hybrid` — the default whenever embeddings are enabled — runs the keyword BM25
+match over `input.query` and `output.answer` and a filtered kNN search over the
+companion index, then fuses the two rankings client-side with reciprocal rank
+fusion. `semantic` uses the vector ranking alone. `keyword` embeds nothing.
+
+Identity lookups stay deterministic. `get`, `events`, and any `query` without
+`--query` read Elasticsearch directly and embed nothing, as does a
+`memory introspect` scoped by `--job-id` or `--record-id`: identity selects the
+evidence, so the question is never embedded and never filters it. An
+introspection scoped by `--sensor` or a time window sends its question through
+the configured retrieval mode.
+
+Recall degrades rather than fails. `--mode semantic` or `--mode hybrid` with
+embeddings disabled warns on stderr and answers from keyword retrieval. A
+provider or companion-index failure during a query also falls back to keyword
+retrieval, logging the failure kind without backend detail.
+
+Records written before embeddings were enabled are indexed by a backfill:
+
+```console
+vss memory embeddings backfill --dry-run
+vss memory embeddings backfill --batch-size 16 --limit 500
+```
+
+It scans authoritative memory in bounded batches and emits one JSON object
+counting `scanned`, `eligible`, `embedded`, `reused`, `skipped`, and `failed`,
+with per-record `failures`. `--dry-run` reports eligibility without provider
+calls or writes. Any failure exits 6 with those counts still on stdout. Only
+`completed` and `partial` records with searchable content are eligible, and
+re-running is cheap: an unchanged record keeps its vector when the model and
+dimensions still match.
+
+Changing the model or the dimensions is not an in-place edit. Point
+`--embedding-index` at a new versioned index and backfill it; a write to an
+index whose mapping disagrees with the configured model or dimensions is
+rejected.
+
 ## Optional OpenClaw Markdown cache
 
 Enable the capability and choose its default once:
@@ -167,7 +264,9 @@ Elasticsearch persistence. Markdown status is reported separately as
 
 This surface preserves parent/child persistence and recall. Introspection adds
 bounded sufficiency analysis and VLM follow-ups without storing an
-introspection trace. Semantic/vector recall and graph memory are not included.
+introspection trace. Semantic and hybrid recall are derived from the companion
+vector index and never change what the authoritative store holds. Graph memory
+is not included.
 
 Trusted persistence callbacks are not supported. No active code or tests
 require them, and arbitrary callback execution is not exposed to agents.

--- a/services/agent/packages/vss_cli/MEMORY.md
+++ b/services/agent/packages/vss_cli/MEMORY.md
@@ -141,37 +141,107 @@ index, document id, model, dimensions, and content hash — never vector values.
 Markdown notes are untouched by this: they carry no vectors and no embedding
 references.
 
-Enable the capability once:
+### Default: reuse the OpenClaw Gateway
+
+VSS does not start OpenClaw, install an embedding model, or load model weights.
+The [OpenClaw Gateway](https://github.com/openclaw/openclaw/blob/main/docs/gateway/index.md)
+must already be running, and its OpenAI-compatible HTTP surface must be enabled.
+The current OpenClaw prerequisite is:
+
+```json
+{
+  "gateway": {
+    "http": {
+      "endpoints": {
+        "chatCompletions": {
+          "enabled": true
+        }
+      }
+    }
+  }
+}
+```
+
+Export the Gateway bearer token by name; never put its value in VSS
+configuration or a command-line endpoint:
+
+```bash
+export OPENCLAW_GATEWAY_TOKEN="<gateway token>"
+```
+
+Smoke-test the Gateway before configuring VSS:
+
+```bash
+curl -sS http://127.0.0.1:18789/v1/embeddings \
+  -H "Authorization: Bearer $OPENCLAW_GATEWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "openclaw/default",
+    "input": ["VSS embedding readiness probe"]
+  }'
+```
+
+Then enable semantic memory with the default profile:
+
+```console
+vss configure memory --embeddings
+```
+
+This resolves to:
+
+```text
+provider: openclaw_gateway
+endpoint: http://127.0.0.1:18789/v1
+model: openclaw/default
+api_key_env: OPENCLAW_GATEWAY_TOKEN
+```
+
+`openclaw/default` is an OpenClaw agent target, not a raw model identifier.
+OpenClaw chooses the embedding provider and model configured for that agent.
+VSS receives vectors over HTTP and stores them, but never downloads or imports
+the model runtime.
+
+If dimensions are omitted, configuration sends one probe and records the
+returned vector length. `--embedding-dimensions INTEGER` sets an expected
+length explicitly and permits offline configuration; the live check and every
+later response still validate it. The default companion index is
+`vss-memory-embeddings-v1`.
+
+### Custom OpenAI-compatible endpoints
+
+A custom endpoint and model must be explicit:
 
 ```console
 vss configure memory \
-  --enable \
-  --backend elasticsearch \
-  --index vss-memory \
   --embeddings \
   --embedding-provider openai_compatible \
-  --embedding-endpoint http://embedding-service:8000/v1 \
-  --embedding-model nvidia/llama-nemotron-embed-300m-v2 \
-  --embedding-dimensions 768 \
-  --embedding-index vss-memory-embeddings-v1 \
-  --embedding-timeout 30 \
-  --embedding-batch-size 16 \
-  --retrieval-mode hybrid \
-  --semantic-candidate-count 50 \
-  --rrf-rank-constant 60
+  --embedding-endpoint https://embedding.example.com/v1 \
+  --embedding-model example-embedding-model \
+  --embedding-api-key-env EXAMPLE_EMBEDDING_TOKEN
 ```
 
-Only the endpoint has to be given: the model, dimensions, companion index, and
-retrieval mode shown above are the defaults. The endpoint is required whenever
-embeddings are enabled and must carry no credentials — name an environment
-variable holding a Bearer token with `--embedding-api-key-env`. The companion
-index must differ from the authoritative one. `--embedding-timeout` (30
-seconds), `--embedding-batch-size` (16), `--semantic-candidate-count` (50), and
-`--rrf-rank-constant` (60) complete the static policy.
+Authentication is optional for a trusted local endpoint:
 
-The CLI never loads an embedding model. It posts to an OpenAI-compatible
-`/embeddings` endpoint, so CPU or GPU execution is a property of that
-endpoint's deployment and not a CLI flag or a host requirement.
+```console
+vss configure memory \
+  --embeddings \
+  --embedding-provider openai_compatible \
+  --embedding-endpoint http://127.0.0.1:9000/v1 \
+  --embedding-model local-custom-model \
+  --no-embedding-auth
+```
+
+Only OpenAI-compatible `/v1/embeddings` is supported. VSS sends only `model`
+and `input` by default. Use `--embedding-query-input-type` and
+`--embedding-document-input-type` only when the custom service requires those
+extensions. Expected dimensions are not sent as a request parameter.
+
+Endpoint URLs must be absolute HTTP(S) URLs and cannot contain usernames or
+passwords. `--embedding-api-key-env` stores only an environment-variable name;
+VSS resolves its value at request time and never prints or persists it.
+`--embedding-timeout-seconds` (30 seconds), `--embedding-batch-size` (16),
+`--semantic-candidate-count` (50), and `--rrf-rank-constant` (60) complete the
+static policy. The companion index must differ from authoritative memory.
 
 Validate the wiring without writing records:
 
@@ -179,11 +249,12 @@ Validate the wiring without writing records:
 vss configure memory check
 ```
 
-With embeddings enabled this also embeds one probe string, reports the model
-and the dimensions actually returned, and inspects the companion mapping. A
-missing companion index is reported as missing — it is created lazily on the
-first embedding write or backfill. An incompatible one is a configuration
-error.
+With embeddings enabled this also embeds one probe string, reports the
+configured target, any resolved model identity returned by the endpoint, and
+the vector dimensions. It distinguishes missing credentials, authentication
+failures, endpoint failures, malformed responses, and dimension mismatches
+without exposing a token. A missing companion index is created lazily on the
+first embedding write or backfill.
 
 Retrieval mode applies only to text queries:
 
@@ -203,10 +274,12 @@ evidence, so the question is never embedded and never filters it. An
 introspection scoped by `--sensor` or a time window sends its question through
 the configured retrieval mode.
 
-Recall degrades rather than fails. `--mode semantic` or `--mode hybrid` with
-embeddings disabled warns on stderr and answers from keyword retrieval. A
-provider or companion-index failure during a query also falls back to keyword
-retrieval, logging the failure kind without backend detail.
+Recall degrades rather than fails under the existing retrieval contract.
+`--mode semantic` or `--mode hybrid` with embeddings disabled warns on stderr
+and answers from keyword retrieval. A provider or companion-index failure
+during a query also falls back to keyword retrieval and emits a diagnostic that
+the semantic leg was unavailable; it does not present the result as successful
+semantic retrieval. Backend details and credentials are not logged.
 
 Records written before embeddings were enabled are indexed by a backfill:
 
@@ -223,10 +296,22 @@ calls or writes. Any failure exits 6 with those counts still on stdout. Only
 re-running is cheap: an unchanged record keeps its vector when the model and
 dimensions still match.
 
-Changing the model or the dimensions is not an in-place edit. Point
-`--embedding-index` at a new versioned index and backfill it; a write to an
-index whose mapping disagrees with the configured model or dimensions is
-rejected.
+The companion mapping binds the index to the VSS embedding schema, provider
+profile, configured model target, expected dimensions, canonical searchable
+text version, cosine similarity, and a credential-free hash of the endpoint.
+Changing any part of that vector-space identity is not an in-place edit. Point
+`--embedding-index` at a fresh versioned index and run:
+
+```console
+vss memory embeddings backfill
+```
+
+VSS never deletes or recreates an incompatible index. OpenClaw may change the
+provider behind `openclaw/default` without changing the target string. A
+same-dimension change hidden behind that alias cannot always be detected.
+After changing OpenClaw's embedding provider or model, rerun
+`vss configure memory --embeddings` with a fresh `--embedding-index`, then
+backfill it.
 
 ## Optional OpenClaw Markdown cache
 

--- a/services/agent/packages/vss_cli/MEMORY.md
+++ b/services/agent/packages/vss_cli/MEMORY.md
@@ -106,6 +106,10 @@ relevance before recency, while queries without text remain newest-first.
 
 `memory introspect` performs bounded, memory-first question answering and emits
 exactly one JSON object to stdout (compact by default, indented with `--pretty`).
+That object includes the sufficiency decision (`sufficient`, `reason`,
+`evidence_record_ids`, and identified `gaps`), each VLM follow-up (`question`,
+`answer`, `model`, `num_frames`, window, and timeout), memory citations, the
+synthesized `answer`, and any `unresolved_gaps` left after inspection.
 The query must be scoped by `--sensor`, `--job-id`, or a complete
 `--start-time`/`--end-time` range. A child lookup requires its full public
 identity: `--job-id`, `--record-type`, and `--record-id`. Time bounds accept

--- a/services/agent/packages/vss_cli/README.md
+++ b/services/agent/packages/vss_cli/README.md
@@ -85,10 +85,12 @@ hybrid ranking — keyword and semantic results fused client-side. Elasticsearch
 canonical memory stays authoritative; its records only gain
 `output.embedding` references to the companion documents.
 
-The CLI loads no model. It calls an OpenAI-compatible `/embeddings` endpoint,
-so CPU or GPU execution is decided by that endpoint's deployment, not here. The
-defaults (`nvidia/llama-nemotron-embed-300m-v2`, 768 dimensions), the exact
-flags, and the backfill are in [MEMORY.md](MEMORY.md).
+The CLI loads no model. By default it reuses the already-running OpenClaw
+Gateway at `http://127.0.0.1:18789/v1` with target `openclaw/default`;
+explicit custom OpenAI-compatible endpoints remain supported. OpenClaw or the
+custom service owns model selection and execution. Gateway prerequisites,
+security guidance, exact flags, and backfill details are in
+[MEMORY.md](MEMORY.md).
 
 ## Extending it
 

--- a/services/agent/packages/vss_cli/README.md
+++ b/services/agent/packages/vss_cli/README.md
@@ -76,6 +76,20 @@ LLM for sufficiency judgment and answer synthesis. RT-VLM is reserved for
 grounded visual follow-ups. See [the memory policy and configuration
 guide](MEMORY.md).
 
+## Memory recall
+
+Static memory policy is set once with `vss configure memory`; reads and writes
+live under `vss memory`. With `--embeddings` enabled, VSS derives text vectors
+into a versioned companion Elasticsearch index and answers text queries with a
+hybrid ranking — keyword and semantic results fused client-side. Elasticsearch
+canonical memory stays authoritative; its records only gain
+`output.embedding` references to the companion documents.
+
+The CLI loads no model. It calls an OpenAI-compatible `/embeddings` endpoint,
+so CPU or GPU execution is decided by that endpoint's deployment, not here. The
+defaults (`nvidia/llama-nemotron-embed-300m-v2`, 768 dimensions), the exact
+flags, and the backfill are in [MEMORY.md](MEMORY.md).
+
 ## Extending it
 
 Groups are discovered from the `vss.commands` entry point, so a third party adds

--- a/services/agent/packages/vss_cli/README.md
+++ b/services/agent/packages/vss_cli/README.md
@@ -6,7 +6,9 @@ JSON on stdout, typed exit codes.
 
 Driving this from an agent or a skill? The bootstrap and the cross-cutting
 contract are in [AGENTS.md at the repository root](../../../../AGENTS.md);
-per-command detail is in [AGENTS.md](AGENTS.md) beside this file.
+per-command detail is in [AGENTS.md](AGENTS.md) beside this file. Memory policy
+invariants (companion-index identity, credential handling, backfill semantics)
+are in [MEMORY.md](MEMORY.md).
 
 ## Run it
 
@@ -19,10 +21,6 @@ uv run --no-dev --extra cli vss --help
 the base meta-package does not pull the `nvidia-vss-cli` distribution that
 provides the executable — and `--no-dev` keeps it to the CLI's runtime
 (256 MB, no `nvidia-nat`) rather than the agent stack (630 MB).
-
-Driving a deployment from a skill or an agent? Read
-[AGENTS.md at the repository root](../../../../AGENTS.md) — it is the one place
-the bootstrap, `vss configure` and the exit-code contract are written down.
 
 ## Develop
 
@@ -40,7 +38,14 @@ two specs share one `.venv`, so pick the one matching what you are doing and
 stay on it.
 
 CI additionally runs a NAT-free lane (`--no-dev --group cli-dev`) to prove the
-CLI imports nothing from the agent stack.
+CLI imports nothing from the agent stack:
+
+```bash
+uv sync --frozen --no-dev --group cli-dev --extra cli
+uv run pytest packages/vss_cli/tests packages/vss_core/tests -q
+uv run ruff check packages/vss_cli packages/vss_core
+uv run mypy packages/vss_cli/src/vss_cli packages/vss_core/src/vss_core/vios
+```
 
 ## Point it at a deployment
 
@@ -52,9 +57,65 @@ vss configure show     # what was recorded
 vss configure check    # re-probe; exit 3 if a route disappeared
 ```
 
-`configure` probes the origin's ingress routes (`/api`, `/vst`, `/elasticsearch`,
-`/cosmos-embed`, `/rtvi-cv`, `/rtvi-vlm`) and writes `~/.vss/config.json` (mode
-0600, no credentials). Re-run it after any deployment change.
+`vss configure` is the only command that works without an existing config. It is
+not a job group: discovery is a probe, not a guess, so a route the deployment
+does not expose is *absent* from the file rather than present-but-broken.
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--base-url` | required | Deployment origin, e.g. `http://10.0.0.1:7777`. A missing scheme is assumed `http://` with a note on stderr |
+| `--timeout` | 5.0 | Per-route probe timeout in seconds (0.1–120) |
+
+| Subcommand | What it does |
+|------------|--------------|
+| `vss configure --base-url URL` | Probe every known route and rewrite the config |
+| `vss configure show` | Print the recorded deployment as JSON |
+| `vss configure check` | Re-probe each recorded route, then list which command groups are available |
+| `vss configure memory …` | Static memory policy (see below) |
+
+### What gets probed and recorded
+
+Each service is requested at its probe path and recorded only if the origin
+answers. `200/201/204/400/401/403/405/422` prove a mapping (an auth challenge
+still means the route exists); `404` means the ingress has no such mapping.
+Where a service can describe itself, the config stores the backend's own answer
+rather than a typed-in value.
+
+| Service key | Mount | Records |
+|-------------|-------|---------|
+| `agent` | `/api` | URL only |
+| `vst` | `/vst` | URL only |
+| `elasticsearch` | `/elasticsearch` | URL + index names |
+| `rt_embed` | `/rtvi-embed` | URL + model ids |
+| `rtvi_cv` | `/rtvi-cv` | URL only (no introspection endpoint) |
+| `rt_vlm` | `/rtvi-vlm` | URL + model ids — the default model for `vss vlm` and introspection follow-ups |
+| `lvs` | `/lvs` | URL + model ids (long-video summarization) |
+
+If the origin exposes none of them, `configure` fails rather than writing an
+empty config. Elasticsearch indices are created by ingestion, not deployment,
+so configuring a fresh stack records zero `mdx-*` indices and says so — re-run
+`configure` after ingesting video and before searching.
+
+### The config file
+
+Written to `~/.vss/config.json` at mode 0600, holding **no credentials**: only
+URLs, discovered model/index names, `written_at`, and static memory policy.
+Set `VSS_CONFIG_HOME` to point at a different directory for a second deployment
+or for tests. The file carries a `version`; one written by a newer CLI is
+refused rather than half-read, with a message telling you to re-run `configure`.
+
+Re-running `vss configure --base-url …` refreshes routes and **preserves valid
+static memory policy**, so re-probing after a deployment change does not reset
+your judge, embedding, or persistence settings.
+
+`vss configure check` prints per-service reachability and a `commands:` table
+marking each group available or unavailable (a group is available only when
+*every* service it needs is routed). It exits 3 if any recorded route no longer
+answers.
+
+That same file is where memory policy lives. `vss configure` records service
+URLs (including RT-VLM). `vss configure memory` records how the CLI uses
+Elasticsearch, embeddings, the text judge, and optional Markdown notes.
 
 ## The surface
 
@@ -63,34 +124,289 @@ vss configure check    # re-probe; exit 3 if a route disappeared
 | `vss search` | Fused archive search over ES + the embedding NIM | `run`, `status`, `get`, `list` |
 | `vss summarize` | VLM summarization of stored video | `run`, `status`, `get`, `list` |
 | `vss vlm` | One VLM answer from a recorded sensor window | `run`, `status`, `get`, `list` |
-| `vss memory` | Unified-memory access and bounded introspection | `upsert`, `get`, `query`, `events`, `introspect` |
+| `vss memory` | Unified-memory access, embeddings backfill, introspection | `upsert`, `get`, `query`, `events`, `introspect`, `embeddings backfill` |
 | `vss vios` | Media plane: sensors, timelines, clip and snapshot URLs | `list`, `timeline`, `clip`, `snapshot`, `add`, `delete` |
-| `vss configure` | Resolve and record a deployment | `show`, `check` |
+| `vss configure` | Resolve a deployment and set static memory policy | `show`, `check`, `memory`, `memory show`, `memory check`, `memory introspection` |
 
 `search`, `summarize`, and `vlm` are **job groups**: every run mints a `job_id`, and the
 result stays retrievable by that id. `vios` is **not** — it resolves handles and
 mints URLs, so it has no job verbs. See [AGENTS.md](AGENTS.md#the-two-shapes).
 
-Memory introspection requires an explicitly configured OpenAI-compatible text
-LLM for sufficiency judgment and answer synthesis. RT-VLM is reserved for
-grounded visual follow-ups. See [the memory policy and configuration
-guide](MEMORY.md).
+There is no per-request `--persist` flag and no `--memory-index` on job or
+memory commands. Persistence defaults come from static config; opt out of one
+run with `--no-persist`.
 
-## Memory recall
+## Configure memory
 
-Static memory policy is set once with `vss configure memory`; reads and writes
-live under `vss memory`. With `--embeddings` enabled, VSS derives text vectors
-into a versioned companion Elasticsearch index and answers text queries with a
-hybrid ranking — keyword and semantic results fused client-side. Elasticsearch
-canonical memory stays authoritative; its records only gain
-`output.embedding` references to the companion documents.
+Static policy is `vss configure memory`, not `vss memory configure`. Unspecified
+flags keep their current values. Inspect without writing records:
 
-The CLI loads no model. By default it reuses the already-running OpenClaw
-Gateway at `http://127.0.0.1:18789/v1` with target `openclaw/default`;
-explicit custom OpenAI-compatible endpoints remain supported. OpenClaw or the
-custom service owns model selection and execution. Gateway prerequisites,
-security guidance, exact flags, and backfill details are in
-[MEMORY.md](MEMORY.md).
+```bash
+vss configure memory show
+vss configure memory check
+```
+
+`show` prints only the memory object. `check` validates policy and probes
+Elasticsearch (and the embedding endpoint when embeddings are enabled). Neither
+runs introspection or calls the judge.
+
+### Store and persistence
+
+```bash
+vss configure memory \
+  --enable \
+  --backend elasticsearch \
+  --index vss-memory \
+  --persist-by-default
+```
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--enable` / `--disable` | enabled | Whether `vss memory` and job persistence can use the store |
+| `--backend` | `elasticsearch` | Only Elasticsearch is supported |
+| `--index` | `vss-memory` | Authoritative document index |
+| `--persist-by-default` / `--no-persist-by-default` | persist | Whether `search` / `summarize` / `vlm` writes on success |
+
+Memory can stay enabled for recall while `--no-persist-by-default` turns off
+automatic writes. One job still opts out with `--no-persist`.
+
+### Text judge (introspection LLM)
+
+The judge is a Chat Completions LLM used for **sufficiency** and **answer
+synthesis**. It is not discovered from the deployment; configure it explicitly.
+RT-VLM is never the judge.
+
+OpenClaw Gateway:
+
+```bash
+export OPENCLAW_GATEWAY_TOKEN='<gateway-token>'
+vss configure memory introspection \
+  --judge-endpoint http://127.0.0.1:18789/v1 \
+  --judge-model openclaw/default \
+  --judge-api-key-env OPENCLAW_GATEWAY_TOKEN
+```
+
+Any other OpenAI-compatible `/v1`:
+
+```bash
+vss configure memory introspection \
+  --judge-endpoint https://llm.example.com/v1 \
+  --judge-model llama-3.3-70b-instruct \
+  --judge-api-key-env CUSTOM_LLM_API_KEY
+```
+
+| Flag | Default (first setup) | Meaning |
+|------|----------------------|---------|
+| `--judge-endpoint` | required first time | OpenAI-compatible base URL (`…/v1`) |
+| `--judge-model` | `openclaw/default` | API-facing model or OpenClaw agent target |
+| `--judge-backend-model` | unset | OpenClaw-only override sent as `x-openclaw-model` |
+| `--clear-judge-backend-model` | — | Remove that override |
+| `--judge-api-key-env` | unset | **Name** of the env var holding the Bearer token |
+| `--clear-judge-api-key-env` | — | Stop sending a token |
+| `--judge-criteria` | built-in prompt | Inline sufficiency criteria |
+| `--judge-criteria-file` | — | UTF-8 file that replaces the criteria prompt |
+
+`--judge-api-key-env` stores the variable name only. The token must be present
+in the environment whenever `vss memory introspect` runs. It is never written
+to `~/.vss/config.json` or printed by `show`.
+
+### Sufficiency prompt
+
+The stored `criteria_prompt` is the only configurable introspection prompt. It
+tells the judge when memory is enough and when to emit grounded VLM gaps. First
+setup installs a default that requires direct, in-scope, cited evidence.
+
+```bash
+vss configure memory introspection --judge-criteria "Require direct evidence for every material claim."
+vss configure memory introspection --judge-criteria-file ./introspection-criteria.txt
+```
+
+Do not combine `--judge-criteria` with `--judge-criteria-file`. Later
+introspection updates keep the current prompt unless you pass one of those
+flags.
+
+Workflow bounds are not CLI flags today: at most 10 memory records, 3 VLM
+follow-ups, 60-second clips, 180-second overall timeout. The introspection
+request itself is never stored.
+
+### VLM / RT-VLM endpoint
+
+Visual follow-ups use the deployment's **`rt_vlm`** service (`/rtvi-vlm` from
+`vss configure --base-url`), not `vss configure memory`. The model defaults to
+whatever that probe recorded. Direct questions:
+
+```bash
+vss vlm run --sensor warehouse --prompt "What happened?" --start-time T --end-time T
+```
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--sensor` / `--media-url` / `--file` | one required | Exactly one media source |
+| `--start-time` / `--end-time` | clip bounds | ISO-8601 UTC; with `--sensor` only |
+| `--prompt` | required | Question sent to the VLM |
+| `--model` | deployment `rt_vlm` model | Override the recorded model name |
+| `--timeout` | 30s (`vlm run`); 180s (introspection follow-ups) | HTTP / workflow budget |
+| `--num-frames` | 8 | Frame-sampling budget |
+| `--max-tokens` / `--temperature` | unset | Optional generation knobs |
+| `--intent` | `qa` (`vlm run`); `introspection` (follow-ups) | Stored on the memory record |
+| `--no-persist` | off | Skip writing this VLM job |
+
+Introspection follow-ups reuse this path and honor `--persist-by-default`.
+Persisted jobs remain visible via `vss vlm get` / `list`.
+
+### Embeddings and retrieval mode
+
+Vectors are **derived**. Authoritative `nv.vss.memory/1.0` documents stay in
+`--index`. Embeddings go to a separate companion index. Records only gain
+`output.embedding` references — never raw vectors.
+
+Enable the OpenClaw Gateway profile (CLI loads no model weights):
+
+```bash
+export OPENCLAW_GATEWAY_TOKEN="<gateway token>"
+vss configure memory --embeddings
+```
+
+That resolves to provider `openclaw_gateway`, endpoint
+`http://127.0.0.1:18789/v1`, model `openclaw/default`, and
+`api_key_env=OPENCLAW_GATEWAY_TOKEN`. Omit `--embedding-dimensions` to probe
+length once at configure time, or set it to configure offline.
+
+Custom OpenAI-compatible `/v1/embeddings`:
+
+```bash
+vss configure memory \
+  --embeddings \
+  --embedding-provider openai_compatible \
+  --embedding-endpoint https://embedding.example.com/v1 \
+  --embedding-model example-embedding-model \
+  --embedding-api-key-env EXAMPLE_EMBEDDING_TOKEN
+```
+
+Local unauthenticated endpoint: add `--no-embedding-auth`. Endpoints must be
+absolute `http`/`https` URLs with **no** userinfo, query string, or fragment.
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--embeddings` / `--no-embeddings` | off | Enable the companion vector index |
+| `--embedding-provider` | `openclaw_gateway` when enabling | `openclaw_gateway` or `openai_compatible` |
+| `--embedding-endpoint` | Gateway `http://127.0.0.1:18789/v1` | Embeddings base URL |
+| `--embedding-model` | `openclaw/default` | Agent target or API model |
+| `--embedding-dimensions` | probed if omitted | Expected vector length |
+| `--embedding-index` | `vss-memory-embeddings-v1` | Companion ES index (must differ from `--index`) |
+| `--embedding-timeout-seconds` | 30 | Provider HTTP timeout (≤ 300) |
+| `--embedding-batch-size` | 16 | Passages per request (1–128) |
+| `--embedding-api-key-env` | `OPENCLAW_GATEWAY_TOKEN` on Gateway profile | Env var **name** for the Bearer token |
+| `--no-embedding-auth` | off | Do not send a token |
+| `--embedding-query-input-type` | unset | Extra `input_type` on query embeds |
+| `--embedding-document-input-type` | unset | Extra `input_type` on passage embeds |
+| `--retrieval-mode` | `hybrid` | Static default for **text** queries |
+| `--semantic-candidate-count` | 50 | kNN candidate pool |
+| `--rrf-rank-constant` | 60 | Reciprocal-rank fusion constant |
+
+**Retrieval modes** (text queries only: `vss memory query --query …` and
+introspection scoped by `--sensor` or a time window):
+
+| Mode | Behavior |
+|------|----------|
+| `hybrid` | Keyword BM25 over `input.query` / `output.answer` **and** kNN, fused client-side with RRF. Default when embeddings are on |
+| `semantic` | Companion-index ranking only |
+| `keyword` | BM25 only; no provider call |
+
+With embeddings **disabled**, the effective mode is always keyword even if
+`--retrieval-mode` is `hybrid`. Override one query with
+`vss memory query --query "…" --mode keyword|semantic|hybrid`. Identity reads
+(`get`, `events`, `query` without `--query`, introspection by `--job-id` /
+`--record-id`) never embed.
+
+If the semantic leg fails at query time, recall falls back to keyword and warns
+on stderr. Changing provider, model, dimensions, or canonical text version
+requires a **new** `--embedding-index` plus backfill; VSS will not rewrite an
+incompatible mapping in place.
+
+```bash
+vss memory embeddings backfill --dry-run
+vss memory embeddings backfill --batch-size 16 --limit 500
+```
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--dry-run` | off | Eligibility scan only; no provider calls or writes |
+| `--batch-size` | configured embedding batch size | Records per batch |
+| `--limit` | all | Max records to scan |
+| `--pretty` | off | Indent JSON |
+
+### Optional Markdown notes
+
+```bash
+vss configure memory \
+  --markdown \
+  --harness openclaw \
+  --workspace /absolute/path/to/openclaw/workspace \
+  --write-notes-by-default
+```
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--markdown` / `--no-markdown` | off | Compact daily notes under the workspace |
+| `--harness` | `openclaw` | Only OpenClaw is supported |
+| `--workspace` | unset | Absolute OpenClaw workspace path |
+| `--write-notes-by-default` / `--no-write-notes-by-default` | off | Write a note after a successful ES persist |
+
+Per-run overrides: `--write-memory-note` / `--no-write-memory-note` on search or
+summarize. Notes never replace Elasticsearch and cannot be enabled with
+`--no-persist`.
+
+## Use memory
+
+```bash
+vss memory upsert --json '{"schema":"nv.vss.memory/1.0", ...}'
+vss memory get --job-id <job-id>
+vss memory query --query "forklift near the dock" --mode hybrid
+vss memory events --asset-id <sensor-name>
+vss memory introspect --query "What happened?" --sensor <sensor-name>
+```
+
+Add `--pretty` to indent JSON.
+
+### `query`
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--query` | unset | Free-text match; omit for filter-only (no embed) |
+| `--mode` | configured retrieval | `keyword`, `semantic`, or `hybrid` |
+| `--job-id` / `--group` / `--status` | unset | Identity and job filters (`summary`, `search`, `alert`, `vlm`) |
+| `--sensor-id` | unset | VIOS sensor name |
+| `--record-type` / `--record-id` | unset | Child identity (`event`, `search_hit`, `incident`) |
+| `--parents-only` | off | Drop children |
+| `--since` / `--until` | unset | ISO-8601 UTC bounds |
+| `--time-field` | `created_at` | Or `window` |
+| `--limit` | 20 | Max records |
+
+### `introspect`
+
+Requires a configured judge. Scope with `--sensor`, `--job-id`, or both
+`--start-time` and `--end-time`. A child lookup needs `--job-id`,
+`--record-type`, and `--record-id` together.
+
+| Flag | Meaning |
+|------|---------|
+| `--query` | Required question |
+| `--sensor` | VIOS sensor name |
+| `--start-time` / `--end-time` | Inclusive ISO-8601 UTC window |
+| `--job-id` / `--record-id` / `--record-type` | Optional identity filters |
+| `--group` | `summary`, `search`, or `alert` (refines scope; does not establish it) |
+
+Stdout is one JSON object: status, `sufficient_from_memory`, citations,
+`vlm_evidence`, synthesized `answer`, and `unresolved_gaps`.
+
+### `get` / `upsert` / `events`
+
+| Command | Required | Other flags |
+|---------|----------|-------------|
+| `get` | `--job-id` | `--record-type` + `--record-id` for a child |
+| `upsert` | JSON object (`--json` or stdin) | One parent or child `nv.vss.memory/1.0` record |
+| `events` | `--asset-id` | `--start-time`, `--end-time`, `--anchor-event-id`, `--direction` (`before`/`after`/`around`, default `around`), `--match`, `--limit` (50) |
 
 ## Extending it
 
@@ -108,14 +424,3 @@ acme = "Acme video operations"
 The object needs `api_version`, `name`, `summary`, and `cli() -> click.Command`.
 Summaries are read as raw strings, so `vss --help` lists every installed group
 without importing any of them.
-
-## Develop
-
-```bash
-cd services/agent
-uv sync --frozen --no-dev --group cli-dev --extra cli
-
-uv run pytest packages/vss_cli/tests packages/vss_core/tests -q
-uv run ruff check packages/vss_cli packages/vss_core
-uv run mypy packages/vss_cli/src/vss_cli packages/vss_core/src/vss_core/vios
-```

--- a/services/agent/packages/vss_cli/src/vss_cli/config.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/config.py
@@ -31,6 +31,7 @@ import os
 from pathlib import Path
 import re
 from typing import Any
+from urllib.parse import urlsplit
 
 #: Where the resolved deployment lives. Override for tests or for a second
 #: deployment via ``VSS_CONFIG_HOME``.

--- a/services/agent/packages/vss_cli/src/vss_cli/config.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/config.py
@@ -291,21 +291,42 @@ class EmbeddingConfig:
     """Static configuration for derived memory embeddings."""
 
     enabled: bool = False
-    provider: str = "openai_compatible"
-    endpoint: str | None = None
-    model: str = "nvidia/llama-nemotron-embed-300m-v2"
-    dimensions: int = 768
+    provider: str = "openclaw_gateway"
+    endpoint: str | None = "http://127.0.0.1:18789/v1"
+    model: str | None = "openclaw/default"
+    dimensions: int | None = None
     index: str = "vss-memory-embeddings-v1"
     timeout_seconds: float = 30.0
     batch_size: int = 16
-    api_key_env: str | None = None
+    api_key_env: str | None = "OPENCLAW_GATEWAY_TOKEN"
+    query_input_type: str | None = None
+    document_input_type: str | None = None
+
+    @classmethod
+    def for_provider(cls, provider: str, *, enabled: bool = False) -> EmbeddingConfig:
+        """Return clean profile defaults without retaining another provider's settings."""
+        if provider == "openclaw_gateway":
+            return cls(enabled=enabled)
+        if provider == "openai_compatible":
+            return cls(
+                enabled=enabled,
+                provider=provider,
+                endpoint=None,
+                model=None,
+                api_key_env=None,
+            )
+        raise ConfigError(
+            f"unsupported embedding provider {provider!r}; choose one of: openclaw_gateway, openai_compatible"
+        )
 
     def validate(self) -> EmbeddingConfig:
-        if self.provider != "openai_compatible":
+        if self.provider not in {"openclaw_gateway", "openai_compatible"}:
             raise ConfigError(
-                f"unsupported embedding provider {self.provider!r}; configure `--embedding-provider openai_compatible`"
+                f"unsupported embedding provider {self.provider!r}; choose one of: openclaw_gateway, openai_compatible"
             )
-        if isinstance(self.dimensions, bool) or not isinstance(self.dimensions, int) or self.dimensions <= 0:
+        if self.dimensions is not None and (
+            isinstance(self.dimensions, bool) or not isinstance(self.dimensions, int) or self.dimensions <= 0
+        ):
             raise ConfigError("embedding dimensions must be a positive integer")
         if isinstance(self.batch_size, bool) or not isinstance(self.batch_size, int) or not 1 <= self.batch_size <= 128:
             raise ConfigError("embedding batch size must be between 1 and 128")
@@ -315,16 +336,20 @@ class EmbeddingConfig:
             or not 0 < self.timeout_seconds <= 300
         ):
             raise ConfigError("embedding timeout must be greater than zero and no greater than 300 seconds")
-        if not isinstance(self.model, str) or not self.model.strip():
+        if self.model is not None and (not isinstance(self.model, str) or not self.model.strip()):
             raise ConfigError("embedding model must be a non-empty string")
         validate_memory_index(self.index)
         if self.api_key_env is not None and (
             not self.api_key_env or not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", self.api_key_env)
         ):
             raise ConfigError("embedding API-key environment variable must be a valid environment variable name")
-        if self.enabled:
-            if not self.endpoint:
-                raise ConfigError("enabled embeddings require `--embedding-endpoint http[s]://host[/v1]`")
+        for name, value in (
+            ("query", self.query_input_type),
+            ("document", self.document_input_type),
+        ):
+            if value is not None and (not isinstance(value, str) or not value.strip()):
+                raise ConfigError(f"embedding {name} input type must be a non-empty string or null")
+        if self.endpoint is not None:
             parsed = urlsplit(self.endpoint)
             if parsed.scheme not in {"http", "https"} or not parsed.netloc:
                 raise ConfigError("embedding endpoint must be an absolute HTTP or HTTPS URL")
@@ -332,6 +357,13 @@ class EmbeddingConfig:
                 raise ConfigError(
                     "embedding endpoint must not contain embedded credentials; use `--embedding-api-key-env`"
                 )
+        if self.enabled and (not self.endpoint or not self.model):
+            if self.provider == "openai_compatible":
+                raise ConfigError(
+                    "enabled openai_compatible embeddings require explicit "
+                    "`--embedding-endpoint` and `--embedding-model`"
+                )
+            raise ConfigError("enabled embeddings require an endpoint and model target")
         return self
 
     def to_json(self) -> dict[str, Any]:
@@ -346,6 +378,8 @@ class EmbeddingConfig:
             "timeout_seconds": self.timeout_seconds,
             "batch_size": self.batch_size,
             "api_key_env": self.api_key_env,
+            "query_input_type": self.query_input_type,
+            "document_input_type": self.document_input_type,
         }
 
     @classmethod
@@ -356,28 +390,35 @@ class EmbeddingConfig:
             "api_key_env",
             "batch_size",
             "dimensions",
+            "document_input_type",
             "enabled",
             "endpoint",
             "index",
             "model",
             "provider",
+            "query_input_type",
             "timeout_seconds",
         }
         unknown = sorted(set(raw) - expected)
         if unknown:
             raise ConfigError(f"config 'memory.embeddings' contains unknown fields: {', '.join(unknown)}")
-        defaults = cls()
+        raw_provider = raw.get("provider", cls().provider)
+        if not isinstance(raw_provider, str):
+            raise ConfigError("config 'memory.embeddings.provider' must be a string")
+        defaults = cls.for_provider(raw_provider)
         values = {name: raw.get(name, getattr(defaults, name)) for name in expected}
         if not isinstance(values["enabled"], bool):
             raise ConfigError("config 'memory.embeddings.enabled' must be true or false")
-        for name in ("provider", "model", "index"):
+        for name in ("provider", "index"):
             if not isinstance(values[name], str):
                 raise ConfigError(f"config 'memory.embeddings.{name}' must be a string")
-        for name in ("endpoint", "api_key_env"):
+        for name in ("endpoint", "model", "api_key_env", "query_input_type", "document_input_type"):
             if values[name] is not None and not isinstance(values[name], str):
                 raise ConfigError(f"config 'memory.embeddings.{name}' must be a string or null")
-        if isinstance(values["dimensions"], bool) or not isinstance(values["dimensions"], int):
-            raise ConfigError("config 'memory.embeddings.dimensions' must be an integer")
+        if values["dimensions"] is not None and (
+            isinstance(values["dimensions"], bool) or not isinstance(values["dimensions"], int)
+        ):
+            raise ConfigError("config 'memory.embeddings.dimensions' must be an integer or null")
         if isinstance(values["batch_size"], bool) or not isinstance(values["batch_size"], int):
             raise ConfigError("config 'memory.embeddings.batch_size' must be an integer")
         if isinstance(values["timeout_seconds"], bool) or not isinstance(values["timeout_seconds"], int | float):

--- a/services/agent/packages/vss_cli/src/vss_cli/config.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/config.py
@@ -287,6 +287,159 @@ class IntrospectionMemoryConfig:
 
 
 @dataclass(frozen=True)
+class EmbeddingConfig:
+    """Static configuration for derived memory embeddings."""
+
+    enabled: bool = False
+    provider: str = "openai_compatible"
+    endpoint: str | None = None
+    model: str = "nvidia/llama-nemotron-embed-300m-v2"
+    dimensions: int = 768
+    index: str = "vss-memory-embeddings-v1"
+    timeout_seconds: float = 30.0
+    batch_size: int = 16
+    api_key_env: str | None = None
+
+    def validate(self) -> EmbeddingConfig:
+        if self.provider != "openai_compatible":
+            raise ConfigError(
+                f"unsupported embedding provider {self.provider!r}; configure `--embedding-provider openai_compatible`"
+            )
+        if isinstance(self.dimensions, bool) or not isinstance(self.dimensions, int) or self.dimensions <= 0:
+            raise ConfigError("embedding dimensions must be a positive integer")
+        if isinstance(self.batch_size, bool) or not isinstance(self.batch_size, int) or not 1 <= self.batch_size <= 128:
+            raise ConfigError("embedding batch size must be between 1 and 128")
+        if (
+            isinstance(self.timeout_seconds, bool)
+            or not isinstance(self.timeout_seconds, int | float)
+            or not 0 < self.timeout_seconds <= 300
+        ):
+            raise ConfigError("embedding timeout must be greater than zero and no greater than 300 seconds")
+        if not isinstance(self.model, str) or not self.model.strip():
+            raise ConfigError("embedding model must be a non-empty string")
+        validate_memory_index(self.index)
+        if self.api_key_env is not None and (
+            not self.api_key_env or not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", self.api_key_env)
+        ):
+            raise ConfigError("embedding API-key environment variable must be a valid environment variable name")
+        if self.enabled:
+            if not self.endpoint:
+                raise ConfigError("enabled embeddings require `--embedding-endpoint http[s]://host[/v1]`")
+            parsed = urlsplit(self.endpoint)
+            if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+                raise ConfigError("embedding endpoint must be an absolute HTTP or HTTPS URL")
+            if parsed.username is not None or parsed.password is not None:
+                raise ConfigError(
+                    "embedding endpoint must not contain embedded credentials; use `--embedding-api-key-env`"
+                )
+        return self
+
+    def to_json(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "enabled": self.enabled,
+            "provider": self.provider,
+            "endpoint": self.endpoint,
+            "model": self.model,
+            "dimensions": self.dimensions,
+            "index": self.index,
+            "timeout_seconds": self.timeout_seconds,
+            "batch_size": self.batch_size,
+            "api_key_env": self.api_key_env,
+        }
+
+    @classmethod
+    def from_json(cls, raw: object) -> EmbeddingConfig:
+        if not isinstance(raw, dict):
+            raise ConfigError("config 'memory.embeddings' must be a JSON object")
+        expected = {
+            "api_key_env",
+            "batch_size",
+            "dimensions",
+            "enabled",
+            "endpoint",
+            "index",
+            "model",
+            "provider",
+            "timeout_seconds",
+        }
+        unknown = sorted(set(raw) - expected)
+        if unknown:
+            raise ConfigError(f"config 'memory.embeddings' contains unknown fields: {', '.join(unknown)}")
+        defaults = cls()
+        values = {name: raw.get(name, getattr(defaults, name)) for name in expected}
+        if not isinstance(values["enabled"], bool):
+            raise ConfigError("config 'memory.embeddings.enabled' must be true or false")
+        for name in ("provider", "model", "index"):
+            if not isinstance(values[name], str):
+                raise ConfigError(f"config 'memory.embeddings.{name}' must be a string")
+        for name in ("endpoint", "api_key_env"):
+            if values[name] is not None and not isinstance(values[name], str):
+                raise ConfigError(f"config 'memory.embeddings.{name}' must be a string or null")
+        if isinstance(values["dimensions"], bool) or not isinstance(values["dimensions"], int):
+            raise ConfigError("config 'memory.embeddings.dimensions' must be an integer")
+        if isinstance(values["batch_size"], bool) or not isinstance(values["batch_size"], int):
+            raise ConfigError("config 'memory.embeddings.batch_size' must be an integer")
+        if isinstance(values["timeout_seconds"], bool) or not isinstance(values["timeout_seconds"], int | float):
+            raise ConfigError("config 'memory.embeddings.timeout_seconds' must be a number")
+        return cls(**values).validate()
+
+
+@dataclass(frozen=True)
+class RetrievalConfig:
+    """Static preference for memory retrieval and hybrid ranking."""
+
+    mode: str = "hybrid"
+    candidate_count: int = 50
+    rrf_rank_constant: int = 60
+
+    def validate(self) -> RetrievalConfig:
+        if self.mode not in {"keyword", "semantic", "hybrid"}:
+            raise ConfigError("retrieval mode must be one of: keyword, semantic, hybrid")
+        if (
+            isinstance(self.candidate_count, bool)
+            or not isinstance(self.candidate_count, int)
+            or self.candidate_count <= 0
+        ):
+            raise ConfigError("semantic candidate count must be a positive integer")
+        if (
+            isinstance(self.rrf_rank_constant, bool)
+            or not isinstance(self.rrf_rank_constant, int)
+            or self.rrf_rank_constant <= 0
+        ):
+            raise ConfigError("RRF rank constant must be a positive integer")
+        return self
+
+    def to_json(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "mode": self.mode,
+            "candidate_count": self.candidate_count,
+            "rrf_rank_constant": self.rrf_rank_constant,
+        }
+
+    @classmethod
+    def from_json(cls, raw: object) -> RetrievalConfig:
+        if not isinstance(raw, dict):
+            raise ConfigError("config 'memory.retrieval' must be a JSON object")
+        expected = {"mode", "candidate_count", "rrf_rank_constant"}
+        unknown = sorted(set(raw) - expected)
+        if unknown:
+            raise ConfigError(f"config 'memory.retrieval' contains unknown fields: {', '.join(unknown)}")
+        defaults = cls()
+        mode = raw.get("mode", defaults.mode)
+        candidate_count = raw.get("candidate_count", defaults.candidate_count)
+        rank_constant = raw.get("rrf_rank_constant", defaults.rrf_rank_constant)
+        if not isinstance(mode, str):
+            raise ConfigError("config 'memory.retrieval.mode' must be a string")
+        if isinstance(candidate_count, bool) or not isinstance(candidate_count, int):
+            raise ConfigError("config 'memory.retrieval.candidate_count' must be an integer")
+        if isinstance(rank_constant, bool) or not isinstance(rank_constant, int):
+            raise ConfigError("config 'memory.retrieval.rrf_rank_constant' must be an integer")
+        return cls(mode=mode, candidate_count=candidate_count, rrf_rank_constant=rank_constant).validate()
+
+
+@dataclass(frozen=True)
 class MemoryConfig:
     """Static policy and infrastructure for authoritative VSS memory."""
 
@@ -296,6 +449,13 @@ class MemoryConfig:
     persist_by_default: bool = True
     markdown: MarkdownMemoryConfig = field(default_factory=MarkdownMemoryConfig)
     introspection: IntrospectionMemoryConfig | None = None
+    embeddings: EmbeddingConfig = field(default_factory=EmbeddingConfig)
+    retrieval: RetrievalConfig = field(default_factory=RetrievalConfig)
+
+    @property
+    def effective_retrieval_mode(self) -> str:
+        """Use keyword retrieval whenever semantic infrastructure is disabled."""
+        return self.retrieval.mode if self.embeddings.enabled else "keyword"
 
     def validate(self) -> MemoryConfig:
         if self.backend != "elasticsearch":
@@ -309,6 +469,10 @@ class MemoryConfig:
         self.markdown.validate()
         if self.introspection is not None:
             self.introspection.validate()
+        self.embeddings.validate()
+        self.retrieval.validate()
+        if self.embeddings.enabled and self.embeddings.index == self.index:
+            raise ConfigError("embedding index must differ from the authoritative memory index")
         if self.markdown.enabled and not self.enabled:
             raise ConfigError("Markdown memory cannot be enabled while authoritative memory is disabled")
         if self.markdown.write_by_default and not self.persist_by_default:
@@ -327,13 +491,24 @@ class MemoryConfig:
             "persist_by_default": self.persist_by_default,
             "markdown": self.markdown.to_json(),
             "introspection": self.introspection.to_json() if self.introspection is not None else None,
+            "embeddings": self.embeddings.to_json(),
+            "retrieval": self.retrieval.to_json(),
         }
 
     @classmethod
     def from_json(cls, raw: object) -> MemoryConfig:
         if not isinstance(raw, dict):
             raise ConfigError("config 'memory' must be a JSON object")
-        expected = {"enabled", "backend", "index", "persist_by_default", "markdown", "introspection"}
+        expected = {
+            "enabled",
+            "backend",
+            "index",
+            "persist_by_default",
+            "markdown",
+            "introspection",
+            "embeddings",
+            "retrieval",
+        }
         unknown = sorted(set(raw) - expected)
         if unknown:
             raise ConfigError(f"config 'memory' contains unknown fields: {', '.join(unknown)}")
@@ -360,6 +535,8 @@ class MemoryConfig:
                 if raw.get("introspection") is not None
                 else None
             ),
+            embeddings=EmbeddingConfig.from_json(raw["embeddings"]) if "embeddings" in raw else EmbeddingConfig(),
+            retrieval=RetrievalConfig.from_json(raw["retrieval"]) if "retrieval" in raw else RetrievalConfig(),
         ).validate()
 
 

--- a/services/agent/packages/vss_cli/src/vss_cli/config.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/config.py
@@ -358,6 +358,11 @@ class EmbeddingConfig:
                 raise ConfigError(
                     "embedding endpoint must not contain embedded credentials; use `--embedding-api-key-env`"
                 )
+            if parsed.query or parsed.fragment:
+                raise ConfigError(
+                    "embedding endpoint must not contain a query string or fragment; "
+                    "use `--embedding-api-key-env` for authentication"
+                )
         if self.enabled and (not self.endpoint or not self.model):
             if self.provider == "openai_compatible":
                 raise ConfigError(

--- a/services/agent/packages/vss_cli/src/vss_cli/configure.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/configure.py
@@ -271,6 +271,12 @@ def _check_embedding_backend(
     """Probe one embedding and inspect the companion mapping without mutation."""
     import httpx
 
+    from vss_core.memory.backends.elasticsearch_embeddings import EMBEDDING_SCHEMA
+    from vss_core.memory.backends.elasticsearch_embeddings import IMPLEMENTATION_VERSION
+    from vss_core.memory.embeddings import CANONICAL_SEARCHABLE_TEXT_VERSION
+    from vss_core.memory.embeddings import SIMILARITY
+    from vss_core.memory.embeddings import embedding_endpoint_identity
+
     embedding = memory_config.embeddings
     dimensions, resolved_model = _probe_embedding(embedding)
     resolved_detail = f"; resolved_model={resolved_model}" if resolved_model is not None else ""
@@ -302,18 +308,29 @@ def _check_embedding_backend(
     properties = mappings.get("properties") if isinstance(mappings, dict) else None
     vector_mapping = properties.get("vector") if isinstance(properties, dict) else None
     metadata = mappings.get("_meta") if isinstance(mappings, dict) else None
+    assert embedding.endpoint is not None
+    expected_metadata = {
+        "schema": EMBEDDING_SCHEMA,
+        "implementation_version": IMPLEMENTATION_VERSION,
+        "provider": embedding.provider,
+        "model_target": embedding.model,
+        "dimensions": dimensions,
+        "canonical_text_version": CANONICAL_SEARCHABLE_TEXT_VERSION,
+        "similarity": SIMILARITY,
+        "endpoint_identity": embedding_endpoint_identity(embedding.endpoint),
+    }
     if (
         not isinstance(vector_mapping, dict)
         or vector_mapping.get("type") != "dense_vector"
         or vector_mapping.get("dims") != dimensions
         or vector_mapping.get("similarity") != "cosine"
         or not isinstance(metadata, dict)
-        or metadata.get("model") != embedding.model
-        or metadata.get("dimensions") != dimensions
+        or any(metadata.get(key) != value for key, value in expected_metadata.items())
     ):
         _memory_config_error(
-            f"companion embedding index {embedding.index!r} has an incompatible vector mapping; "
-            "configure a new versioned embedding index and backfill it"
+            f"Embedding index {embedding.index!r} was created for a different model, provider, "
+            "vector dimension, or canonical text version. Configure a new `--embedding-index` "
+            "and run `vss memory embeddings backfill`."
         )
     return probe_detail, f"Companion embedding index mapping is compatible: {embedding.index}"
 

--- a/services/agent/packages/vss_cli/src/vss_cli/configure.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/configure.py
@@ -224,6 +224,76 @@ def _check_memory_backend(
     return f"Elasticsearch reachable at {endpoint}; authoritative index={memory_config.index}"
 
 
+def _check_embedding_backend(
+    deployment: config_mod.Deployment,
+    memory_config: config_mod.MemoryConfig,
+) -> tuple[str, str]:
+    """Probe one embedding and inspect the companion mapping without mutation."""
+    import httpx
+
+    from vss_core.memory import EmbeddingProviderError
+    from vss_core.memory import OpenAICompatibleEmbeddingProvider
+
+    embedding = memory_config.embeddings
+    provider = OpenAICompatibleEmbeddingProvider(
+        endpoint=embedding.endpoint or "",
+        model=embedding.model,
+        dimensions=embedding.dimensions,
+        timeout_seconds=embedding.timeout_seconds,
+        batch_size=embedding.batch_size,
+        api_key_env=embedding.api_key_env,
+    )
+    try:
+        vector = provider.embed_query("VSS memory embedding health check")
+    except EmbeddingProviderError as error:
+        _memory_backend_error(str(error))
+    finally:
+        provider.close()
+    if len(vector) != embedding.dimensions:
+        _memory_backend_error(
+            f"embedding probe returned {len(vector)} dimensions; configured dimensions are {embedding.dimensions}"
+        )
+    probe_detail = f"Embedding endpoint reachable; model={embedding.model}; dimensions={len(vector)}"
+
+    endpoint = deployment.endpoint_or_none("elasticsearch")
+    if not endpoint:
+        _memory_config_error("cannot inspect the embedding index because the deployment exposes no Elasticsearch route")
+    mapping_url = f"{endpoint.rstrip('/')}/{embedding.index}/_mapping"
+    try:
+        response = httpx.get(mapping_url, timeout=embedding.timeout_seconds)
+    except httpx.HTTPError as error:
+        _memory_backend_error(f"could not inspect companion embedding index mapping ({type(error).__name__})")
+    if response.status_code == 404:
+        return probe_detail, (
+            f"Companion embedding index {embedding.index} is missing; it will be created lazily "
+            "on the first embedding write or backfill"
+        )
+    try:
+        response.raise_for_status()
+        payload = response.json()
+    except (httpx.HTTPError, ValueError) as error:
+        _memory_backend_error(f"could not inspect companion embedding index mapping ({type(error).__name__})")
+    index_mapping = payload.get(embedding.index) if isinstance(payload, dict) else None
+    mappings = index_mapping.get("mappings") if isinstance(index_mapping, dict) else None
+    properties = mappings.get("properties") if isinstance(mappings, dict) else None
+    vector_mapping = properties.get("vector") if isinstance(properties, dict) else None
+    metadata = mappings.get("_meta") if isinstance(mappings, dict) else None
+    if (
+        not isinstance(vector_mapping, dict)
+        or vector_mapping.get("type") != "dense_vector"
+        or vector_mapping.get("dims") != embedding.dimensions
+        or vector_mapping.get("similarity") != "cosine"
+        or not isinstance(metadata, dict)
+        or metadata.get("model") != embedding.model
+        or metadata.get("dimensions") != embedding.dimensions
+    ):
+        _memory_config_error(
+            f"companion embedding index {embedding.index!r} has an incompatible vector mapping; "
+            "configure a new versioned embedding index and backfill it"
+        )
+    return probe_detail, f"Companion embedding index mapping is compatible: {embedding.index}"
+
+
 @configure.group(name="memory", invoke_without_command=True)
 @click.option("--enable/--disable", "enabled", default=None, help="Enable or disable the memory subsystem.")
 @click.option("--backend", default=None, help="Authoritative structured-memory backend (elasticsearch only).")
@@ -241,6 +311,23 @@ def _check_memory_backend(
     default=None,
     help="Whether persisted jobs write compact Markdown notes by default.",
 )
+@click.option("--embeddings/--no-embeddings", "embeddings_enabled", default=None, help="Enable derived embeddings.")
+@click.option("--embedding-provider", default=None, help="Embedding provider (openai_compatible only).")
+@click.option("--embedding-endpoint", default=None, help="OpenAI-compatible embedding base URL.")
+@click.option("--embedding-model", default=None, help="Static embedding model identifier.")
+@click.option("--embedding-dimensions", type=int, default=None, help="Embedding vector dimensions.")
+@click.option("--embedding-index", default=None, help="Companion Elasticsearch vector index.")
+@click.option("--embedding-timeout", type=float, default=None, help="Embedding request timeout in seconds.")
+@click.option("--embedding-batch-size", type=int, default=None, help="Maximum passage embeddings per request.")
+@click.option("--embedding-api-key-env", default=None, help="Environment variable containing a Bearer token.")
+@click.option(
+    "--retrieval-mode",
+    type=click.Choice(["keyword", "semantic", "hybrid"]),
+    default=None,
+    help="Preferred static memory retrieval mode.",
+)
+@click.option("--semantic-candidate-count", type=int, default=None, help="Semantic candidates before ranking.")
+@click.option("--rrf-rank-constant", type=int, default=None, help="Reciprocal rank fusion constant.")
 @click.pass_context
 def configure_memory(
     ctx: click.Context,
@@ -252,6 +339,18 @@ def configure_memory(
     harness: str | None,
     workspace: str | None,
     write_notes_by_default: bool | None,
+    embeddings_enabled: bool | None,
+    embedding_provider: str | None,
+    embedding_endpoint: str | None,
+    embedding_model: str | None,
+    embedding_dimensions: int | None,
+    embedding_index: str | None,
+    embedding_timeout: float | None,
+    embedding_batch_size: int | None,
+    embedding_api_key_env: str | None,
+    retrieval_mode: str | None,
+    semantic_candidate_count: int | None,
+    rrf_rank_constant: int | None,
 ) -> None:
     """Configure static VSS memory infrastructure and persistence policy."""
     if ctx.invoked_subcommand is not None:
@@ -259,6 +358,8 @@ def configure_memory(
     deployment = _load_memory_deployment()
     current = deployment.memory or config_mod.MemoryConfig()
     current_markdown = current.markdown
+    current_embeddings = current.embeddings
+    current_retrieval = current.retrieval
     candidate = config_mod.MemoryConfig(
         enabled=current.enabled if enabled is None else enabled,
         backend=current.backend if backend is None else backend,
@@ -273,6 +374,24 @@ def configure_memory(
             else write_notes_by_default,
         ),
         introspection=current.introspection,
+        embeddings=config_mod.EmbeddingConfig(
+            enabled=current_embeddings.enabled if embeddings_enabled is None else embeddings_enabled,
+            provider=current_embeddings.provider if embedding_provider is None else embedding_provider,
+            endpoint=current_embeddings.endpoint if embedding_endpoint is None else embedding_endpoint,
+            model=current_embeddings.model if embedding_model is None else embedding_model,
+            dimensions=current_embeddings.dimensions if embedding_dimensions is None else embedding_dimensions,
+            index=current_embeddings.index if embedding_index is None else embedding_index,
+            timeout_seconds=current_embeddings.timeout_seconds if embedding_timeout is None else embedding_timeout,
+            batch_size=current_embeddings.batch_size if embedding_batch_size is None else embedding_batch_size,
+            api_key_env=current_embeddings.api_key_env if embedding_api_key_env is None else embedding_api_key_env,
+        ),
+        retrieval=config_mod.RetrievalConfig(
+            mode=current_retrieval.mode if retrieval_mode is None else retrieval_mode,
+            candidate_count=current_retrieval.candidate_count
+            if semantic_candidate_count is None
+            else semantic_candidate_count,
+            rrf_rank_constant=current_retrieval.rrf_rank_constant if rrf_rank_constant is None else rrf_rank_constant,
+        ),
     )
     try:
         candidate.validate()
@@ -412,6 +531,10 @@ def check_memory() -> None:
     if not memory_config.enabled:
         _memory_config_error("memory is disabled; run `vss configure memory --enable`")
     click.echo(_check_memory_backend(deployment, memory_config))
+    if memory_config.embeddings.enabled:
+        embedding_probe, mapping_probe = _check_embedding_backend(deployment, memory_config)
+        click.echo(embedding_probe)
+        click.echo(mapping_probe)
     if memory_config.markdown.enabled:
         try:
             from vss_core.memory import OpenClawDailyNoteStore

--- a/services/agent/packages/vss_cli/src/vss_cli/configure.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/configure.py
@@ -312,14 +312,29 @@ def _check_embedding_backend(
     help="Whether persisted jobs write compact Markdown notes by default.",
 )
 @click.option("--embeddings/--no-embeddings", "embeddings_enabled", default=None, help="Enable derived embeddings.")
-@click.option("--embedding-provider", default=None, help="Embedding provider (openai_compatible only).")
+@click.option(
+    "--embedding-provider",
+    type=click.Choice(["openclaw_gateway", "openai_compatible"]),
+    default=None,
+    help="Embedding endpoint profile.",
+)
 @click.option("--embedding-endpoint", default=None, help="OpenAI-compatible embedding base URL.")
-@click.option("--embedding-model", default=None, help="Static embedding model identifier.")
-@click.option("--embedding-dimensions", type=int, default=None, help="Embedding vector dimensions.")
+@click.option("--embedding-model", default=None, help="OpenClaw agent target or custom embedding model.")
+@click.option("--embedding-dimensions", type=int, default=None, help="Expected embedding vector dimensions.")
 @click.option("--embedding-index", default=None, help="Companion Elasticsearch vector index.")
-@click.option("--embedding-timeout", type=float, default=None, help="Embedding request timeout in seconds.")
+@click.option(
+    "--embedding-timeout-seconds",
+    "--embedding-timeout",
+    "embedding_timeout_seconds",
+    type=float,
+    default=None,
+    help="Embedding request timeout in seconds.",
+)
 @click.option("--embedding-batch-size", type=int, default=None, help="Maximum passage embeddings per request.")
 @click.option("--embedding-api-key-env", default=None, help="Environment variable containing a Bearer token.")
+@click.option("--no-embedding-auth", is_flag=True, help="Do not send a Bearer token to the embedding endpoint.")
+@click.option("--embedding-query-input-type", default=None, help="Optional input_type for query embeddings.")
+@click.option("--embedding-document-input-type", default=None, help="Optional input_type for document embeddings.")
 @click.option(
     "--retrieval-mode",
     type=click.Choice(["keyword", "semantic", "hybrid"]),
@@ -345,9 +360,12 @@ def configure_memory(
     embedding_model: str | None,
     embedding_dimensions: int | None,
     embedding_index: str | None,
-    embedding_timeout: float | None,
+    embedding_timeout_seconds: float | None,
     embedding_batch_size: int | None,
     embedding_api_key_env: str | None,
+    no_embedding_auth: bool,
+    embedding_query_input_type: str | None,
+    embedding_document_input_type: str | None,
     retrieval_mode: str | None,
     semantic_candidate_count: int | None,
     rrf_rank_constant: int | None,
@@ -360,6 +378,20 @@ def configure_memory(
     current_markdown = current.markdown
     current_embeddings = current.embeddings
     current_retrieval = current.retrieval
+    if embedding_api_key_env is not None and no_embedding_auth:
+        _memory_config_error("cannot combine `--embedding-api-key-env` with `--no-embedding-auth`")
+    requested_provider = embedding_provider
+    if embeddings_enabled is True and requested_provider is None:
+        requested_provider = "openclaw_gateway"
+    if requested_provider is not None and (
+        requested_provider != current_embeddings.provider or embeddings_enabled is True
+    ):
+        embedding_base = config_mod.EmbeddingConfig.for_provider(
+            requested_provider,
+            enabled=current_embeddings.enabled if embeddings_enabled is None else embeddings_enabled,
+        )
+    else:
+        embedding_base = current_embeddings
     candidate = config_mod.MemoryConfig(
         enabled=current.enabled if enabled is None else enabled,
         backend=current.backend if backend is None else backend,
@@ -375,15 +407,27 @@ def configure_memory(
         ),
         introspection=current.introspection,
         embeddings=config_mod.EmbeddingConfig(
-            enabled=current_embeddings.enabled if embeddings_enabled is None else embeddings_enabled,
-            provider=current_embeddings.provider if embedding_provider is None else embedding_provider,
-            endpoint=current_embeddings.endpoint if embedding_endpoint is None else embedding_endpoint,
-            model=current_embeddings.model if embedding_model is None else embedding_model,
-            dimensions=current_embeddings.dimensions if embedding_dimensions is None else embedding_dimensions,
-            index=current_embeddings.index if embedding_index is None else embedding_index,
-            timeout_seconds=current_embeddings.timeout_seconds if embedding_timeout is None else embedding_timeout,
-            batch_size=current_embeddings.batch_size if embedding_batch_size is None else embedding_batch_size,
-            api_key_env=current_embeddings.api_key_env if embedding_api_key_env is None else embedding_api_key_env,
+            enabled=embedding_base.enabled if embeddings_enabled is None else embeddings_enabled,
+            provider=embedding_base.provider if embedding_provider is None else embedding_provider,
+            endpoint=embedding_base.endpoint if embedding_endpoint is None else embedding_endpoint,
+            model=embedding_base.model if embedding_model is None else embedding_model,
+            dimensions=embedding_base.dimensions if embedding_dimensions is None else embedding_dimensions,
+            index=embedding_base.index if embedding_index is None else embedding_index,
+            timeout_seconds=embedding_base.timeout_seconds
+            if embedding_timeout_seconds is None
+            else embedding_timeout_seconds,
+            batch_size=embedding_base.batch_size if embedding_batch_size is None else embedding_batch_size,
+            api_key_env=None
+            if no_embedding_auth
+            else embedding_base.api_key_env
+            if embedding_api_key_env is None
+            else embedding_api_key_env,
+            query_input_type=embedding_base.query_input_type
+            if embedding_query_input_type is None
+            else embedding_query_input_type,
+            document_input_type=embedding_base.document_input_type
+            if embedding_document_input_type is None
+            else embedding_document_input_type,
         ),
         retrieval=config_mod.RetrievalConfig(
             mode=current_retrieval.mode if retrieval_mode is None else retrieval_mode,

--- a/services/agent/packages/vss_cli/src/vss_cli/configure.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/configure.py
@@ -19,6 +19,7 @@ error inside a search.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import UTC
 from datetime import datetime
 import json
@@ -179,6 +180,20 @@ def _memory_backend_error(message: str) -> NoReturn:
     raise SystemExit(int(Exit.BACKEND_UNREACHABLE))
 
 
+def _embedding_probe_error(error: BaseException) -> NoReturn:
+    message = str(error)
+    if "environment variable" in message or "authentication failed" in message or "authorization failed" in message:
+        click.echo(f"vss configure memory: embedding credential error: {message}", err=True)
+        raise SystemExit(int(Exit.CONFIGURATION))
+    if "dimension" in message:
+        click.echo(f"vss configure memory: embedding dimension error: {message}", err=True)
+        raise SystemExit(int(Exit.CONFIGURATION))
+    if "response" in message or "JSON" in message:
+        click.echo(f"vss configure memory: malformed embedding response: {message}", err=True)
+        raise SystemExit(int(Exit.BACKEND_UNREACHABLE))
+    _memory_backend_error(message)
+
+
 def _load_memory_deployment() -> config_mod.Deployment:
     try:
         return config_mod.load()
@@ -224,6 +239,31 @@ def _check_memory_backend(
     return f"Elasticsearch reachable at {endpoint}; authoritative index={memory_config.index}"
 
 
+def _probe_embedding(embedding: config_mod.EmbeddingConfig) -> tuple[int, str | None]:
+    from vss_core.memory import EmbeddingProviderError
+    from vss_core.memory import OpenAICompatibleEmbeddingProvider
+
+    assert embedding.endpoint is not None
+    assert embedding.model is not None
+    provider = OpenAICompatibleEmbeddingProvider(
+        endpoint=embedding.endpoint,
+        model=embedding.model,
+        dimensions=embedding.dimensions,
+        timeout_seconds=embedding.timeout_seconds,
+        batch_size=embedding.batch_size,
+        api_key_env=embedding.api_key_env,
+        query_input_type=embedding.query_input_type,
+        document_input_type=embedding.document_input_type,
+    )
+    try:
+        vector = provider.embed_query("VSS memory embedding health check")
+    except EmbeddingProviderError as error:
+        _embedding_probe_error(error)
+    finally:
+        provider.close()
+    return len(vector), provider.resolved_model
+
+
 def _check_embedding_backend(
     deployment: config_mod.Deployment,
     memory_config: config_mod.MemoryConfig,
@@ -231,29 +271,13 @@ def _check_embedding_backend(
     """Probe one embedding and inspect the companion mapping without mutation."""
     import httpx
 
-    from vss_core.memory import EmbeddingProviderError
-    from vss_core.memory import OpenAICompatibleEmbeddingProvider
-
     embedding = memory_config.embeddings
-    provider = OpenAICompatibleEmbeddingProvider(
-        endpoint=embedding.endpoint or "",
-        model=embedding.model,
-        dimensions=embedding.dimensions,
-        timeout_seconds=embedding.timeout_seconds,
-        batch_size=embedding.batch_size,
-        api_key_env=embedding.api_key_env,
+    dimensions, resolved_model = _probe_embedding(embedding)
+    resolved_detail = f"; resolved_model={resolved_model}" if resolved_model is not None else ""
+    probe_detail = (
+        f"Embedding endpoint reachable; provider={embedding.provider}; target={embedding.model}; "
+        f"dimensions={dimensions}{resolved_detail}"
     )
-    try:
-        vector = provider.embed_query("VSS memory embedding health check")
-    except EmbeddingProviderError as error:
-        _memory_backend_error(str(error))
-    finally:
-        provider.close()
-    if len(vector) != embedding.dimensions:
-        _memory_backend_error(
-            f"embedding probe returned {len(vector)} dimensions; configured dimensions are {embedding.dimensions}"
-        )
-    probe_detail = f"Embedding endpoint reachable; model={embedding.model}; dimensions={len(vector)}"
 
     endpoint = deployment.endpoint_or_none("elasticsearch")
     if not endpoint:
@@ -281,11 +305,11 @@ def _check_embedding_backend(
     if (
         not isinstance(vector_mapping, dict)
         or vector_mapping.get("type") != "dense_vector"
-        or vector_mapping.get("dims") != embedding.dimensions
+        or vector_mapping.get("dims") != dimensions
         or vector_mapping.get("similarity") != "cosine"
         or not isinstance(metadata, dict)
         or metadata.get("model") != embedding.model
-        or metadata.get("dimensions") != embedding.dimensions
+        or metadata.get("dimensions") != dimensions
     ):
         _memory_config_error(
             f"companion embedding index {embedding.index!r} has an incompatible vector mapping; "
@@ -439,6 +463,14 @@ def configure_memory(
     )
     try:
         candidate.validate()
+        if candidate.embeddings.enabled and candidate.embeddings.dimensions is None:
+            dimensions, resolved_model = _probe_embedding(candidate.embeddings)
+            candidate = replace(
+                candidate,
+                embeddings=replace(candidate.embeddings, dimensions=dimensions),
+            )
+            resolved_detail = f" (endpoint reported {resolved_model})" if resolved_model is not None else ""
+            click.echo(f"discovered embedding dimensions: {dimensions}{resolved_detail}", err=True)
         path = config_mod.save(
             config_mod.Deployment(
                 base_url=deployment.base_url,

--- a/services/agent/packages/vss_cli/src/vss_cli/configure.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/configure.py
@@ -581,12 +581,8 @@ def configure_memory_introspection(
             else config_mod.DEFAULT_INTROSPECTION_CRITERIA_PROMPT
         ),
     )
-    candidate = config_mod.MemoryConfig(
-        enabled=current_memory.enabled,
-        backend=current_memory.backend,
-        index=current_memory.index,
-        persist_by_default=current_memory.persist_by_default,
-        markdown=current_memory.markdown,
+    candidate = replace(
+        current_memory,
         introspection=config_mod.IntrospectionMemoryConfig(judge=candidate_judge),
     )
     try:

--- a/services/agent/packages/vss_cli/src/vss_cli/group.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/group.py
@@ -309,6 +309,9 @@ class CommandGroup(ABC):
         """
         if ctx.memory is None:
             ctx.memory = memory_mod.build(ctx.deployment)
+            click_context = click.get_current_context(silent=True)
+            if click_context is not None:
+                click_context.call_on_close(ctx.memory.close)
         return ctx.memory
 
     @final

--- a/services/agent/packages/vss_cli/src/vss_cli/memory.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/memory.py
@@ -227,6 +227,7 @@ def build(deployment: config_mod.Deployment | None) -> Memory:
     from vss_core.memory import EmbeddingBackfillService
     from vss_core.memory import MemoryService
     from vss_core.memory import OpenAICompatibleEmbeddingProvider
+    from vss_core.memory import embedding_endpoint_identity
     from vss_core.memory.backends.elasticsearch import ElasticsearchMemoryStore
 
     authoritative = ElasticsearchMemoryStore(endpoint=endpoint, index=memory_config.index)
@@ -262,6 +263,8 @@ def build(deployment: config_mod.Deployment | None) -> Memory:
             index=embedding_config.index,
             provider=provider,
             authoritative_store=authoritative,
+            provider_name=embedding_config.provider,
+            embedding_endpoint_identity=embedding_endpoint_identity(embedding_config.endpoint),
         )
         retrieval = memory_config.retrieval
         service = MemoryService(

--- a/services/agent/packages/vss_cli/src/vss_cli/memory.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/memory.py
@@ -16,6 +16,7 @@ Elasticsearch client load on the first call that actually touches memory, so
 
 from __future__ import annotations
 
+from contextlib import suppress
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import cast
@@ -25,6 +26,8 @@ import click
 from .exits import Exit
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from vss_core.memory import MemoryService
     from vss_core.memory import UnifiedMemoryRecord
     from vss_core.memory.models import MemoryGroup
@@ -64,6 +67,18 @@ class MemoryUnavailable(click.ClickException):
     exit_code = int(Exit.CONFIGURATION)
 
 
+def _close_resources(resources: tuple[Any, ...]) -> None:
+    first_error: Exception | None = None
+    for resource in resources:
+        try:
+            resource.close()
+        except Exception as error:
+            if first_error is None:
+                first_error = error
+    if first_error is not None:
+        raise first_error
+
+
 def group_token(name: str) -> MemoryGroup:
     """The unified-schema group a CLI group writes under.
 
@@ -82,13 +97,28 @@ class Memory:
     ``put`` here would only re-state the adapter's signature.
     """
 
-    def __init__(self, service: MemoryService, *, index: str) -> None:
+    def __init__(
+        self,
+        service: MemoryService,
+        *,
+        index: str,
+        closeables: tuple[Any, ...] = (),
+    ) -> None:
         self._service = service
         self.index = index
+        self._closeables = closeables
+        self._closed = False
 
     @property
     def service(self) -> MemoryService:
         return self._service
+
+    def close(self) -> None:
+        """Close each runtime resource exactly once."""
+        if self._closed:
+            return
+        self._closed = True
+        _close_resources(self._closeables)
 
     def status(self, group: str, job_id: str) -> dict[str, Any]:
         return self._scoped(group, job_id).model_dump_memory()
@@ -188,11 +218,57 @@ def build(deployment: config_mod.Deployment | None) -> Memory:
             f"Re-run `vss configure --base-url {deployment.base_url}` if that changed."
         )
 
-    from vss_core.memory import build_memory_service
+    from vss_core.memory import ElasticsearchEmbeddingStore
+    from vss_core.memory import MemoryService
+    from vss_core.memory import OpenAICompatibleEmbeddingProvider
+    from vss_core.memory.backends.elasticsearch import ElasticsearchMemoryStore
 
+    authoritative = ElasticsearchMemoryStore(endpoint=endpoint, index=memory_config.index)
+    if not memory_config.embeddings.enabled:
+        return Memory(
+            MemoryService(authoritative),
+            index=memory_config.index,
+            closeables=(authoritative,),
+        )
+
+    embedding_config = memory_config.embeddings
+    provider: OpenAICompatibleEmbeddingProvider | None = None
+    companion: ElasticsearchEmbeddingStore | None = None
+    try:
+        # Validation guarantees an endpoint whenever embeddings are enabled.
+        assert embedding_config.endpoint is not None
+        provider = OpenAICompatibleEmbeddingProvider(
+            endpoint=embedding_config.endpoint,
+            model=embedding_config.model,
+            dimensions=embedding_config.dimensions,
+            timeout_seconds=embedding_config.timeout_seconds,
+            batch_size=embedding_config.batch_size,
+            api_key_env=embedding_config.api_key_env,
+        )
+        companion = ElasticsearchEmbeddingStore(
+            endpoint=endpoint,
+            index=embedding_config.index,
+            provider=provider,
+            authoritative_store=authoritative,
+        )
+        retrieval = memory_config.retrieval
+        service = MemoryService(
+            authoritative,
+            semantic_memory=companion,
+            embedding_provider=provider,
+            retrieval_mode=cast("Literal['keyword', 'semantic', 'hybrid']", memory_config.effective_retrieval_mode),
+            semantic_candidate_count=retrieval.candidate_count,
+            rrf_rank_constant=retrieval.rrf_rank_constant,
+        )
+    except Exception:
+        resources = tuple(resource for resource in (companion, provider, authoritative) if resource is not None)
+        with suppress(Exception):
+            _close_resources(resources)
+        raise
     return Memory(
-        build_memory_service(es_endpoint=endpoint, memory_index=memory_config.index),
+        service,
         index=memory_config.index,
+        closeables=(companion, provider, authoritative),
     )
 
 

--- a/services/agent/packages/vss_cli/src/vss_cli/memory.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/memory.py
@@ -241,8 +241,10 @@ def build(deployment: config_mod.Deployment | None) -> Memory:
     provider: OpenAICompatibleEmbeddingProvider | None = None
     companion: ElasticsearchEmbeddingStore | None = None
     try:
-        # Validation guarantees an endpoint whenever embeddings are enabled.
+        # Normal CLI configuration resolves dimensions before saving. A
+        # hand-written configuration can still discover them on first use.
         assert embedding_config.endpoint is not None
+        assert embedding_config.model is not None
         provider = OpenAICompatibleEmbeddingProvider(
             endpoint=embedding_config.endpoint,
             model=embedding_config.model,
@@ -250,7 +252,11 @@ def build(deployment: config_mod.Deployment | None) -> Memory:
             timeout_seconds=embedding_config.timeout_seconds,
             batch_size=embedding_config.batch_size,
             api_key_env=embedding_config.api_key_env,
+            query_input_type=embedding_config.query_input_type,
+            document_input_type=embedding_config.document_input_type,
         )
+        if embedding_config.dimensions is None:
+            provider.embed_query("VSS memory embedding dimension discovery")
         companion = ElasticsearchEmbeddingStore(
             endpoint=endpoint,
             index=embedding_config.index,

--- a/services/agent/packages/vss_cli/src/vss_cli/memory.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/memory.py
@@ -28,6 +28,7 @@ from .exits import Exit
 if TYPE_CHECKING:
     from typing import Literal
 
+    from vss_core.memory import EmbeddingBackfillService
     from vss_core.memory import MemoryService
     from vss_core.memory import UnifiedMemoryRecord
     from vss_core.memory.models import MemoryGroup
@@ -102,10 +103,14 @@ class Memory:
         service: MemoryService,
         *,
         index: str,
+        embedding_backfill: EmbeddingBackfillService | None = None,
+        embedding_batch_size: int | None = None,
         closeables: tuple[Any, ...] = (),
     ) -> None:
         self._service = service
         self.index = index
+        self.embedding_backfill = embedding_backfill
+        self.embedding_batch_size = embedding_batch_size
         self._closeables = closeables
         self._closed = False
 
@@ -219,6 +224,7 @@ def build(deployment: config_mod.Deployment | None) -> Memory:
         )
 
     from vss_core.memory import ElasticsearchEmbeddingStore
+    from vss_core.memory import EmbeddingBackfillService
     from vss_core.memory import MemoryService
     from vss_core.memory import OpenAICompatibleEmbeddingProvider
     from vss_core.memory.backends.elasticsearch import ElasticsearchMemoryStore
@@ -268,6 +274,8 @@ def build(deployment: config_mod.Deployment | None) -> Memory:
     return Memory(
         service,
         index=memory_config.index,
+        embedding_backfill=EmbeddingBackfillService(authoritative, companion),
+        embedding_batch_size=embedding_config.batch_size,
         closeables=(companion, provider, authoritative),
     )
 

--- a/services/agent/packages/vss_cli/src/vss_cli/memory.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/memory.py
@@ -195,8 +195,13 @@ class Memory:
         return record
 
 
-def build(deployment: config_mod.Deployment | None) -> Memory:
-    """Open the statically configured authoritative memory store."""
+def build(deployment: config_mod.Deployment | None, *, discover_dimensions: bool = True) -> Memory:
+    """Open the statically configured authoritative memory store.
+
+    ``discover_dimensions=False`` skips the first-use provider probe so a
+    scan-only caller (``vss memory embeddings backfill --dry-run``) can inspect
+    eligibility without contacting the embedding endpoint.
+    """
     if deployment is None:
         raise MemoryUnavailable(
             "cannot reach unified memory: no deployment is configured. Run `vss configure --base-url <origin>` first."
@@ -239,6 +244,15 @@ def build(deployment: config_mod.Deployment | None) -> Memory:
         )
 
     embedding_config = memory_config.embeddings
+    if embedding_config.dimensions is None and not discover_dimensions:
+        return Memory(
+            MemoryService(authoritative),
+            index=memory_config.index,
+            embedding_backfill=EmbeddingBackfillService(authoritative, None),
+            embedding_batch_size=embedding_config.batch_size,
+            closeables=(authoritative,),
+        )
+
     provider: OpenAICompatibleEmbeddingProvider | None = None
     companion: ElasticsearchEmbeddingStore | None = None
     try:

--- a/services/agent/packages/vss_cli/src/vss_cli/memory_cmd.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/memory_cmd.py
@@ -311,6 +311,50 @@ def query_records(
     _emit({"records": [record.model_dump_memory() for record in records]}, pretty=pretty)
 
 
+@memory.group("embeddings")
+def embeddings() -> None:
+    """Manage derived memory embeddings."""
+
+
+@embeddings.command("backfill")
+@click.option(
+    "--batch-size",
+    type=click.IntRange(1),
+    default=None,
+    help="Records per backfill batch (default: configured embedding batch size).",
+)
+@click.option("--limit", type=click.IntRange(1), default=None, help="Maximum records to scan (default: all).")
+@click.option("--dry-run", is_flag=True, help="Scan eligibility without provider calls or writes.")
+@_output_options
+def backfill_embeddings(
+    batch_size: int | None,
+    limit: int | None,
+    dry_run: bool,
+    pretty: bool,
+) -> None:
+    """Backfill derived embeddings for all eligible memory records."""
+    try:
+        facade = _memory()
+        backfill = facade.embedding_backfill
+        configured_batch_size = facade.embedding_batch_size
+        if backfill is None or configured_batch_size is None:
+            raise config_mod.ConfigError(
+                "memory embeddings are disabled or incomplete; run `vss configure memory "
+                "--embeddings --embedding-endpoint http[s]://host[/v1]`"
+            )
+        result = backfill.run(
+            batch_size=batch_size or configured_batch_size,
+            limit=limit,
+            dry_run=dry_run,
+        )
+    except Exception as error:
+        _fail("embedding backfill failed", error, _exception_exit(error))
+        raise AssertionError("unreachable") from error
+    _emit(result.to_dict(), pretty=pretty)
+    if result.failed:
+        raise SystemExit(int(Exit.PARTIAL))
+
+
 @memory.command("introspect")
 @click.option("--query", required=True, help="Question to answer from stored memory.")
 @click.option("--sensor", help="Limit recall to one VIOS sensor name.")

--- a/services/agent/packages/vss_cli/src/vss_cli/memory_cmd.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/memory_cmd.py
@@ -248,6 +248,7 @@ def get_record(
 
 @memory.command("query")
 @click.option("--query", "text", default=None, help="Free-text match over memory content.")
+@click.option("--mode", type=click.Choice(("keyword", "semantic", "hybrid")), help="Override the retrieval strategy.")
 @click.option("--job-id")
 @click.option("--group", type=click.Choice(("summary", "search", "alert", "vlm")))
 @click.option("--status", type=click.Choice(("submitted", "running", "completed", "failed", "partial", "timeout")))
@@ -262,6 +263,7 @@ def get_record(
 @_output_options
 def query_records(
     text: str | None,
+    mode: str | None,
     job_id: str | None,
     group: str | None,
     status: str | None,
@@ -292,8 +294,16 @@ def query_records(
             until=until,
             time_field=time_field,
             limit=limit,
+            mode=mode,  # type: ignore[arg-type]
         )
-        records = _memory().service.query(query)
+        service = _memory().service
+        if mode in {"semantic", "hybrid"} and not service.semantic_retrieval_available:
+            click.echo(
+                "vss memory: warning: memory embeddings are disabled; falling back to keyword retrieval",
+                err=True,
+            )
+            query.mode = "keyword"
+        records = service.query(query)
     except ValueError as error:
         _fail("invalid input", error, Exit.INVALID_INPUT)
     except Exception as error:

--- a/services/agent/packages/vss_cli/src/vss_cli/memory_cmd.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/memory_cmd.py
@@ -55,7 +55,11 @@ def set_test_introspect(
 def _memory(deployment: config_mod.Deployment | None = None) -> Memory:
     if _TEST_MEMORY is not None:
         return _TEST_MEMORY
-    return memory_mod.build(deployment or config_mod.load())
+    memory = memory_mod.build(deployment or config_mod.load())
+    context = click.get_current_context(silent=True)
+    if context is not None:
+        context.call_on_close(memory.close)
+    return memory
 
 
 def _emit(value: Any, *, pretty: bool) -> None:
@@ -148,7 +152,6 @@ async def _execute_introspection(request: IntrospectionRequest) -> tuple[Introsp
                 f"introspection judge credential environment variable {judge_config.api_key_env!r} is missing or empty"
             )
     memory = _memory(deployment)
-    owns_memory = _TEST_MEMORY is None
     client: OpenAIIntrospectionClient | None = None
     try:
         settings = IntrospectionSettings()
@@ -176,10 +179,6 @@ async def _execute_introspection(request: IntrospectionRequest) -> tuple[Introsp
     finally:
         if client is not None:
             await client.aclose()
-        if owns_memory:
-            close_memory = getattr(memory.service.store, "close", None)
-            if close_memory is not None:
-                close_memory()
 
     if result.failure_kind == "timeout" or runner.timed_out:
         return result, Exit.TIMEOUT

--- a/services/agent/packages/vss_cli/src/vss_cli/memory_cmd.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/memory_cmd.py
@@ -52,10 +52,14 @@ def set_test_introspect(
     _TEST_INTROSPECT = function
 
 
-def _memory(deployment: config_mod.Deployment | None = None) -> Memory:
+def _memory(
+    deployment: config_mod.Deployment | None = None,
+    *,
+    discover_dimensions: bool = True,
+) -> Memory:
     if _TEST_MEMORY is not None:
         return _TEST_MEMORY
-    memory = memory_mod.build(deployment or config_mod.load())
+    memory = memory_mod.build(deployment or config_mod.load(), discover_dimensions=discover_dimensions)
     context = click.get_current_context(silent=True)
     if context is not None:
         context.call_on_close(memory.close)
@@ -334,7 +338,7 @@ def backfill_embeddings(
 ) -> None:
     """Backfill derived embeddings for all eligible memory records."""
     try:
-        facade = _memory()
+        facade = _memory(discover_dimensions=not dry_run)
         backfill = facade.embedding_backfill
         configured_batch_size = facade.embedding_batch_size
         if backfill is None or configured_batch_size is None:

--- a/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
@@ -200,7 +200,20 @@ class IntrospectionVLMJobRunner:
             end_time=result.end_time,
             question=prompt,
             answer=result.answer,
+            intent="introspection",
+            model=result.model,
+            num_frames=_introspection_frame_budget(self._analyzer),
+            timeout_seconds=effective_timeout,
         )
+
+
+def _introspection_frame_budget(analyzer: Any | None) -> int | None:
+    if analyzer is None:
+        return _RT_VLM_FRAME_BUDGET
+    budget = getattr(analyzer, "_rt_vlm_frame_budget", None)
+    if budget is None:
+        return None
+    return int(budget)
 
 
 def _is_backend_error(error: BaseException) -> bool:

--- a/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
@@ -194,6 +194,7 @@ class IntrospectionVLMJobRunner:
             sensor=result.sensor_name,
             start_time=result.start_time,
             end_time=result.end_time,
+            question=prompt,
             answer=result.answer,
         )
 

--- a/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
@@ -39,6 +39,10 @@ if TYPE_CHECKING:
 _CROCKFORD32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 _TERMINAL_WRITE_RESERVE_SECONDS = 1.0
 _CLEANUP_TIMEOUT_SECONDS = 1.0
+# Matches the ``vss vlm run --num-frames`` default. RT-VLM samples the opening
+# frame alone when the budget is absent, which is not enough to ground a
+# question about an interval.
+_RT_VLM_FRAME_BUDGET = 8
 
 
 def _ulid() -> str:
@@ -231,6 +235,7 @@ def _production_analyzer(deployment: config_mod.Deployment, timeout_seconds: int
             # not reject the host-side localhost origin.
             video_url_scope="internal",
             cosmos_nim_runtime_options=False,
+            rt_vlm_frame_budget=_RT_VLM_FRAME_BUDGET,
         ),
         model,
     )

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_configure_memory.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_configure_memory.py
@@ -218,7 +218,7 @@ def test_memory_check_reports_backend_reachability_as_exit_three(
     assert "vss configure memory check" in result.output
 
 
-def test_version_one_config_has_actionable_migration_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_older_config_without_memory_remains_valid(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(config_mod.CONFIG_HOME_ENV, str(tmp_path))
     tmp_path.joinpath("config.json").write_text(
         json.dumps(
@@ -231,10 +231,7 @@ def test_version_one_config_has_actionable_migration_error(tmp_path: Path, monke
         ),
         encoding="utf-8",
     )
-    with pytest.raises(config_mod.ConfigError) as error:
-        config_mod.load()
-    assert "vss configure --base-url <origin>" in str(error.value)
-    assert "then re-run `vss configure memory" in str(error.value)
+    assert config_mod.load().memory is None
 
 
 def test_main_configure_preserves_memory_policy(
@@ -332,7 +329,7 @@ def test_memory_config_without_markdown_section_uses_disabled_defaults(
     tmp_path.joinpath("config.json").write_text(
         json.dumps(
             {
-                "version": 2,
+                "version": 1,
                 "base_url": "http://example",
                 "services": {"elasticsearch": {"url": "http://example/elasticsearch"}},
                 "memory": {
@@ -620,7 +617,7 @@ def test_custom_embedding_and_retrieval_configuration_round_trip(config_home: Pa
     )
     assert memory_config.retrieval == config_mod.RetrievalConfig(mode="semantic")
     assert config_mod.MemoryConfig.from_json(memory_config.to_json()) == memory_config
-    assert config_mod.CONFIG_VERSION == 2
+    assert config_mod.CONFIG_VERSION == 1
 
 
 def test_disabled_embeddings_force_effective_keyword_retrieval() -> None:

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_configure_memory.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_configure_memory.py
@@ -87,6 +87,22 @@ def test_memory_show_prints_only_effective_memory_configuration(config_home: Pat
             "write_by_default": False,
         },
         "introspection": None,
+        "embeddings": {
+            "enabled": False,
+            "provider": "openai_compatible",
+            "endpoint": None,
+            "model": "nvidia/llama-nemotron-embed-300m-v2",
+            "dimensions": 768,
+            "index": "vss-memory-embeddings-v1",
+            "timeout_seconds": 30.0,
+            "batch_size": 16,
+            "api_key_env": None,
+        },
+        "retrieval": {
+            "mode": "hybrid",
+            "candidate_count": 50,
+            "rrf_rank_constant": 60,
+        },
     }
     assert "services" not in result.output
     assert "base_url" not in result.output
@@ -200,7 +216,7 @@ def test_memory_check_reports_backend_reachability_as_exit_three(
     assert "vss configure memory check" in result.output
 
 
-def test_older_config_without_memory_remains_valid(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_version_one_config_has_actionable_migration_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(config_mod.CONFIG_HOME_ENV, str(tmp_path))
     tmp_path.joinpath("config.json").write_text(
         json.dumps(
@@ -213,7 +229,10 @@ def test_older_config_without_memory_remains_valid(tmp_path: Path, monkeypatch: 
         ),
         encoding="utf-8",
     )
-    assert config_mod.load().memory is None
+    with pytest.raises(config_mod.ConfigError) as error:
+        config_mod.load()
+    assert "vss configure --base-url <origin>" in str(error.value)
+    assert "then re-run `vss configure memory" in str(error.value)
 
 
 def test_main_configure_preserves_memory_policy(
@@ -311,7 +330,7 @@ def test_memory_config_without_markdown_section_uses_disabled_defaults(
     tmp_path.joinpath("config.json").write_text(
         json.dumps(
             {
-                "version": 1,
+                "version": 2,
                 "base_url": "http://example",
                 "services": {"elasticsearch": {"url": "http://example/elasticsearch"}},
                 "memory": {
@@ -327,6 +346,7 @@ def test_memory_config_without_markdown_section_uses_disabled_defaults(
     memory_config = config_mod.load().memory
     assert memory_config is not None
     assert memory_config.markdown == config_mod.MarkdownMemoryConfig()
+
 
 
 def test_configure_introspection_judge_round_trip_and_show(config_home: Path) -> None:
@@ -543,3 +563,145 @@ def test_show_never_resolves_or_displays_judge_secret(
     assert shown.exit_code == 0
     assert "CUSTOM_LLM_API_KEY" in shown.output
     assert "super-secret-value" not in shown.output
+
+
+def test_embedding_and_retrieval_configuration_round_trip(config_home: Path) -> None:
+    result = _invoke(
+        "--embeddings",
+        "--embedding-endpoint",
+        "http://embedding.example/v1",
+        "--embedding-api-key-env",
+        "VSS_EMBED_KEY",
+        "--retrieval-mode",
+        "semantic",
+    )
+    assert result.exit_code == 0, result.output
+    memory_config = config_mod.load().memory
+    assert memory_config is not None
+    assert memory_config.embeddings == config_mod.EmbeddingConfig(
+        enabled=True,
+        endpoint="http://embedding.example/v1",
+        api_key_env="VSS_EMBED_KEY",
+    )
+    assert memory_config.retrieval == config_mod.RetrievalConfig(mode="semantic")
+    assert config_mod.MemoryConfig.from_json(memory_config.to_json()) == memory_config
+    assert config_mod.CONFIG_VERSION == 2
+
+
+def test_disabled_embeddings_force_effective_keyword_retrieval() -> None:
+    assert config_mod.MemoryConfig().retrieval.mode == "hybrid"
+    assert config_mod.MemoryConfig().effective_retrieval_mode == "keyword"
+    assert (
+        config_mod.MemoryConfig(
+            embeddings=config_mod.EmbeddingConfig(enabled=True, endpoint="http://embedding.example/v1")
+        ).effective_retrieval_mode
+        == "hybrid"
+    )
+
+
+@pytest.mark.parametrize(
+    ("embeddings", "retrieval", "message"),
+    [
+        (config_mod.EmbeddingConfig(enabled=True), config_mod.RetrievalConfig(), "require"),
+        (
+            config_mod.EmbeddingConfig(enabled=True, endpoint="ftp://example"),
+            config_mod.RetrievalConfig(),
+            "absolute HTTP",
+        ),
+        (
+            config_mod.EmbeddingConfig(enabled=True, endpoint="http://user:" + "password@example"),
+            config_mod.RetrievalConfig(),
+            "embedded credentials",
+        ),
+        (config_mod.EmbeddingConfig(dimensions=0), config_mod.RetrievalConfig(), "positive integer"),
+        (config_mod.EmbeddingConfig(timeout_seconds=0), config_mod.RetrievalConfig(), "timeout"),
+        (config_mod.EmbeddingConfig(batch_size=129), config_mod.RetrievalConfig(), "batch size"),
+        (config_mod.EmbeddingConfig(), config_mod.RetrievalConfig(mode="other"), "retrieval mode"),
+        (config_mod.EmbeddingConfig(), config_mod.RetrievalConfig(candidate_count=0), "candidate count"),
+        (config_mod.EmbeddingConfig(), config_mod.RetrievalConfig(rrf_rank_constant=0), "RRF"),
+    ],
+)
+def test_invalid_embedding_and_retrieval_configuration(
+    embeddings: config_mod.EmbeddingConfig,
+    retrieval: config_mod.RetrievalConfig,
+    message: str,
+) -> None:
+    with pytest.raises(config_mod.ConfigError, match=message):
+        config_mod.MemoryConfig(embeddings=embeddings, retrieval=retrieval).validate()
+
+
+def test_embedding_index_must_differ_from_authoritative_index() -> None:
+    with pytest.raises(config_mod.ConfigError, match="must differ"):
+        config_mod.MemoryConfig(
+            embeddings=config_mod.EmbeddingConfig(
+                enabled=True,
+                endpoint="http://embedding.example/v1",
+                index="vss-memory",
+            )
+        ).validate()
+
+
+def test_show_names_api_key_environment_without_resolving_secret(
+    config_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VSS_EMBED_KEY", "do-not-print-this")
+    assert _invoke("--embedding-api-key-env", "VSS_EMBED_KEY").exit_code == 0
+    result = _invoke("show")
+    assert "VSS_EMBED_KEY" in result.output
+    assert "do-not-print-this" not in result.output
+
+
+def test_embedding_check_probes_once_and_reports_lazy_missing_index(
+    config_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert _invoke("--embeddings", "--embedding-endpoint", "http://embedding.example/v1").exit_code == 0
+    probes: list[str] = []
+
+    class Provider:
+        def __init__(self, **_kwargs: object) -> None:
+            return None
+
+        def embed_query(self, text: str) -> list[float]:
+            probes.append(text)
+            return [0.0] * 768
+
+        def close(self) -> None:
+            return None
+
+    class Missing:
+        status_code = 404
+
+    monkeypatch.setattr("vss_core.memory.OpenAICompatibleEmbeddingProvider", Provider)
+    monkeypatch.setattr(configure_mod, "_check_memory_backend", lambda *_args, **_kwargs: "elasticsearch reachable")
+    monkeypatch.setattr("httpx.get", lambda *_args, **_kwargs: Missing())
+    result = _invoke("check")
+    assert result.exit_code == 0, result.output
+    assert len(probes) == 1
+    assert "created lazily" in result.output
+
+
+def test_embedding_check_rejects_malformed_probe_as_backend_failure(
+    config_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert _invoke("--embeddings", "--embedding-endpoint", "http://embedding.example/v1").exit_code == 0
+
+    class Provider:
+        def __init__(self, **_kwargs: object) -> None:
+            return None
+
+        def embed_query(self, _text: str) -> list[float]:
+            from vss_core.memory import EmbeddingProviderError
+
+            raise EmbeddingProviderError("malformed response")
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr("vss_core.memory.OpenAICompatibleEmbeddingProvider", Provider)
+    monkeypatch.setattr(configure_mod, "_check_memory_backend", lambda *_args, **_kwargs: "elasticsearch reachable")
+    result = _invoke("check")
+    assert result.exit_code == int(Exit.BACKEND_UNREACHABLE)
+    assert "malformed response" in result.output

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_configure_memory.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_configure_memory.py
@@ -89,14 +89,16 @@ def test_memory_show_prints_only_effective_memory_configuration(config_home: Pat
         "introspection": None,
         "embeddings": {
             "enabled": False,
-            "provider": "openai_compatible",
-            "endpoint": None,
-            "model": "nvidia/llama-nemotron-embed-300m-v2",
-            "dimensions": 768,
+            "provider": "openclaw_gateway",
+            "endpoint": "http://127.0.0.1:18789/v1",
+            "model": "openclaw/default",
+            "dimensions": None,
             "index": "vss-memory-embeddings-v1",
             "timeout_seconds": 30.0,
             "batch_size": 16,
-            "api_key_env": None,
+            "api_key_env": "OPENCLAW_GATEWAY_TOKEN",
+            "query_input_type": None,
+            "document_input_type": None,
         },
         "retrieval": {
             "mode": "hybrid",
@@ -348,7 +350,6 @@ def test_memory_config_without_markdown_section_uses_disabled_defaults(
     assert memory_config.markdown == config_mod.MarkdownMemoryConfig()
 
 
-
 def test_configure_introspection_judge_round_trip_and_show(config_home: Path) -> None:
     criteria = "Require direct support from every cited record."
     result = _invoke(
@@ -565,13 +566,42 @@ def test_show_never_resolves_or_displays_judge_secret(
     assert "super-secret-value" not in shown.output
 
 
-def test_embedding_and_retrieval_configuration_round_trip(config_home: Path) -> None:
+def test_embeddings_select_openclaw_defaults_and_discover_dimensions(
+    config_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    probes: list[config_mod.EmbeddingConfig] = []
+
+    def probe(config: config_mod.EmbeddingConfig) -> tuple[int, str | None]:
+        probes.append(config)
+        return 768, "resolved/backend-model"
+
+    monkeypatch.setattr(configure_mod, "_probe_embedding", probe)
+    result = _invoke("--embeddings")
+    assert result.exit_code == 0, result.output
+    embedding = config_mod.load().memory.embeddings  # type: ignore[union-attr]
+    assert embedding == config_mod.EmbeddingConfig(enabled=True, dimensions=768)
+    assert probes == [config_mod.EmbeddingConfig(enabled=True)]
+    assert "discovered embedding dimensions: 768" in result.output
+
+
+def test_custom_embedding_and_retrieval_configuration_round_trip(config_home: Path) -> None:
     result = _invoke(
         "--embeddings",
+        "--embedding-provider",
+        "openai_compatible",
         "--embedding-endpoint",
         "http://embedding.example/v1",
+        "--embedding-model",
+        "example-embedding-model",
+        "--embedding-dimensions",
+        "384",
         "--embedding-api-key-env",
         "VSS_EMBED_KEY",
+        "--embedding-query-input-type",
+        "query",
+        "--embedding-document-input-type",
+        "document",
         "--retrieval-mode",
         "semantic",
     )
@@ -580,8 +610,13 @@ def test_embedding_and_retrieval_configuration_round_trip(config_home: Path) -> 
     assert memory_config is not None
     assert memory_config.embeddings == config_mod.EmbeddingConfig(
         enabled=True,
+        provider="openai_compatible",
         endpoint="http://embedding.example/v1",
+        model="example-embedding-model",
+        dimensions=384,
         api_key_env="VSS_EMBED_KEY",
+        query_input_type="query",
+        document_input_type="document",
     )
     assert memory_config.retrieval == config_mod.RetrievalConfig(mode="semantic")
     assert config_mod.MemoryConfig.from_json(memory_config.to_json()) == memory_config
@@ -593,23 +628,105 @@ def test_disabled_embeddings_force_effective_keyword_retrieval() -> None:
     assert config_mod.MemoryConfig().effective_retrieval_mode == "keyword"
     assert (
         config_mod.MemoryConfig(
-            embeddings=config_mod.EmbeddingConfig(enabled=True, endpoint="http://embedding.example/v1")
+            embeddings=config_mod.EmbeddingConfig(enabled=True, dimensions=768)
         ).effective_retrieval_mode
         == "hybrid"
+    )
+
+
+def test_custom_unauthenticated_endpoint_does_not_retain_openclaw_token(config_home: Path) -> None:
+    result = _invoke(
+        "--embeddings",
+        "--embedding-provider",
+        "openai_compatible",
+        "--embedding-endpoint",
+        "http://127.0.0.1:9000/v1",
+        "--embedding-model",
+        "local-custom-model",
+        "--embedding-dimensions",
+        "256",
+        "--no-embedding-auth",
+    )
+    assert result.exit_code == 0, result.output
+    embedding = config_mod.load().memory.embeddings  # type: ignore[union-attr]
+    assert embedding.provider == "openai_compatible"
+    assert embedding.api_key_env is None
+
+
+def test_explicit_dimensions_allow_offline_configuration(
+    config_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        configure_mod,
+        "_probe_embedding",
+        lambda *_args: pytest.fail("explicit dimensions must not probe the endpoint"),
+    )
+    result = _invoke(
+        "--embeddings",
+        "--embedding-provider",
+        "openai_compatible",
+        "--embedding-endpoint",
+        "http://127.0.0.1:9000/v1",
+        "--embedding-model",
+        "offline-model",
+        "--embedding-dimensions",
+        "512",
+        "--no-embedding-auth",
+    )
+    assert result.exit_code == 0, result.output
+    assert config_mod.load().memory.embeddings.dimensions == 512  # type: ignore[union-attr]
+
+
+def test_switching_provider_profiles_applies_new_defaults_before_overrides(config_home: Path) -> None:
+    assert _invoke("--embeddings", "--embedding-dimensions", "768").exit_code == 0
+    switched = _invoke(
+        "--embedding-provider",
+        "openai_compatible",
+        "--embedding-endpoint",
+        "https://embedding.example/v1",
+        "--embedding-model",
+        "custom-model",
+        "--embedding-dimensions",
+        "1024",
+        "--no-embedding-auth",
+    )
+    assert switched.exit_code == 0, switched.output
+    embedding = config_mod.load().memory.embeddings  # type: ignore[union-attr]
+    assert embedding == config_mod.EmbeddingConfig(
+        enabled=True,
+        provider="openai_compatible",
+        endpoint="https://embedding.example/v1",
+        model="custom-model",
+        dimensions=1024,
+        api_key_env=None,
     )
 
 
 @pytest.mark.parametrize(
     ("embeddings", "retrieval", "message"),
     [
-        (config_mod.EmbeddingConfig(enabled=True), config_mod.RetrievalConfig(), "require"),
         (
-            config_mod.EmbeddingConfig(enabled=True, endpoint="ftp://example"),
+            config_mod.EmbeddingConfig(
+                enabled=True,
+                provider="openai_compatible",
+                endpoint=None,
+                model=None,
+            ),
+            config_mod.RetrievalConfig(),
+            "require explicit",
+        ),
+        (
+            config_mod.EmbeddingConfig(enabled=True, endpoint="ftp://example", dimensions=3),
             config_mod.RetrievalConfig(),
             "absolute HTTP",
         ),
         (
-            config_mod.EmbeddingConfig(enabled=True, endpoint="http://user:" + "password@example"),
+            config_mod.EmbeddingConfig(
+                enabled=True,
+                endpoint="http://user:" + "password@example",
+                dimensions=3,
+            ),
             config_mod.RetrievalConfig(),
             "embedded credentials",
         ),
@@ -635,7 +752,7 @@ def test_embedding_index_must_differ_from_authoritative_index() -> None:
         config_mod.MemoryConfig(
             embeddings=config_mod.EmbeddingConfig(
                 enabled=True,
-                endpoint="http://embedding.example/v1",
+                dimensions=768,
                 index="vss-memory",
             )
         ).validate()
@@ -652,11 +769,39 @@ def test_show_names_api_key_environment_without_resolving_secret(
     assert "do-not-print-this" not in result.output
 
 
+@pytest.mark.parametrize(
+    ("args", "message"),
+    (
+        (("--embedding-provider", "unsupported"), "Invalid value"),
+        (("--embedding-endpoint", "relative/path"), "absolute HTTP"),
+        (("--embedding-endpoint", "https://user:" + "secret@example/v1"), "embedded credentials"),
+        (("--embedding-dimensions", "0"), "positive integer"),
+        (("--embedding-timeout-seconds", "0"), "timeout"),
+        (("--embedding-batch-size", "0"), "batch size"),
+        (("--embedding-api-key-env", "NOT-VALID"), "environment variable"),
+    ),
+)
+def test_embedding_cli_rejects_invalid_profile_values(
+    config_home: Path,
+    args: tuple[str, ...],
+    message: str,
+) -> None:
+    result = _invoke(*args)
+    assert result.exit_code != 0
+    assert message in result.output
+
+
+def test_embedding_config_strictly_rejects_unknown_fields() -> None:
+    raw = config_mod.EmbeddingConfig().to_json() | {"token": "must-not-be-accepted"}
+    with pytest.raises(config_mod.ConfigError, match="unknown fields: token"):
+        config_mod.EmbeddingConfig.from_json(raw)
+
+
 def test_embedding_check_probes_once_and_reports_lazy_missing_index(
     config_home: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    assert _invoke("--embeddings", "--embedding-endpoint", "http://embedding.example/v1").exit_code == 0
+    assert _invoke("--embeddings", "--embedding-dimensions", "768").exit_code == 0
     probes: list[str] = []
 
     class Provider:
@@ -666,6 +811,10 @@ def test_embedding_check_probes_once_and_reports_lazy_missing_index(
         def embed_query(self, text: str) -> list[float]:
             probes.append(text)
             return [0.0] * 768
+
+        @property
+        def resolved_model(self) -> str:
+            return "resolved/backend-model"
 
         def close(self) -> None:
             return None
@@ -679,6 +828,8 @@ def test_embedding_check_probes_once_and_reports_lazy_missing_index(
     result = _invoke("check")
     assert result.exit_code == 0, result.output
     assert len(probes) == 1
+    assert "target=openclaw/default" in result.output
+    assert "resolved_model=resolved/backend-model" in result.output
     assert "created lazily" in result.output
 
 
@@ -686,7 +837,7 @@ def test_embedding_check_rejects_malformed_probe_as_backend_failure(
     config_home: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    assert _invoke("--embeddings", "--embedding-endpoint", "http://embedding.example/v1").exit_code == 0
+    assert _invoke("--embeddings", "--embedding-dimensions", "768").exit_code == 0
 
     class Provider:
         def __init__(self, **_kwargs: object) -> None:
@@ -697,6 +848,10 @@ def test_embedding_check_rejects_malformed_probe_as_backend_failure(
 
             raise EmbeddingProviderError("malformed response")
 
+        @property
+        def resolved_model(self) -> None:
+            return None
+
         def close(self) -> None:
             return None
 
@@ -705,3 +860,33 @@ def test_embedding_check_rejects_malformed_probe_as_backend_failure(
     result = _invoke("check")
     assert result.exit_code == int(Exit.BACKEND_UNREACHABLE)
     assert "malformed response" in result.output
+
+
+def test_embedding_check_reports_missing_credential_as_configuration_error(
+    config_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert _invoke("--embeddings", "--embedding-dimensions", "768").exit_code == 0
+
+    class Provider:
+        def __init__(self, **_kwargs: object) -> None:
+            return None
+
+        def embed_query(self, _text: str) -> list[float]:
+            from vss_core.memory import EmbeddingProviderError
+
+            raise EmbeddingProviderError("embedding API key environment variable 'OPENCLAW_GATEWAY_TOKEN' is not set")
+
+        @property
+        def resolved_model(self) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr("vss_core.memory.OpenAICompatibleEmbeddingProvider", Provider)
+    monkeypatch.setattr(configure_mod, "_check_memory_backend", lambda *_args, **_kwargs: "elasticsearch reachable")
+    result = _invoke("check")
+    assert result.exit_code == int(Exit.CONFIGURATION)
+    assert "embedding credential error" in result.output
+    assert "OPENCLAW_GATEWAY_TOKEN" in result.output

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_configure_memory.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_configure_memory.py
@@ -393,6 +393,39 @@ def test_first_introspection_configuration_requires_only_endpoint(config_home: P
     assert judge.api_key_env is None
 
 
+def test_introspection_update_preserves_configured_embeddings_and_retrieval(config_home: Path) -> None:
+    configured = _invoke(
+        "--embeddings",
+        "--embedding-provider",
+        "openai_compatible",
+        "--embedding-endpoint",
+        "http://embedding.example/v1",
+        "--embedding-model",
+        "example-embedding-model",
+        "--embedding-dimensions",
+        "384",
+        "--no-embedding-auth",
+        "--retrieval-mode",
+        "semantic",
+        "--semantic-candidate-count",
+        "17",
+        "--rrf-rank-constant",
+        "41",
+    )
+    assert configured.exit_code == 0, configured.output
+    before = config_mod.load().memory
+    assert before is not None
+
+    result = _invoke("introspection", "--judge-endpoint", "http://127.0.0.1:18789/v1")
+    assert result.exit_code == 0, result.output
+    after = config_mod.load().memory
+    assert after is not None
+    assert after.embeddings == before.embeddings
+    assert after.retrieval == before.retrieval
+    assert after.introspection is not None
+    assert after.introspection.judge.endpoint == "http://127.0.0.1:18789/v1"
+
+
 def test_introspection_criteria_file_stores_utf8_contents(config_home: Path) -> None:
     criteria_file = config_home / "criteria.txt"
     criteria_file.write_text("Require direct evidence.\nPreserve uncertainty.\n", encoding="utf-8")
@@ -726,6 +759,24 @@ def test_switching_provider_profiles_applies_new_defaults_before_overrides(confi
             ),
             config_mod.RetrievalConfig(),
             "embedded credentials",
+        ),
+        (
+            config_mod.EmbeddingConfig(
+                enabled=True,
+                endpoint="http://example/v1?api_key=secret",
+                dimensions=3,
+            ),
+            config_mod.RetrievalConfig(),
+            "query string or fragment",
+        ),
+        (
+            config_mod.EmbeddingConfig(
+                enabled=True,
+                endpoint="http://example/v1#token=secret",
+                dimensions=3,
+            ),
+            config_mod.RetrievalConfig(),
+            "query string or fragment",
         ),
         (config_mod.EmbeddingConfig(dimensions=0), config_mod.RetrievalConfig(), "positive integer"),
         (config_mod.EmbeddingConfig(timeout_seconds=0), config_mod.RetrievalConfig(), "timeout"),

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_job_grammar.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_job_grammar.py
@@ -295,7 +295,11 @@ def test_right_version_wrong_shape_is_refused(tmp_path, monkeypatch: pytest.Monk
     (none)" -- which reads like a broken backend, not an unreadable file.
     """
     monkeypatch.setenv(config_mod.CONFIG_HOME_ENV, str(tmp_path))
-    foreign = {"version": 1, "current": "default", "deployments": {"default": {"base_url": "http://x"}}}
+    foreign = {
+        "version": config_mod.CONFIG_VERSION,
+        "current": "default",
+        "deployments": {"default": {"base_url": "http://x"}},
+    }
     (tmp_path / "config.json").write_text(json.dumps(foreign), encoding="utf-8")
 
     with pytest.raises(config_mod.ConfigError) as excinfo:
@@ -309,7 +313,8 @@ def test_right_version_wrong_shape_is_refused(tmp_path, monkeypatch: pytest.Monk
 def test_config_without_services_is_refused(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(config_mod.CONFIG_HOME_ENV, str(tmp_path))
     (tmp_path / "config.json").write_text(
-        json.dumps({"version": 1, "base_url": "http://h:7777", "services": {}}), encoding="utf-8"
+        json.dumps({"version": config_mod.CONFIG_VERSION, "base_url": "http://h:7777", "services": {}}),
+        encoding="utf-8",
     )
     with pytest.raises(config_mod.ConfigError) as excinfo:
         config_mod.load()

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_job_grammar.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_job_grammar.py
@@ -209,15 +209,18 @@ def test_read_verbs_do_not_expose_static_memory_index() -> None:
 
 def test_memory_builder_uses_configured_authoritative_index(monkeypatch: pytest.MonkeyPatch) -> None:
     from vss_cli import memory as memory_mod
-    import vss_core.memory as core_memory
+    import vss_core.memory.backends.elasticsearch as elasticsearch_mod
 
     built: list[tuple[str, str]] = []
 
-    def build_memory_service(*, es_endpoint: str, memory_index: str) -> object:
-        built.append((es_endpoint, memory_index))
-        return object()
+    class Store:
+        def __init__(self, *, endpoint: str, index: str) -> None:
+            built.append((endpoint, index))
 
-    monkeypatch.setattr(core_memory, "build_memory_service", build_memory_service)
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(elasticsearch_mod, "ElasticsearchMemoryStore", Store)
     deployment = config_mod.Deployment(
         base_url="http://h:7777",
         services={"elasticsearch": config_mod.Service(url="http://h:7777/elasticsearch")},

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_memory_cmd.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_memory_cmd.py
@@ -139,6 +139,37 @@ def test_query_and_events_return_child_records(injected_memory: Memory) -> None:
     assert events[0]["description"] == "forklift entered aisle"
 
 
+def test_query_help_exposes_only_dynamic_retrieval_mode_override() -> None:
+    result = _invoke("query", "--help")
+    assert result.exit_code == 0
+    assert "--mode" in result.output
+    assert "keyword" in result.output
+    assert "semantic" in result.output
+    assert "hybrid" in result.output
+    for option in (
+        "--embedding-model",
+        "--embedding-endpoint",
+        "--embedding-index",
+        "--embedding-dimensions",
+        "--device",
+    ):
+        assert option not in result.output
+
+
+@pytest.mark.parametrize("mode", ("semantic", "hybrid"))
+def test_explicit_semantic_mode_warns_and_preserves_json_when_embeddings_disabled(
+    injected_memory: Memory,
+    mode: str,
+) -> None:
+    injected_memory.service.upsert(UnifiedMemoryRecord.model_validate(_event()))
+
+    result = _invoke("query", "--query", "forklift", "--mode", mode)
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["records"][0]["job"]["record_id"] == "event-1"
+    assert "embeddings are disabled" in result.stderr
+
+
 def test_events_empty_filters_succeed_for_known_asset(injected_memory: Memory) -> None:
     injected_memory.service.upsert(UnifiedMemoryRecord.model_validate(_parent()))
     result = _invoke("events", "--asset-id", "camera-1", "--match", "not present")

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_memory_cmd.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_memory_cmd.py
@@ -170,6 +170,115 @@ def test_explicit_semantic_mode_warns_and_preserves_json_when_embeddings_disable
     assert "embeddings are disabled" in result.stderr
 
 
+def test_production_builder_wires_hybrid_memory_and_closes_owned_resources_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import vss_cli.memory as memory_mod
+    import vss_core.memory as core_memory
+    import vss_core.memory.backends.elasticsearch as elasticsearch_mod
+
+    set_test_memory(None)
+    closed: list[str] = []
+    observed: dict[str, Any] = {}
+
+    class FakeAuthoritativeStore(InMemoryStore):
+        def __init__(self, **kwargs: Any) -> None:
+            super().__init__()
+            observed["authoritative"] = self
+            observed["authoritative_kwargs"] = kwargs
+
+        def close(self) -> None:
+            closed.append("authoritative")
+
+    class FakeProvider:
+        def __init__(self, **kwargs: Any) -> None:
+            observed["provider"] = self
+            observed["provider_kwargs"] = kwargs
+
+        @property
+        def model(self) -> str:
+            return "embed-model"
+
+        @property
+        def dimensions(self) -> int:
+            return 4
+
+        def embed_query(self, _text: str) -> list[float]:
+            return [1.0] * 4
+
+        def close(self) -> None:
+            closed.append("provider")
+
+    class FakeCompanion:
+        def __init__(self, **kwargs: Any) -> None:
+            observed["companion"] = self
+            observed["companion_kwargs"] = kwargs
+
+        def semantic_search(self, *_args: Any) -> list[str]:
+            return []
+
+        def sync_record(self, _record: Any) -> None:
+            return None
+
+        def close(self) -> None:
+            closed.append("companion")
+
+    deployment = config_mod.Deployment(
+        base_url="http://vss.test",
+        services={"elasticsearch": config_mod.Service(url="http://es.test")},
+        memory=config_mod.MemoryConfig(
+            embeddings=config_mod.EmbeddingConfig(
+                enabled=True,
+                endpoint="http://embed.test/v1",
+                model="embed-model",
+                dimensions=4,
+                index="memory-vectors-v1",
+                timeout_seconds=12,
+                batch_size=3,
+                api_key_env="EMBED_TOKEN",
+            ),
+            retrieval=config_mod.RetrievalConfig(mode="hybrid", candidate_count=17, rrf_rank_constant=41),
+        ),
+    )
+    built: list[Memory] = []
+    original_build = memory_mod.build
+
+    def capture_build(value: Any) -> Memory:
+        facade = original_build(value)
+        built.append(facade)
+        return facade
+
+    monkeypatch.setattr(config_mod, "load", lambda: deployment)
+    monkeypatch.setattr(memory_mod, "build", capture_build)
+    monkeypatch.setattr(elasticsearch_mod, "ElasticsearchMemoryStore", FakeAuthoritativeStore)
+    monkeypatch.setattr(core_memory, "OpenAICompatibleEmbeddingProvider", FakeProvider)
+    monkeypatch.setattr(core_memory, "ElasticsearchEmbeddingStore", FakeCompanion)
+
+    result = _invoke("query", "--job-id", "missing")
+
+    assert result.exit_code == 0, result.output
+    assert len(built) == 1
+    assert observed["companion_kwargs"]["authoritative_store"] is observed["authoritative"]
+    assert observed["companion_kwargs"]["provider"] is observed["provider"]
+    assert built[0].service.store is observed["authoritative"]
+    assert built[0].service.semantic_retrieval_available is True
+    assert built[0].service._retrieval_mode == "hybrid"
+    assert built[0].service._semantic_candidate_count == 17
+    assert built[0].service._rrf_rank_constant == 41
+    assert observed["provider_kwargs"] == {
+        "endpoint": "http://embed.test/v1",
+        "model": "embed-model",
+        "dimensions": 4,
+        "timeout_seconds": 12,
+        "batch_size": 3,
+        "api_key_env": "EMBED_TOKEN",
+    }
+    assert closed == ["companion", "provider", "authoritative"]
+
+    built[0].close()
+    assert closed == ["companion", "provider", "authoritative"]
+
+
 def test_events_empty_filters_succeed_for_known_asset(injected_memory: Memory) -> None:
     injected_memory.service.upsert(UnifiedMemoryRecord.model_validate(_parent()))
     result = _invoke("events", "--asset-id", "camera-1", "--match", "not present")

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_memory_cmd.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_memory_cmd.py
@@ -18,6 +18,7 @@ from vss_cli.memory_cmd import memory
 from vss_cli.memory_cmd import set_test_introspect
 from vss_cli.memory_cmd import set_test_memory
 from vss_core.introspection import IntrospectionResult
+from vss_core.memory import EmbeddingBackfillResult
 from vss_core.memory import MemoryService
 from vss_core.memory import UnifiedMemoryRecord
 from vss_core.memory.backends.in_memory import InMemoryStore
@@ -92,6 +93,54 @@ def test_memory_verbs_do_not_expose_static_index_selection() -> None:
         result = _invoke(verb, "--help")
         assert result.exit_code == 0, result.output
         assert "--memory-index" not in result.output
+
+
+def test_embeddings_backfill_help_has_only_global_backfill_controls() -> None:
+    result = _invoke("embeddings", "backfill", "--help")
+    assert result.exit_code == 0, result.output
+    for option in ("--batch-size", "--limit", "--dry-run", "--pretty"):
+        assert option in result.output
+    for excluded in ("--job-id", "--markdown", "--vlm", "--no-persist"):
+        assert excluded not in result.output
+
+
+def test_embeddings_backfill_uses_configured_batch_size_and_stable_json() -> None:
+    observed: dict[str, Any] = {}
+
+    class Backfill:
+        def run(self, **kwargs: Any) -> EmbeddingBackfillResult:
+            observed.update(kwargs)
+            return EmbeddingBackfillResult(scanned=3, eligible=2, embedded=1, reused=1, skipped=1)
+
+    facade = Memory(
+        MemoryService(InMemoryStore()),
+        index="vss-memory",
+        embedding_backfill=Backfill(),  # type: ignore[arg-type]
+        embedding_batch_size=7,
+    )
+    set_test_memory(facade)
+
+    result = _invoke("embeddings", "backfill", "--dry-run", "--pretty")
+
+    assert result.exit_code == 0, result.output
+    assert observed == {"batch_size": 7, "limit": None, "dry_run": True}
+    assert json.loads(result.output) == {
+        "scanned": 3,
+        "eligible": 2,
+        "embedded": 1,
+        "reused": 1,
+        "skipped": 1,
+        "failed": 0,
+        "failures": [],
+    }
+    assert '\n  "scanned"' in result.output
+
+
+def test_embeddings_backfill_requires_enabled_configuration() -> None:
+    result = _invoke("embeddings", "backfill")
+    assert result.exit_code == int(Exit.CONFIGURATION)
+    assert "embeddings are disabled or incomplete" in result.output
+    assert "configure memory --embeddings" in result.output
 
 
 def test_events_does_not_advertise_undefined_duration_window() -> None:

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_memory_cmd.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_memory_cmd.py
@@ -252,6 +252,10 @@ def test_production_builder_wires_hybrid_memory_and_closes_owned_resources_once(
         def dimensions(self) -> int:
             return 4
 
+        @property
+        def resolved_model(self) -> str | None:
+            return None
+
         def embed_query(self, _text: str) -> list[float]:
             return [1.0] * 4
 
@@ -309,6 +313,8 @@ def test_production_builder_wires_hybrid_memory_and_closes_owned_resources_once(
     assert len(built) == 1
     assert observed["companion_kwargs"]["authoritative_store"] is observed["authoritative"]
     assert observed["companion_kwargs"]["provider"] is observed["provider"]
+    assert observed["companion_kwargs"]["provider_name"] == "openclaw_gateway"
+    assert observed["companion_kwargs"]["embedding_endpoint_identity"].startswith("sha256:")
     assert built[0].service.store is observed["authoritative"]
     assert built[0].service.semantic_retrieval_available is True
     assert built[0].service._retrieval_mode == "hybrid"
@@ -321,6 +327,8 @@ def test_production_builder_wires_hybrid_memory_and_closes_owned_resources_once(
         "timeout_seconds": 12,
         "batch_size": 3,
         "api_key_env": "EMBED_TOKEN",
+        "query_input_type": None,
+        "document_input_type": None,
     }
     assert closed == ["companion", "provider", "authoritative"]
 

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_memory_cmd.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_memory_cmd.py
@@ -296,8 +296,8 @@ def test_production_builder_wires_hybrid_memory_and_closes_owned_resources_once(
     built: list[Memory] = []
     original_build = memory_mod.build
 
-    def capture_build(value: Any) -> Memory:
-        facade = original_build(value)
+    def capture_build(value: Any, **kwargs: Any) -> Memory:
+        facade = original_build(value, **kwargs)
         built.append(facade)
         return facade
 
@@ -334,6 +334,66 @@ def test_production_builder_wires_hybrid_memory_and_closes_owned_resources_once(
 
     built[0].close()
     assert closed == ["companion", "provider", "authoritative"]
+
+
+def test_dry_run_backfill_skips_dimension_discovery_for_handwritten_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import vss_core.memory as core_memory
+    import vss_core.memory.backends.elasticsearch as elasticsearch_mod
+
+    set_test_memory(None)
+    observed: dict[str, Any] = {}
+
+    class FakeAuthoritativeStore(InMemoryStore):
+        def __init__(self, **kwargs: Any) -> None:
+            super().__init__()
+            self.upsert(UnifiedMemoryRecord.model_validate(_parent()))
+
+        def close(self) -> None:
+            return None
+
+    class FakeProvider:
+        def __init__(self, **kwargs: Any) -> None:
+            observed["provider"] = True
+            raise AssertionError("dry-run must not construct the embedding provider")
+
+        def embed_query(self, _text: str) -> list[float]:
+            observed["embed_query"] = True
+            raise AssertionError("dry-run must not contact the embedding provider")
+
+    class FakeCompanion:
+        def __init__(self, **kwargs: Any) -> None:
+            observed["companion"] = True
+            raise AssertionError("dry-run must not construct the companion index")
+
+    deployment = config_mod.Deployment(
+        base_url="http://vss.test",
+        services={"elasticsearch": config_mod.Service(url="http://es.test")},
+        memory=config_mod.MemoryConfig(
+            embeddings=config_mod.EmbeddingConfig(
+                enabled=True,
+                endpoint="http://embed.test/v1",
+                model="embed-model",
+                dimensions=None,
+                index="memory-vectors-v1",
+            )
+        ),
+    )
+    monkeypatch.setattr(config_mod, "load", lambda: deployment)
+    monkeypatch.setattr(elasticsearch_mod, "ElasticsearchMemoryStore", FakeAuthoritativeStore)
+    monkeypatch.setattr(core_memory, "OpenAICompatibleEmbeddingProvider", FakeProvider)
+    monkeypatch.setattr(core_memory, "ElasticsearchEmbeddingStore", FakeCompanion)
+
+    result = _invoke("embeddings", "backfill", "--dry-run")
+
+    assert result.exit_code == 0, result.output
+    assert observed == {}
+    payload = json.loads(result.output)
+    assert payload["scanned"] == 1
+    assert payload["eligible"] == 1
+    assert payload["embedded"] == 0
+    assert payload["failed"] == 0
 
 
 def test_events_empty_filters_succeed_for_known_asset(injected_memory: Memory) -> None:
@@ -502,6 +562,7 @@ def test_introspect_no_memory_emits_json_and_exit_five() -> None:
         "sufficient_from_memory": False,
         "answer": None,
         "memory_evidence": [],
+        "sufficiency": None,
         "vlm_evidence": [],
         "unresolved_gaps": [],
     }

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_vlm.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_vlm.py
@@ -153,6 +153,11 @@ def test_introspection_adapter_runs_direct_job_with_normal_persistence() -> None
 
     assert evidence.persisted is True
     assert evidence.answer == analyzer.answer
+    assert evidence.question == "What happened?"
+    assert evidence.model == "test-vlm"
+    assert evidence.intent == "introspection"
+    assert evidence.num_frames is None
+    assert evidence.timeout_seconds == 180
     assert memory.service.list_jobs()[0].input.intent == "introspection"
     assert runner.persistence_errors == []
 

--- a/services/agent/packages/vss_core/src/vss_core/introspection/judge.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/judge.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import TYPE_CHECKING
 from typing import Any
 
@@ -100,7 +101,6 @@ class OpenAIIntrospectionClient:
     async def _chat(self, prompt: str) -> str:
         payload: dict[str, Any] = {
             "model": self._model,
-            "temperature": 0,
             "messages": [{"role": "user", "content": prompt}],
         }
         headers = {"Content-Type": "application/json"}
@@ -117,7 +117,7 @@ class OpenAIIntrospectionClient:
             raise ValueError("OpenAI-compatible response contained no message content") from error
         if not isinstance(content, str):
             raise ValueError("OpenAI-compatible message content must be text")
-        return content
+        return _strip_reasoning(content)
 
     @property
     def _chat_completions_url(self) -> str:
@@ -134,11 +134,37 @@ def _parse_decision(content: str) -> SufficiencyDecision:
     stripped = _strip_code_fence(content)
     try:
         payload = json.loads(stripped)
-    except json.JSONDecodeError as error:
-        raise InvalidJudgeResponseError("response is not valid JSON") from error
+    except json.JSONDecodeError:
+        payload = _extract_json_object(stripped)
     if not isinstance(payload, dict):
         raise InvalidJudgeResponseError("response JSON must be an object")
     return SufficiencyDecision.model_validate(payload)
+
+
+_REASONING_BLOCK = re.compile(r"<(think|thinking|reasoning)>.*?</\1>", re.DOTALL)
+_REASONING_CLOSE = re.compile(r"</(?:think|thinking|reasoning)>")
+
+
+def _strip_reasoning(content: str) -> str:
+    """Drop chain-of-thought that reasoning-capable models emit around their answer."""
+    without_blocks = _REASONING_BLOCK.sub("", content)
+    # Some models emit only the closing tag, leaving the answer after it.
+    return _REASONING_CLOSE.split(without_blocks)[-1].strip()
+
+
+def _extract_json_object(content: str) -> Any:
+    """Recover the first embedded JSON object from a response wrapped in prose."""
+    decoder = json.JSONDecoder()
+    for index, character in enumerate(content):
+        if character != "{":
+            continue
+        try:
+            payload, _ = decoder.raw_decode(content[index:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            return payload
+    raise InvalidJudgeResponseError("response is not valid JSON")
 
 
 def _strip_code_fence(content: str) -> str:

--- a/services/agent/packages/vss_core/src/vss_core/introspection/models.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/models.py
@@ -128,8 +128,12 @@ class VLMEvidence(_StrictModel):
     end_time: str
     question: str
     answer: str
+    intent: str = "introspection"
+    model: str | None = None
+    num_frames: int | None = Field(default=None, ge=1)
+    timeout_seconds: float | None = Field(default=None, gt=0)
 
-    @field_validator("job_id", "sensor", "question", "answer", mode="after")
+    @field_validator("job_id", "sensor", "question", "answer", "intent", mode="after")
     @classmethod
     def _require_text(cls, value: str, info: Any) -> str:
         return _nonempty(value, info.field_name)
@@ -222,6 +226,7 @@ class IntrospectionResult(_StrictModel):
     sufficient_from_memory: bool
     answer: str | None
     memory_evidence: list[MemoryEvidence] = Field(default_factory=list)
+    sufficiency: SufficiencyDecision | None = None
     vlm_evidence: list[VLMEvidence] = Field(default_factory=list)
     unresolved_gaps: list[str] = Field(default_factory=list)
     failure_kind: Literal["backend_unreachable", "timeout"] | None = Field(default=None, exclude=True)

--- a/services/agent/packages/vss_core/src/vss_core/introspection/models.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/models.py
@@ -126,9 +126,10 @@ class VLMEvidence(_StrictModel):
     sensor: str
     start_time: str
     end_time: str
+    question: str
     answer: str
 
-    @field_validator("job_id", "sensor", "answer", mode="after")
+    @field_validator("job_id", "sensor", "question", "answer", mode="after")
     @classmethod
     def _require_text(cls, value: str, info: Any) -> str:
         return _nonempty(value, info.field_name)

--- a/services/agent/packages/vss_core/src/vss_core/introspection/orchestrator.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/orchestrator.py
@@ -36,6 +36,7 @@ class _WorkflowState:
     unresolved: list[str] = field(default_factory=list)
     pending: list[GroundedGap] = field(default_factory=list)
     sufficient_from_memory: bool = False
+    sufficiency: SufficiencyDecision | None = None
     failure_kind: Literal["backend_unreachable"] | None = None
 
 
@@ -72,6 +73,7 @@ async def introspect(
             sufficient_from_memory=state.sufficient_from_memory,
             answer=None,
             memory_records=state.memory_records,
+            sufficiency=state.sufficiency,
             vlm_evidence=state.vlm_evidence,
             unresolved=state.unresolved,
             failure_kind="timeout",
@@ -137,6 +139,7 @@ async def _run_workflow(
         )
 
     state.sufficient_from_memory = decision.sufficient
+    state.sufficiency = decision
     state.memory_records = _validated_memory_evidence(decision, state.records, state.unresolved)
     if decision.sufficient:
         answer = await _synthesize_best_effort(request, synthesizer, state)
@@ -145,6 +148,7 @@ async def _run_workflow(
             sufficient_from_memory=True,
             answer=answer,
             memory_records=state.memory_records,
+            sufficiency=state.sufficiency,
             unresolved=state.unresolved,
             failure_kind=state.failure_kind,
         )
@@ -182,6 +186,7 @@ async def _run_workflow(
         sufficient_from_memory=False,
         answer=answer,
         memory_records=state.memory_records,
+        sufficiency=state.sufficiency,
         vlm_evidence=state.vlm_evidence,
         unresolved=state.unresolved,
         failure_kind=state.failure_kind,
@@ -354,6 +359,7 @@ def _result(
     sufficient_from_memory: bool,
     answer: str | None,
     memory_records: list[UnifiedMemoryRecord] | None = None,
+    sufficiency: SufficiencyDecision | None = None,
     vlm_evidence: list[VLMEvidence] | None = None,
     unresolved: list[str] | None = None,
     failure_kind: Literal["backend_unreachable", "timeout"] | None = None,
@@ -365,6 +371,7 @@ def _result(
         memory_evidence=[
             MemoryEvidence(record_id=_record_id(record), job_id=record.job.job_id) for record in (memory_records or [])
         ],
+        sufficiency=sufficiency,
         vlm_evidence=vlm_evidence or [],
         unresolved_gaps=unresolved or [],
         failure_kind=failure_kind,

--- a/services/agent/packages/vss_core/src/vss_core/memory/__init__.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/__init__.py
@@ -18,8 +18,10 @@ from typing import Any
 
 __all__ = [
     "SCHEMA_ID",
+    "ElasticsearchEmbeddingStore",
     "EmbeddingProvider",
     "EmbeddingProviderError",
+    "EmbeddingSyncResult",
     "InMemoryStore",
     "JobFilters",
     "JobInfo",
@@ -38,6 +40,7 @@ __all__ = [
     "OpenClawDailyNoteStore",
     "PersistResult",
     "RecordBundle",
+    "SemanticMemorySynchronizer",
     "UnifiedMemoryRecord",
     "build_memory_service",
     "canonical_searchable_text",
@@ -56,6 +59,8 @@ _LAZY_EXPORTS = {
     "JobInfo": ".models",
     "EmbeddingProvider": ".embeddings",
     "EmbeddingProviderError": ".embeddings",
+    "EmbeddingSyncResult": ".backends.elasticsearch_embeddings",
+    "ElasticsearchEmbeddingStore": ".backends.elasticsearch_embeddings",
     "OpenAICompatibleEmbeddingProvider": ".embeddings",
     "canonical_searchable_text": ".embeddings",
     "content_hash": ".embeddings",
@@ -69,6 +74,7 @@ _LAZY_EXPORTS = {
     "MemoryNotFoundError": ".service",
     "NestedCollectionError": ".service",
     "PersistResult": ".service",
+    "SemanticMemorySynchronizer": ".service",
     "build_memory_service": ".service",
     "RecordBundle": ".adapters",
     "LifecycleAdapter": ".adapters",
@@ -86,6 +92,8 @@ if TYPE_CHECKING:
     from .adapters import RecordBundle
     from .adapters import get_adapter
     from .adapters import register_adapter
+    from .backends.elasticsearch_embeddings import ElasticsearchEmbeddingStore
+    from .backends.elasticsearch_embeddings import EmbeddingSyncResult
     from .backends.in_memory import InMemoryStore
     from .embeddings import EmbeddingProvider
     from .embeddings import EmbeddingProviderError
@@ -105,6 +113,7 @@ if TYPE_CHECKING:
     from .service import MemoryService
     from .service import NestedCollectionError
     from .service import PersistResult
+    from .service import SemanticMemorySynchronizer
     from .service import build_memory_service
     from .store import JobFilters
     from .store import MemoryDecodeError

--- a/services/agent/packages/vss_core/src/vss_core/memory/__init__.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/__init__.py
@@ -19,6 +19,9 @@ from typing import Any
 __all__ = [
     "SCHEMA_ID",
     "ElasticsearchEmbeddingStore",
+    "EmbeddingBackfillFailure",
+    "EmbeddingBackfillResult",
+    "EmbeddingBackfillService",
     "EmbeddingProvider",
     "EmbeddingProviderError",
     "EmbeddingSyncResult",
@@ -61,6 +64,9 @@ _LAZY_EXPORTS = {
     "EmbeddingProviderError": ".embeddings",
     "EmbeddingSyncResult": ".backends.elasticsearch_embeddings",
     "ElasticsearchEmbeddingStore": ".backends.elasticsearch_embeddings",
+    "EmbeddingBackfillFailure": ".backfill",
+    "EmbeddingBackfillResult": ".backfill",
+    "EmbeddingBackfillService": ".backfill",
     "OpenAICompatibleEmbeddingProvider": ".embeddings",
     "canonical_searchable_text": ".embeddings",
     "content_hash": ".embeddings",
@@ -95,6 +101,9 @@ if TYPE_CHECKING:
     from .backends.elasticsearch_embeddings import ElasticsearchEmbeddingStore
     from .backends.elasticsearch_embeddings import EmbeddingSyncResult
     from .backends.in_memory import InMemoryStore
+    from .backfill import EmbeddingBackfillFailure
+    from .backfill import EmbeddingBackfillResult
+    from .backfill import EmbeddingBackfillService
     from .embeddings import EmbeddingProvider
     from .embeddings import EmbeddingProviderError
     from .embeddings import OpenAICompatibleEmbeddingProvider

--- a/services/agent/packages/vss_core/src/vss_core/memory/__init__.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/__init__.py
@@ -18,6 +18,8 @@ from typing import Any
 
 __all__ = [
     "SCHEMA_ID",
+    "EmbeddingProvider",
+    "EmbeddingProviderError",
     "InMemoryStore",
     "JobFilters",
     "JobInfo",
@@ -32,12 +34,16 @@ __all__ = [
     "MemoryService",
     "MemoryStore",
     "NestedCollectionError",
+    "OpenAICompatibleEmbeddingProvider",
     "OpenClawDailyNoteStore",
     "PersistResult",
     "RecordBundle",
     "UnifiedMemoryRecord",
     "build_memory_service",
+    "canonical_searchable_text",
+    "content_hash",
     "get_adapter",
+    "is_embedding_eligible",
     "register_adapter",
     "render_memory_note",
 ]
@@ -48,6 +54,12 @@ _LAZY_EXPORTS = {
     "MemoryInput": ".models",
     "MemoryOutput": ".models",
     "JobInfo": ".models",
+    "EmbeddingProvider": ".embeddings",
+    "EmbeddingProviderError": ".embeddings",
+    "OpenAICompatibleEmbeddingProvider": ".embeddings",
+    "canonical_searchable_text": ".embeddings",
+    "content_hash": ".embeddings",
+    "is_embedding_eligible": ".embeddings",
     "MemoryStore": ".store",
     "MemoryQuery": ".store",
     "JobFilters": ".store",
@@ -75,6 +87,12 @@ if TYPE_CHECKING:
     from .adapters import get_adapter
     from .adapters import register_adapter
     from .backends.in_memory import InMemoryStore
+    from .embeddings import EmbeddingProvider
+    from .embeddings import EmbeddingProviderError
+    from .embeddings import OpenAICompatibleEmbeddingProvider
+    from .embeddings import canonical_searchable_text
+    from .embeddings import content_hash
+    from .embeddings import is_embedding_eligible
     from .models import SCHEMA_ID
     from .models import JobInfo
     from .models import MemoryInput

--- a/services/agent/packages/vss_core/src/vss_core/memory/__init__.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/__init__.py
@@ -48,6 +48,7 @@ __all__ = [
     "build_memory_service",
     "canonical_searchable_text",
     "content_hash",
+    "embedding_endpoint_identity",
     "get_adapter",
     "is_embedding_eligible",
     "register_adapter",
@@ -70,6 +71,7 @@ _LAZY_EXPORTS = {
     "OpenAICompatibleEmbeddingProvider": ".embeddings",
     "canonical_searchable_text": ".embeddings",
     "content_hash": ".embeddings",
+    "embedding_endpoint_identity": ".embeddings",
     "is_embedding_eligible": ".embeddings",
     "MemoryStore": ".store",
     "MemoryQuery": ".store",
@@ -109,6 +111,7 @@ if TYPE_CHECKING:
     from .embeddings import OpenAICompatibleEmbeddingProvider
     from .embeddings import canonical_searchable_text
     from .embeddings import content_hash
+    from .embeddings import embedding_endpoint_identity
     from .embeddings import is_embedding_eligible
     from .models import SCHEMA_ID
     from .models import JobInfo

--- a/services/agent/packages/vss_core/src/vss_core/memory/backends/elasticsearch.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/backends/elasticsearch.py
@@ -14,6 +14,7 @@ own compound ``_id``. ``list_jobs`` returns parents only
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime
 import logging
 from typing import Any
@@ -109,6 +110,27 @@ class ElasticsearchMemoryStore:
         if not isinstance(source, dict):
             return None
         return _decode(source, storage_id)
+
+    def get_many(self, storage_ids: Sequence[str]) -> list[UnifiedMemoryRecord]:
+        """Batch-fetch canonical documents while preserving requested order."""
+        requested = list(storage_ids)
+        if not requested:
+            return []
+        try:
+            response = self._client.mget(index=self._index, ids=requested)
+        except ESNotFoundError:
+            return []
+        except (ESConnectionError, ESTransportError) as error:
+            raise BackendUnreachableError("elasticsearch", "batch get failed", cause=error) from error
+        by_id: dict[str, UnifiedMemoryRecord] = {}
+        for document in response.get("docs", []):
+            if not isinstance(document, dict) or document.get("found") is False:
+                continue
+            storage_id = document.get("_id")
+            source = document.get("_source")
+            if isinstance(storage_id, str) and isinstance(source, dict):
+                by_id[storage_id] = _decode(source, storage_id)
+        return [by_id[storage_id] for storage_id in requested if storage_id in by_id]
 
     def query(self, query: MemoryQuery) -> list[UnifiedMemoryRecord]:
         body = self._build_search_body(

--- a/services/agent/packages/vss_core/src/vss_core/memory/backends/elasticsearch.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/backends/elasticsearch.py
@@ -14,6 +14,7 @@ own compound ``_id``. ``list_jobs`` returns parents only
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from collections.abc import Sequence
 from datetime import datetime
 import logging
@@ -131,6 +132,51 @@ class ElasticsearchMemoryStore:
             if isinstance(storage_id, str) and isinstance(source, dict):
                 by_id[storage_id] = _decode(source, storage_id)
         return [by_id[storage_id] for storage_id in requested if storage_id in by_id]
+
+    def scan(self, *, batch_size: int, limit: int | None = None) -> Iterator[UnifiedMemoryRecord]:
+        """Stream bounded ``search_after`` pages in storage-ID order."""
+        if batch_size <= 0:
+            raise ValueError("scan batch_size must be positive")
+        if limit is not None and limit < 0:
+            raise ValueError("scan limit must not be negative")
+        remaining = limit
+        search_after: list[Any] | None = None
+        while remaining is None or remaining > 0:
+            size = batch_size if remaining is None else min(batch_size, remaining)
+            body: dict[str, Any] = {
+                "size": size,
+                "query": {"match_all": {}},
+                "sort": [
+                    {"job.job_id.keyword": {"order": "asc"}},
+                    {"job.record_type.keyword": {"order": "asc", "missing": "_first"}},
+                    {"job.record_id.keyword": {"order": "asc", "missing": "_first"}},
+                ],
+            }
+            if search_after is not None:
+                body["search_after"] = search_after
+            try:
+                response = self._client.search(index=self._index, body=body)
+            except ESNotFoundError:
+                return
+            except (ESConnectionError, ESTransportError) as error:
+                raise BackendUnreachableError("elasticsearch", "scan failed", cause=error) from error
+            hits = response.get("hits", {}).get("hits", [])
+            if not isinstance(hits, list) or not hits:
+                return
+            for hit in hits:
+                if not isinstance(hit, dict):
+                    continue
+                source = hit.get("_source")
+                if isinstance(source, dict):
+                    yield _decode(source, str(hit.get("_id", "(unknown)")))
+                    if remaining is not None:
+                        remaining -= 1
+                        if remaining == 0:
+                            return
+            last_sort = hits[-1].get("sort") if isinstance(hits[-1], dict) else None
+            if not isinstance(last_sort, list) or len(hits) < size:
+                return
+            search_after = last_sort
 
     def query(self, query: MemoryQuery) -> list[UnifiedMemoryRecord]:
         body = self._build_search_body(

--- a/services/agent/packages/vss_core/src/vss_core/memory/backends/elasticsearch_embeddings.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/backends/elasticsearch_embeddings.py
@@ -48,6 +48,14 @@ class EmbeddingSyncResult:
 
 
 @dataclass(frozen=True, slots=True)
+class EmbeddingSyncFailure:
+    """One record that could not be synchronized during a batch."""
+
+    storage_id: str
+    error: str
+
+
+@dataclass(frozen=True, slots=True)
 class EmbeddingDeleteResult:
     """Outcome of deleting one derived vector and its owned reference."""
 
@@ -178,6 +186,92 @@ class ElasticsearchEmbeddingStore:
 
         referenced = self._write_reference(record)
         return EmbeddingSyncResult(storage_id=doc_id, index=self._index, action=action, record=referenced)
+
+    def sync_records(
+        self,
+        records: list[UnifiedMemoryRecord],
+    ) -> list[EmbeddingSyncResult | EmbeddingSyncFailure]:
+        """Synchronize eligible records while batching passage generation.
+
+        Metadata reads and writes remain record-isolated. Provider requests are
+        never retried here; a failed batch is reported once for each member and
+        the backfill proceeds with its next bounded batch.
+        """
+        if not records:
+            return []
+        try:
+            self._ensure_compatible_index()
+        except Exception as error:
+            return [EmbeddingSyncFailure(storage_id_for(record), str(error)) for record in records]
+
+        outcomes: dict[str, EmbeddingSyncResult | EmbeddingSyncFailure] = {}
+        pending: list[tuple[UnifiedMemoryRecord, str, dict[str, Any], bool]] = []
+        for record in records:
+            doc_id = storage_id_for(record)
+            try:
+                text = canonical_searchable_text(record)
+                digest = content_hash(text)
+                existing = self._get_metadata(doc_id)
+                reusable = (
+                    existing is not None
+                    and existing.get("content_hash") == digest
+                    and existing.get("model") == self._provider.model
+                    and existing.get("dimensions") == self._provider.dimensions
+                )
+                metadata = self._document(record, text=text, digest=digest)
+                if reusable:
+                    if existing != metadata:
+                        self._client.update(
+                            index=self._index,
+                            id=doc_id,
+                            doc=metadata,
+                            refresh="wait_for",
+                        )
+                    referenced = self._write_reference(record)
+                    outcomes[doc_id] = EmbeddingSyncResult(
+                        storage_id=doc_id,
+                        index=self._index,
+                        action="reused",
+                        record=referenced,
+                    )
+                else:
+                    pending.append((record, text, metadata, existing is not None))
+            except Exception as error:
+                outcomes[doc_id] = EmbeddingSyncFailure(doc_id, str(error))
+
+        texts = [text for _, text, _, _ in pending]
+        try:
+            vectors = self._provider.embed_passages(texts)
+            if len(vectors) != len(texts):
+                raise ConfigurationError(
+                    f"embedding provider returned {len(vectors)} vectors for {len(texts)} passages"
+                )
+        except Exception as error:
+            for record, _, _, _ in pending:
+                doc_id = storage_id_for(record)
+                outcomes[doc_id] = EmbeddingSyncFailure(doc_id, str(error))
+            return [outcomes[storage_id_for(record)] for record in records]
+
+        for (record, _text, metadata, existed), vector in zip(pending, vectors, strict=True):
+            doc_id = storage_id_for(record)
+            try:
+                if len(vector) != self._provider.dimensions:
+                    raise ConfigurationError(
+                        f"embedding provider returned {len(vector)} dimensions; configured dimensions are "
+                        f"{self._provider.dimensions}"
+                    )
+                metadata["vector"] = vector
+                self._client.index(index=self._index, id=doc_id, document=metadata, refresh="wait_for")
+                referenced = self._write_reference(record)
+                outcomes[doc_id] = EmbeddingSyncResult(
+                    storage_id=doc_id,
+                    index=self._index,
+                    action="reembedded" if existed else "created",
+                    record=referenced,
+                )
+            except Exception as error:
+                outcomes[doc_id] = EmbeddingSyncFailure(doc_id, str(error))
+        return [outcomes[storage_id_for(record)] for record in records]
 
     def delete_record(self, record: UnifiedMemoryRecord) -> EmbeddingDeleteResult:
         """Delete one derived document and remove only this index's reference."""
@@ -424,6 +518,7 @@ __all__ = [
     "IMPLEMENTATION_VERSION",
     "ElasticsearchEmbeddingStore",
     "EmbeddingDeleteResult",
+    "EmbeddingSyncFailure",
     "EmbeddingSyncResult",
     "SyncAction",
 ]

--- a/services/agent/packages/vss_core/src/vss_core/memory/backends/elasticsearch_embeddings.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/backends/elasticsearch_embeddings.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 from typing import Literal
@@ -397,15 +398,17 @@ class ElasticsearchEmbeddingStore:
         except (ESConnectionError, ESTransportError) as error:
             raise BackendUnreachableError("elasticsearch", "embedding index validation failed", cause=error) from error
         mapping = _mapping_for(response, self._index)
-        vector = mapping.get("properties", {}).get("vector")
+        properties = mapping.get("properties")
+        vector = properties.get("vector") if isinstance(properties, Mapping) else None
         metadata = mapping.get("_meta")
         expected_meta = self.mapping["_meta"]
         if (
-            not isinstance(vector, dict)
+            not isinstance(vector, Mapping)
             or vector.get("type") != "dense_vector"
             or vector.get("dims") != self._provider.dimensions
             or vector.get("similarity") != SIMILARITY
-            or metadata != expected_meta
+            or not isinstance(metadata, Mapping)
+            or any(metadata.get(key) != value for key, value in expected_meta.items())
         ):
             raise ConfigurationError(
                 f"companion embedding index {self._index!r} has an incompatible mapping; "
@@ -493,14 +496,21 @@ class ElasticsearchEmbeddingStore:
         return self._authoritative_store.upsert(updated)
 
 
+def _as_mapping(value: Any) -> Mapping[str, Any] | None:
+    return value if isinstance(value, Mapping) else None
+
+
 def _mapping_for(response: Any, index: str) -> dict[str, Any]:
-    if not isinstance(response, dict):
+    """Extract mappings from the Elasticsearch client or a raw dict body."""
+    payload = getattr(response, "body", response)
+    root = _as_mapping(payload)
+    if root is None:
         return {}
-    entry = response.get(index)
-    if not isinstance(entry, dict):
+    entry = _as_mapping(root.get(index))
+    if entry is None:
         return {}
-    mapping = entry.get("mappings")
-    return mapping if isinstance(mapping, dict) else {}
+    mapping = _as_mapping(entry.get("mappings"))
+    return dict(mapping) if mapping is not None else {}
 
 
 def _is_already_exists(error: BadRequestError) -> bool:

--- a/services/agent/packages/vss_core/src/vss_core/memory/backends/elasticsearch_embeddings.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/backends/elasticsearch_embeddings.py
@@ -28,6 +28,7 @@ from ..models import MemoryOutput
 from ..models import UnifiedMemoryRecord
 from ..store import MemoryQuery
 from ..store import MemoryStore
+from ..store import coerce_utc_instant
 from ..store import storage_id_for
 
 EMBEDDING_SCHEMA = "nv.vss.memory.embedding/1.0"
@@ -199,10 +200,95 @@ class ElasticsearchEmbeddingStore:
         query_vector: list[float],
         candidate_count: int,
     ) -> list[str]:
-        """Semantic retrieval is added with query-mode support in the next change."""
-        del query, query_vector, candidate_count
+        """Return filtered kNN hits as ordered authoritative storage IDs."""
+        if candidate_count <= 0:
+            return []
+        if len(query_vector) != self._provider.dimensions:
+            raise ConfigurationError(
+                f"query embedding has {len(query_vector)} dimensions; expected {self._provider.dimensions}"
+            )
         self._ensure_compatible_index()
-        raise NotImplementedError("semantic memory queries are not implemented yet")
+        body = {
+            "size": candidate_count,
+            "_source": ["storage_id"],
+            "knn": {
+                "field": "vector",
+                "query_vector": query_vector,
+                "k": candidate_count,
+                "num_candidates": candidate_count,
+                "filter": {"bool": self._semantic_filter(query)},
+            },
+        }
+        try:
+            response = self._client.search(index=self._index, body=body)
+        except ESNotFoundError:
+            return []
+        except (ESConnectionError, ESTransportError) as error:
+            raise BackendUnreachableError("elasticsearch", "embedding search failed", cause=error) from error
+        storage_ids: list[str] = []
+        for hit in response.get("hits", {}).get("hits", []):
+            if not isinstance(hit, dict):
+                continue
+            source = hit.get("_source")
+            storage_id = source.get("storage_id") if isinstance(source, dict) else None
+            if not isinstance(storage_id, str):
+                storage_id = hit.get("_id")
+            if isinstance(storage_id, str):
+                storage_ids.append(storage_id)
+        return storage_ids
+
+    @staticmethod
+    def _semantic_filter(query: MemoryQuery) -> dict[str, list[dict[str, Any]]]:
+        filters: list[dict[str, Any]] = []
+        must_not: list[dict[str, Any]] = []
+        if query.job_id:
+            filters.append({"term": {"job_id": query.job_id}})
+        if query.group:
+            filters.append({"term": {"group": query.group}})
+        if query.status:
+            filters.append({"term": {"status": query.status}})
+        if query.sensor_id:
+            filters.append({"term": {"sensor_ids": query.sensor_id}})
+        if query.record_type:
+            filters.append({"term": {"record_type": query.record_type}})
+        if query.record_id:
+            filters.append({"term": {"record_id": query.record_id}})
+        if query.parents_only or not query.include_children:
+            filters.append({"term": {"is_child": False}})
+
+        since = coerce_utc_instant(query.since)
+        until = coerce_utc_instant(query.until)
+        if since is not None or until is not None:
+            if query.time_field == "window":
+                if until is not None:
+                    filters.append({"range": {"window_start": {"lte": datetime_to_iso8601(until)}}})
+                if since is not None:
+                    filters.append(
+                        {
+                            "bool": {
+                                "should": [
+                                    {"range": {"window_end": {"gte": datetime_to_iso8601(since)}}},
+                                    {
+                                        "bool": {
+                                            "must_not": [{"exists": {"field": "window_end"}}],
+                                            "filter": [
+                                                {"range": {"window_start": {"gte": datetime_to_iso8601(since)}}}
+                                            ],
+                                        }
+                                    },
+                                ],
+                                "minimum_should_match": 1,
+                            }
+                        }
+                    )
+            else:
+                bounds: dict[str, str] = {}
+                if since is not None:
+                    bounds["gte"] = datetime_to_iso8601(since)
+                if until is not None:
+                    bounds["lte"] = datetime_to_iso8601(until)
+                filters.append({"range": {"created_at": bounds}})
+        return {"filter": filters, "must_not": must_not}
 
     def _ensure_compatible_index(self) -> None:
         try:
@@ -248,6 +334,14 @@ class ElasticsearchEmbeddingStore:
         memory_input = record.input
         window = memory_input.window if memory_input is not None else None
         sensors = memory_input.sensors if memory_input is not None else None
+        sensor_ids = list(
+            dict.fromkeys(
+                value
+                for sensor in sensors or []
+                for value in (sensor.id, sensor.info.get("name") if sensor.info is not None else None)
+                if isinstance(value, str) and value
+            )
+        )
         document: dict[str, Any] = {
             "storage_id": storage_id_for(record),
             "schema": EMBEDDING_SCHEMA,
@@ -260,7 +354,7 @@ class ElasticsearchEmbeddingStore:
             "status": record.job.status,
             "is_child": record.job.is_child,
             "created_at": datetime_to_iso8601(record.job.created_at),
-            "sensor_ids": [sensor.id for sensor in sensors or []],
+            "sensor_ids": sensor_ids,
         }
         if record.job.record_id is not None:
             document["record_id"] = record.job.record_id

--- a/services/agent/packages/vss_core/src/vss_core/memory/backends/elasticsearch_embeddings.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/backends/elasticsearch_embeddings.py
@@ -19,6 +19,7 @@ from vss_core._foundation.errors import BackendUnreachableError
 from vss_core._foundation.errors import ConfigurationError
 from vss_core._foundation.time import datetime_to_iso8601
 
+from ..embeddings import CANONICAL_SEARCHABLE_TEXT_VERSION
 from ..embeddings import SIMILARITY
 from ..embeddings import EmbeddingProvider
 from ..embeddings import canonical_searchable_text
@@ -76,6 +77,8 @@ class ElasticsearchEmbeddingStore:
         index: str,
         provider: EmbeddingProvider,
         authoritative_store: MemoryStore,
+        provider_name: str = "openai_compatible",
+        embedding_endpoint_identity: str | None = None,
         client: Elasticsearch | None = None,
         request_timeout: int = 30,
     ) -> None:
@@ -87,6 +90,8 @@ class ElasticsearchEmbeddingStore:
             raise ConfigurationError("embedding dimensions must be positive")
         self._index = index
         self._provider = provider
+        self._provider_name = provider_name
+        self._embedding_endpoint_identity = embedding_endpoint_identity
         self._authoritative_store = authoritative_store
         self._owned = client is None
         self._client = client or Elasticsearch(endpoint, request_timeout=request_timeout)
@@ -101,17 +106,23 @@ class ElasticsearchEmbeddingStore:
         return {
             "dynamic": "strict",
             "_meta": {
-                "model": self._provider.model,
-                "dimensions": self._provider.dimensions,
                 "schema": EMBEDDING_SCHEMA,
                 "implementation_version": IMPLEMENTATION_VERSION,
+                "provider": self._provider_name,
+                "model_target": self._provider.model,
+                "dimensions": self._provider.dimensions,
+                "canonical_text_version": CANONICAL_SEARCHABLE_TEXT_VERSION,
+                "similarity": SIMILARITY,
+                "endpoint_identity": self._embedding_endpoint_identity,
             },
             "properties": {
                 "storage_id": {"type": "keyword"},
                 "schema": {"type": "keyword"},
                 "content_hash": {"type": "keyword"},
                 "model": {"type": "keyword"},
+                "provider": {"type": "keyword"},
                 "dimensions": {"type": "integer"},
+                "canonical_text_version": {"type": "integer"},
                 "content": {"type": "text"},
                 "vector": {
                     "type": "dense_vector",
@@ -157,7 +168,9 @@ class ElasticsearchEmbeddingStore:
             existing is not None
             and existing.get("content_hash") == digest
             and existing.get("model") == self._provider.model
+            and existing.get("provider") == self._provider_name
             and existing.get("dimensions") == self._provider.dimensions
+            and existing.get("canonical_text_version") == CANONICAL_SEARCHABLE_TEXT_VERSION
         )
         metadata = self._document(record, text=text, digest=digest)
         try:
@@ -217,7 +230,9 @@ class ElasticsearchEmbeddingStore:
                     existing is not None
                     and existing.get("content_hash") == digest
                     and existing.get("model") == self._provider.model
+                    and existing.get("provider") == self._provider_name
                     and existing.get("dimensions") == self._provider.dimensions
+                    and existing.get("canonical_text_version") == CANONICAL_SEARCHABLE_TEXT_VERSION
                 )
                 metadata = self._document(record, text=text, digest=digest)
                 if reusable:
@@ -411,8 +426,9 @@ class ElasticsearchEmbeddingStore:
             or any(metadata.get(key) != value for key, value in expected_meta.items())
         ):
             raise ConfigurationError(
-                f"companion embedding index {self._index!r} has an incompatible mapping; "
-                "configure a new versioned embedding index and backfill it"
+                f"Embedding index {self._index!r} was created for a different model, provider, "
+                "vector dimension, or canonical text version. Configure a new `--embedding-index` "
+                "and run `vss memory embeddings backfill`."
             )
 
     def _get_metadata(self, doc_id: str) -> dict[str, Any] | None:
@@ -444,7 +460,9 @@ class ElasticsearchEmbeddingStore:
             "schema": EMBEDDING_SCHEMA,
             "content_hash": digest,
             "model": self._provider.model,
+            "provider": self._provider_name,
             "dimensions": self._provider.dimensions,
+            "canonical_text_version": CANONICAL_SEARCHABLE_TEXT_VERSION,
             "content": text,
             "job_id": record.job.job_id,
             "group": record.job.group,
@@ -481,6 +499,7 @@ class ElasticsearchEmbeddingStore:
                     doc_ids=[doc_id],
                     kind="text",
                     info={
+                        "provider": self._provider_name,
                         "model": self._provider.model,
                         "dimensions": self._provider.dimensions,
                         "content_hash": content_hash(record),

--- a/services/agent/packages/vss_core/src/vss_core/memory/backends/elasticsearch_embeddings.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/backends/elasticsearch_embeddings.py
@@ -1,0 +1,335 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Derived semantic-memory documents in a companion Elasticsearch index."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from typing import Literal
+
+from elasticsearch import BadRequestError
+from elasticsearch import Elasticsearch
+from elasticsearch import NotFoundError as ESNotFoundError
+from elasticsearch.exceptions import ConnectionError as ESConnectionError
+from elasticsearch.exceptions import TransportError as ESTransportError
+
+from vss_core._foundation.errors import BackendUnreachableError
+from vss_core._foundation.errors import ConfigurationError
+from vss_core._foundation.time import datetime_to_iso8601
+
+from ..embeddings import SIMILARITY
+from ..embeddings import EmbeddingProvider
+from ..embeddings import canonical_searchable_text
+from ..embeddings import content_hash
+from ..embeddings import is_embedding_eligible
+from ..models import EmbeddingRef
+from ..models import MemoryOutput
+from ..models import UnifiedMemoryRecord
+from ..store import MemoryQuery
+from ..store import MemoryStore
+from ..store import storage_id_for
+
+EMBEDDING_SCHEMA = "nv.vss.memory.embedding/1.0"
+IMPLEMENTATION_VERSION = 1
+
+SyncAction = Literal["created", "reembedded", "reused", "deleted", "unchanged"]
+
+
+@dataclass(frozen=True, slots=True)
+class EmbeddingSyncResult:
+    """Outcome of synchronizing one authoritative record."""
+
+    storage_id: str
+    index: str
+    action: SyncAction
+    record: UnifiedMemoryRecord
+
+
+@dataclass(frozen=True, slots=True)
+class EmbeddingDeleteResult:
+    """Outcome of deleting one derived vector and its owned reference."""
+
+    storage_id: str
+    index: str
+    deleted: bool
+    record: UnifiedMemoryRecord
+
+
+class ElasticsearchEmbeddingStore:
+    """Synchronize canonical memory into a versioned companion vector index."""
+
+    def __init__(
+        self,
+        *,
+        endpoint: str,
+        index: str,
+        provider: EmbeddingProvider,
+        authoritative_store: MemoryStore,
+        client: Elasticsearch | None = None,
+        request_timeout: int = 30,
+    ) -> None:
+        if not index:
+            raise ConfigurationError("Elasticsearch embedding store requires a configured companion index")
+        if not endpoint and client is None:
+            raise ConfigurationError("Elasticsearch embedding store requires an endpoint or injected client")
+        if provider.dimensions <= 0:
+            raise ConfigurationError("embedding dimensions must be positive")
+        self._index = index
+        self._provider = provider
+        self._authoritative_store = authoritative_store
+        self._owned = client is None
+        self._client = client or Elasticsearch(endpoint, request_timeout=request_timeout)
+
+    @property
+    def index(self) -> str:
+        return self._index
+
+    @property
+    def mapping(self) -> dict[str, Any]:
+        """Return the exact mapping installed for this provider/index version."""
+        return {
+            "dynamic": "strict",
+            "_meta": {
+                "model": self._provider.model,
+                "dimensions": self._provider.dimensions,
+                "schema": EMBEDDING_SCHEMA,
+                "implementation_version": IMPLEMENTATION_VERSION,
+            },
+            "properties": {
+                "storage_id": {"type": "keyword"},
+                "schema": {"type": "keyword"},
+                "content_hash": {"type": "keyword"},
+                "model": {"type": "keyword"},
+                "dimensions": {"type": "integer"},
+                "content": {"type": "text"},
+                "vector": {
+                    "type": "dense_vector",
+                    "dims": self._provider.dimensions,
+                    "index": True,
+                    "similarity": SIMILARITY,
+                },
+                "job_id": {"type": "keyword"},
+                "record_id": {"type": "keyword"},
+                "record_type": {"type": "keyword"},
+                "group": {"type": "keyword"},
+                "status": {"type": "keyword"},
+                "is_child": {"type": "boolean"},
+                "created_at": {"type": "date"},
+                "updated_at": {"type": "date"},
+                "sensor_ids": {"type": "keyword"},
+                "window_start": {"type": "date"},
+                "window_end": {"type": "date"},
+            },
+        }
+
+    def close(self) -> None:
+        if self._owned:
+            self._client.close()
+
+    def sync_record(self, record: UnifiedMemoryRecord) -> EmbeddingSyncResult:
+        """Synchronize a vector, then attach only this index's canonical reference."""
+        doc_id = storage_id_for(record)
+        if not is_embedding_eligible(record):
+            deleted = self.delete_record(record)
+            return EmbeddingSyncResult(
+                storage_id=doc_id,
+                index=self._index,
+                action="deleted" if deleted.deleted else "unchanged",
+                record=deleted.record,
+            )
+
+        self._ensure_compatible_index()
+        text = canonical_searchable_text(record)
+        digest = content_hash(text)
+        existing = self._get_metadata(doc_id)
+        reusable = (
+            existing is not None
+            and existing.get("content_hash") == digest
+            and existing.get("model") == self._provider.model
+            and existing.get("dimensions") == self._provider.dimensions
+        )
+        metadata = self._document(record, text=text, digest=digest)
+        try:
+            if reusable:
+                if existing != metadata:
+                    self._client.update(
+                        index=self._index,
+                        id=doc_id,
+                        doc=metadata,
+                        refresh="wait_for",
+                    )
+                action: SyncAction = "reused"
+            else:
+                vector = self._provider.embed_passages([text])[0]
+                if len(vector) != self._provider.dimensions:
+                    raise ConfigurationError(
+                        f"embedding provider returned {len(vector)} dimensions; configured dimensions are "
+                        f"{self._provider.dimensions}"
+                    )
+                metadata["vector"] = vector
+                self._client.index(index=self._index, id=doc_id, document=metadata, refresh="wait_for")
+                action = "reembedded" if existing is not None else "created"
+        except (ESConnectionError, ESTransportError) as error:
+            raise BackendUnreachableError(
+                "elasticsearch", f"embedding sync failed for {doc_id}", cause=error
+            ) from error
+
+        referenced = self._write_reference(record)
+        return EmbeddingSyncResult(storage_id=doc_id, index=self._index, action=action, record=referenced)
+
+    def delete_record(self, record: UnifiedMemoryRecord) -> EmbeddingDeleteResult:
+        """Delete one derived document and remove only this index's reference."""
+        doc_id = storage_id_for(record)
+        deleted = True
+        try:
+            self._client.delete(index=self._index, id=doc_id, refresh="wait_for")
+        except ESNotFoundError:
+            deleted = False
+        except (ESConnectionError, ESTransportError) as error:
+            raise BackendUnreachableError(
+                "elasticsearch", f"embedding delete failed for {doc_id}", cause=error
+            ) from error
+        unreferenced = self._write_reference(record, remove=True)
+        return EmbeddingDeleteResult(storage_id=doc_id, index=self._index, deleted=deleted, record=unreferenced)
+
+    def semantic_search(
+        self,
+        query: MemoryQuery,
+        query_vector: list[float],
+        candidate_count: int,
+    ) -> list[str]:
+        """Semantic retrieval is added with query-mode support in the next change."""
+        del query, query_vector, candidate_count
+        self._ensure_compatible_index()
+        raise NotImplementedError("semantic memory queries are not implemented yet")
+
+    def _ensure_compatible_index(self) -> None:
+        try:
+            exists = bool(self._client.indices.exists(index=self._index))
+            if not exists:
+                try:
+                    self._client.indices.create(index=self._index, mappings=self.mapping)
+                except BadRequestError as error:
+                    if not _is_already_exists(error):
+                        raise
+            response = self._client.indices.get_mapping(index=self._index)
+        except (ESConnectionError, ESTransportError) as error:
+            raise BackendUnreachableError("elasticsearch", "embedding index validation failed", cause=error) from error
+        mapping = _mapping_for(response, self._index)
+        vector = mapping.get("properties", {}).get("vector")
+        metadata = mapping.get("_meta")
+        expected_meta = self.mapping["_meta"]
+        if (
+            not isinstance(vector, dict)
+            or vector.get("type") != "dense_vector"
+            or vector.get("dims") != self._provider.dimensions
+            or vector.get("similarity") != SIMILARITY
+            or metadata != expected_meta
+        ):
+            raise ConfigurationError(
+                f"companion embedding index {self._index!r} has an incompatible mapping; "
+                "configure a new versioned embedding index and backfill it"
+            )
+
+    def _get_metadata(self, doc_id: str) -> dict[str, Any] | None:
+        try:
+            response = self._client.get(index=self._index, id=doc_id, source_excludes=["vector"])
+        except ESNotFoundError:
+            return None
+        except (ESConnectionError, ESTransportError) as error:
+            raise BackendUnreachableError(
+                "elasticsearch", f"embedding metadata read failed for {doc_id}", cause=error
+            ) from error
+        source = response.get("_source")
+        return source if isinstance(source, dict) else None
+
+    def _document(self, record: UnifiedMemoryRecord, *, text: str, digest: str) -> dict[str, Any]:
+        memory_input = record.input
+        window = memory_input.window if memory_input is not None else None
+        sensors = memory_input.sensors if memory_input is not None else None
+        document: dict[str, Any] = {
+            "storage_id": storage_id_for(record),
+            "schema": EMBEDDING_SCHEMA,
+            "content_hash": digest,
+            "model": self._provider.model,
+            "dimensions": self._provider.dimensions,
+            "content": text,
+            "job_id": record.job.job_id,
+            "group": record.job.group,
+            "status": record.job.status,
+            "is_child": record.job.is_child,
+            "created_at": datetime_to_iso8601(record.job.created_at),
+            "sensor_ids": [sensor.id for sensor in sensors or []],
+        }
+        if record.job.record_id is not None:
+            document["record_id"] = record.job.record_id
+        if record.job.record_type is not None:
+            document["record_type"] = record.job.record_type
+        if record.job.updated_at is not None:
+            document["updated_at"] = datetime_to_iso8601(record.job.updated_at)
+        if window is not None:
+            document["window_start"] = datetime_to_iso8601(window.start.timestamp)
+            if window.end is not None:
+                document["window_end"] = datetime_to_iso8601(window.end.timestamp)
+        return document
+
+    def _write_reference(self, record: UnifiedMemoryRecord, *, remove: bool = False) -> UnifiedMemoryRecord:
+        if remove and record.output is None:
+            return record
+        output = record.output or MemoryOutput()
+        doc_id = storage_id_for(record)
+        reference_path = f"{self._index}/{doc_id}"
+        unrelated = [
+            reference for reference in output.embedding or [] if reference.es_ref not in {self._index, reference_path}
+        ]
+        if not remove:
+            unrelated.append(
+                EmbeddingRef(
+                    es_ref=reference_path,
+                    doc_ids=[doc_id],
+                    kind="text",
+                    info={
+                        "model": self._provider.model,
+                        "dimensions": self._provider.dimensions,
+                        "content_hash": content_hash(record),
+                    },
+                )
+            )
+        updated_output = output.model_copy(update={"embedding": unrelated or None})
+        updated = record.model_copy(update={"output": updated_output})
+        if updated == record:
+            return record
+        # Deliberately cross the raw authoritative-store boundary. Calling a
+        # MemoryService here would recursively trigger semantic synchronization.
+        return self._authoritative_store.upsert(updated)
+
+
+def _mapping_for(response: Any, index: str) -> dict[str, Any]:
+    if not isinstance(response, dict):
+        return {}
+    entry = response.get(index)
+    if not isinstance(entry, dict):
+        return {}
+    mapping = entry.get("mappings")
+    return mapping if isinstance(mapping, dict) else {}
+
+
+def _is_already_exists(error: BadRequestError) -> bool:
+    body = getattr(error, "body", None)
+    if not isinstance(body, dict):
+        return False
+    detail = body.get("error")
+    if isinstance(detail, dict):
+        return detail.get("type") == "resource_already_exists_exception"
+    return "resource_already_exists_exception" in str(detail)
+
+
+__all__ = [
+    "EMBEDDING_SCHEMA",
+    "IMPLEMENTATION_VERSION",
+    "ElasticsearchEmbeddingStore",
+    "EmbeddingDeleteResult",
+    "EmbeddingSyncResult",
+    "SyncAction",
+]

--- a/services/agent/packages/vss_core/src/vss_core/memory/backends/elasticsearch_embeddings.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/backends/elasticsearch_embeddings.py
@@ -184,6 +184,10 @@ class ElasticsearchEmbeddingStore:
                     )
                 action: SyncAction = "reused"
             else:
+                # Drop the former vector before replacement. A failed re-embed
+                # must not keep semantic search pointed at the updated record.
+                if existing is not None:
+                    self.delete_record(record)
                 vector = self._provider.embed_passages([text])[0]
                 if len(vector) != self._provider.dimensions:
                     raise ConfigurationError(
@@ -251,6 +255,8 @@ class ElasticsearchEmbeddingStore:
                         record=referenced,
                     )
                 else:
+                    if existing is not None:
+                        self.delete_record(record)
                     pending.append((record, text, metadata, existing is not None))
             except Exception as error:
                 outcomes[doc_id] = EmbeddingSyncFailure(doc_id, str(error))

--- a/services/agent/packages/vss_core/src/vss_core/memory/backends/in_memory.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/backends/in_memory.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from collections.abc import Sequence
 from datetime import datetime
 
@@ -145,6 +146,18 @@ class InMemoryStore:
     def get_many(self, storage_ids: Sequence[str]) -> list[UnifiedMemoryRecord]:
         """Return existing records in caller-supplied storage-ID order."""
         return [record for storage_id in storage_ids if (record := self._records.get(storage_id)) is not None]
+
+    def scan(self, *, batch_size: int, limit: int | None = None) -> Iterator[UnifiedMemoryRecord]:
+        """Yield a stable snapshot in ascending storage-ID order."""
+        if batch_size <= 0:
+            raise ValueError("scan batch_size must be positive")
+        if limit is not None and limit < 0:
+            raise ValueError("scan limit must not be negative")
+        storage_ids = sorted(self._records)
+        if limit is not None:
+            storage_ids = storage_ids[:limit]
+        for storage_id in storage_ids:
+            yield self._records[storage_id]
 
     def query(self, query: MemoryQuery) -> list[UnifiedMemoryRecord]:
         matched = [record for record in self._records.values() if _matches_query(record, query)]

--- a/services/agent/packages/vss_core/src/vss_core/memory/backends/in_memory.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/backends/in_memory.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime
 
 from ..models import UnifiedMemoryRecord
@@ -140,6 +141,10 @@ class InMemoryStore:
         record_id: str,
     ) -> UnifiedMemoryRecord | None:
         return self._records.get(make_storage_id(job_id=job_id, record_type=record_type, record_id=record_id))
+
+    def get_many(self, storage_ids: Sequence[str]) -> list[UnifiedMemoryRecord]:
+        """Return existing records in caller-supplied storage-ID order."""
+        return [record for storage_id in storage_ids if (record := self._records.get(storage_id)) is not None]
 
     def query(self, query: MemoryQuery) -> list[UnifiedMemoryRecord]:
         matched = [record for record in self._records.values() if _matches_query(record, query)]

--- a/services/agent/packages/vss_core/src/vss_core/memory/backfill.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/backfill.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Reusable bounded backfill orchestration for derived memory embeddings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+
+from .backends.elasticsearch_embeddings import ElasticsearchEmbeddingStore
+from .backends.elasticsearch_embeddings import EmbeddingSyncFailure
+from .backends.elasticsearch_embeddings import EmbeddingSyncResult
+from .embeddings import is_embedding_eligible
+from .models import UnifiedMemoryRecord
+from .store import MemoryStore
+from .store import storage_id_for
+
+
+@dataclass(frozen=True, slots=True)
+class EmbeddingBackfillFailure:
+    """Stable public representation of one failed record."""
+
+    storage_id: str
+    error: str
+
+
+@dataclass(slots=True)
+class EmbeddingBackfillResult:
+    """Aggregate counts emitted by the CLI and available to library callers."""
+
+    scanned: int = 0
+    eligible: int = 0
+    embedded: int = 0
+    reused: int = 0
+    skipped: int = 0
+    failures: list[EmbeddingBackfillFailure] = field(default_factory=list)
+
+    @property
+    def failed(self) -> int:
+        return len(self.failures)
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the exact stable JSON-compatible result shape."""
+        return {
+            "scanned": self.scanned,
+            "eligible": self.eligible,
+            "embedded": self.embedded,
+            "reused": self.reused,
+            "skipped": self.skipped,
+            "failed": self.failed,
+            "failures": [{"storage_id": failure.storage_id, "error": failure.error} for failure in self.failures],
+        }
+
+
+class EmbeddingBackfillService:
+    """Scan authoritative memory and synchronize its eligible records."""
+
+    def __init__(
+        self,
+        store: MemoryStore,
+        embeddings: ElasticsearchEmbeddingStore,
+    ) -> None:
+        self._store = store
+        self._embeddings = embeddings
+
+    def run(
+        self,
+        *,
+        batch_size: int,
+        limit: int | None = None,
+        dry_run: bool = False,
+    ) -> EmbeddingBackfillResult:
+        """Backfill in bounded batches without materializing the full store."""
+        if batch_size <= 0:
+            raise ValueError("batch_size must be positive")
+        if limit is not None and limit < 0:
+            raise ValueError("limit must not be negative")
+
+        result = EmbeddingBackfillResult()
+        pending: list[UnifiedMemoryRecord] = []
+        for record in self._store.scan(batch_size=batch_size, limit=limit):
+            result.scanned += 1
+            if not is_embedding_eligible(record):
+                result.skipped += 1
+                continue
+            result.eligible += 1
+            if dry_run:
+                continue
+            pending.append(record)
+            if len(pending) == batch_size:
+                self._sync_batch(pending, result)
+                pending = []
+        if pending:
+            self._sync_batch(pending, result)
+        return result
+
+    def _sync_batch(
+        self,
+        records: list[UnifiedMemoryRecord],
+        result: EmbeddingBackfillResult,
+    ) -> None:
+        try:
+            outcomes = self._embeddings.sync_records(records)
+        except Exception as error:
+            outcomes = [EmbeddingSyncFailure(storage_id=storage_id_for(record), error=str(error)) for record in records]
+        for outcome in outcomes:
+            if isinstance(outcome, EmbeddingSyncFailure):
+                result.failures.append(EmbeddingBackfillFailure(storage_id=outcome.storage_id, error=outcome.error))
+            elif isinstance(outcome, EmbeddingSyncResult) and outcome.action == "reused":
+                result.reused += 1
+            elif isinstance(outcome, EmbeddingSyncResult):
+                result.embedded += 1
+
+
+__all__ = [
+    "EmbeddingBackfillFailure",
+    "EmbeddingBackfillResult",
+    "EmbeddingBackfillService",
+]

--- a/services/agent/packages/vss_core/src/vss_core/memory/backfill.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/backfill.py
@@ -58,7 +58,7 @@ class EmbeddingBackfillService:
     def __init__(
         self,
         store: MemoryStore,
-        embeddings: ElasticsearchEmbeddingStore,
+        embeddings: ElasticsearchEmbeddingStore | None,
     ) -> None:
         self._store = store
         self._embeddings = embeddings
@@ -86,6 +86,8 @@ class EmbeddingBackfillService:
             result.eligible += 1
             if dry_run:
                 continue
+            if self._embeddings is None:
+                raise ValueError("embedding companion is required unless dry_run is set")
             pending.append(record)
             if len(pending) == batch_size:
                 self._sync_batch(pending, result)
@@ -99,6 +101,8 @@ class EmbeddingBackfillService:
         records: list[UnifiedMemoryRecord],
         result: EmbeddingBackfillResult,
     ) -> None:
+        if self._embeddings is None:
+            raise ValueError("embedding companion is required unless dry_run is set")
         try:
             outcomes = self._embeddings.sync_records(records)
         except Exception as error:

--- a/services/agent/packages/vss_core/src/vss_core/memory/embeddings.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/embeddings.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Canonical memory text and lightweight HTTP embedding providers."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+import hashlib
+import math
+import os
+import re
+from typing import Protocol
+
+import httpx
+
+from vss_core._foundation.time import datetime_to_iso8601
+
+from .models import UnifiedMemoryRecord
+
+DOCUMENT_INPUT_TYPE = "passage"
+QUERY_INPUT_TYPE = "query"
+SIMILARITY = "cosine"
+_SEARCHABLE_CONTEXT_KEYS = ("description", "category", "kind", "original_query", "search_mode")
+_ELIGIBLE_STATUSES = frozenset({"completed", "partial"})
+
+
+class EmbeddingProviderError(RuntimeError):
+    """An embedding request failed or returned an invalid response."""
+
+
+class EmbeddingProvider(Protocol):
+    """Dependency-injection boundary for text embedding services."""
+
+    @property
+    def model(self) -> str: ...
+
+    @property
+    def dimensions(self) -> int: ...
+
+    def embed_passages(self, texts: Sequence[str]) -> list[list[float]]: ...
+
+    def embed_query(self, text: str) -> list[float]: ...
+
+    def close(self) -> None: ...
+
+
+def _canonical_scalar(value: object) -> str | None:
+    if isinstance(value, str):
+        normalized = re.sub(r"\s+", " ", value.replace("\r\n", "\n").replace("\r", "\n")).strip()
+        return normalized or None
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float) and math.isfinite(value):
+        return str(value)
+    return None
+
+
+def canonical_searchable_text(record: UnifiedMemoryRecord) -> str:
+    """Build stable, deliberately bounded searchable text for one record."""
+    lines = [
+        f"Group: {record.job.group}",
+        f"Record type: {record.job.record_type or 'parent_job'}",
+    ]
+    memory_input = record.input
+    if memory_input is not None:
+        for label, value in (("Intent", memory_input.intent), ("Query", memory_input.query)):
+            scalar = _canonical_scalar(value)
+            if scalar is not None:
+                lines.append(f"{label}: {scalar}")
+    if record.output is not None:
+        answer = _canonical_scalar(record.output.answer)
+        if answer is not None:
+            lines.append(f"Answer: {answer}")
+    if memory_input is not None:
+        if memory_input.sensors:
+            sensors = [_canonical_scalar(sensor.id) for sensor in memory_input.sensors]
+            present = [sensor for sensor in sensors if sensor is not None]
+            if present:
+                lines.append(f"Sensors: {', '.join(present)}")
+        if memory_input.window is not None:
+            lines.append(f"Start: {datetime_to_iso8601(memory_input.window.start.timestamp)}")
+            if memory_input.window.end is not None:
+                lines.append(f"End: {datetime_to_iso8601(memory_input.window.end.timestamp)}")
+    if record.output is not None and record.output.ext:
+        context = [
+            f"{key}={scalar}"
+            for key in _SEARCHABLE_CONTEXT_KEYS
+            if (scalar := _canonical_scalar(record.output.ext.get(key))) is not None
+        ]
+        if context:
+            lines.append(f"Context: {', '.join(context)}")
+    return "\n".join(lines).strip()
+
+
+def content_hash(text_or_record: str | UnifiedMemoryRecord) -> str:
+    """Return lowercase SHA-256 for canonical text or a record."""
+    text = (
+        canonical_searchable_text(text_or_record) if isinstance(text_or_record, UnifiedMemoryRecord) else text_or_record
+    )
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def is_embedding_eligible(record: UnifiedMemoryRecord) -> bool:
+    """Whether a persisted parent or supported child has searchable content."""
+    return record.job.status in _ELIGIBLE_STATUSES and bool(canonical_searchable_text(record))
+
+
+def _embeddings_url(endpoint: str) -> str:
+    normalized = endpoint.rstrip("/")
+    return normalized if normalized.endswith("/embeddings") else f"{normalized}/embeddings"
+
+
+class OpenAICompatibleEmbeddingProvider:
+    """OpenAI-compatible ``POST /embeddings`` provider using one HTTP client."""
+
+    def __init__(
+        self,
+        *,
+        endpoint: str,
+        model: str,
+        dimensions: int,
+        timeout_seconds: float = 30.0,
+        batch_size: int = 16,
+        api_key_env: str | None = None,
+        client: httpx.Client | None = None,
+    ) -> None:
+        if not endpoint:
+            raise ValueError("embedding endpoint is required")
+        if dimensions <= 0:
+            raise ValueError("embedding dimensions must be positive")
+        if not 1 <= batch_size <= 128:
+            raise ValueError("embedding batch size must be between 1 and 128")
+        self._url = _embeddings_url(endpoint)
+        self._model = model
+        self._dimensions = dimensions
+        self._batch_size = batch_size
+        self._api_key_env = api_key_env
+        self._owned_client = client is None
+        self._client = client or httpx.Client(timeout=timeout_seconds, follow_redirects=True)
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def dimensions(self) -> int:
+        return self._dimensions
+
+    def embed_passages(self, texts: Sequence[str]) -> list[list[float]]:
+        vectors: list[list[float]] = []
+        for offset in range(0, len(texts), self._batch_size):
+            vectors.extend(self._embed(list(texts[offset : offset + self._batch_size]), DOCUMENT_INPUT_TYPE))
+        return vectors
+
+    def embed_query(self, text: str) -> list[float]:
+        return self._embed([text], QUERY_INPUT_TYPE)[0]
+
+    def close(self) -> None:
+        if self._owned_client:
+            self._client.close()
+
+    def _embed(self, texts: list[str], input_type: str) -> list[list[float]]:
+        headers: dict[str, str] = {}
+        if self._api_key_env:
+            token = os.environ.get(self._api_key_env)
+            if not token:
+                raise EmbeddingProviderError(f"embedding API key environment variable {self._api_key_env!r} is not set")
+            headers["Authorization"] = f"Bearer {token}"
+        payload = {
+            "model": self._model,
+            "input": texts,
+            "dimensions": self._dimensions,
+            "input_type": input_type,
+            "encoding_format": "float",
+        }
+        try:
+            response = self._client.post(self._url, json=payload, headers=headers)
+            response.raise_for_status()
+            raw = response.json()
+        except (httpx.HTTPError, ValueError) as error:
+            raise EmbeddingProviderError(
+                f"embedding request failed ({type(error).__name__}); check the configured endpoint"
+            ) from None
+        return self._validate_response(raw, expected_count=len(texts))
+
+    def _validate_response(self, raw: object, *, expected_count: int) -> list[list[float]]:
+        if not isinstance(raw, dict) or raw.get("model") != self._model or not isinstance(raw.get("data"), list):
+            raise EmbeddingProviderError("embedding response has an invalid model or data field")
+        data = raw["data"]
+        if len(data) != expected_count:
+            raise EmbeddingProviderError(f"embedding response returned {len(data)} vectors for {expected_count} inputs")
+        indexed: dict[int, list[float]] = {}
+        for item in data:
+            if not isinstance(item, dict):
+                raise EmbeddingProviderError("embedding response data items must be objects")
+            index = item.get("index")
+            vector = item.get("embedding")
+            if isinstance(index, bool) or not isinstance(index, int) or not 0 <= index < expected_count:
+                raise EmbeddingProviderError("embedding response contains an invalid index")
+            if index in indexed:
+                raise EmbeddingProviderError(f"embedding response contains duplicate index {index}")
+            if not isinstance(vector, list) or len(vector) != self._dimensions:
+                raise EmbeddingProviderError(
+                    f"embedding response vector {index} must contain exactly {self._dimensions} values"
+                )
+            converted: list[float] = []
+            for value in vector:
+                if isinstance(value, bool) or not isinstance(value, int | float) or not math.isfinite(value):
+                    raise EmbeddingProviderError(f"embedding response vector {index} contains a non-finite number")
+                converted.append(float(value))
+            indexed[index] = converted
+        if set(indexed) != set(range(expected_count)):
+            raise EmbeddingProviderError("embedding response contains missing indices")
+        return [indexed[index] for index in range(expected_count)]
+
+
+__all__ = [
+    "DOCUMENT_INPUT_TYPE",
+    "QUERY_INPUT_TYPE",
+    "SIMILARITY",
+    "EmbeddingProvider",
+    "EmbeddingProviderError",
+    "OpenAICompatibleEmbeddingProvider",
+    "canonical_searchable_text",
+    "content_hash",
+    "is_embedding_eligible",
+]

--- a/services/agent/packages/vss_core/src/vss_core/memory/embeddings.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/embeddings.py
@@ -10,6 +10,8 @@ import math
 import os
 import re
 from typing import Protocol
+from urllib.parse import urlsplit
+from urllib.parse import urlunsplit
 
 import httpx
 
@@ -36,6 +38,9 @@ class EmbeddingProvider(Protocol):
 
     @property
     def dimensions(self) -> int: ...
+
+    @property
+    def resolved_model(self) -> str | None: ...
 
     def embed_passages(self, texts: Sequence[str]) -> list[list[float]]: ...
 
@@ -108,8 +113,11 @@ def is_embedding_eligible(record: UnifiedMemoryRecord) -> bool:
 
 
 def _embeddings_url(endpoint: str) -> str:
-    normalized = endpoint.rstrip("/")
-    return normalized if normalized.endswith("/embeddings") else f"{normalized}/embeddings"
+    parsed = urlsplit(endpoint)
+    path = parsed.path.rstrip("/")
+    if not path.endswith("/embeddings"):
+        path = f"{path}/embeddings"
+    return urlunsplit((parsed.scheme, parsed.netloc, path, parsed.query, parsed.fragment))
 
 
 class OpenAICompatibleEmbeddingProvider:
@@ -120,15 +128,19 @@ class OpenAICompatibleEmbeddingProvider:
         *,
         endpoint: str,
         model: str,
-        dimensions: int,
+        dimensions: int | None,
         timeout_seconds: float = 30.0,
         batch_size: int = 16,
         api_key_env: str | None = None,
+        query_input_type: str | None = None,
+        document_input_type: str | None = None,
         client: httpx.Client | None = None,
     ) -> None:
         if not endpoint:
             raise ValueError("embedding endpoint is required")
-        if dimensions <= 0:
+        if not model:
+            raise ValueError("embedding model is required")
+        if dimensions is not None and dimensions <= 0:
             raise ValueError("embedding dimensions must be positive")
         if not 1 <= batch_size <= 128:
             raise ValueError("embedding batch size must be between 1 and 128")
@@ -137,6 +149,9 @@ class OpenAICompatibleEmbeddingProvider:
         self._dimensions = dimensions
         self._batch_size = batch_size
         self._api_key_env = api_key_env
+        self._query_input_type = query_input_type
+        self._document_input_type = document_input_type
+        self._resolved_model: str | None = None
         self._owned_client = client is None
         self._client = client or httpx.Client(timeout=timeout_seconds, follow_redirects=True)
 
@@ -146,22 +161,28 @@ class OpenAICompatibleEmbeddingProvider:
 
     @property
     def dimensions(self) -> int:
+        if self._dimensions is None:
+            raise EmbeddingProviderError("embedding dimensions have not been discovered")
         return self._dimensions
+
+    @property
+    def resolved_model(self) -> str | None:
+        return self._resolved_model
 
     def embed_passages(self, texts: Sequence[str]) -> list[list[float]]:
         vectors: list[list[float]] = []
         for offset in range(0, len(texts), self._batch_size):
-            vectors.extend(self._embed(list(texts[offset : offset + self._batch_size]), DOCUMENT_INPUT_TYPE))
+            vectors.extend(self._embed(list(texts[offset : offset + self._batch_size]), self._document_input_type))
         return vectors
 
     def embed_query(self, text: str) -> list[float]:
-        return self._embed([text], QUERY_INPUT_TYPE)[0]
+        return self._embed([text], self._query_input_type)[0]
 
     def close(self) -> None:
         if self._owned_client:
             self._client.close()
 
-    def _embed(self, texts: list[str], input_type: str) -> list[list[float]]:
+    def _embed(self, texts: list[str], input_type: str | None) -> list[list[float]]:
         headers: dict[str, str] = {}
         if self._api_key_env:
             token = os.environ.get(self._api_key_env)
@@ -171,23 +192,38 @@ class OpenAICompatibleEmbeddingProvider:
         payload = {
             "model": self._model,
             "input": texts,
-            "dimensions": self._dimensions,
-            "input_type": input_type,
-            "encoding_format": "float",
         }
+        if input_type is not None:
+            payload["input_type"] = input_type
         try:
             response = self._client.post(self._url, json=payload, headers=headers)
             response.raise_for_status()
             raw = response.json()
-        except (httpx.HTTPError, ValueError) as error:
-            raise EmbeddingProviderError(
-                f"embedding request failed ({type(error).__name__}); check the configured endpoint"
-            ) from None
+        except httpx.HTTPStatusError as error:
+            if error.response.status_code == 401:
+                detail = "embedding endpoint authentication failed (HTTP 401)"
+            elif error.response.status_code == 403:
+                detail = "embedding endpoint authorization failed (HTTP 403)"
+            else:
+                detail = f"embedding endpoint returned HTTP {error.response.status_code}"
+            raise EmbeddingProviderError(detail) from None
+        except httpx.TimeoutException:
+            raise EmbeddingProviderError("embedding endpoint request timed out") from None
+        except httpx.ConnectError:
+            raise EmbeddingProviderError("could not connect to the embedding endpoint") from None
+        except httpx.HTTPError as error:
+            raise EmbeddingProviderError(f"embedding endpoint request failed ({type(error).__name__})") from None
+        except ValueError:
+            raise EmbeddingProviderError("embedding endpoint returned invalid JSON") from None
         return self._validate_response(raw, expected_count=len(texts))
 
     def _validate_response(self, raw: object, *, expected_count: int) -> list[list[float]]:
-        if not isinstance(raw, dict) or raw.get("model") != self._model or not isinstance(raw.get("data"), list):
-            raise EmbeddingProviderError("embedding response has an invalid model or data field")
+        if not isinstance(raw, dict) or not isinstance(raw.get("data"), list):
+            raise EmbeddingProviderError("embedding response must contain a data array")
+        response_model = raw.get("model")
+        if response_model is not None and not isinstance(response_model, str):
+            raise EmbeddingProviderError("embedding response model must be a string when present")
+        self._resolved_model = response_model
         data = raw["data"]
         if len(data) != expected_count:
             raise EmbeddingProviderError(f"embedding response returned {len(data)} vectors for {expected_count} inputs")
@@ -201,19 +237,29 @@ class OpenAICompatibleEmbeddingProvider:
                 raise EmbeddingProviderError("embedding response contains an invalid index")
             if index in indexed:
                 raise EmbeddingProviderError(f"embedding response contains duplicate index {index}")
-            if not isinstance(vector, list) or len(vector) != self._dimensions:
-                raise EmbeddingProviderError(
-                    f"embedding response vector {index} must contain exactly {self._dimensions} values"
-                )
+            if not isinstance(vector, list) or not vector:
+                raise EmbeddingProviderError(f"embedding response vector {index} must be a non-empty array")
             converted: list[float] = []
             for value in vector:
-                if isinstance(value, bool) or not isinstance(value, int | float) or not math.isfinite(value):
+                if isinstance(value, bool) or not isinstance(value, int | float):
+                    raise EmbeddingProviderError(f"embedding response vector {index} contains a non-numeric value")
+                if not math.isfinite(value):
                     raise EmbeddingProviderError(f"embedding response vector {index} contains a non-finite number")
                 converted.append(float(value))
             indexed[index] = converted
         if set(indexed) != set(range(expected_count)):
             raise EmbeddingProviderError("embedding response contains missing indices")
-        return [indexed[index] for index in range(expected_count)]
+        ordered = [indexed[index] for index in range(expected_count)]
+        returned_dimensions = len(ordered[0])
+        if any(len(vector) != returned_dimensions for vector in ordered):
+            raise EmbeddingProviderError("embedding response contains vectors with inconsistent dimensions")
+        if self._dimensions is None:
+            self._dimensions = returned_dimensions
+        elif returned_dimensions != self._dimensions:
+            raise EmbeddingProviderError(
+                f"embedding response returned {returned_dimensions} dimensions; expected {self._dimensions}"
+            )
+        return ordered
 
 
 __all__ = [

--- a/services/agent/packages/vss_core/src/vss_core/memory/embeddings.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/embeddings.py
@@ -22,6 +22,7 @@ from .models import UnifiedMemoryRecord
 DOCUMENT_INPUT_TYPE = "passage"
 QUERY_INPUT_TYPE = "query"
 SIMILARITY = "cosine"
+CANONICAL_SEARCHABLE_TEXT_VERSION = 1
 _SEARCHABLE_CONTEXT_KEYS = ("description", "category", "kind", "original_query", "search_mode")
 _ELIGIBLE_STATUSES = frozenset({"completed", "partial"})
 
@@ -118,6 +119,18 @@ def _embeddings_url(endpoint: str) -> str:
     if not path.endswith("/embeddings"):
         path = f"{path}/embeddings"
     return urlunsplit((parsed.scheme, parsed.netloc, path, parsed.query, parsed.fragment))
+
+
+def embedding_endpoint_identity(endpoint: str) -> str:
+    """Hash a normalized endpoint without userinfo, query parameters, or fragments."""
+    parsed = urlsplit(_embeddings_url(endpoint))
+    hostname = parsed.hostname or ""
+    port = parsed.port
+    default_port = (parsed.scheme == "http" and port == 80) or (parsed.scheme == "https" and port == 443)
+    normalized_host = f"[{hostname.lower()}]" if ":" in hostname else hostname.lower()
+    authority = normalized_host if port is None or default_port else f"{normalized_host}:{port}"
+    normalized = urlunsplit((parsed.scheme.lower(), authority, parsed.path, "", ""))
+    return f"sha256:{hashlib.sha256(normalized.encode('utf-8')).hexdigest()}"
 
 
 class OpenAICompatibleEmbeddingProvider:
@@ -263,6 +276,7 @@ class OpenAICompatibleEmbeddingProvider:
 
 
 __all__ = [
+    "CANONICAL_SEARCHABLE_TEXT_VERSION",
     "DOCUMENT_INPUT_TYPE",
     "QUERY_INPUT_TYPE",
     "SIMILARITY",
@@ -271,5 +285,6 @@ __all__ = [
     "OpenAICompatibleEmbeddingProvider",
     "canonical_searchable_text",
     "content_hash",
+    "embedding_endpoint_identity",
     "is_embedding_eligible",
 ]

--- a/services/agent/packages/vss_core/src/vss_core/memory/service.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/service.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from dataclasses import field
 from datetime import UTC
 from datetime import datetime
+import logging
 from typing import Any
 from typing import Protocol
 
@@ -25,6 +26,8 @@ from .store import MemoryStore
 from .store import coerce_utc_instant
 from .store import storage_id_for
 
+logger = logging.getLogger(__name__)
+
 
 class BackendReconciler(Protocol):
     """Optional one-shot poll of a still-pending backend job.
@@ -35,6 +38,12 @@ class BackendReconciler(Protocol):
     """
 
     def reconcile(self, record: UnifiedMemoryRecord) -> UnifiedMemoryRecord | None: ...
+
+
+class SemanticMemorySynchronizer(Protocol):
+    """Derived-memory boundary invoked only after authoritative persistence."""
+
+    def sync_record(self, record: UnifiedMemoryRecord) -> object: ...
 
 
 class MemoryNotFoundError(LookupError):
@@ -175,9 +184,11 @@ class MemoryService:
         store: MemoryStore | None = None,
         *,
         reconciler: BackendReconciler | None = None,
+        semantic_memory: SemanticMemorySynchronizer | None = None,
     ) -> None:
         self._store: MemoryStore = store if store is not None else InMemoryStore()
         self._reconciler = reconciler
+        self._semantic_memory = semantic_memory
 
     @property
     def store(self) -> MemoryStore:
@@ -185,7 +196,9 @@ class MemoryService:
 
     def upsert(self, record: UnifiedMemoryRecord) -> UnifiedMemoryRecord:
         _reject_nested_collections(record)
-        return self._store.upsert(record)
+        persisted = self._store.upsert(record)
+        self._sync_nonfatal(persisted)
+        return persisted
 
     def upsert_bundle(self, bundle: RecordBundle) -> PersistResult:
         """Idempotently upsert parent then children; never raises on partial failure.
@@ -222,7 +235,7 @@ class MemoryService:
         written_children_by_id: dict[str, UnifiedMemoryRecord] = {}
 
         try:
-            self._store.upsert(bundle.parent)
+            persisted_parent = self._store.upsert(bundle.parent)
             written_ids.add(storage_id_for(bundle.parent))
         except Exception as error:
             failed.append(
@@ -255,9 +268,9 @@ class MemoryService:
         for child in bundle.children:
             child_storage_id = storage_id_for(child)
             try:
-                self._store.upsert(child)
+                persisted_child = self._store.upsert(child)
                 written_ids.add(child_storage_id)
-                written_children_by_id[child_storage_id] = child
+                written_children_by_id[child_storage_id] = persisted_child
             except Exception as error:
                 failed.append(
                     PersistFailure(
@@ -279,7 +292,7 @@ class MemoryService:
             corrected = _parent_after_partial_children(bundle.parent, written_children)
             if corrected != bundle.parent:
                 try:
-                    self._store.upsert(corrected)
+                    persisted_parent = self._store.upsert(corrected)
                 except Exception as error:
                     failed.append(
                         PersistFailure(
@@ -291,12 +304,46 @@ class MemoryService:
                         )
                     )
 
+        if self._semantic_memory is not None:
+            # Derived synchronization starts only after every authoritative write
+            # (including partial-parent correction) has finished. Read the parent
+            # back so its final corrected status/counts are what gets embedded.
+            try:
+                final_parent = self._store.get(bundle.parent.job.job_id) or persisted_parent
+            except Exception as error:
+                # A post-write read is required only for derived indexing. Preserve
+                # the authoritative persistence result if that read is unavailable.
+                logger.warning(
+                    "semantic memory parent refresh failed for %r (%s)",
+                    storage_id_for(persisted_parent),
+                    type(error).__name__,
+                )
+                final_parent = persisted_parent
+            self._sync_nonfatal(final_parent)
+            for child in written_children_by_id.values():
+                self._sync_nonfatal(child)
+
         return PersistResult(
             requested=requested,
             expected=expected,
             written=len(written_ids),
             failed=failed,
         )
+
+    def _sync_nonfatal(self, record: UnifiedMemoryRecord) -> None:
+        if self._semantic_memory is None:
+            return
+        try:
+            self._semantic_memory.sync_record(record)
+        except Exception as error:
+            # Embedding infrastructure is derived and must never alter the
+            # authoritative result. Do not include backend messages: they may
+            # contain endpoint credentials, payload text, or vector values.
+            logger.warning(
+                "semantic memory synchronization failed for %r (%s)",
+                storage_id_for(record),
+                type(error).__name__,
+            )
 
     def get(
         self,
@@ -431,10 +478,11 @@ def build_memory_service(
     memory_index: str | None = None,
     store: MemoryStore | None = None,
     reconciler: BackendReconciler | None = None,
+    semantic_memory: SemanticMemorySynchronizer | None = None,
 ) -> MemoryService:
     """Construct a memory service from explicit runtime settings (no process env)."""
     if store is not None:
-        return MemoryService(store, reconciler=reconciler)
+        return MemoryService(store, reconciler=reconciler, semantic_memory=semantic_memory)
     if es_endpoint:
         from .backends.elasticsearch import DEFAULT_MEMORY_INDEX
         from .backends.elasticsearch import ElasticsearchMemoryStore
@@ -443,7 +491,7 @@ def build_memory_service(
             endpoint=es_endpoint,
             index=memory_index or DEFAULT_MEMORY_INDEX,
         )
-        return MemoryService(es_store, reconciler=reconciler)
+        return MemoryService(es_store, reconciler=reconciler, semantic_memory=semantic_memory)
     raise ConfigurationError("memory service requires --es-endpoint (or an injected store); process env is not read")
 
 
@@ -555,5 +603,6 @@ __all__ = [
     "MemoryService",
     "PersistFailure",
     "PersistResult",
+    "SemanticMemorySynchronizer",
     "build_memory_service",
 ]

--- a/services/agent/packages/vss_core/src/vss_core/memory/service.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/service.py
@@ -6,11 +6,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from dataclasses import field
+from dataclasses import replace
 from datetime import UTC
 from datetime import datetime
 import logging
 from typing import Any
+from typing import Literal
 from typing import Protocol
+from typing import cast
 
 from vss_core._foundation.errors import ConfigurationError
 
@@ -44,6 +47,23 @@ class SemanticMemorySynchronizer(Protocol):
     """Derived-memory boundary invoked only after authoritative persistence."""
 
     def sync_record(self, record: UnifiedMemoryRecord) -> object: ...
+
+
+class QueryEmbeddingProvider(Protocol):
+    """Provider boundary needed by semantic retrieval."""
+
+    def embed_query(self, text: str) -> list[float]: ...
+
+
+class SemanticMemorySearcher(Protocol):
+    """Companion-index boundary needed by semantic retrieval."""
+
+    def semantic_search(
+        self,
+        query: MemoryQuery,
+        query_vector: list[float],
+        candidate_count: int,
+    ) -> list[str]: ...
 
 
 class MemoryNotFoundError(LookupError):
@@ -172,6 +192,53 @@ def _parent_after_partial_children(
     return parent.model_copy(update=updates)
 
 
+def _deduplicate(storage_ids: list[str]) -> list[str]:
+    return list(dict.fromkeys(storage_ids))
+
+
+def _record_recency(record: UnifiedMemoryRecord) -> datetime:
+    return record.job.updated_at or record.job.created_at
+
+
+def _matches_authoritative_filters(record: UnifiedMemoryRecord, query: MemoryQuery) -> bool:
+    """Defensively reapply non-text selectors after companion-index resolution."""
+    if query.job_id is not None and record.job.job_id != query.job_id:
+        return False
+    if (query.parents_only or not query.include_children) and record.job.is_child:
+        return False
+    if query.record_type is not None and record.job.record_type != query.record_type:
+        return False
+    if query.record_id is not None and record.job.record_id != query.record_id:
+        return False
+    if query.group is not None and record.job.group != query.group:
+        return False
+    if query.status is not None and record.job.status != query.status:
+        return False
+    if query.sensor_id is not None:
+        sensors = (record.input.sensors if record.input is not None else None) or []
+        if not any(
+            sensor.id == query.sensor_id or (sensor.info is not None and sensor.info.get("name") == query.sensor_id)
+            for sensor in sensors
+        ):
+            return False
+    assert query.since is None or isinstance(query.since, datetime)
+    assert query.until is None or isinstance(query.until, datetime)
+    if query.time_field == "window":
+        if query.since is None and query.until is None:
+            return True
+        if record.input is None or record.input.window is None:
+            return False
+        start = record.input.window.start.timestamp
+        end = record.input.window.end.timestamp if record.input.window.end is not None else start
+        return not (
+            (query.until is not None and start > query.until) or (query.since is not None and end < query.since)
+        )
+    created_at = record.job.created_at
+    return not (
+        (query.since is not None and created_at < query.since) or (query.until is not None and created_at > query.until)
+    )
+
+
 class MemoryService:
     """Orchestrates memory writes and memory-first reads.
 
@@ -185,14 +252,35 @@ class MemoryService:
         *,
         reconciler: BackendReconciler | None = None,
         semantic_memory: SemanticMemorySynchronizer | None = None,
+        embedding_provider: QueryEmbeddingProvider | None = None,
+        retrieval_mode: Literal["keyword", "semantic", "hybrid"] = "keyword",
+        semantic_candidate_count: int = 50,
+        rrf_rank_constant: int = 60,
     ) -> None:
+        if retrieval_mode not in {"keyword", "semantic", "hybrid"}:
+            raise ValueError("retrieval_mode must be 'keyword', 'semantic', or 'hybrid'")
+        if semantic_candidate_count <= 0:
+            raise ValueError("semantic_candidate_count must be positive")
+        if rrf_rank_constant <= 0:
+            raise ValueError("rrf_rank_constant must be positive")
         self._store: MemoryStore = store if store is not None else InMemoryStore()
         self._reconciler = reconciler
         self._semantic_memory = semantic_memory
+        self._embedding_provider = embedding_provider
+        self._retrieval_mode = retrieval_mode
+        self._semantic_candidate_count = semantic_candidate_count
+        self._rrf_rank_constant = rrf_rank_constant
 
     @property
     def store(self) -> MemoryStore:
         return self._store
+
+    @property
+    def semantic_retrieval_available(self) -> bool:
+        """Whether this service has both semantic retrieval dependencies."""
+        return self._embedding_provider is not None and callable(
+            getattr(self._semantic_memory, "semantic_search", None)
+        )
 
     def upsert(self, record: UnifiedMemoryRecord) -> UnifiedMemoryRecord:
         _reject_nested_collections(record)
@@ -389,7 +477,74 @@ class MemoryService:
         return self._store.list_jobs(filters or JobFilters())
 
     def query(self, query: MemoryQuery) -> list[UnifiedMemoryRecord]:
-        return self._store.query(query)
+        if not query.text:
+            return self._store.query(query)
+
+        mode = query.mode or self._retrieval_mode
+        if mode == "keyword" or not self.semantic_retrieval_available:
+            return self._store.query(query)
+        if mode == "semantic":
+            try:
+                storage_ids = self._semantic_ids(query)
+            except Exception as error:
+                self._warn_semantic_fallback(error)
+                return self._store.query(query)
+            return self._resolve_semantic(query, storage_ids)
+        return self._hybrid_query(query)
+
+    def _semantic_ids(self, query: MemoryQuery) -> list[str]:
+        assert query.text is not None
+        assert self._embedding_provider is not None
+        semantic_search = cast("SemanticMemorySearcher", self._semantic_memory).semantic_search
+        vector = self._embedding_provider.embed_query(query.text)
+        return semantic_search(query, vector, self._semantic_candidate_count)
+
+    def _resolve_semantic(self, query: MemoryQuery, storage_ids: list[str]) -> list[UnifiedMemoryRecord]:
+        records = self._store.get_many(_deduplicate(storage_ids))
+        return [record for record in records if _matches_authoritative_filters(record, query)][: max(query.limit, 0)]
+
+    def _hybrid_query(self, query: MemoryQuery) -> list[UnifiedMemoryRecord]:
+        candidate_limit = max(self._semantic_candidate_count, query.limit, 0)
+        keyword_records = self._store.query(replace(query, mode="keyword", limit=candidate_limit))
+        try:
+            semantic_ids = self._semantic_ids(query)
+        except Exception as error:
+            self._warn_semantic_fallback(error)
+            return keyword_records[: max(query.limit, 0)]
+
+        keyword_ids = [storage_id_for(record) for record in keyword_records]
+        ordered_ids = _deduplicate([*keyword_ids, *semantic_ids])
+        authoritative = {
+            storage_id_for(record): record
+            for record in self._store.get_many(ordered_ids)
+            if _matches_authoritative_filters(record, query)
+        }
+        scores: dict[str, float] = {}
+        best_ranks: dict[str, int] = {}
+        for ranking in (keyword_ids, _deduplicate(semantic_ids)):
+            for rank, storage_id in enumerate(ranking, start=1):
+                if storage_id not in authoritative:
+                    continue
+                scores[storage_id] = scores.get(storage_id, 0.0) + 1.0 / (self._rrf_rank_constant + rank)
+                best_ranks[storage_id] = min(best_ranks.get(storage_id, rank), rank)
+
+        ranked_ids = sorted(
+            scores,
+            key=lambda storage_id: (
+                -scores[storage_id],
+                best_ranks[storage_id],
+                -_record_recency(authoritative[storage_id]).timestamp(),
+                storage_id,
+            ),
+        )
+        return [authoritative[storage_id] for storage_id in ranked_ids[: max(query.limit, 0)]]
+
+    @staticmethod
+    def _warn_semantic_fallback(error: Exception) -> None:
+        logger.warning(
+            "semantic memory retrieval failed (%s); falling back to keyword retrieval",
+            type(error).__name__,
+        )
 
     def events(
         self,

--- a/services/agent/packages/vss_core/src/vss_core/memory/store.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/store.py
@@ -22,6 +22,7 @@ Internal storage IDs (backend document keys) use a shared helper:
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC
@@ -189,6 +190,10 @@ class MemoryStore(Protocol):
 
     def get_many(self, storage_ids: Sequence[str]) -> list[UnifiedMemoryRecord]:
         """Return existing records in input storage-ID order."""
+        ...
+
+    def scan(self, *, batch_size: int, limit: int | None = None) -> Iterator[UnifiedMemoryRecord]:
+        """Stream records in deterministic ascending storage-ID order."""
         ...
 
     def query(self, query: MemoryQuery) -> list[UnifiedMemoryRecord]: ...

--- a/services/agent/packages/vss_core/src/vss_core/memory/store.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/store.py
@@ -22,9 +22,11 @@ Internal storage IDs (backend document keys) use a shared helper:
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC
 from datetime import datetime
+from typing import Literal
 from typing import Protocol
 
 from vss_core._foundation.errors import LibraryError
@@ -133,6 +135,7 @@ class MemoryQuery:
     until: datetime | str | None = None
     time_field: str = "created_at"
     limit: int = 20
+    mode: Literal["keyword", "semantic", "hybrid"] | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "since", coerce_utc_instant(self.since))
@@ -141,6 +144,8 @@ class MemoryQuery:
             raise ValueError("time_field must be 'created_at' or 'window'")
         if self.parents_only and self.record_type is not None:
             raise ValueError("parents_only cannot be combined with record_type")
+        if self.mode not in {None, "keyword", "semantic", "hybrid"}:
+            raise ValueError("mode must be 'keyword', 'semantic', 'hybrid', or None")
 
 
 @dataclass(slots=True)
@@ -180,6 +185,10 @@ class MemoryStore(Protocol):
         record_id: str,
     ) -> UnifiedMemoryRecord | None:
         """Return a child record by public identity, or ``None``."""
+        ...
+
+    def get_many(self, storage_ids: Sequence[str]) -> list[UnifiedMemoryRecord]:
+        """Return existing records in input storage-ID order."""
         ...
 
     def query(self, query: MemoryQuery) -> list[UnifiedMemoryRecord]: ...

--- a/services/agent/packages/vss_core/src/vss_core/vlm/openai.py
+++ b/services/agent/packages/vss_core/src/vss_core/vlm/openai.py
@@ -63,6 +63,7 @@ class OpenAIVLMAnalyzer:
         max_frames: int = 60,
         max_fps: int = 2,
         cosmos_nim_runtime_options: bool = True,
+        rt_vlm_frame_budget: int | None = None,
     ) -> None:
         if not base_url.strip():
             raise ConfigurationError("VLM base_url must be non-empty")
@@ -74,6 +75,8 @@ class OpenAIVLMAnalyzer:
             raise ConfigurationError(f"unsupported VLM media_mode: {media_mode!r}")
         if video_url_scope not in {"internal", "external"}:
             raise ConfigurationError(f"unsupported VLM video_url_scope: {video_url_scope!r}")
+        if rt_vlm_frame_budget is not None and rt_vlm_frame_budget < 1:
+            raise ConfigurationError("VLM rt_vlm_frame_budget must be >= 1")
         self._base_url = _normalize_base_url(base_url)
         self._model = model
         self._api_key = api_key
@@ -85,6 +88,7 @@ class OpenAIVLMAnalyzer:
         self._max_frames = max(1, max_frames)
         self._max_fps = max(1, max_fps)
         self._cosmos_nim_runtime_options = cosmos_nim_runtime_options
+        self._rt_vlm_frame_budget = rt_vlm_frame_budget
         self._client: httpx.AsyncClient | None = None
 
     @property
@@ -199,6 +203,11 @@ class OpenAIVLMAnalyzer:
                     "num_frames": _dynamic_num_frames(duration_seconds, self._max_frames, self._max_fps),
                 }
             }
+        if self._rt_vlm_frame_budget is not None:
+            # RT-VLM does its own preprocessing and ignores media_io_kwargs, but
+            # it defaults the budget to 0 (opening frame only) when absent, so a
+            # window-scoped question would be answered from a single frame.
+            payload["num_frames_per_second_or_fixed_frames_chunk"] = self._rt_vlm_frame_budget
         if not self._disable_audio and "omni" in model:
             payload["mm_processor_kwargs"] = {"use_audio_in_video": True}
 

--- a/services/agent/packages/vss_core/tests/unit_test/introspection/test_introspection.py
+++ b/services/agent/packages/vss_core/tests/unit_test/introspection/test_introspection.py
@@ -155,6 +155,7 @@ def test_vlm_evidence_validation(updates: dict[str, object]) -> None:
         "sensor": "camera-east",
         "start_time": "2026-08-26T12:00:10Z",
         "end_time": "2026-08-26T12:00:20Z",
+        "question": "Was the worker wearing a hard hat?",
         "answer": "A person carried a small box.",
     }
     payload.update(updates)
@@ -233,7 +234,7 @@ async def test_judge_retries_once_after_invalid_json_then_accepts_fenced_json() 
         nonlocal calls
         calls += 1
         body = json.loads(request.content)
-        assert body["temperature"] == 0
+        assert "temperature" not in body
         assert body["model"] == "openclaw/default"
         assert "response_format" not in body
         assert request.headers["authorization"] == "Bearer gateway-secret"
@@ -411,6 +412,7 @@ async def test_synthesize_uses_supplied_evidence_only() -> None:
             "sensor": "camera-east",
             "start_time": "2026-08-26T12:00:10Z",
             "end_time": "2026-08-26T12:00:20Z",
+            "question": "Was the worker wearing a hard hat?",
             "answer": "A person carried a small box.",
         }
     )

--- a/services/agent/packages/vss_core/tests/unit_test/introspection/test_introspection.py
+++ b/services/agent/packages/vss_core/tests/unit_test/introspection/test_introspection.py
@@ -163,6 +163,36 @@ def test_vlm_evidence_validation(updates: dict[str, object]) -> None:
         VLMEvidence.model_validate(payload)
 
 
+def test_vlm_evidence_records_call_parameters() -> None:
+    evidence = VLMEvidence.model_validate(
+        {
+            "job_id": "vlm-1",
+            "persisted": False,
+            "sensor": "camera-east",
+            "start_time": "2026-08-26T12:00:10Z",
+            "end_time": "2026-08-26T12:00:20Z",
+            "question": "Was the worker wearing a hard hat?",
+            "answer": "No",
+            "model": "nim_nvidia_cosmos3-nano-reasoner",
+            "num_frames": 8,
+            "timeout_seconds": 180.0,
+        }
+    )
+    assert evidence.model_dump() == {
+        "job_id": "vlm-1",
+        "persisted": False,
+        "sensor": "camera-east",
+        "start_time": "2026-08-26T12:00:10Z",
+        "end_time": "2026-08-26T12:00:20Z",
+        "question": "Was the worker wearing a hard hat?",
+        "answer": "No",
+        "intent": "introspection",
+        "model": "nim_nvidia_cosmos3-nano-reasoner",
+        "num_frames": 8,
+        "timeout_seconds": 180.0,
+    }
+
+
 def test_grounding_accepts_canonical_and_legacy_sensor_names() -> None:
     records = [_record()]
     canonical = SufficiencyDecision.model_validate(_decision())

--- a/services/agent/packages/vss_core/tests/unit_test/introspection/test_orchestrator.py
+++ b/services/agent/packages/vss_core/tests/unit_test/introspection/test_orchestrator.py
@@ -28,6 +28,7 @@ from vss_core.memory.models import TimestampPoint
 from vss_core.memory.models import TimeWindow
 from vss_core.memory.models import UnifiedMemoryRecord
 from vss_core.memory.service import MemoryService
+from vss_core.memory.store import storage_id_for
 
 START = "2026-08-26T12:00:00Z"
 END = "2026-08-26T12:01:00Z"
@@ -294,6 +295,109 @@ async def test_exact_identity_uses_paraphrased_question_only_as_judge_prompt(ide
     assert result.status == "completed"
     assert judge.calls == 1
     assert [record.job.record_id for record in judge.records] == ["event-1"]
+
+
+@pytest.mark.asyncio
+async def test_exact_identity_never_embeds_the_question_when_semantic_retrieval_is_enabled() -> None:
+    child = _record()
+    store = InMemoryStore()
+    store.upsert(child)
+
+    class _Provider:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def embed_query(self, text: str) -> list[float]:
+            self.calls.append(text)
+            return [1.0]
+
+    class _Semantic:
+        def semantic_search(self, *_args: Any) -> list[str]:
+            raise AssertionError("identity lookup must not use semantic search")
+
+    provider = _Provider()
+    memory = MemoryService(
+        store,
+        semantic_memory=_Semantic(),  # type: ignore[arg-type]
+        embedding_provider=provider,
+        retrieval_mode="hybrid",
+    )
+    judge = _Judge(_decision(sufficient=True), expected_query="Was the worker wearing PPE?")
+
+    result = await introspect(
+        IntrospectionRequest(query="Was the worker wearing PPE?", job_id="search-1"),
+        memory=memory,
+        judge=judge,
+        synthesizer=_Synthesizer(),
+        vlm_runner=_Runner(),
+        settings=IntrospectionSettings(),
+    )
+
+    assert result.status == "completed"
+    assert provider.calls == []
+    assert [record.job.record_id for record in judge.records] == ["event-1"]
+
+
+@pytest.mark.asyncio
+async def test_hybrid_sensor_time_recall_resolves_semantic_child_and_hydrates_parent_for_judge() -> None:
+    parent = _record(record_id=None, query="shift overview", answer="Loading bay shift summary.")
+    child = _record(query="worker activity", answer="A worker crossed the loading bay.")
+    store = InMemoryStore()
+    store.upsert(parent)
+    store.upsert(child)
+
+    class _Provider:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def embed_query(self, text: str) -> list[float]:
+            self.calls.append(text)
+            return [1.0]
+
+    class _Semantic:
+        def __init__(self) -> None:
+            self.queries: list[Any] = []
+
+        def semantic_search(self, query: Any, _vector: list[float], candidate_count: int) -> list[str]:
+            self.queries.append(query)
+            assert candidate_count == 7
+            return [storage_id_for(child)]
+
+    provider = _Provider()
+    semantic = _Semantic()
+    memory = MemoryService(
+        store,
+        semantic_memory=semantic,  # type: ignore[arg-type]
+        embedding_provider=provider,
+        retrieval_mode="hybrid",
+        semantic_candidate_count=7,
+    )
+    judge = _Judge(_decision(sufficient=True), expected_query="Were safety procedures followed?")
+
+    result = await introspect(
+        IntrospectionRequest(
+            query="Were safety procedures followed?",
+            sensor="camera-east",
+            start_time=START,
+            end_time=END,
+        ),
+        memory=memory,
+        judge=judge,
+        synthesizer=_Synthesizer(),
+        vlm_runner=_Runner(),
+        settings=IntrospectionSettings(),
+    )
+
+    assert result.status == "completed"
+    assert provider.calls == ["Were safety procedures followed?"]
+    semantic_query = semantic.queries[0]
+    assert semantic_query.sensor_id == "camera-east"
+    assert semantic_query.time_field == "window"
+    assert semantic_query.since is not None
+    assert semantic_query.until is not None
+    assert [record.job.is_child for record in judge.records] == [True, False]
+    assert judge.records[0] is child
+    assert judge.records[1] is parent
 
 
 @pytest.mark.asyncio

--- a/services/agent/packages/vss_core/tests/unit_test/introspection/test_orchestrator.py
+++ b/services/agent/packages/vss_core/tests/unit_test/introspection/test_orchestrator.py
@@ -161,6 +161,7 @@ class _Runner:
             sensor=kwargs["sensor"],
             start_time=kwargs["start_time"],
             end_time=kwargs["end_time"],
+            question=kwargs["prompt"],
             answer=f"visual answer {index + 1}",
         )
 

--- a/services/agent/packages/vss_core/tests/unit_test/introspection/test_orchestrator.py
+++ b/services/agent/packages/vss_core/tests/unit_test/introspection/test_orchestrator.py
@@ -202,9 +202,13 @@ async def test_sufficient_memory_uses_zero_vlm_and_one_synthesis() -> None:
         "sufficient_from_memory",
         "answer",
         "memory_evidence",
+        "sufficiency",
         "vlm_evidence",
         "unresolved_gaps",
     }
+    assert result.sufficiency is not None
+    assert result.sufficiency.sufficient is True
+    assert result.sufficiency.gaps == []
     assert judge.calls == 1
     assert len(synthesizer.calls) == 1
     assert runner.calls == []
@@ -522,7 +526,13 @@ async def test_one_grounded_gap_runs_one_vlm_and_one_final_synthesis() -> None:
 
     assert result.status == "completed"
     assert result.sufficient_from_memory is False
+    assert result.sufficiency is not None
+    assert result.sufficiency.sufficient is False
+    assert result.sufficiency.reason == "A visual detail is missing."
+    assert result.sufficiency.gaps[0].question == "What was the forklift carrying?"
     assert len(result.vlm_evidence) == 1
+    assert result.vlm_evidence[0].question == "What was the forklift carrying?"
+    assert result.vlm_evidence[0].answer == "visual answer 1"
     assert result.unresolved_gaps == []
     assert judge.calls == len(synthesizer.calls) == len(runner.calls) == 1
 
@@ -575,6 +585,7 @@ async def test_no_memory_returns_structured_result_without_model_calls() -> None
         "sufficient_from_memory": False,
         "answer": None,
         "memory_evidence": [],
+        "sufficiency": None,
         "vlm_evidence": [],
         "unresolved_gaps": [],
     }

--- a/services/agent/packages/vss_core/tests/unit_test/lib/search_core/test_search_archive_e2e.py
+++ b/services/agent/packages/vss_core/tests/unit_test/lib/search_core/test_search_archive_e2e.py
@@ -20,6 +20,8 @@ from urllib.parse import quote
 
 import pytest
 
+from vss_cli.config import CONFIG_VERSION
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -647,7 +649,7 @@ def _write_deployment_config(
     (home / "config.json").write_text(
         json.dumps(
             {
-                "version": 1,
+                "version": CONFIG_VERSION,
                 "base_url": services.base_url,
                 "written_at": "2025-01-01T00:00:00+00:00",
                 "services": configured_services,

--- a/services/agent/packages/vss_core/tests/unit_test/lib/search_core/test_vlm_openai.py
+++ b/services/agent/packages/vss_core/tests/unit_test/lib/search_core/test_vlm_openai.py
@@ -59,6 +59,7 @@ async def test_rt_vlm_uses_video_url_without_direct_cosmos_nim_options() -> None
     def handler(request: httpx.Request) -> httpx.Response:
         payload = json.loads(request.content)
         assert "media_io_kwargs" not in payload
+        assert "num_frames_per_second_or_fixed_frames_chunk" not in payload
         assert payload["messages"][0]["content"][1] == {
             "type": "video_url",
             "video_url": {"url": "https://vst.example/clip.mp4"},
@@ -89,6 +90,51 @@ async def test_rt_vlm_uses_video_url_without_direct_cosmos_nim_options() -> None
         assert answer == '{"subject:forklift": true}'
     finally:
         await analyzer.aclose()
+
+
+@pytest.mark.asyncio
+async def test_rt_vlm_frame_budget_is_sent_instead_of_media_io_kwargs() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        assert "media_io_kwargs" not in payload
+        assert payload["num_frames_per_second_or_fixed_frames_chunk"] == 8
+        return httpx.Response(
+            200,
+            json={"choices": [{"message": {"content": "No"}}]},
+            request=request,
+        )
+
+    analyzer = OpenAIVLMAnalyzer(
+        base_url="https://rt-vlm.example/v1",
+        model="nim_nvidia_cosmos3-nano-reasoner",
+        vst=_VST(),  # type: ignore[arg-type]
+        media_mode="video_url",
+        video_url_scope="external",
+        cosmos_nim_runtime_options=False,
+        rt_vlm_frame_budget=8,
+    )
+    analyzer._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        answer = await analyzer.analyze(
+            sensor_id="sensor-1",
+            start_timestamp="0.0",
+            end_timestamp="5.0",
+            prompt="was the worker wearing a hard hat?",
+            time_format="offset",
+        )
+        assert answer == "No"
+    finally:
+        await analyzer.aclose()
+
+
+def test_rt_vlm_frame_budget_must_be_positive() -> None:
+    with pytest.raises(ConfigurationError, match="rt_vlm_frame_budget"):
+        OpenAIVLMAnalyzer(
+            base_url="https://rt-vlm.example/v1",
+            model="model",
+            vst=_VST(),  # type: ignore[arg-type]
+            rt_vlm_frame_budget=0,
+        )
 
 
 @pytest.mark.asyncio

--- a/services/agent/packages/vss_core/tests/unit_test/memory/test_backfill.py
+++ b/services/agent/packages/vss_core/tests/unit_test/memory/test_backfill.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Focused tests for bounded embedding backfill orchestration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vss_core.memory.backends.elasticsearch_embeddings import EmbeddingSyncFailure
+from vss_core.memory.backends.elasticsearch_embeddings import EmbeddingSyncResult
+from vss_core.memory.backends.in_memory import InMemoryStore
+from vss_core.memory.backfill import EmbeddingBackfillService
+from vss_core.memory.models import UnifiedMemoryRecord
+from vss_core.memory.store import storage_id_for
+
+
+def _record(
+    job_id: str,
+    *,
+    status: str = "completed",
+    record_id: str | None = None,
+) -> UnifiedMemoryRecord:
+    job: dict[str, Any] = {
+        "job_id": job_id,
+        "group": "summary",
+        "status": status,
+        "created_at": "2026-08-31T12:00:00Z",
+    }
+    if record_id is not None:
+        job.update(record_type="event", record_id=record_id)
+    return UnifiedMemoryRecord.model_validate(
+        {
+            "job": job,
+            "input": {"query": "What happened?"},
+            "output": {"answer": f"answer {record_id or job_id}"},
+        }
+    )
+
+
+class _Embeddings:
+    def __init__(self, actions: dict[str, str] | None = None) -> None:
+        self.actions = actions or {}
+        self.calls: list[list[str]] = []
+
+    def sync_records(
+        self,
+        records: list[UnifiedMemoryRecord],
+    ) -> list[EmbeddingSyncResult | EmbeddingSyncFailure]:
+        ids = [storage_id_for(record) for record in records]
+        self.calls.append(ids)
+        outcomes: list[EmbeddingSyncResult | EmbeddingSyncFailure] = []
+        for storage_id, record in zip(ids, records, strict=True):
+            action = self.actions.get(storage_id, "created")
+            if action == "failed":
+                outcomes.append(EmbeddingSyncFailure(storage_id, f"failure for {storage_id}"))
+            else:
+                outcomes.append(
+                    EmbeddingSyncResult(
+                        storage_id=storage_id,
+                        index="embeddings",
+                        action=action,  # type: ignore[arg-type]
+                        record=record,
+                    )
+                )
+        return outcomes
+
+
+def _service(
+    actions: dict[str, str] | None = None,
+) -> tuple[EmbeddingBackfillService, InMemoryStore, _Embeddings]:
+    store = InMemoryStore()
+    embeddings = _Embeddings(actions)
+    return EmbeddingBackfillService(store, embeddings), store, embeddings  # type: ignore[arg-type]
+
+
+def test_dry_run_scans_parent_and_child_without_provider_or_writes() -> None:
+    service, store, embeddings = _service()
+    store.upsert(_record("b", record_id="child"))
+    store.upsert(_record("a"))
+    store.upsert(_record("c", status="failed"))
+    writes_before = list(store.upsert_ids)
+
+    result = service.run(batch_size=2, dry_run=True)
+
+    assert result.to_dict() == {
+        "scanned": 3,
+        "eligible": 2,
+        "embedded": 0,
+        "reused": 0,
+        "skipped": 1,
+        "failed": 0,
+        "failures": [],
+    }
+    assert embeddings.calls == []
+    assert store.upsert_ids == writes_before
+
+
+def test_batches_in_storage_id_order_counts_reuse_and_continues_failures() -> None:
+    service, store, embeddings = _service(
+        {
+            "a": "reused",
+            "a#event#child": "reembedded",
+            "b": "failed",
+            "c": "created",
+        }
+    )
+    for record in (
+        _record("c"),
+        _record("a", record_id="child"),
+        _record("b"),
+        _record("a"),
+    ):
+        store.upsert(record)
+
+    result = service.run(batch_size=2)
+
+    assert embeddings.calls == [["a", "a#event#child"], ["b", "c"]]
+    assert result.to_dict() == {
+        "scanned": 4,
+        "eligible": 4,
+        "embedded": 2,
+        "reused": 1,
+        "skipped": 0,
+        "failed": 1,
+        "failures": [{"storage_id": "b", "error": "failure for b"}],
+    }
+
+
+def test_limit_is_applied_in_deterministic_storage_id_order() -> None:
+    service, store, embeddings = _service()
+    for job_id in ("c", "a", "b"):
+        store.upsert(_record(job_id))
+
+    result = service.run(batch_size=5, limit=2)
+
+    assert result.scanned == 2
+    assert embeddings.calls == [["a", "b"]]

--- a/services/agent/packages/vss_core/tests/unit_test/memory/test_backfill.py
+++ b/services/agent/packages/vss_core/tests/unit_test/memory/test_backfill.py
@@ -95,6 +95,18 @@ def test_dry_run_scans_parent_and_child_without_provider_or_writes() -> None:
     assert store.upsert_ids == writes_before
 
 
+def test_dry_run_does_not_require_an_embedding_companion() -> None:
+    store = InMemoryStore()
+    store.upsert(_record("a"))
+    service = EmbeddingBackfillService(store, None)
+
+    result = service.run(batch_size=8, dry_run=True)
+
+    assert result.scanned == 1
+    assert result.eligible == 1
+    assert result.embedded == 0
+
+
 def test_batches_in_storage_id_order_counts_reuse_and_continues_failures() -> None:
     service, store, embeddings = _service(
         {

--- a/services/agent/packages/vss_core/tests/unit_test/memory/test_elasticsearch.py
+++ b/services/agent/packages/vss_core/tests/unit_test/memory/test_elasticsearch.py
@@ -162,6 +162,46 @@ def test_elasticsearch_get_many_uses_mget_and_preserves_input_order() -> None:
     assert client.last_mget_ids == ["second", "missing", "first", "second"]
 
 
+def test_elasticsearch_scan_uses_bounded_search_after_in_storage_id_order() -> None:
+    class PagedES(_FakeES):
+        def __init__(self) -> None:
+            super().__init__()
+            self.bodies: list[dict[str, Any]] = []
+
+        def search(self, *, index: str, body: dict[str, Any]) -> dict[str, Any]:
+            self.bodies.append(body)
+            ordered = sorted(self.docs.items())
+            offset = int(body.get("search_after", [-1])[0]) + 1
+            page = ordered[offset : offset + body["size"]]
+            return {
+                "hits": {
+                    "hits": [
+                        {"_id": storage_id, "_source": source, "sort": [offset + index]}
+                        for index, (storage_id, source) in enumerate(page)
+                    ]
+                }
+            }
+
+    client = PagedES()
+    store = ElasticsearchMemoryStore(endpoint="http://unused", client=client)
+    for record in (_parent("b", "completed"), _child("a"), _parent("a", "completed"), _parent("c", "completed")):
+        store.upsert(record)
+
+    assert [record.job.record_id or record.job.job_id for record in store.scan(batch_size=2, limit=3)] == [
+        "a",
+        "evt-001",
+        "b",
+    ]
+    assert [body["size"] for body in client.bodies] == [2, 1]
+    assert "search_after" not in client.bodies[0]
+    assert client.bodies[1]["search_after"] == [1]
+    assert client.bodies[0]["sort"] == [
+        {"job.job_id.keyword": {"order": "asc"}},
+        {"job.record_type.keyword": {"order": "asc", "missing": "_first"}},
+        {"job.record_id.keyword": {"order": "asc", "missing": "_first"}},
+    ]
+
+
 def test_elasticsearch_list_before_anything_is_ingested_is_empty() -> None:
     """A missing index means nothing has been written, not that reading broke.
 

--- a/services/agent/packages/vss_core/tests/unit_test/memory/test_elasticsearch.py
+++ b/services/agent/packages/vss_core/tests/unit_test/memory/test_elasticsearch.py
@@ -70,6 +70,7 @@ class _FakeES:
         self.docs: dict[str, dict[str, Any]] = {}
         self.indexed: list[str] = []
         self.last_body: dict[str, Any] | None = None
+        self.last_mget_ids: list[str] | None = None
 
     def index(self, *, index: str, id: str, document: dict[str, Any], refresh: str | None = None) -> dict[str, Any]:
         self.docs[id] = document
@@ -87,6 +88,19 @@ class _FakeES:
         self.last_body = body
         hits = [{"_id": doc_id, "_source": doc} for doc_id, doc in self.docs.items()]
         return {"hits": {"hits": hits}}
+
+    def mget(self, *, index: str, ids: list[str]) -> dict[str, Any]:
+        self.last_mget_ids = ids
+        return {
+            "docs": [
+                {
+                    "_id": doc_id,
+                    "found": doc_id in self.docs,
+                    **({"_source": self.docs[doc_id]} if doc_id in self.docs else {}),
+                }
+                for doc_id in reversed(ids)
+            ]
+        }
 
     def close(self) -> None:
         return None
@@ -136,6 +150,16 @@ def test_elasticsearch_get_missing_returns_none() -> None:
     store = ElasticsearchMemoryStore(endpoint="http://unused", client=_FakeES())
     assert store.get("missing") is None
     assert store.get_record("missing", "event", "x") is None
+
+
+def test_elasticsearch_get_many_uses_mget_and_preserves_input_order() -> None:
+    client = _FakeES()
+    store = ElasticsearchMemoryStore(endpoint="http://unused", client=client)
+    first = store.upsert(_parent("first", status="completed"))
+    second = store.upsert(_parent("second", status="completed"))
+
+    assert store.get_many(["second", "missing", "first", "second"]) == [second, first, second]
+    assert client.last_mget_ids == ["second", "missing", "first", "second"]
 
 
 def test_elasticsearch_list_before_anything_is_ingested_is_empty() -> None:

--- a/services/agent/packages/vss_core/tests/unit_test/memory/test_elasticsearch_embeddings.py
+++ b/services/agent/packages/vss_core/tests/unit_test/memory/test_elasticsearch_embeddings.py
@@ -475,3 +475,20 @@ def test_semantic_search_created_at_range_and_dimension_validation() -> None:
     } in filters
     with pytest.raises(ConfigurationError, match="query embedding has 2 dimensions"):
         backend.semantic_search(MemoryQuery(text="summary"), [0.1, 0.2], 5)
+
+
+def test_mapping_for_accepts_elasticsearch_client_response_objects() -> None:
+    from vss_core.memory.backends.elasticsearch_embeddings import _mapping_for
+
+    class _ClientResponse:
+        def __init__(self, body: dict[str, Any]) -> None:
+            self.body = body
+
+    mapping = {
+        "dynamic": "strict",
+        "_meta": {"model": MODEL},
+        "properties": {"vector": {"type": "dense_vector", "dims": 3}},
+    }
+    body = {INDEX: {"mappings": mapping}}
+    assert _mapping_for(_ClientResponse(body), INDEX) == mapping
+    assert _mapping_for(body, INDEX) == mapping

--- a/services/agent/packages/vss_core/tests/unit_test/memory/test_elasticsearch_embeddings.py
+++ b/services/agent/packages/vss_core/tests/unit_test/memory/test_elasticsearch_embeddings.py
@@ -18,6 +18,7 @@ from vss_core.memory.backends.elasticsearch_embeddings import ElasticsearchEmbed
 from vss_core.memory.backends.in_memory import InMemoryStore
 from vss_core.memory.models import UnifiedMemoryRecord
 from vss_core.memory.service import MemoryService
+from vss_core.memory.store import MemoryQuery
 from vss_core.memory.store import storage_id_for
 
 MODEL = "embed-model"
@@ -98,6 +99,8 @@ class _FakeES:
         self.docs: dict[str, dict[str, Any]] = {}
         self.index_calls: list[str] = []
         self.update_calls: list[str] = []
+        self.search_hits: list[str] = []
+        self.search_body: dict[str, Any] | None = None
         self.indices = _Indices(self)
 
     def get(self, *, index: str, id: str, source_excludes: list[str] | None = None) -> dict[str, Any]:
@@ -123,6 +126,14 @@ class _FakeES:
             raise ESNotFoundError("not found", {}, {"_id": id})
         del self.docs[id]
         return {"result": "deleted"}
+
+    def search(self, *, index: str, body: dict[str, Any]) -> dict[str, Any]:
+        self.search_body = body
+        return {
+            "hits": {
+                "hits": [{"_id": storage_id, "_source": {"storage_id": storage_id}} for storage_id in self.search_hits]
+            }
+        }
 
     def close(self) -> None:
         return None
@@ -330,3 +341,81 @@ def test_bundle_finishes_writes_then_syncs_final_partial_parent_and_successful_d
     assert semantic.records[0].output is not None
     assert semantic.records[0].output.ext == {"event_count": 1}
     assert semantic.records[1].output is not None and semantic.records[1].output.answer == "second"
+
+
+def test_semantic_search_builds_filtered_knn_and_returns_ordered_storage_ids() -> None:
+    backend, client, _, _ = _backend()
+    client.mapping = backend.mapping
+    client.search_hits = ["job-2#event#event-2", "job-1"]
+    query = MemoryQuery(
+        text="forklift paraphrase",
+        job_id="job-1",
+        group="summary",
+        status="completed",
+        sensor_id="camera-1",
+        record_type="event",
+        record_id="event-1",
+        since="2026-08-31T10:00:00Z",
+        until="2026-08-31T12:00:00Z",
+        time_field="window",
+    )
+
+    assert backend.semantic_search(query, [0.1, 0.2, 0.3], 25) == ["job-2#event#event-2", "job-1"]
+    assert client.search_body is not None
+    assert client.search_body["size"] == 25
+    knn = client.search_body["knn"]
+    assert knn["field"] == "vector"
+    assert knn["query_vector"] == [0.1, 0.2, 0.3]
+    assert knn["k"] == knn["num_candidates"] == 25
+    filters = knn["filter"]["bool"]["filter"]
+    assert {"term": {"job_id": "job-1"}} in filters
+    assert {"term": {"group": "summary"}} in filters
+    assert {"term": {"status": "completed"}} in filters
+    assert {"term": {"sensor_ids": "camera-1"}} in filters
+    assert {"term": {"record_type": "event"}} in filters
+    assert {"term": {"record_id": "event-1"}} in filters
+    assert any("window_start" in str(item) for item in filters)
+    assert any("window_end" in str(item) for item in filters)
+
+
+@pytest.mark.parametrize(("parents_only", "include_children"), ((True, True), (False, False)))
+def test_semantic_search_filters_out_children(parents_only: bool, include_children: bool) -> None:
+    backend, client, _, _ = _backend()
+    client.mapping = backend.mapping
+
+    backend.semantic_search(
+        MemoryQuery(text="summary", parents_only=parents_only, include_children=include_children),
+        [0.1, 0.2, 0.3],
+        5,
+    )
+
+    assert client.search_body is not None
+    assert {"term": {"is_child": False}} in client.search_body["knn"]["filter"]["bool"]["filter"]
+
+
+def test_semantic_search_created_at_range_and_dimension_validation() -> None:
+    backend, client, _, _ = _backend()
+    client.mapping = backend.mapping
+
+    backend.semantic_search(
+        MemoryQuery(
+            text="summary",
+            since="2026-08-30T10:00:00Z",
+            until="2026-08-31T12:00:00Z",
+        ),
+        [0.1, 0.2, 0.3],
+        5,
+    )
+
+    assert client.search_body is not None
+    filters = client.search_body["knn"]["filter"]["bool"]["filter"]
+    assert {
+        "range": {
+            "created_at": {
+                "gte": "2026-08-30T10:00:00Z",
+                "lte": "2026-08-31T12:00:00Z",
+            }
+        }
+    } in filters
+    with pytest.raises(ConfigurationError, match="query embedding has 2 dimensions"):
+        backend.semantic_search(MemoryQuery(text="summary"), [0.1, 0.2], 5)

--- a/services/agent/packages/vss_core/tests/unit_test/memory/test_elasticsearch_embeddings.py
+++ b/services/agent/packages/vss_core/tests/unit_test/memory/test_elasticsearch_embeddings.py
@@ -15,6 +15,8 @@ from vss_core.memory.adapters import RecordBundle
 from vss_core.memory.backends.elasticsearch_embeddings import EMBEDDING_SCHEMA
 from vss_core.memory.backends.elasticsearch_embeddings import IMPLEMENTATION_VERSION
 from vss_core.memory.backends.elasticsearch_embeddings import ElasticsearchEmbeddingStore
+from vss_core.memory.backends.elasticsearch_embeddings import EmbeddingSyncFailure
+from vss_core.memory.backends.elasticsearch_embeddings import EmbeddingSyncResult
 from vss_core.memory.backends.in_memory import InMemoryStore
 from vss_core.memory.models import UnifiedMemoryRecord
 from vss_core.memory.service import MemoryService
@@ -64,8 +66,10 @@ class _Provider:
 
     def __init__(self) -> None:
         self.passages: list[str] = []
+        self.batches: list[list[str]] = []
 
     def embed_passages(self, texts: Any) -> list[list[float]]:
+        self.batches.append(list(texts))
         self.passages.extend(texts)
         return [[0.1, 0.2, 0.3] for _ in texts]
 
@@ -255,6 +259,58 @@ def test_hash_reuse_updates_metadata_without_inline_vector_or_reembedding() -> N
     assert stored is not None and stored.output is not None
     assert [reference.es_ref for reference in stored.output.embedding or []] == ["other-index", f"{INDEX}/job-1"]
     assert all(reference.model_dump().get("vector") is None for reference in stored.output.embedding or [])
+
+
+def test_batch_sync_generates_passages_together_and_attaches_references_after_writes() -> None:
+    backend, client, provider, raw = _backend()
+    records = [_record(job_id="a"), _record(job_id="b", record_id="event-1")]
+    for record in records:
+        raw.upsert(record)
+
+    outcomes = backend.sync_records(records)
+
+    assert [outcome.action for outcome in outcomes if isinstance(outcome, EmbeddingSyncResult)] == [
+        "created",
+        "created",
+    ]
+    assert len(provider.batches) == 1
+    assert len(provider.batches[0]) == 2
+    assert client.index_calls == ["a", "b#event#event-1"]
+    for record in records:
+        stored = (
+            raw.get(record.job.job_id)
+            if not record.job.is_child
+            else raw.get_record(
+                record.job.job_id,
+                record.job.record_type or "",
+                record.job.record_id or "",
+            )
+        )
+        assert stored is not None and stored.job.status == record.job.status
+        assert stored.output is not None and stored.output.embedding is not None
+
+
+def test_batch_provider_failure_is_not_retried() -> None:
+    class SelectiveProvider(_Provider):
+        def embed_passages(self, texts: Any) -> list[list[float]]:
+            values = list(texts)
+            self.batches.append(values)
+            raise RuntimeError("cannot embed batch")
+
+    provider = SelectiveProvider()
+    backend, client, _, raw = _backend(provider=provider)
+    records = [_record(job_id="a", answer="bad"), _record(job_id="b", answer="good")]
+    for record in records:
+        raw.upsert(record)
+
+    outcomes = backend.sync_records(records)
+
+    assert isinstance(outcomes[0], EmbeddingSyncFailure)
+    assert outcomes[0].storage_id == "a"
+    assert isinstance(outcomes[1], EmbeddingSyncFailure)
+    assert outcomes[1].storage_id == "b"
+    assert client.index_calls == []
+    assert len(provider.batches) == 1
 
 
 def test_changed_content_reembeds_and_ineligible_deletes_only_owned_reference() -> None:

--- a/services/agent/packages/vss_core/tests/unit_test/memory/test_elasticsearch_embeddings.py
+++ b/services/agent/packages/vss_core/tests/unit_test/memory/test_elasticsearch_embeddings.py
@@ -18,6 +18,7 @@ from vss_core.memory.backends.elasticsearch_embeddings import ElasticsearchEmbed
 from vss_core.memory.backends.elasticsearch_embeddings import EmbeddingSyncFailure
 from vss_core.memory.backends.elasticsearch_embeddings import EmbeddingSyncResult
 from vss_core.memory.backends.in_memory import InMemoryStore
+from vss_core.memory.embeddings import CANONICAL_SEARCHABLE_TEXT_VERSION
 from vss_core.memory.models import UnifiedMemoryRecord
 from vss_core.memory.service import MemoryService
 from vss_core.memory.store import MemoryQuery
@@ -25,6 +26,8 @@ from vss_core.memory.store import storage_id_for
 
 MODEL = "embed-model"
 INDEX = "vss-memory-embeddings-v1"
+PROVIDER_NAME = "openclaw_gateway"
+ENDPOINT_IDENTITY = "sha256:test-endpoint"
 
 
 def _record(
@@ -63,6 +66,7 @@ def _record(
 class _Provider:
     model = MODEL
     dimensions = 3
+    resolved_model = "resolved-model"
 
     def __init__(self) -> None:
         self.passages: list[str] = []
@@ -158,6 +162,8 @@ def _backend(
             index=INDEX,
             provider=embedder,
             authoritative_store=raw,
+            provider_name=PROVIDER_NAME,
+            embedding_endpoint_identity=ENDPOINT_IDENTITY,
             client=es,  # type: ignore[arg-type]
         ),
         es,
@@ -177,10 +183,14 @@ def test_exact_strict_mapping_meta_and_complete_filter_document() -> None:
     assert client.mapping == backend.mapping
     assert client.mapping["dynamic"] == "strict"
     assert client.mapping["_meta"] == {
-        "model": MODEL,
-        "dimensions": 3,
         "schema": EMBEDDING_SCHEMA,
         "implementation_version": IMPLEMENTATION_VERSION,
+        "provider": PROVIDER_NAME,
+        "model_target": MODEL,
+        "dimensions": 3,
+        "canonical_text_version": CANONICAL_SEARCHABLE_TEXT_VERSION,
+        "similarity": "cosine",
+        "endpoint_identity": ENDPOINT_IDENTITY,
     }
     assert client.mapping["properties"]["vector"] == {
         "type": "dense_vector",
@@ -198,6 +208,8 @@ def test_exact_strict_mapping_meta_and_complete_filter_document() -> None:
     assert document["status"] == "completed"
     assert document["is_child"] is True
     assert document["schema"] == EMBEDDING_SCHEMA
+    assert document["provider"] == PROVIDER_NAME
+    assert document["canonical_text_version"] == CANONICAL_SEARCHABLE_TEXT_VERSION
     assert document["content"].startswith("Group: summary")
     assert document["sensor_ids"] == ["camera-1"]
     assert document["window_start"] == "2026-08-31T11:00:00Z"
@@ -226,17 +238,40 @@ def test_concurrent_first_create_accepts_other_process_valid_mapping() -> None:
 @pytest.mark.parametrize(
     "mutate",
     [
-        lambda mapping: mapping["_meta"].update(model="other"),
+        lambda mapping: mapping["_meta"].update(model_target="other"),
+        lambda mapping: mapping["_meta"].update(provider="other"),
         lambda mapping: mapping["_meta"].update(dimensions=4),
+        lambda mapping: mapping["_meta"].update(canonical_text_version=99),
+        lambda mapping: mapping["_meta"].update(endpoint_identity="sha256:other"),
         lambda mapping: mapping["properties"]["vector"].update(dims=4),
     ],
 )
-def test_mismatch_requires_new_versioned_index_and_backfill(mutate: Any) -> None:
+def test_mismatch_requires_new_index_and_backfill_without_recreation(mutate: Any) -> None:
     backend, client, _, _ = _backend()
     client.mapping = backend.mapping
     mutate(client.mapping)
-    with pytest.raises(ConfigurationError, match="new versioned embedding index and backfill"):
+    with pytest.raises(ConfigurationError, match=r"Configure a new `--embedding-index`.*backfill"):
         backend.sync_record(_record())
+    assert not client.docs
+    assert client.created == 0
+
+
+def test_batch_rejects_provider_vectors_with_wrong_dimensions_before_writing() -> None:
+    class WrongDimensions(_Provider):
+        def embed_passages(self, texts: Any) -> list[list[float]]:
+            return [[0.1, 0.2] for _ in texts]
+
+    backend, client, _, raw = _backend(provider=WrongDimensions())
+    records = [_record(job_id="parent"), _record(job_id="parent", record_id="child")]
+    for record in records:
+        raw.upsert(record)
+
+    outcomes = backend.sync_records(records)
+
+    assert all(isinstance(outcome, EmbeddingSyncFailure) for outcome in outcomes)
+    assert all(
+        "returned 2 dimensions" in outcome.error for outcome in outcomes if isinstance(outcome, EmbeddingSyncFailure)
+    )
     assert not client.docs
 
 

--- a/services/agent/packages/vss_core/tests/unit_test/memory/test_elasticsearch_embeddings.py
+++ b/services/agent/packages/vss_core/tests/unit_test/memory/test_elasticsearch_embeddings.py
@@ -1,0 +1,332 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Focused companion-index and authoritative-write synchronization tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from elasticsearch import BadRequestError
+from elasticsearch import NotFoundError as ESNotFoundError
+import pytest
+
+from vss_core._foundation.errors import ConfigurationError
+from vss_core.memory.adapters import RecordBundle
+from vss_core.memory.backends.elasticsearch_embeddings import EMBEDDING_SCHEMA
+from vss_core.memory.backends.elasticsearch_embeddings import IMPLEMENTATION_VERSION
+from vss_core.memory.backends.elasticsearch_embeddings import ElasticsearchEmbeddingStore
+from vss_core.memory.backends.in_memory import InMemoryStore
+from vss_core.memory.models import UnifiedMemoryRecord
+from vss_core.memory.service import MemoryService
+from vss_core.memory.store import storage_id_for
+
+MODEL = "embed-model"
+INDEX = "vss-memory-embeddings-v1"
+
+
+def _record(
+    *,
+    job_id: str = "job-1",
+    status: str = "completed",
+    record_id: str | None = None,
+    answer: str = "Forklift arrived.",
+    embedding: list[dict[str, Any]] | None = None,
+) -> UnifiedMemoryRecord:
+    job: dict[str, Any] = {
+        "job_id": job_id,
+        "group": "summary",
+        "status": status,
+        "created_at": "2026-08-31T12:00:00Z",
+        "updated_at": "2026-08-31T12:01:00Z",
+    }
+    if record_id is not None:
+        job.update(record_id=record_id, record_type="event")
+    return UnifiedMemoryRecord.model_validate(
+        {
+            "job": job,
+            "input": {
+                "query": "What happened?",
+                "sensors": [{"id": "camera-1"}],
+                "window": {
+                    "start": {"timestamp": "2026-08-31T11:00:00Z"},
+                    "end": {"timestamp": "2026-08-31T11:30:00Z"},
+                },
+            },
+            "output": {"answer": answer, "embedding": embedding},
+        }
+    )
+
+
+class _Provider:
+    model = MODEL
+    dimensions = 3
+
+    def __init__(self) -> None:
+        self.passages: list[str] = []
+
+    def embed_passages(self, texts: Any) -> list[list[float]]:
+        self.passages.extend(texts)
+        return [[0.1, 0.2, 0.3] for _ in texts]
+
+    def embed_query(self, text: str) -> list[float]:
+        return [0.1, 0.2, 0.3]
+
+    def close(self) -> None:
+        return None
+
+
+class _Indices:
+    def __init__(self, client: _FakeES) -> None:
+        self.client = client
+
+    def exists(self, *, index: str) -> bool:
+        return self.client.mapping is not None
+
+    def create(self, *, index: str, mappings: dict[str, Any]) -> dict[str, Any]:
+        self.client.mapping = mappings
+        self.client.created += 1
+        return {"acknowledged": True}
+
+    def get_mapping(self, *, index: str) -> dict[str, Any]:
+        return {index: {"mappings": self.client.mapping}}
+
+
+class _FakeES:
+    def __init__(self) -> None:
+        self.mapping: dict[str, Any] | None = None
+        self.created = 0
+        self.docs: dict[str, dict[str, Any]] = {}
+        self.index_calls: list[str] = []
+        self.update_calls: list[str] = []
+        self.indices = _Indices(self)
+
+    def get(self, *, index: str, id: str, source_excludes: list[str] | None = None) -> dict[str, Any]:
+        if id not in self.docs:
+            raise ESNotFoundError("not found", {}, {"_id": id})
+        source = dict(self.docs[id])
+        for excluded in source_excludes or []:
+            source.pop(excluded, None)
+        return {"_source": source}
+
+    def index(self, *, index: str, id: str, document: dict[str, Any], refresh: str | None = None) -> dict[str, Any]:
+        self.docs[id] = dict(document)
+        self.index_calls.append(id)
+        return {"result": "created"}
+
+    def update(self, *, index: str, id: str, doc: dict[str, Any], refresh: str | None = None) -> dict[str, Any]:
+        self.docs[id].update(doc)
+        self.update_calls.append(id)
+        return {"result": "updated"}
+
+    def delete(self, *, index: str, id: str, refresh: str | None = None) -> dict[str, Any]:
+        if id not in self.docs:
+            raise ESNotFoundError("not found", {}, {"_id": id})
+        del self.docs[id]
+        return {"result": "deleted"}
+
+    def close(self) -> None:
+        return None
+
+
+def _backend(
+    *,
+    client: _FakeES | None = None,
+    provider: _Provider | None = None,
+    authoritative: InMemoryStore | None = None,
+) -> tuple[ElasticsearchEmbeddingStore, _FakeES, _Provider, InMemoryStore]:
+    es = client or _FakeES()
+    embedder = provider or _Provider()
+    raw = authoritative or InMemoryStore()
+    return (
+        ElasticsearchEmbeddingStore(
+            endpoint="http://unused",
+            index=INDEX,
+            provider=embedder,
+            authoritative_store=raw,
+            client=es,  # type: ignore[arg-type]
+        ),
+        es,
+        embedder,
+        raw,
+    )
+
+
+def test_exact_strict_mapping_meta_and_complete_filter_document() -> None:
+    backend, client, _, raw = _backend()
+    record = _record(record_id="event-1")
+    raw.upsert(record)
+    result = backend.sync_record(record)
+
+    assert result.storage_id == "job-1#event#event-1"
+    assert client.created == 1
+    assert client.mapping == backend.mapping
+    assert client.mapping["dynamic"] == "strict"
+    assert client.mapping["_meta"] == {
+        "model": MODEL,
+        "dimensions": 3,
+        "schema": EMBEDDING_SCHEMA,
+        "implementation_version": IMPLEMENTATION_VERSION,
+    }
+    assert client.mapping["properties"]["vector"] == {
+        "type": "dense_vector",
+        "dims": 3,
+        "index": True,
+        "similarity": "cosine",
+    }
+    document = client.docs[result.storage_id]
+    assert document["vector"] == [0.1, 0.2, 0.3]
+    assert document["storage_id"] == result.storage_id
+    assert document["job_id"] == "job-1"
+    assert document["record_id"] == "event-1"
+    assert document["record_type"] == "event"
+    assert document["group"] == "summary"
+    assert document["status"] == "completed"
+    assert document["is_child"] is True
+    assert document["schema"] == EMBEDDING_SCHEMA
+    assert document["content"].startswith("Group: summary")
+    assert document["sensor_ids"] == ["camera-1"]
+    assert document["window_start"] == "2026-08-31T11:00:00Z"
+    assert document["window_end"] == "2026-08-31T11:30:00Z"
+
+
+def test_concurrent_first_create_accepts_other_process_valid_mapping() -> None:
+    backend, client, _, raw = _backend()
+
+    class RacingIndices(_Indices):
+        def create(self, *, index: str, mappings: dict[str, Any]) -> dict[str, Any]:
+            self.client.mapping = mappings
+            raise BadRequestError(
+                "already exists",
+                {},
+                {"error": {"type": "resource_already_exists_exception"}},
+            )
+
+    client.indices = RacingIndices(client)
+    record = _record()
+    raw.upsert(record)
+    assert backend.sync_record(record).action == "created"
+    assert "job-1" in client.docs
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda mapping: mapping["_meta"].update(model="other"),
+        lambda mapping: mapping["_meta"].update(dimensions=4),
+        lambda mapping: mapping["properties"]["vector"].update(dims=4),
+    ],
+)
+def test_mismatch_requires_new_versioned_index_and_backfill(mutate: Any) -> None:
+    backend, client, _, _ = _backend()
+    client.mapping = backend.mapping
+    mutate(client.mapping)
+    with pytest.raises(ConfigurationError, match="new versioned embedding index and backfill"):
+        backend.sync_record(_record())
+    assert not client.docs
+
+
+def test_hash_reuse_updates_metadata_without_inline_vector_or_reembedding() -> None:
+    backend, client, provider, raw = _backend()
+    first = _record(embedding=[{"es_ref": "other-index", "doc_ids": ["other"]}])
+    raw.upsert(first)
+    backend.sync_record(first)
+    assert len(provider.passages) == 1
+
+    second = first.model_copy(update={"job": first.job.model_copy(update={"status": "partial"})})
+    result = backend.sync_record(second)
+    assert result.action == "reused"
+    assert len(provider.passages) == 1
+    assert client.update_calls == ["job-1"]
+    assert client.docs["job-1"]["vector"] == [0.1, 0.2, 0.3]
+    backend.sync_record(result.record)
+    assert client.update_calls == ["job-1"]
+    stored = raw.get("job-1")
+    assert stored is not None and stored.output is not None
+    assert [reference.es_ref for reference in stored.output.embedding or []] == ["other-index", f"{INDEX}/job-1"]
+    assert all(reference.model_dump().get("vector") is None for reference in stored.output.embedding or [])
+
+
+def test_changed_content_reembeds_and_ineligible_deletes_only_owned_reference() -> None:
+    backend, client, provider, raw = _backend()
+    record = _record(embedding=[{"es_ref": "other-index", "doc_ids": ["other"]}])
+    raw.upsert(record)
+    backend.sync_record(record)
+    changed = _record(answer="Truck arrived.")
+    assert backend.sync_record(changed).action == "reembedded"
+    assert len(provider.passages) == 2
+
+    failed = _record(
+        status="failed",
+        answer="Truck arrived.",
+        embedding=[
+            {"es_ref": "other-index", "doc_ids": ["other"]},
+            {"es_ref": f"{INDEX}/job-1", "doc_ids": ["job-1"]},
+        ],
+    )
+    raw.upsert(failed)
+    assert backend.sync_record(failed).action == "deleted"
+    assert "job-1" not in client.docs
+    stored = raw.get("job-1")
+    assert stored is not None and stored.output is not None
+    assert [reference.es_ref for reference in stored.output.embedding or []] == ["other-index"]
+
+
+def test_service_is_authoritative_first_nonfatal_and_does_not_recurse(caplog: pytest.LogCaptureFixture) -> None:
+    events: list[str] = []
+
+    class Store(InMemoryStore):
+        def upsert(self, record: UnifiedMemoryRecord) -> UnifiedMemoryRecord:
+            events.append(f"write:{storage_id_for(record)}")
+            return super().upsert(record)
+
+    class Semantic:
+        def sync_record(self, record: UnifiedMemoryRecord) -> None:
+            events.append(f"sync:{storage_id_for(record)}")
+            raise RuntimeError("secret [0.1, 0.2, 0.3]")
+
+    service = MemoryService(Store(), semantic_memory=Semantic())
+    persisted = service.upsert(_record())
+    assert persisted.output is not None and persisted.output.embedding is None
+    assert events == ["write:job-1", "sync:job-1"]
+    assert "secret" not in caplog.text
+    assert "0.1" not in caplog.text
+
+
+def test_bundle_finishes_writes_then_syncs_final_partial_parent_and_successful_deduped_children() -> None:
+    events: list[str] = []
+
+    class Store(InMemoryStore):
+        def upsert(self, record: UnifiedMemoryRecord) -> UnifiedMemoryRecord:
+            doc_id = storage_id_for(record)
+            events.append(f"write:{doc_id}:{record.job.status}")
+            if record.job.record_id == "bad":
+                raise RuntimeError("child failed")
+            return super().upsert(record)
+
+    class Semantic:
+        def __init__(self) -> None:
+            self.records: list[UnifiedMemoryRecord] = []
+
+        def sync_record(self, record: UnifiedMemoryRecord) -> None:
+            events.append(f"sync:{storage_id_for(record)}:{record.job.status}")
+            self.records.append(record)
+
+    semantic = Semantic()
+    service = MemoryService(Store(), semantic_memory=semantic)
+    parent = _record()
+    parent = parent.model_copy(
+        update={"output": parent.output.model_copy(update={"ext": {"event_count": 3}}) if parent.output else None}
+    )
+    duplicate_a = _record(record_id="same", answer="first")
+    duplicate_b = _record(record_id="same", answer="second")
+    bad = _record(record_id="bad")
+    result = service.upsert_bundle(RecordBundle(parent=parent, children=(duplicate_a, bad, duplicate_b)))
+
+    assert not result.ok
+    first_sync = next(index for index, event in enumerate(events) if event.startswith("sync:"))
+    assert all(event.startswith("write:") for event in events[:first_sync])
+    assert [storage_id_for(record) for record in semantic.records] == ["job-1", "job-1#event#same"]
+    assert semantic.records[0].job.status == "partial"
+    assert semantic.records[0].output is not None
+    assert semantic.records[0].output.ext == {"event_count": 1}
+    assert semantic.records[1].output is not None and semantic.records[1].output.answer == "second"

--- a/services/agent/packages/vss_core/tests/unit_test/memory/test_elasticsearch_embeddings.py
+++ b/services/agent/packages/vss_core/tests/unit_test/memory/test_elasticsearch_embeddings.py
@@ -394,6 +394,54 @@ def test_service_is_authoritative_first_nonfatal_and_does_not_recurse(caplog: py
     assert "0.1" not in caplog.text
 
 
+def test_failed_reembed_drops_stale_vector_after_authoritative_update() -> None:
+    class FailOnReplacement(_Provider):
+        def embed_passages(self, texts: Any) -> list[list[float]]:
+            if self.passages:
+                raise RuntimeError("provider unavailable")
+            return super().embed_passages(texts)
+
+    backend, client, _, raw = _backend(provider=FailOnReplacement())
+    service = MemoryService(raw, semantic_memory=backend)
+    service.upsert(_record(answer="Forklift arrived."))
+    assert "job-1" in client.docs
+    assert "Forklift arrived." in client.docs["job-1"]["content"]
+
+    updated = service.upsert(_record(answer="Truck arrived."))
+
+    assert updated.output is not None and updated.output.answer == "Truck arrived."
+    stored = raw.get("job-1")
+    assert stored is not None and stored.output is not None
+    assert stored.output.answer == "Truck arrived."
+    assert "job-1" not in client.docs
+
+
+def test_batch_provider_failure_drops_obsolete_vectors() -> None:
+    class FailBatch(_Provider):
+        def embed_passages(self, texts: Any) -> list[list[float]]:
+            values = list(texts)
+            self.batches.append(values)
+            if self.passages:
+                raise RuntimeError("cannot embed batch")
+            self.passages.extend(values)
+            return [[0.1, 0.2, 0.3] for _ in values]
+
+    provider = FailBatch()
+    backend, client, _, raw = _backend(provider=provider)
+    first = _record(job_id="a", answer="forklift")
+    second = _record(job_id="b", answer="pallet")
+    raw.upsert(first)
+    raw.upsert(second)
+    backend.sync_records([first, second])
+    assert set(client.docs) == {"a", "b"}
+
+    changed = [_record(job_id="a", answer="truck"), _record(job_id="b", answer="crate")]
+    outcomes = backend.sync_records(changed)
+
+    assert all(isinstance(outcome, EmbeddingSyncFailure) for outcome in outcomes)
+    assert client.docs == {}
+
+
 def test_bundle_finishes_writes_then_syncs_final_partial_parent_and_successful_deduped_children() -> None:
     events: list[str] = []
 

--- a/services/agent/packages/vss_core/tests/unit_test/memory/test_embeddings.py
+++ b/services/agent/packages/vss_core/tests/unit_test/memory/test_embeddings.py
@@ -14,10 +14,11 @@ from vss_core.memory.embeddings import EmbeddingProviderError
 from vss_core.memory.embeddings import OpenAICompatibleEmbeddingProvider
 from vss_core.memory.embeddings import canonical_searchable_text
 from vss_core.memory.embeddings import content_hash
+from vss_core.memory.embeddings import embedding_endpoint_identity
 from vss_core.memory.embeddings import is_embedding_eligible
 from vss_core.memory.models import UnifiedMemoryRecord
 
-MODEL = "nvidia/llama-nemotron-embed-300m-v2"
+MODEL = "openclaw/default"
 
 
 def _record(**overrides: object) -> UnifiedMemoryRecord:
@@ -126,72 +127,247 @@ def test_nonterminal_or_unsuccessful_records_are_ineligible(status: str) -> None
     assert not is_embedding_eligible(record)
 
 
-def _provider(handler: object, *, batch_size: int = 16, api_key_env: str | None = None):
+def _provider(
+    handler: object,
+    *,
+    endpoint: str = "http://127.0.0.1:18789/v1",
+    dimensions: int | None = 3,
+    batch_size: int = 16,
+    api_key_env: str | None = None,
+    query_input_type: str | None = None,
+    document_input_type: str | None = None,
+):
     transport = httpx.MockTransport(handler)  # type: ignore[arg-type]
     client = httpx.Client(transport=transport)
     provider = OpenAICompatibleEmbeddingProvider(
-        endpoint="http://embedding.example/v1",
+        endpoint=endpoint,
         model=MODEL,
-        dimensions=3,
+        dimensions=dimensions,
         batch_size=batch_size,
         api_key_env=api_key_env,
+        query_input_type=query_input_type,
+        document_input_type=document_input_type,
         client=client,
     )
     return provider, client
 
 
-def test_provider_uses_input_types_normalized_url_batching_and_response_order() -> None:
-    requests: list[tuple[str, dict[str, object]]] = []
+@pytest.mark.parametrize(
+    "endpoint",
+    (
+        "http://127.0.0.1:18789/v1",
+        "http://127.0.0.1:18789/v1/",
+        "http://127.0.0.1:18789/v1/embeddings",
+    ),
+)
+def test_openclaw_url_normalization_and_minimal_batched_requests(endpoint: str) -> None:
+    requests: list[tuple[str, dict[str, object], str | None]] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         payload = json.loads(request.content)
-        requests.append((str(request.url), payload))
+        requests.append((str(request.url), payload, request.headers.get("Authorization")))
         data = [
             {"index": index, "embedding": [float(index), 1.0, 2.0]} for index in reversed(range(len(payload["input"])))
         ]
-        return httpx.Response(200, json={"model": MODEL, "data": data})
+        return httpx.Response(200, json={"model": "resolved/backend-model", "data": data})
 
-    provider, client = _provider(handler, batch_size=2)
+    provider, client = _provider(handler, endpoint=endpoint, batch_size=2, api_key_env="OPENCLAW_GATEWAY_TOKEN")
     try:
-        assert provider.embed_passages(["a", "b", "c"]) == [[0.0, 1.0, 2.0], [1.0, 1.0, 2.0], [0.0, 1.0, 2.0]]
-        assert provider.embed_query("question") == [0.0, 1.0, 2.0]
+        with pytest.MonkeyPatch.context() as patch:
+            patch.setenv("OPENCLAW_GATEWAY_TOKEN", "gateway-token")
+            passages = provider.embed_passages(["a", "b", "c"])
+            query = provider.embed_query("question")
+        assert passages == [[0.0, 1.0, 2.0], [1.0, 1.0, 2.0], [0.0, 1.0, 2.0]]
+        assert query == [0.0, 1.0, 2.0]
+        assert provider.resolved_model == "resolved/backend-model"
     finally:
         client.close()
-    assert [request[0] for request in requests] == ["http://embedding.example/v1/embeddings"] * 3
-    assert [request[1]["input_type"] for request in requests] == ["passage", "passage", "query"]
-    assert [request[1]["dimensions"] for request in requests] == [3, 3, 3]
+    assert [request[0] for request in requests] == ["http://127.0.0.1:18789/v1/embeddings"] * 3
+    assert [request[1] for request in requests] == [
+        {"model": MODEL, "input": ["a", "b"]},
+        {"model": MODEL, "input": ["c"]},
+        {"model": MODEL, "input": ["question"]},
+    ]
+    assert [request[2] for request in requests] == ["Bearer gateway-token"] * 3
+
+
+def test_custom_input_types_are_sent_only_when_explicitly_configured() -> None:
+    payloads: list[dict[str, object]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        payloads.append(payload)
+        return httpx.Response(
+            200,
+            json={"data": [{"index": index, "embedding": [0.0, 1.0, 2.0]} for index, _ in enumerate(payload["input"])]},
+        )
+
+    provider, client = _provider(handler, query_input_type="query", document_input_type="passage")
+    try:
+        provider.embed_passages(["document"])
+        provider.embed_query("question")
+    finally:
+        client.close()
+    assert payloads == [
+        {"model": MODEL, "input": ["document"], "input_type": "passage"},
+        {"model": MODEL, "input": ["question"], "input_type": "query"},
+    ]
+    assert all("dimensions" not in payload and "encoding_format" not in payload for payload in payloads)
+
+
+@pytest.mark.parametrize("response_model", (None, "resolved/backend-model"))
+def test_response_model_is_optional_and_may_differ_from_target(response_model: str | None) -> None:
+    response = {"data": [{"index": 0, "embedding": [0.0, 1.0, 2.0]}]}
+    if response_model is not None:
+        response["model"] = response_model
+    provider, client = _provider(lambda _request: httpx.Response(200, json=response))
+    try:
+        assert provider.embed_query("question") == [0.0, 1.0, 2.0]
+        assert provider.resolved_model == response_model
+    finally:
+        client.close()
+
+
+def test_dimension_discovery_is_sticky_and_later_responses_are_validated() -> None:
+    response_dimensions = iter((4, 4, 3))
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        dimensions = next(response_dimensions)
+        return httpx.Response(200, json={"data": [{"index": 0, "embedding": [0.0] * dimensions}]})
+
+    provider, client = _provider(handler, dimensions=None)
+    try:
+        assert provider.embed_query("discover") == [0.0] * 4
+        assert provider.dimensions == 4
+        assert provider.embed_query("same") == [0.0] * 4
+        with pytest.raises(EmbeddingProviderError, match="returned 3 dimensions; expected 4"):
+            provider.embed_query("changed")
+    finally:
+        client.close()
+
+
+def test_explicit_expected_dimension_is_validated() -> None:
+    provider, client = _provider(
+        lambda _request: httpx.Response(200, json={"data": [{"index": 0, "embedding": [0.0, 1.0]}]}),
+        dimensions=3,
+    )
+    try:
+        with pytest.raises(EmbeddingProviderError, match="returned 2 dimensions; expected 3"):
+            provider.embed_query("question")
+    finally:
+        client.close()
 
 
 @pytest.mark.parametrize(
-    "data",
+    ("data", "message"),
     [
-        [{"index": 0, "embedding": [0.0, 1.0, 2.0]}],
+        ([{"embedding": [0.0, 1.0, 2.0]}], "invalid index"),
         [
-            {"index": 0, "embedding": [0.0, 1.0, 2.0]},
-            {"index": 0, "embedding": [0.0, 1.0, 2.0]},
+            [
+                {"index": 0, "embedding": [0.0, 1.0, 2.0]},
+                {"index": 0, "embedding": [0.0, 1.0, 2.0]},
+            ],
+            "duplicate index",
         ],
         [
-            {"index": 0, "embedding": [0.0, 1.0]},
-            {"index": 1, "embedding": [0.0, 1.0, 2.0]},
+            [
+                {"index": 0, "embedding": [0.0, 1.0]},
+                {"index": 1, "embedding": [0.0, 1.0, 2.0]},
+            ],
+            "inconsistent dimensions",
         ],
         [
-            {"index": 0, "embedding": [math.nan, 1.0, 2.0]},
-            {"index": 1, "embedding": [0.0, 1.0, math.inf]},
+            [
+                {"index": 0, "embedding": [math.nan, 1.0, 2.0]},
+                {"index": 1, "embedding": [0.0, 1.0, math.inf]},
+            ],
+            "non-finite",
         ],
+        ([{"index": 0, "embedding": [True, 1.0, 2.0]}], "non-numeric"),
+        ([{"index": 0, "embedding": ["0", 1.0, 2.0]}], "non-numeric"),
+        ([{"index": 0, "embedding": []}], "non-empty array"),
     ],
 )
-def test_provider_rejects_missing_duplicate_wrong_size_and_nonfinite(data: list[dict[str, object]]) -> None:
-    provider, client = _provider(lambda _request: httpx.Response(200, json={"model": MODEL, "data": data}))
+def test_provider_rejects_malformed_vectors(data: list[dict[str, object]], message: str) -> None:
+    expected_inputs = 2 if len(data) == 2 else 1
+    provider, client = _provider(
+        lambda _request: httpx.Response(
+            200,
+            content=json.dumps({"data": data}, allow_nan=True),
+            headers={"Content-Type": "application/json"},
+        ),
+        dimensions=None if "inconsistent" in message else 3,
+    )
     try:
-        with pytest.raises(EmbeddingProviderError):
-            provider.embed_passages(["a", "b"])
+        with pytest.raises(EmbeddingProviderError, match=message):
+            provider.embed_passages(["text"] * expected_inputs)
     finally:
         client.close()
 
 
-def test_provider_uses_named_bearer_token_without_leaking_it(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_provider_rejects_wrong_vector_count() -> None:
+    provider, client = _provider(
+        lambda _request: httpx.Response(
+            200,
+            json={"data": [{"index": 0, "embedding": [0.0, 1.0, 2.0]}]},
+        )
+    )
+    try:
+        with pytest.raises(EmbeddingProviderError, match="returned 1 vectors for 2 inputs"):
+            provider.embed_passages(["one", "two"])
+    finally:
+        client.close()
+
+
+@pytest.mark.parametrize("status", (401, 403))
+def test_authentication_failures_are_distinct(status: int) -> None:
+    provider, client = _provider(lambda _request: httpx.Response(status))
+    try:
+        with pytest.raises(EmbeddingProviderError, match=f"HTTP {status}"):
+            provider.embed_query("question")
+    finally:
+        client.close()
+
+
+@pytest.mark.parametrize(
+    ("failure", "message"),
+    (
+        (httpx.ReadTimeout("slow"), "timed out"),
+        (httpx.ConnectError("refused"), "connect"),
+    ),
+)
+def test_transport_failures_are_clear(failure: httpx.HTTPError, message: str) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        failure.request = request
+        raise failure
+
+    provider, client = _provider(handler)
+    try:
+        with pytest.raises(EmbeddingProviderError, match=message):
+            provider.embed_query("question")
+    finally:
+        client.close()
+
+
+def test_missing_named_credential_fails_before_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = False
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal called
+        called = True
+        return httpx.Response(500)
+
+    monkeypatch.delenv("OPENCLAW_GATEWAY_TOKEN", raising=False)
+    provider, client = _provider(handler, api_key_env="OPENCLAW_GATEWAY_TOKEN")
+    try:
+        with pytest.raises(EmbeddingProviderError, match=r"OPENCLAW_GATEWAY_TOKEN.*not set"):
+            provider.embed_query("question")
+    finally:
+        client.close()
+    assert not called
+
+
+def test_provider_uses_named_bearer_token_without_leaking_it(monkeypatch: pytest.MonkeyPatch) -> None:
     secret = "super-secret-token"
     monkeypatch.setenv("VSS_EMBED_KEY", secret)
     seen_authorization: list[str | None] = []
@@ -208,3 +384,11 @@ def test_provider_uses_named_bearer_token_without_leaking_it(
         client.close()
     assert seen_authorization == [f"Bearer {secret}"]
     assert secret not in str(error.value)
+
+
+def test_endpoint_identity_normalizes_paths_and_drops_sensitive_query_values() -> None:
+    expected = embedding_endpoint_identity("https://EMBEDDING.example:443/v1")
+    assert embedding_endpoint_identity("https://embedding.example/v1/") == expected
+    assert embedding_endpoint_identity("https://embedding.example/v1/embeddings") == expected
+    assert embedding_endpoint_identity("https://embedding.example/v1?api_key=secret") == expected
+    assert "secret" not in expected

--- a/services/agent/packages/vss_core/tests/unit_test/memory/test_embeddings.py
+++ b/services/agent/packages/vss_core/tests/unit_test/memory/test_embeddings.py
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Canonical text and OpenAI-compatible embedding provider tests."""
+
+from __future__ import annotations
+
+import json
+import math
+
+import httpx
+import pytest
+
+from vss_core.memory.embeddings import EmbeddingProviderError
+from vss_core.memory.embeddings import OpenAICompatibleEmbeddingProvider
+from vss_core.memory.embeddings import canonical_searchable_text
+from vss_core.memory.embeddings import content_hash
+from vss_core.memory.embeddings import is_embedding_eligible
+from vss_core.memory.models import UnifiedMemoryRecord
+
+MODEL = "nvidia/llama-nemotron-embed-300m-v2"
+
+
+def _record(**overrides: object) -> UnifiedMemoryRecord:
+    raw: dict[str, object] = {
+        "job": {
+            "job_id": "summary-secret-id",
+            "group": "summary",
+            "status": "completed",
+            "created_at": "2026-08-31T12:00:00Z",
+            "backend_ref": "private-backend",
+        },
+        "input": {
+            "intent": "  inspect\r\n loading   bay ",
+            "query": " What happened? ",
+            "sensors": [{"id": "camera-1"}],
+            "window": {
+                "start": {"timestamp": "2026-08-31T11:00:00Z"},
+                "end": {"timestamp": "2026-08-31T12:00:00Z"},
+            },
+            "params": {"secret": "excluded"},
+        },
+        "output": {
+            "answer": " A forklift   arrived. ",
+            "handles": {"media_urls": ["https://excluded.example/video"]},
+            "embedding": [{"es_ref": "vectors/id", "doc_ids": ["id"]}],
+            "ext": {
+                "description": " loading\r\n activity ",
+                "category": "logistics",
+                "arbitrary": "excluded",
+                "nested": {"description": "excluded"},
+            },
+        },
+    }
+    raw.update(overrides)
+    return UnifiedMemoryRecord.model_validate(raw)
+
+
+def test_canonical_parent_text_is_stable_bounded_and_ordered() -> None:
+    record = _record()
+    assert canonical_searchable_text(record) == "\n".join(
+        [
+            "Group: summary",
+            "Record type: parent_job",
+            "Intent: inspect loading bay",
+            "Query: What happened?",
+            "Answer: A forklift arrived.",
+            "Sensors: camera-1",
+            "Start: 2026-08-31T11:00:00Z",
+            "End: 2026-08-31T12:00:00Z",
+            "Context: description=loading activity, category=logistics",
+        ]
+    )
+    text = canonical_searchable_text(record)
+    for excluded in ("summary-secret-id", "private-backend", "secret", "https://", "arbitrary", "vectors/id"):
+        assert excluded not in text
+
+
+@pytest.mark.parametrize(
+    ("record_type", "group"),
+    [("event", "summary"), ("search_hit", "search"), ("incident", "alert")],
+)
+def test_canonical_child_types(record_type: str, group: str) -> None:
+    record = _record(
+        job={
+            "job_id": "job",
+            "record_id": "child",
+            "record_type": record_type,
+            "group": group,
+            "status": "partial",
+            "created_at": "2026-08-31T12:00:00Z",
+        }
+    )
+    assert canonical_searchable_text(record).splitlines()[:2] == [
+        f"Group: {group}",
+        f"Record type: {record_type}",
+    ]
+    assert is_embedding_eligible(record)
+
+
+def test_vlm_parent_with_missing_optional_blocks() -> None:
+    record = _record(
+        job={"job_id": "vlm", "group": "vlm", "status": "completed", "created_at": "2026-08-31T12:00:00Z"},
+        input=None,
+        output={"answer": "Door is closed."},
+    )
+    assert canonical_searchable_text(record) == "Group: vlm\nRecord type: parent_job\nAnswer: Door is closed."
+
+
+def test_hash_ignores_references_and_changes_with_searchable_content() -> None:
+    record = _record()
+    without_reference = record.model_copy(
+        update={"output": record.output.model_copy(update={"embedding": None}) if record.output else None}
+    )
+    assert content_hash(record) == content_hash(without_reference)
+    changed = record.model_copy(
+        update={"output": record.output.model_copy(update={"answer": "A truck arrived."}) if record.output else None}
+    )
+    assert content_hash(record) != content_hash(changed)
+    assert content_hash(record) == content_hash(canonical_searchable_text(record))
+    assert len(content_hash(record)) == 64
+
+
+@pytest.mark.parametrize("status", ["submitted", "running", "failed", "timeout"])
+def test_nonterminal_or_unsuccessful_records_are_ineligible(status: str) -> None:
+    record = _record(job={"job_id": "job", "group": "summary", "status": status, "created_at": "2026-08-31T12:00:00Z"})
+    assert not is_embedding_eligible(record)
+
+
+def _provider(handler: object, *, batch_size: int = 16, api_key_env: str | None = None):
+    transport = httpx.MockTransport(handler)  # type: ignore[arg-type]
+    client = httpx.Client(transport=transport)
+    provider = OpenAICompatibleEmbeddingProvider(
+        endpoint="http://embedding.example/v1",
+        model=MODEL,
+        dimensions=3,
+        batch_size=batch_size,
+        api_key_env=api_key_env,
+        client=client,
+    )
+    return provider, client
+
+
+def test_provider_uses_input_types_normalized_url_batching_and_response_order() -> None:
+    requests: list[tuple[str, dict[str, object]]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        requests.append((str(request.url), payload))
+        data = [
+            {"index": index, "embedding": [float(index), 1.0, 2.0]} for index in reversed(range(len(payload["input"])))
+        ]
+        return httpx.Response(200, json={"model": MODEL, "data": data})
+
+    provider, client = _provider(handler, batch_size=2)
+    try:
+        assert provider.embed_passages(["a", "b", "c"]) == [[0.0, 1.0, 2.0], [1.0, 1.0, 2.0], [0.0, 1.0, 2.0]]
+        assert provider.embed_query("question") == [0.0, 1.0, 2.0]
+    finally:
+        client.close()
+    assert [request[0] for request in requests] == ["http://embedding.example/v1/embeddings"] * 3
+    assert [request[1]["input_type"] for request in requests] == ["passage", "passage", "query"]
+    assert [request[1]["dimensions"] for request in requests] == [3, 3, 3]
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        [{"index": 0, "embedding": [0.0, 1.0, 2.0]}],
+        [
+            {"index": 0, "embedding": [0.0, 1.0, 2.0]},
+            {"index": 0, "embedding": [0.0, 1.0, 2.0]},
+        ],
+        [
+            {"index": 0, "embedding": [0.0, 1.0]},
+            {"index": 1, "embedding": [0.0, 1.0, 2.0]},
+        ],
+        [
+            {"index": 0, "embedding": [math.nan, 1.0, 2.0]},
+            {"index": 1, "embedding": [0.0, 1.0, math.inf]},
+        ],
+    ],
+)
+def test_provider_rejects_missing_duplicate_wrong_size_and_nonfinite(data: list[dict[str, object]]) -> None:
+    provider, client = _provider(lambda _request: httpx.Response(200, json={"model": MODEL, "data": data}))
+    try:
+        with pytest.raises(EmbeddingProviderError):
+            provider.embed_passages(["a", "b"])
+    finally:
+        client.close()
+
+
+def test_provider_uses_named_bearer_token_without_leaking_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secret = "super-secret-token"
+    monkeypatch.setenv("VSS_EMBED_KEY", secret)
+    seen_authorization: list[str | None] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_authorization.append(request.headers.get("Authorization"))
+        raise httpx.ReadTimeout(f"request carrying {secret}", request=request)
+
+    provider, client = _provider(handler, api_key_env="VSS_EMBED_KEY")
+    try:
+        with pytest.raises(EmbeddingProviderError) as error:
+            provider.embed_query("question")
+    finally:
+        client.close()
+    assert seen_authorization == [f"Bearer {secret}"]
+    assert secret not in str(error.value)

--- a/services/agent/packages/vss_core/tests/unit_test/memory/test_retrieval.py
+++ b/services/agent/packages/vss_core/tests/unit_test/memory/test_retrieval.py
@@ -1,0 +1,224 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Semantic and hybrid unified-memory retrieval tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from vss_core.memory.backends.in_memory import InMemoryStore
+from vss_core.memory.models import UnifiedMemoryRecord
+from vss_core.memory.service import MemoryService
+from vss_core.memory.store import MemoryQuery
+from vss_core.memory.store import storage_id_for
+
+
+def _record(
+    job_id: str,
+    *,
+    answer: str = "forklift",
+    sensor: str = "camera-1",
+    created_at: str = "2026-08-31T12:00:00Z",
+    updated_at: str | None = None,
+    record_id: str | None = None,
+) -> UnifiedMemoryRecord:
+    job: dict[str, Any] = {
+        "job_id": job_id,
+        "group": "summary",
+        "status": "completed",
+        "created_at": created_at,
+    }
+    if updated_at is not None:
+        job["updated_at"] = updated_at
+    if record_id is not None:
+        job.update(record_type="event", record_id=record_id)
+    return UnifiedMemoryRecord.model_validate(
+        {
+            "job": job,
+            "input": {
+                "query": answer,
+                "sensors": [{"id": sensor}],
+                "window": {
+                    "start": {"timestamp": "2026-08-31T11:00:00Z"},
+                    "end": {"timestamp": "2026-08-31T11:30:00Z"},
+                },
+            },
+            "output": {"answer": answer},
+        }
+    )
+
+
+class _Provider:
+    def __init__(self, error: Exception | None = None) -> None:
+        self.error = error
+        self.queries: list[str] = []
+
+    def embed_query(self, text: str) -> list[float]:
+        self.queries.append(text)
+        if self.error is not None:
+            raise self.error
+        return [0.1, 0.2, 0.3]
+
+
+class _Semantic:
+    def __init__(self, storage_ids: list[str], error: Exception | None = None) -> None:
+        self.storage_ids = storage_ids
+        self.error = error
+        self.calls: list[tuple[MemoryQuery, list[float], int]] = []
+
+    def sync_record(self, record: UnifiedMemoryRecord) -> None:
+        return None
+
+    def semantic_search(
+        self,
+        query: MemoryQuery,
+        query_vector: list[float],
+        candidate_count: int,
+    ) -> list[str]:
+        self.calls.append((query, query_vector, candidate_count))
+        if self.error is not None:
+            raise self.error
+        return self.storage_ids
+
+
+def _service(
+    store: InMemoryStore,
+    semantic: _Semantic,
+    provider: _Provider,
+    *,
+    mode: str = "hybrid",
+) -> MemoryService:
+    return MemoryService(
+        store,
+        semantic_memory=semantic,
+        embedding_provider=provider,
+        retrieval_mode=mode,  # type: ignore[arg-type]
+        semantic_candidate_count=50,
+        rrf_rank_constant=60,
+    )
+
+
+def test_in_memory_get_many_preserves_order_duplicates_and_excludes_missing() -> None:
+    store = InMemoryStore()
+    first = store.upsert(_record("a"))
+    second = store.upsert(_record("b"))
+
+    assert store.get_many(["b", "missing", "a", "b"]) == [second, first, second]
+
+
+def test_query_without_text_preserves_filtering_and_never_calls_provider() -> None:
+    store = InMemoryStore()
+    store.upsert(_record("a", sensor="camera-1"))
+    expected = store.upsert(_record("b", sensor="camera-2"))
+    provider = _Provider()
+    semantic = _Semantic(["a"])
+    service = _service(store, semantic, provider)
+
+    assert service.query(MemoryQuery(sensor_id="camera-2", mode="semantic")) == [expected]
+    assert provider.queries == []
+    assert semantic.calls == []
+
+
+def test_keyword_mode_is_unchanged_and_does_not_call_semantic_dependencies() -> None:
+    store = InMemoryStore()
+    older = store.upsert(_record("older", answer="forklift"))
+    newer = store.upsert(_record("newer", answer="forklift forklift", created_at="2026-08-31T13:00:00Z"))
+    provider = _Provider()
+    semantic = _Semantic(["older"])
+    service = _service(store, semantic, provider)
+
+    assert service.query(MemoryQuery(text="forklift", mode="keyword")) == [newer, older]
+    assert provider.queries == []
+    assert semantic.calls == []
+
+
+@pytest.mark.parametrize("mode", (None, "semantic", "hybrid"))
+def test_service_without_semantic_dependencies_retains_keyword_behavior(mode: str | None) -> None:
+    store = InMemoryStore()
+    expected = store.upsert(_record("keyword", answer="forklift"))
+    service = MemoryService(store, retrieval_mode="hybrid")
+
+    assert service.query(MemoryQuery(text="forklift", mode=mode)) == [expected]  # type: ignore[arg-type]
+
+
+def test_semantic_resolves_authoritative_ids_in_rank_order_and_skips_missing_or_stale() -> None:
+    store = InMemoryStore()
+    first = store.upsert(_record("first", sensor="camera-1"))
+    store.upsert(_record("wrong-sensor", sensor="camera-2"))
+    third = store.upsert(_record("third", sensor="camera-1"))
+    provider = _Provider()
+    semantic = _Semantic(["first", "missing", "wrong-sensor", "third"])
+    service = _service(store, semantic, provider, mode="semantic")
+
+    result = service.query(MemoryQuery(text="paraphrase", sensor_id="camera-1", limit=2))
+
+    assert result == [first, third]
+    assert provider.queries == ["paraphrase"]
+    assert semantic.calls[0][2] == 50
+
+
+def test_hybrid_uses_client_side_rrf_and_deduplicates_storage_ids() -> None:
+    class RankedStore(InMemoryStore):
+        def query(self, query: MemoryQuery) -> list[UnifiedMemoryRecord]:
+            records = self.get_many(["a", "b"])
+            return records[: query.limit]
+
+    store = RankedStore()
+    a = store.upsert(_record("a"))
+    b = store.upsert(_record("b"))
+    c = store.upsert(_record("c"))
+    service = _service(store, _Semantic(["b", "c", "b"]), _Provider())
+
+    assert service.query(MemoryQuery(text="anything", mode="hybrid", limit=3)) == [b, a, c]
+
+
+@pytest.mark.parametrize(
+    ("newer_b", "expected"),
+    (
+        (False, ["a", "b"]),
+        (True, ["b", "a"]),
+    ),
+)
+def test_hybrid_equal_scores_break_ties_by_recency_then_storage_id(newer_b: bool, expected: list[str]) -> None:
+    class RankedStore(InMemoryStore):
+        def query(self, query: MemoryQuery) -> list[UnifiedMemoryRecord]:
+            return self.get_many(["a"])
+
+    store = RankedStore()
+    store.upsert(_record("a"))
+    store.upsert(_record("b", updated_at="2026-08-31T13:00:00Z" if newer_b else None))
+    service = _service(store, _Semantic(["b"]), _Provider())
+
+    result = service.query(MemoryQuery(text="anything", mode="hybrid"))
+
+    assert [storage_id_for(record) for record in result] == expected
+
+
+@pytest.mark.parametrize("mode", ("semantic", "hybrid"))
+@pytest.mark.parametrize("failure_at", ("provider", "index"))
+def test_semantic_failures_warn_and_fall_back_to_keyword(
+    mode: str,
+    failure_at: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = InMemoryStore()
+    expected = store.upsert(_record("keyword", answer="forklift"))
+    provider = _Provider(RuntimeError("provider secret")) if failure_at == "provider" else _Provider()
+    semantic = _Semantic([], RuntimeError("index secret")) if failure_at == "index" else _Semantic([])
+    service = _service(store, semantic, provider)
+
+    assert service.query(MemoryQuery(text="forklift", mode=mode)) == [expected]  # type: ignore[arg-type]
+    assert "falling back to keyword" in caplog.text
+    assert "secret" not in caplog.text
+
+
+def test_keyword_failure_preserves_existing_exception_behavior() -> None:
+    class FailingStore(InMemoryStore):
+        def query(self, query: MemoryQuery) -> list[UnifiedMemoryRecord]:
+            raise RuntimeError("authoritative unavailable")
+
+    service = _service(FailingStore(), _Semantic([]), _Provider(RuntimeError("semantic unavailable")))
+    with pytest.raises(RuntimeError, match="authoritative unavailable"):
+        service.query(MemoryQuery(text="forklift", mode="semantic"))


### PR DESCRIPTION
## Summary
- Canonical memory stays in Elasticsearch; vectors live in a companion index. Records store embedding refs only, never inline vectors.
- `vss configure memory --embeddings` defaults to the OpenClaw Gateway (`openclaw/default` + `OPENCLAW_GATEWAY_TOKEN`). VSS does not start OpenClaw or load models.
- Custom OpenAI-compatible endpoints are opt-in (`--embedding-provider openai_compatible` with explicit endpoint and model). Profile switches do not leak OpenClaw auth onto custom endpoints.
- Embedding HTTP is OpenClaw-compatible: `{model, input}` only by default; dims are probed if omitted; response `model` is not required to match the request.
- Companion index identity is enforced (provider, model, dims, schema). Incompatible indexes fail closed; they are never deleted or recreated.
- Retrieval adds semantic and hybrid (default) recall, plus `vss memory embeddings backfill`. Keyword search still works if embeddings are unavailable.

JIRA Reference: https://jirasw.nvidia.com/browse/VIA-2572

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
