### PR TITLE
feat(rt-vlm): support finite-choice output constraints

### DIFF
--- a/services/rtvi/rt-vlm/src/api_models/captions.py
+++ b/services/rtvi/rt-vlm/src/api_models/captions.py
@@ -100,6 +100,7 @@ OptionalCaptionMetricInt32 = (
 class ResponseType(str, Enum):
     """Query Response Type."""
 
+    CHOICE = "choice"
     JSON_SCHEMA = "json_schema"
     JSON_OBJECT = "json_object"
     TEXT = "text"
@@ -118,16 +119,31 @@ class ResponseFormat(CommonBaseModel):
     """Query Response Format Object."""
 
     type: ResponseType = Field(
-        description="Response format type", examples=[ResponseType.JSON_OBJECT, ResponseType.TEXT]
+        description="Response format type",
+        examples=[ResponseType.CHOICE, ResponseType.JSON_OBJECT, ResponseType.TEXT],
     )
     json_schema: Optional[JsonSchemaDefinition] = None
+    choices: Optional[List[Annotated[str, Field(min_length=1, max_length=2048)]]] = Field(
+        default=None,
+        min_length=1,
+        max_length=256,
+    )
 
     @model_validator(mode="after")
-    def validate_json_schema(self):
+    def validate_constraint(self):
         if self.type == ResponseType.JSON_SCHEMA and self.json_schema is None:
             raise ValueError("json_schema is required when response format type is json_schema")
         if self.type != ResponseType.JSON_SCHEMA and self.json_schema is not None:
             raise ValueError("json_schema is only valid when response format type is json_schema")
+        if self.type == ResponseType.CHOICE:
+            if self.choices is None:
+                raise ValueError("choices is required when response format type is choice")
+            if any(not choice.strip() for choice in self.choices):
+                raise ValueError("choices must not contain blank values")
+            if len(set(self.choices)) != len(self.choices):
+                raise ValueError("choices must be unique")
+        elif self.choices is not None:
+            raise ValueError("choices is only valid when response format type is choice")
         return self
 
 

--- a/services/rtvi/rt-vlm/src/models/vllm_compatible/vllm_compatible_model.py
+++ b/services/rtvi/rt-vlm/src/models/vllm_compatible/vllm_compatible_model.py
@@ -675,7 +675,7 @@ def _build_vllm_sampling_kwargs(config: VlmGenerationConfig) -> dict:
         kwargs["min_tokens"] = config.min_tokens
     response_format = config.response_format or {}
     response_type = response_format.get("type")
-    is_structured_output = response_type in {"json_object", "json_schema"}
+    is_structured_output = response_type in {"choice", "json_object", "json_schema"}
     env_ignore_eos = _get_rtvi_vllm_env("VLLM_IGNORE_EOS", "false").lower() == "true"
     if is_structured_output:
         kwargs["ignore_eos"] = False
@@ -691,6 +691,12 @@ def _build_vllm_sampling_kwargs(config: VlmGenerationConfig) -> dict:
         json_schema = response_format["json_schema"]
         kwargs["structured_outputs"] = StructuredOutputsParams(
             json=json_schema["schema"],
+        )
+    elif response_type == "choice":
+        from vllm.sampling_params import StructuredOutputsParams
+
+        kwargs["structured_outputs"] = StructuredOutputsParams(
+            choice=response_format["choices"],
         )
     return kwargs
 

--- a/services/rtvi/rt-vlm/tests/model/vllm_compatible/test_input_error_handling.py
+++ b/services/rtvi/rt-vlm/tests/model/vllm_compatible/test_input_error_handling.py
@@ -1520,6 +1520,19 @@ def test_vllm_sampling_kwargs_enforces_json_object(monkeypatch):
     assert kwargs["ignore_eos"] is False
 
 
+def test_vllm_sampling_kwargs_enforces_choice(monkeypatch):
+    monkeypatch.setenv("VLLM_IGNORE_EOS", "true")
+    monkeypatch.delenv("RTVI_VLLM_IGNORE_EOS", raising=False)
+    choices = ["N", "Y collision_happening"]
+
+    kwargs = vllm_compatible_model._build_vllm_sampling_kwargs(
+        VlmGenerationConfig(response_format={"type": "choice", "choices": choices})
+    )
+
+    assert kwargs["structured_outputs"].choice == choices
+    assert kwargs["ignore_eos"] is False
+
+
 def test_cosmos_no_repeat_ngram_is_disabled_for_structured_output():
     params = SimpleNamespace(structured_outputs=object())
 

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_nim_api_compat.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_nim_api_compat.py
@@ -170,6 +170,30 @@ class TestVlmQueryValidation:
         with pytest.raises(ValidationError, match="json_schema is required"):
             _vlm_query(response_format={"type": "json_schema"})
 
+    def test_choice_response_format_reaches_generation_config(self):
+        choices = ["N", "Y collision_happening"]
+        query = _vlm_query(response_format={"type": "choice", "choices": choices})
+
+        params = VlmRequestParams.from_vlm_query(query)
+
+        assert params.vlm_generation_config.response_format == {
+            "type": "choice",
+            "choices": choices,
+        }
+
+    @pytest.mark.parametrize(
+        ("response_format", "message"),
+        [
+            ({"type": "choice"}, "choices is required"),
+            ({"type": "choice", "choices": [" "]}, "must not contain blank"),
+            ({"type": "choice", "choices": ["N", "N"]}, "choices must be unique"),
+            ({"type": "text", "choices": ["N"]}, "choices is only valid"),
+        ],
+    )
+    def test_choice_response_format_rejects_invalid_values(self, response_format, message):
+        with pytest.raises(ValidationError, match=message):
+            _vlm_query(response_format=response_format)
+
     def test_structured_output_rejects_ignore_eos(self):
         with pytest.raises(ValidationError, match="ignore_eos=true is incompatible"):
             _vlm_query(response_format={"type": "json_object"}, ignore_eos=True)

--- a/services/rtvi/rt-vlm/tests/run_choice_output_contract.py
+++ b/services/rtvi/rt-vlm/tests/run_choice_output_contract.py
@@ -77,6 +77,7 @@ def upload_video(session, backend, video_path, timeout):
     with open(video_path, "rb") as video:
         response = session.post(
             f"{backend}/v1/files",
+            data={"purpose": "vision", "media_type": "video"},
             files={"file": (os.path.basename(video_path), video)},
             timeout=timeout,
         )

--- a/services/rtvi/rt-vlm/tests/run_choice_output_contract.py
+++ b/services/rtvi/rt-vlm/tests/run_choice_output_contract.py
@@ -76,7 +76,7 @@ def discover_model(session, backend, timeout):
 def upload_video(session, backend, video_path, timeout):
     with open(video_path, "rb") as video:
         response = session.post(
-            f"{backend}/v1/files/add",
+            f"{backend}/v1/files",
             files={"file": (os.path.basename(video_path), video)},
             timeout=timeout,
         )

--- a/services/rtvi/rt-vlm/tests/run_choice_output_contract.py
+++ b/services/rtvi/rt-vlm/tests/run_choice_output_contract.py
@@ -83,10 +83,13 @@ def upload_video(session, backend, video_path, timeout):
         )
     response.raise_for_status()
     payload = response.json()
