### PR TITLE
Fix/MV3DT OSD/VIS preflight

### DIFF
--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/docker/compose.yml
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/docker/compose.yml
@@ -72,7 +72,9 @@ services:
       kafka:
         condition: service_healthy
         required: false
-    # Uncomment the following 2 lines docker logs shows "libEGL warning: egl: failed to create dri2 screen"
+    # Uncomment for OSD on x86 if the log shows "Failed to query drm device" or
+    # "failed to create dri[N] screen". Kept commented for hosts with no DRM
+    # node, headless included.
     # devices:
     #   - /dev/dri
 

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/docker/init-scripts/ds-start-mv3dt.sh
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/docker/init-scripts/ds-start-mv3dt.sh
@@ -125,8 +125,8 @@ PY
     NOSERVER*) bail "nothing is listening on ${DISPLAY}: ${probe#NOSERVER }"; return $? ;;
     REFUSED*)  bail "the X server on ${DISPLAY} refused this client: ${probe#REFUSED?*? }" \
                     "this is X access control, not a device or driver problem" \
-                    "grant by uid (this container is uid $(id -u)):  xhost +SI:localuser:\$(id -un)" \
-                    "or open it:  xhost +local:" \
+                    "on the host, grant this container's uid:  xhost +SI:localuser:#$(id -u)" \
+                    "or open it to all local clients:  xhost +local:" \
                     "or mount the display cookie and set XAUTHORITY (see README)"
                return $? ;;
     *)         echo "   X connection: unverified (${probe:-no result})" ;;

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/docker/init-scripts/ds-start-mv3dt.sh
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/docker/init-scripts/ds-start-mv3dt.sh
@@ -29,12 +29,149 @@ ARCH="$(uname -m)"
 MV3DT_PRELOAD="/usr/lib/${ARCH}-linux-gnu/libgomp.so.1:/usr/lib/${ARCH}-linux-gnu/libGLdispatch.so.0"
 export LD_PRELOAD="${MV3DT_PRELOAD}${LD_PRELOAD:+:${LD_PRELOAD}}"
 
