### PR TITLE
fix(mv3dt): stream removal verification, --remove-all, and CLI corrections

### DIFF
--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/README.md
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/README.md
@@ -306,7 +306,9 @@ Register your RTSP streams via the perception REST API — one
 ./scripts/add-streams.sh --file my-streams.txt
 
 # runtime removal / inspection:
-./scripts/add-streams.sh --remove <sensor_id_2>
+./scripts/add-streams.sh --remove <sensor_id_2>   # one stream, by the id --list shows
+./scripts/add-streams.sh --remove-all             # every registered stream, after confirming
+./scripts/add-streams.sh --remove-all --yes       # same, unattended
 ./scripts/add-streams.sh --list
 ```
 

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/add-streams.sh
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/add-streams.sh
@@ -29,6 +29,8 @@
 #   ./scripts/add-streams.sh --remove Camera_01                   # remove one stream
 #   ./scripts/add-streams.sh --remove Camera_01=rtsp://host/cam1  # also accepted
 #   ./scripts/add-streams.sh --remove --file streams.txt          # remove every listed stream
+#   ./scripts/add-streams.sh --remove-all                         # remove every registered stream
+#   ./scripts/add-streams.sh --remove-all --yes                   # same, no confirmation prompt
 #   ./scripts/add-streams.sh --list                      # show current stream-info
 #
 # Options / env:
@@ -36,6 +38,7 @@
 #   --delay S          seconds between adds      (default: 1)
 #   --no-url-check     skip the pre-add RTSP reachability check
 #   --no-sei-check     skip the VST SEI frame-ID prerequisite check
+#   -y, --yes          answer yes to the --remove-all confirmation
 #   --activation-timeout S  wait for added streams to produce frames (default: 60;
 #                      0 disables). A stream the server accepts but never decodes
 #                      is reported as inactive.
@@ -62,6 +65,8 @@ VST_HTTP_PORT="${VST_HTTP_PORT:-30000}"
 STREAMS=()
 MODE=add
 LIST=0
+REMOVE_ALL=0
+ASSUME_YES=0
 
 usage() { sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
 
@@ -69,6 +74,8 @@ while (($#)); do
   case "$1" in
     --file)           mapfile -t -O "${#STREAMS[@]}" STREAMS < <(grep -vE '^\s*(#|$)' "$2"); shift 2 ;;
     --remove)         MODE=remove; shift ;;
+    --remove-all)     MODE=remove; REMOVE_ALL=1; shift ;;
+    -y|--yes)         ASSUME_YES=1; shift ;;
     --list)           LIST=1; shift ;;
     --ds-host)        DS_HOST="$2"; shift 2 ;;
     --ds-port)        DS_PORT="$2"; shift 2 ;;
@@ -479,40 +486,58 @@ if (( LIST )); then
   exit 1
 fi
 
-(( ${#STREAMS[@]} )) || { echo "ERROR: no streams given (NAME=URL args or --file)" >&2; usage 2; }
+(( ${#STREAMS[@]} || REMOVE_ALL )) || { echo "ERROR: no streams given (NAME=URL args, --file, or --remove-all)" >&2; usage 2; }
 
 # ── --remove mode: delete each listed stream (camera_id or NAME=URL) ──────────
 # Paced by --delay, mirroring the add path.
-# True when the requested removals would leave the perception service with no
-# registered streams. On this build the REST API stops answering once no sources
-# remain: the container keeps running but every /api/v1 request times out, and it
-# has to be recreated. Worth saying before it happens rather than after a silent
-# timeout, but not worth refusing -- clearing every stream is a normal request.
-removal_empties_registry() {
+# Camera ids currently registered, one per line. No output means either an empty
+# registry or an unreachable API; callers tell them apart by the exit status.
+registered_camera_ids() {
   local payload
   payload="$(curl -fsS --max-time 5 --connect-timeout 3 \
              "${BASE}/api/v1/stream/get-stream-info" 2>/dev/null)" || return 1
   STREAM_INFO_PAYLOAD="$payload" python3 -c '
 import json, os, sys
-
-wanted = {a.split("=", 1)[0] for a in sys.argv[1:] if a}
 try:
     streams = json.loads(os.environ["STREAM_INFO_PAYLOAD"])["stream-info"]["stream-info"]
 except Exception:
     sys.exit(1)
-registered = {str(s.get("camera_id", "")) for s in streams if isinstance(s, dict)}
-registered.discard("")
-sys.exit(0 if registered and registered <= wanted else 1)
-' "$@"
+for cam in sorted({str(s.get("camera_id", "")) for s in streams if isinstance(s, dict)} - {""}):
+    print(cam)
+'
+}
+
+# Recovery guidance, printed only once the API has actually stopped answering.
+# Removing the last source can wedge the REST server (bug 6631012), but it does
+# not always, so report it after the fact instead of predicting it.
+report_api_lost() {
+  echo >&2
+  echo "   ⚠ the perception REST API stopped responding after the removal." >&2
+  echo "     The container keeps running but /api/v1 requests time out; recreate it" >&2
+  echo "     before adding or listing streams again:" >&2
+  echo "       (cd docker && docker compose up -d --force-recreate perception)" >&2
 }
 
 if [[ "$MODE" == remove ]]; then
-  if removal_empties_registry "${STREAMS[@]}"; then
-    echo "   ⚠ this removes every registered stream. With no sources left the perception" >&2
-    echo "     REST API stops responding: the container keeps running but /api/v1 requests" >&2
-    echo "     time out, and it has to be recreated before streams can be added again:" >&2
-    echo "       (cd docker && docker compose up -d --force-recreate perception)" >&2
+  if (( REMOVE_ALL )); then
+    if ! mapfile -t STREAMS < <(registered_camera_ids); then
+      echo "ERROR: cannot reach the perception REST API at ${BASE} to list streams." >&2
+      exit 1
+    fi
+    (( ${#STREAMS[@]} )) || { echo "No streams are registered; nothing to remove."; exit 0; }
+    echo "── ${#STREAMS[@]} registered stream(s) will be removed:"
+    printf '     %s\n' "${STREAMS[@]}"
+    if ! (( ASSUME_YES )); then
+      if [[ ! -t 0 ]]; then
+        echo "ERROR: --remove-all needs confirmation but stdin is not a terminal." >&2
+        echo "       Re-run with --yes to confirm non-interactively." >&2
+        exit 1
+      fi
+      read -r -p "   Remove all of them? [y/N] " reply || reply=""
+      [[ "$reply" =~ ^[Yy]$ ]] || { echo "Aborted."; exit 0; }
+    fi
   fi
+
   echo "── Removing ${#STREAMS[@]} stream(s) (delay=${DELAY}s)"
   rc=0; idx=0
   for entry in "${STREAMS[@]}"; do
@@ -544,7 +569,14 @@ if [[ "$MODE" == remove ]]; then
     idx=$((idx + 1))
     (( idx < ${#STREAMS[@]} )) && sleep "$DELAY"
   done
-  echo; show_stream_info
+  echo
+  # On failure show_stream_info prints its own connectivity block, which just
+  # repeats what the removal already said. Keep its success output, replace its
+  # error with the one message that explains the removal context.
+  if ! show_stream_info 2>/dev/null; then
+    report_api_lost
+    (( rc )) || rc=1
+  fi
   exit "$rc"
 fi
 

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/add-streams.sh
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/add-streams.sh
@@ -68,11 +68,13 @@ LIST=0
 REMOVE_ALL=0
 ASSUME_YES=0
 
-usage() { sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
+# Print the commented Usage/Options block, skipping the SPDX licence header.
+usage() { sed -n '/^# Usage:/,/^set -euo pipefail/p' "$0" | sed '$d; s/^#\{0,1\} \{0,1\}//'; exit "${1:-0}"; }
 
 while (($#)); do
   case "$1" in
-    --file)           mapfile -t -O "${#STREAMS[@]}" STREAMS < <(grep -vE '^\s*(#|$)' "$2"); shift 2 ;;
+    --file)           mapfile -t -O "${#STREAMS[@]}" STREAMS \
+                        < <(sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' "$2" | grep -vE '^(#|$)'); shift 2 ;;
     --remove)         MODE=remove; shift ;;
     --remove-all)     MODE=remove; REMOVE_ALL=1; shift ;;
     -y|--yes)         ASSUME_YES=1; shift ;;

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/add-streams.sh
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/add-streams.sh
@@ -251,7 +251,12 @@ if registered < required:
 PY
 }
 
-lookup_stream_url() {  # $1=camera_id; prints URL when stream-info includes one.
+# True when camera_id is currently registered. That is all the removal needs:
+# the REST API identifies a stream by camera_id and accepts an empty
+# camera_url (nvbugs/6557680).
+#
+# Returns 0 registered, 1 not registered, 2 API unreachable.
+stream_is_registered() {  # $1=camera_id
   local cam="$1"
   if [[ -z "$STREAM_INFO_JSON" ]]; then
     if ! STREAM_INFO_JSON="$(curl -fsS --max-time 5 --connect-timeout 3 \
@@ -261,21 +266,12 @@ lookup_stream_url() {  # $1=camera_id; prints URL when stream-info includes one.
   fi
   printf '%s' "$STREAM_INFO_JSON" | python3 -c '
 import json, sys
-
-camera_id = sys.argv[1]
-d = json.load(sys.stdin)
-info = d.get("stream-info", {})
-streams = info.get("stream-info", [])
-for stream in streams:
-    if str(stream.get("camera_id", "")) != camera_id:
-        continue
-    for key in ("camera_url", "url", "rtsp_url", "uri"):
-        value = stream.get(key)
-        if isinstance(value, str):
-            print(value)
-            break
-    sys.exit(0)
-sys.exit(1)
+try:
+    streams = json.load(sys.stdin)["stream-info"]["stream-info"]
+except Exception:
+    sys.exit(1)
+sys.exit(0 if any(str(s.get("camera_id", "")) == sys.argv[1] for s in streams
+                  if isinstance(s, dict)) else 1)
 ' "$cam"
 }
 
@@ -555,9 +551,9 @@ if [[ "$MODE" == remove ]]; then
         echo "   ⚠ skipping malformed removal entry: [${entry}] (want NAME=rtsp://... or camera_id)" >&2
         rc=2; continue
       fi
-      lu=0; url="$(lookup_stream_url "$cam")" || lu=$?
+      lu=0; stream_is_registered "$cam" || lu=$?
       if (( lu == 2 )); then
-        echo "   ✗ cannot reach the perception REST API at ${BASE} to look up [${cam}]" >&2
+        echo "   ✗ cannot reach the perception REST API at ${BASE} to check [${cam}]" >&2
         echo "     Check whether it is alive:  docker logs --tail 120 vss-rtvi-cv-mv3dt" >&2
         rc=2; continue
       fi

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/add-streams.sh
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/add-streams.sh
@@ -27,7 +27,7 @@
 #   ./scripts/add-streams.sh Camera=rtsp://host/cam0 Camera_01=rtsp://host/cam1 ...
 #   ./scripts/add-streams.sh --file streams.txt          # one NAME=URL per line, # comments
 #   ./scripts/add-streams.sh --remove Camera_01                   # remove one stream
-#   ./scripts/add-streams.sh --remove Camera_01=rtsp://host/cam1  # also accepted
+#   ./scripts/add-streams.sh --remove Camera_01=rtsp://host/cam1  # also accepted, any URL scheme
 #   ./scripts/add-streams.sh --remove --file streams.txt          # remove every listed stream
 #   ./scripts/add-streams.sh --remove-all                         # remove every registered stream
 #   ./scripts/add-streams.sh --remove-all --yes                   # same, no confirmation prompt
@@ -452,6 +452,10 @@ print(json.dumps({
     echo "   ✗ HTTP ${code} failed to ${3#camera_} stream"
     cat "$tmp" >&2 || true
     echo >&2
+    if grep -q 'Source url empty' "$tmp"; then
+      echo "     This build of the API will not drop a stream by camera_id alone." >&2
+      echo "     Retry with the source URL:  --remove ${1}=<url>" >&2
+    fi
     rm -f "$tmp"; return 1
   fi
   if [[ "$code" == "200" || "$code" == "201" ]]; then
@@ -541,14 +545,14 @@ if [[ "$MODE" == remove ]]; then
   for entry in "${STREAMS[@]}"; do
     if [[ "$entry" == *=* ]]; then
       cam="${entry%%=*}"; url="${entry#*=}"
-      if [[ -z "$cam" || "$url" != rtsp://* ]]; then
-        echo "   ⚠ skipping malformed removal entry: [${entry}] (want NAME=rtsp://... or camera_id)" >&2
+      if [[ -z "$cam" || "$url" != *://* ]]; then
+        echo "   ⚠ skipping malformed removal entry: [${entry}] (want NAME=URL or camera_id)" >&2
         rc=2; continue
       fi
     else
       cam="$entry"; url=""
       if [[ -z "$cam" ]]; then
-        echo "   ⚠ skipping malformed removal entry: [${entry}] (want NAME=rtsp://... or camera_id)" >&2
+        echo "   ⚠ skipping malformed removal entry: [${entry}] (want NAME=URL or camera_id)" >&2
         rc=2; continue
       fi
       lu=0; stream_is_registered "$cam" || lu=$?

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/add-streams.sh
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/add-streams.sh
@@ -522,10 +522,15 @@ report_api_lost() {
 
 if [[ "$MODE" == remove ]]; then
   if (( REMOVE_ALL )); then
-    if ! mapfile -t STREAMS < <(registered_camera_ids); then
+    # Assign first, then split. A process substitution reports only mapfile's
+    # own status, so a failed lookup would arrive as an empty list and be
+    # reported as "nothing to remove" rather than as the error it is.
+    if ! registered_ids="$(registered_camera_ids)"; then
       echo "ERROR: cannot reach the perception REST API at ${BASE} to list streams." >&2
       exit 1
     fi
+    STREAMS=()
+    [[ -n "$registered_ids" ]] && mapfile -t STREAMS <<<"$registered_ids"
     (( ${#STREAMS[@]} )) || { echo "No streams are registered; nothing to remove."; exit 0; }
     echo "── ${#STREAMS[@]} registered stream(s) will be removed:"
     printf '     %s\n' "${STREAMS[@]}"

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/generate-configs.sh
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/generate-configs.sh
@@ -42,7 +42,15 @@
 set -euo pipefail
 
 CALIB="${1:-}"
-[ -n "$CALIB" ] && [ -f "$CALIB" ] || { echo "Usage: $0 /path/to/calibration.json" >&2; exit 1; }
+if [ -z "$CALIB" ]; then
+  echo "ERROR: calibration path is required" >&2
+  echo "Usage: $0 /path/to/calibration.json" >&2
+  exit 2
+fi
+if [ ! -f "$CALIB" ]; then
+  echo "ERROR: calibration file not found: $CALIB" >&2
+  exit 2
+fi
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REPO_ROOT="$(cd "$ROOT/../../../.." && pwd)"


### PR DESCRIPTION
## Summary
`add-streams.sh` printed recovery instructions before sending any request, had no way to clear a deployment, and `-h` printed the licence header instead of usage. This verifies removal against the API instead of predicting it, adds `--remove-all [--yes]`, and fixes three CLI defects.

## Related Issue
- NVBug 6635198 — recovery instructions printed before verifying whether removal actually failed
- NVBug 6636703 — no explicit option to remove all registered streams
- NVBug 6630744 — `-h` prints the SPDX licence text instead of the documented Usage block
- NVBug 6633350 — `--file` does not trim whitespace from stream entries
- NVBug 6563185 — missing calibration file and missing argument give the same message

## Changes
- `scripts/add-streams.sh`: verify removal via `get-stream-info` and only warn when the API actually stops answering; add `--remove-all` with confirmation, `--yes` for unattended use, and a non-tty guard; accept any URL scheme on the removal path; content-based `usage()`; trim whitespace in `--file`.
- `scripts/generate-configs.sh`: report a missing calibration path and a missing calibration file separately, both exit 2.
- `README.md`: document `--remove-all` and `--yes`.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.