-    results = payload.get("results", [])
-    if not results or not results[0].get("id"):
+    file_id = payload.get("id")
+    if not file_id:
+        results = payload.get("results", [])
+        file_id = results[0].get("id") if results else None
+    if not file_id:
         raise RuntimeError(f"file upload returned no ID: {payload}")
-    return results[0]["id"]
+    return file_id
 
 
 def extract_contents(payload):

--- a/services/rtvi/rt-vlm/tests/run_choice_output_contract.py
+++ b/services/rtvi/rt-vlm/tests/run_choice_output_contract.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fail-closed device test for RT-VLM finite-choice output constraints."""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+
+COMPACT_CHOICES = [
+    "N",
+    "Y collision_happening",
+    "Y collision_aftermath stalled_vehicle blocks_active_lane",
+]
+JSON_CHOICES = [
+    '{"normal":true,"collision_happening":false,"collision_aftermath":false}',
+    '{"normal":false,"collision_happening":true,"collision_aftermath":false}',
+    '{"normal":false,"collision_happening":false,"collision_aftermath":true}',
+]
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--backend",
+        default=os.environ.get("RTVI_BACKEND", "http://localhost:8000"),
+    )
+    parser.add_argument(
+        "--video-path", required=True, help="Use a short device-local test clip"
+    )
+    parser.add_argument(
+        "--model", help="Defaults to the first model returned by /v1/models"
+    )
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--timeout", type=int, default=180)
+    parser.add_argument("--chunk-duration", type=int, default=10)
+    parser.add_argument("--report", type=Path)
+    return parser.parse_args()
+
+
+def gpu_identity():
+    try:
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=name,uuid,driver_version",
+                "--format=csv,noheader",
+            ],
+            capture_output=True,
+            check=True,
+            text=True,
+            timeout=10,
+        )
+        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return []
+
+
+def discover_model(session, backend, timeout):
+    response = session.get(f"{backend}/v1/models", timeout=timeout)
+    response.raise_for_status()
+    models = response.json().get("data", [])
+    if not models:
+        raise RuntimeError("/v1/models returned no models")
+    return models[0]["id"]
+
+
+def upload_video(session, backend, video_path, timeout):
+    with open(video_path, "rb") as video:
+        response = session.post(
+            f"{backend}/v1/files/add",
+            files={"file": (os.path.basename(video_path), video)},
+            timeout=timeout,
+        )
+    response.raise_for_status()
+    payload = response.json()
+    results = payload.get("results", [])
+    if not results or not results[0].get("id"):
+        raise RuntimeError(f"file upload returned no ID: {payload}")
+    return results[0]["id"]
+
+
+def extract_contents(payload):
+    chunks = payload.get("chunk_responses", [])
+    if not chunks:
+        raise AssertionError(f"response has no chunk_responses: {payload}")
+    contents = [chunk.get("content") for chunk in chunks]
+    if any(not isinstance(content, str) or not content for content in contents):
+        raise AssertionError(f"response has an empty chunk content: {payload}")
+    return [content.strip() for content in contents]
+
+
+def generation_payload(model, file_id, prompt, response_format, chunk_duration):
+    return {
+        "id": file_id,
+        "model": model,
+        "prompt": prompt,
+        "stream": False,
+        "temperature": 0,
+        "max_tokens": 64,
+        "chunk_duration": chunk_duration,
+        "response_format": response_format,
+    }
+
+
+def run_generation_case(
+    session,
+    backend,
+    timeout,
+    name,
+    payload,
+    validate,
+):
+    started = time.monotonic()
+    record = {"name": name}
+    try:
+        response = session.post(
+            f"{backend}/v1/generate_captions",
+            json=payload,
+            timeout=timeout,
+        )
+        record["status_code"] = response.status_code
+        response.raise_for_status()
+        contents = extract_contents(response.json())
+        validate(contents)
+        record.update(status="pass", outputs=contents)
+    except (
+        AssertionError,
+        KeyError,
+        TypeError,
+        ValueError,
+        requests.RequestException,
+    ) as exc:
+        record.update(status="fail", error=str(exc))
+    record["duration_ms"] = round((time.monotonic() - started) * 1000, 2)
+    return record
+
+
+def run_rejection_case(session, backend, timeout, name, payload):
+    started = time.monotonic()
+    record = {"name": name}
+    try:
+        response = session.post(
+            f"{backend}/v1/generate_captions",
+            json=payload,
+            timeout=timeout,
+        )
+        record["status_code"] = response.status_code
+        if response.status_code != 422:
+            raise AssertionError(
+                f"expected HTTP 422, got {response.status_code}: {response.text[:500]}"
+            )
+        record["status"] = "pass"
+    except (AssertionError, requests.RequestException) as exc:
+        record.update(status="fail", error=str(exc))
+    record["duration_ms"] = round((time.monotonic() - started) * 1000, 2)
+    return record
+
+
+def require_exact(expected):
+    def validate(contents):
+        unexpected = [content for content in contents if content != expected]
+        if unexpected:
+            raise AssertionError(f"expected {expected!r}, got {unexpected!r}")
+
+    return validate
+
+
+def require_member(allowed):
+    def validate(contents):
+        unexpected = [content for content in contents if content not in allowed]
+        if unexpected:
+            raise AssertionError(f"outputs are outside allowed choices: {unexpected!r}")
+
+    return validate
+
+
+def require_json_member(allowed):
+    def validate(contents):
+        unexpected = [content for content in contents if content not in allowed]
+        if unexpected:
+            raise AssertionError(
+                f"outputs are outside allowed JSON choices: {unexpected!r}"
+            )
+        if any(not isinstance(json.loads(content), dict) for content in contents):
+            raise ValueError("JSON choice did not decode to an object")
+
+    return validate
+
+
+def require_json(contents):
+    if any(not isinstance(json.loads(content), dict) for content in contents):
+        raise ValueError("json_object output did not decode to an object")
+
+
+def main():
+    args = parse_args()
+    backend = args.backend.rstrip("/")
+    video_path = os.path.abspath(args.video_path)
+    if not os.path.isfile(video_path):
+        raise SystemExit(f"video does not exist: {video_path}")
+    if args.repetitions < 1:
+        raise SystemExit("--repetitions must be at least 1")
+
+    report_path = args.report or Path(
+        f"rtvi-choice-contract-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}.json"
+    )
+    report = {
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "backend": backend,
+        "video_path": video_path,
+        "gpu": gpu_identity(),
+        "cases": [],
+    }
+
+    session = requests.Session()
+    file_id = None
+    try:
+        model = args.model or discover_model(session, backend, args.timeout)
+        report["model"] = model
+        file_id = upload_video(session, backend, video_path, args.timeout)
+        base = generation_payload(
+            model,
+            file_id,
+            "Return exactly one allowed classification.",
+            {"type": "choice", "choices": COMPACT_CHOICES},
+            args.chunk_duration,
+        )
+
+        invalid_formats = [
+            ("reject_missing_choices", {"type": "choice"}),
+            ("reject_empty_choices", {"type": "choice", "choices": []}),
+            ("reject_blank_choice", {"type": "choice", "choices": [" "]}),
+            ("reject_duplicate_choices", {"type": "choice", "choices": ["N", "N"]}),
+            (
+                "reject_too_many_choices",
+                {"type": "choice", "choices": [str(i) for i in range(257)]},
+            ),
+            ("reject_overlong_choice", {"type": "choice", "choices": ["x" * 2049]}),
+            ("reject_choices_on_text", {"type": "text", "choices": ["N"]}),
+        ]
+        for name, response_format in invalid_formats:
+            payload = dict(base, response_format=response_format)
+            report["cases"].append(
+                run_rejection_case(session, backend, args.timeout, name, payload)
+            )
+
+        for expected in COMPACT_CHOICES:
+            payload = dict(
+                base, response_format={"type": "choice", "choices": [expected]}
+            )
+            report["cases"].append(
+                run_generation_case(
+                    session,
+                    backend,
+                    args.timeout,
+                    f"single_choice_{expected.replace(' ', '_')}",
+                    payload,
+                    require_exact(expected),
+                )
+            )
+
+        for repetition in range(args.repetitions):
+            report["cases"].append(
+                run_generation_case(
+                    session,
+                    backend,
+                    args.timeout,
+                    f"compact_choice_repeat_{repetition + 1}",
+                    base,
+                    require_member(COMPACT_CHOICES),
+                )
+            )
+
+        json_payload = dict(
+            base,
+            prompt="Return exactly one allowed JSON traffic state.",
+            response_format={"type": "choice", "choices": JSON_CHOICES},
+        )
+        report["cases"].append(
+            run_generation_case(
+                session,
+                backend,
+                args.timeout,
+                "protocol_constrained_json",
+                json_payload,
+                require_json_member(JSON_CHOICES),
+            )
+        )
+
+        legacy_payload = dict(
+            base,
+            prompt='Return a JSON object with one key named "status".',
+            response_format={"type": "json_object"},
+        )
+        report["cases"].append(
+            run_generation_case(
+                session,
+                backend,
+                args.timeout,
+                "legacy_json_object_regression",
+                legacy_payload,
+                require_json,
+            )
+        )
+    except (
+        KeyError,
+        OSError,
+        RuntimeError,
+        ValueError,
+        requests.RequestException,
+    ) as exc:
+        report["setup_error"] = str(exc)
+    finally:
+        if file_id:
+            try:
+                session.delete(f"{backend}/v1/files/delete/{file_id}", timeout=30)
+            except requests.RequestException as exc:
+                report["cleanup_error"] = str(exc)
+        session.close()
+
+    report["finished_at"] = datetime.now(timezone.utc).isoformat()
+    report["passed"] = (
+        bool(report["cases"])
+        and "setup_error" not in report
+        and "cleanup_error" not in report
+        and all(case["status"] == "pass" for case in report["cases"])
+    )
+    report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(report, indent=2))
+    print(f"report: {report_path.resolve()}")
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/rtvi/rt-vlm/tests/run_choice_output_contract.py
+++ b/services/rtvi/rt-vlm/tests/run_choice_output_contract.py
@@ -326,7 +326,8 @@ def main():
     finally:
         if file_id:
             try:
-                session.delete(f"{backend}/v1/files/delete/{file_id}", timeout=30)
+                response = session.delete(f"{backend}/v1/files/{file_id}", timeout=30)
+                response.raise_for_status()
             except requests.RequestException as exc:
                 report["cleanup_error"] = str(exc)
         session.close()


### PR DESCRIPTION
## Description

Adds finite-choice structured output support to RT-VLM.

- Accepts `response_format={"type":"choice","choices":[...]}` with bounded, non-blank, unique choices.
- Preserves the choice contract through the existing shared generation configuration.
- Maps the contract to vLLM `StructuredOutputsParams(choice=...)`.
- Treats finite choice as structured output, including forced EOS handling.
- Adds API validation, propagation, vLLM mapping tests, and a fail-closed device runner.

This enables protocol-constrained JSON strings and compact event-code experiments without changing existing `text`, `json_object`, or `json_schema` defaults.

## Device validation

Run on the target device with a short local clip and a freshly built PR image:

```bash
cd services/rtvi/rt-vlm
python3 tests/run_choice_output_contract.py \
  --backend http://localhost:8000 \
  --video-path /path/to/short-test.mp4 \
  --report /tmp/rtvi-choice-contract.json
```

The default matrix is fail-closed and contains 15 cases:

- Seven request-boundary rejections: missing, empty, blank, duplicate, excessive-count, overlong, and misplaced choices.
- Three forced singleton choices, including compact normal and event encodings.
- Three repeated multi-choice generations; every output from every chunk must belong to the allowed set.
- One protocol-constrained JSON choice case; every chunk must be one exact legal JSON string.
- One existing `json_object` regression case.

The JSON report records GPU identity, model, per-case status, latency, and generated chunk outputs. The process exits nonzero on setup, validation, generation, or cleanup failure.

## Validation

- Passed the device runner helper self-check and command-line smoke test.
- Passed `ruff check`, `ruff format --check`, `python3 -m py_compile`, and `git diff --check`.
- Passed repository hooks: TruffleHog, large-file policy, SPDX headers, and DCO.
- Passed an isolated Pydantic request-model self-check covering valid, missing, blank, duplicate, and misplaced choices.
- Full RT-VLM pytest was not run locally because the synchronized `make rtvi_vlm` target currently skips unit tests; focused tests are included for container and PR CI.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally.
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco) compliant.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.