+# ── Display preflight ─────────────────────────────────────────────────────────
+# OSD renders through an EGL sink needing an X display connection. Without one
+# the app dies at "Failed to set pipeline to PAUSED" with nothing pointing at
+# the display (bug 6636932). This names the cause before launch, and fixes
+# DISPLAY when the choice is unambiguous, so it need not be exported.
+#
+# On Tegra the tracker maps buffers via NvBufSurfaceMapEglImage and so needs an
+# EGL connection even with OSD off; there the checks run advisory only.
+osd_preflight() {
+  local cfg="$1" enabled advisory=0 sockets n disp probe
+
+  [ -f "${cfg}" ] || return 0
+  enabled="$(awk '/^[[:space:]]*\[/ { s = ($0 ~ /^[[:space:]]*\[sink0\]/) }
+                  s && /^[[:space:]]*enable[[:space:]]*=/ { sub(/.*=[[:space:]]*/, ""); print $1; exit }' "${cfg}")"
+
+  if [ "${enabled}" = 1 ]; then
+    echo "── OSD preflight (sink0 enabled)"
+  elif [ "$(uname -m)" = aarch64 ] && [ -d /usr/lib/aarch64-linux-gnu/tegra ]; then
+    advisory=1
+    echo "── display preflight (OSD off; Tegra needs EGL for buffer sharing, advisory)"
+  else
+    echo "** INFO: OSD disabled (sink0 enable=${enabled:-0}); skipping display preflight"
+    return 0
+  fi
+  echo "   uid=$(id -u) gid=$(id -g) groups=$(id -G | tr ' ' ,)"
+
+  # Blocking condition. Advisory mode reports but never stops the pipeline.
+  bail() {
+    [ "${advisory}" = 1 ] && { echo "   ⚠ $1"; return 0; }
+    { echo "** ERROR: $1"; shift; printf '          %s\n' "$@"; } >&2
+    return 1
+  }
+
+  [ -d /tmp/.X11-unix ] || { bail "/tmp/.X11-unix is not mounted, so no X server is reachable" \
+      "add to the perception service:  volumes: [ /tmp/.X11-unix:/tmp/.X11-unix ]"; return $?; }
+
+  sockets="$(ls /tmp/.X11-unix 2>/dev/null | grep -E '^X[0-9]+$' | sort)"
+  [ -n "${sockets}" ] || { bail "no X server sockets in /tmp/.X11-unix" \
+      "start an X session on the host"; return $?; }
+  n="$(printf '%s\n' "${sockets}" | wc -l)"
+  echo "   X sockets: $(printf '%s' "${sockets}" | tr '\n' ' ')"
+
+  # DISPLAY must name one of them. Correct it when there is only one candidate:
+  # the compose default of :0 is simply wrong on a host whose session is :1.
+  disp="${DISPLAY#*:}"; disp="${disp%%.*}"
+  if [ -n "${DISPLAY}" ] && [ -S "/tmp/.X11-unix/X${disp}" ]; then
+    echo "   DISPLAY=${DISPLAY}"
+  elif [ "${n}" = 1 ]; then
+    echo "   DISPLAY '${DISPLAY:-unset}' does not exist here; using :${sockets#X}"
+    export DISPLAY=":${sockets#X}"
+  else
+    bail "DISPLAY='${DISPLAY}' matches no X socket and several exist" \
+         "set DISPLAY in docker/.env to one of: $(printf '%s' "${sockets}" | sed 's/^X/:/' | tr '\n' ' ')"
+    return $?
+  fi
+
+  # Complete an X handshake, presenting the cookie as the real client does.
+  # Probing without it would report "refused" wherever access control is on,
+  # even with a valid XAUTHORITY mounted.
+  probe="$(DISPLAY="${DISPLAY}" XAUTHORITY="${XAUTHORITY:-${HOME:-/root}/.Xauthority}" python3 - <<'PY' 2>/dev/null
+import os, socket, struct, sys
+num = os.environ.get("DISPLAY", "").split(":", 1)[-1].split(".")[0]
+name = data = b""; src = "none"
+auth = os.environ.get("XAUTHORITY", "")
+if auth and os.path.exists(auth):
+    try:
+        b = open(auth, "rb").read(); i = 0
+        while i + 2 <= len(b):
+            i += 2                                     # family
+            f = []
+            for _ in range(4):                         # addr, display, name, data
+                ln = struct.unpack(">H", b[i:i+2])[0]; i += 2
+                f.append(b[i:i+ln]); i += ln
+            if f[2] == b"MIT-MAGIC-COOKIE-1" and f[1].decode("latin-1") in (num, ""):
+                name, data, src = f[2], f[3], "cookie"; break
+    except Exception:
+        src = "unreadable"
+try:
+    s = socket.socket(socket.AF_UNIX); s.settimeout(5)
+    s.connect("/tmp/.X11-unix/X%s" % num)
+except OSError as e:
+    print("NOSERVER %s" % e); sys.exit(0)
+pad = lambda k: (4 - k % 4) % 4
+s.sendall(struct.pack("<BBHHHH2x", 0x6C, 0, 11, 0, len(name), len(data))
+          + name + b"\0" * pad(len(name)) + data + b"\0" * pad(len(data)))
+h = s.recv(8)
+if len(h) < 8:      print("SHORT")
+elif h[0] == 1:     print("OK %s" % src)
+else:               print("REFUSED[%s] %s" % (src, s.recv(1024)[:h[1]].decode("latin-1", "replace").strip()))
+PY
+)"
+  case "${probe}" in
+    OK*)       echo "   X connection: OK (auth: ${probe#OK })" ;;
+    NOSERVER*) bail "nothing is listening on ${DISPLAY}: ${probe#NOSERVER }"; return $? ;;
+    REFUSED*)  bail "the X server on ${DISPLAY} refused this client: ${probe#REFUSED?*? }" \
+                    "this is X access control, not a device or driver problem" \
+                    "grant by uid (this container is uid $(id -u)):  xhost +SI:localuser:\$(id -un)" \
+                    "or open it:  xhost +local:" \
+                    "or mount the display cookie and set XAUTHORITY (see README)"
+               return $? ;;
+    *)         echo "   X connection: unverified (${probe:-no result})" ;;
+  esac
+
+  [ -d /dev/dri ] && echo "   /dev/dri: $(find /dev/dri -maxdepth 1 -type c -readable -writable 2>/dev/null | wc -l) node(s) usable" \
+                  || echo "   /dev/dri: not mapped"
+  echo "   NVIDIA_DRIVER_CAPABILITIES=${NVIDIA_DRIVER_CAPABILITIES:-unset}"
+  echo "   confinement: seccomp=$(awk '/^Seccomp:/{print $2}' /proc/self/status 2>/dev/null)" \
+       "apparmor=$(tr -d '\0' </proc/self/attr/current 2>/dev/null)"
+
+  # Exercise the sink rather than guess: a one-buffer pipeline through the same
+  # EGL sink either returns in about a second or hangs exactly as the real
+  # pipeline would. Skipped in advisory mode, where no sink is in use.
+  if [ "${advisory}" = 1 ]; then
+    echo "   display checks passed (advisory)"
+  elif timeout 20 gst-launch-1.0 -q videotestsrc num-buffers=1 ! nveglglessink >/tmp/egl-probe.log 2>&1; then
+    echo "   EGL sink probe: OK"
+    echo "   OSD preflight passed"
+  else
+    { echo "** WARNING: the EGL sink could not render a test frame, so OSD will not work."
+      grep -iE 'drm|dri2|EGL' /tmp/egl-probe.log 2>/dev/null | tail -3 | sed 's/^/          /'
+      # The NVIDIA runtime always exposes a couple of DRI nodes, so their
+      # presence says nothing about whether the full set is mapped.
+      grep -qiE 'drm|dri2' /tmp/egl-probe.log 2>/dev/null &&
+        echo "          Mesa cannot reach the DRM device: uncomment the devices block in docker/compose.yml"
+      echo "          Continuing; the pipeline may stall at PAUSED."; } >&2
+  fi
+  return 0
+}
+
 MQTT_HOST=${MQTT_HOST:-localhost}
 MQTT_PORT=${MQTT_PORT:-1883}
 MQTT_ENDPOINT="${MQTT_HOST}:${MQTT_PORT}"
 cd /opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/metropolis_perception_app
 APP_DIR="$(pwd)"
 CONFIG_DIR="${APP_DIR}/configs"
+
+if ! osd_preflight "${CONFIG_DIR}/ds-main-config-mv3dt.txt"; then
+  { echo
+    echo "** ERROR: not starting the pipeline: it would fail at 'Failed to set pipeline"
+    echo "          to PAUSED' with no explanation. Fix the cause reported above, or"
+    echo "          drop the on-screen display:  OSD=0 ./scripts/stage-configs.sh"; } >&2
+  exit 1
+fi
 
 GENERATED_DIR="/tmp/generated"
 mkdir -p "${GENERATED_DIR}"

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/docker/init-scripts/ds-start-mv3dt.sh
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/docker/init-scripts/ds-start-mv3dt.sh
@@ -143,17 +143,21 @@ PY
   # pipeline would. Skipped in advisory mode, where no sink is in use.
   if [ "${advisory}" = 1 ]; then
     echo "   display checks passed (advisory)"
+  elif ! command -v gst-launch-1.0 >/dev/null 2>&1; then
+    echo "   EGL sink probe: skipped (gst-launch-1.0 not available)"
   elif timeout 20 gst-launch-1.0 -q videotestsrc num-buffers=1 ! nveglglessink >/tmp/egl-probe.log 2>&1; then
     echo "   EGL sink probe: OK"
     echo "   OSD preflight passed"
   else
-    { echo "** WARNING: the EGL sink could not render a test frame, so OSD will not work."
+    # sink0 is the EGL sink this probe exercises, so a failure here is the
+    # pipeline's failure: stop rather than stall at PAUSED.
+    { echo "** ERROR: the EGL sink could not render a test frame, so OSD will not work."
       grep -iE 'drm|dri2|EGL' /tmp/egl-probe.log 2>/dev/null | tail -3 | sed 's/^/          /'
       # The NVIDIA runtime always exposes a couple of DRI nodes, so their
       # presence says nothing about whether the full set is mapped.
       grep -qiE 'drm|dri2' /tmp/egl-probe.log 2>/dev/null &&
-        echo "          Mesa cannot reach the DRM device: uncomment the devices block in docker/compose.yml"
-      echo "          Continuing; the pipeline may stall at PAUSED."; } >&2
+        echo "          Mesa cannot reach the DRM device: uncomment the devices block in docker/compose.yml"; } >&2
+    return 1
   fi
   return 0
 }


### PR DESCRIPTION
## Summary
When the on-screen display is enabled but the container cannot reach the host X display, the pipeline dies with Failed to set pipeline to PAUSED and no explanation, and the usual workaround has been privileged: true. This adds a preflight to `ds-start-mv3dt.sh` that runs only when `sink0` is enabled: it diagnoses the display path before the pipeline starts, names the actual cause, and prints the exact remedy. No privileged mode, no image rebuild since the script is bind-mounted and is the container command.

## Related Issue
  - NVBug 6551512 — OSD fails unless perception runs privileged: true
  - NVBug 6636932 — OSD failure emits no actionable host-display diagnostics
 
## Changes
- `docker/init-scripts/ds-start-mv3dt.sh`: add an OSD preflight that runs only when sink0 is enabled — enumerates X sockets and auto-corrects a bad DISPLAY, does a real cookie-authenticated X11 handshake, reports /dev/dri, driver capabilities and seccomp confinement, probes the EGL sink, and exits before the pipeline with the cause and the fix instead of a bare Failed to set pipeline to PAUSED.
- `docker/compose.yml`: update the documentation hint about the usage of `devices: /dev/dri`, kept commented because docker refuses to start when a listed device is absent, which would break headless hosts.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.
