### PR TITLE
fix(deploy): export GHCR container channel for compose in dev-profile

### DIFF
--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -1497,6 +1497,30 @@ function print_args() {
   echo "=========================="
 }
 
+function export_managed_container_channel() {
+  local deployment_directory="$1"
+
+  # Read containers.env in a subshell: `set -a` exports everything it defines,
+  # and Compose gives the process environment precedence over every --env-file.
+  # Leaking those exports silently overrode the image tags this script wrote to
+  # generated.env -- including the SBSA tag swap, which appeared to succeed
+  # while Compose kept deploying the default tags.
+  #
+  # GHCR acceptance only exports VSS_CONTAINER_TAG. Export the shared registry
+  # and tag pair here so compose does not fall back to nvstaging/nvidia inline
+  # defaults while still leaving per-image tag overrides in generated.env.
+  eval "$(
+    (
+      set -a
+      # shellcheck disable=SC1091
+      source "${deployment_directory}/containers.env"
+      set +a
+      printf 'export VSS_CONTAINER_REGISTRY=%q\n' "${VSS_CONTAINER_REGISTRY}"
+      printf 'export VSS_CONTAINER_TAG=%q\n' "${VSS_CONTAINER_TAG}"
+    )
+  )"
+}
+
 function state_up() {
   local _profile_dir _source_env _overrides_env _generated_env
   _profile_dir="${deployment_directory}/developer-profiles/dev-profile-${profile}"
@@ -1998,19 +2022,9 @@ function state_up() {
   fi
 
   # Resolve and display the managed container channel before deployment.
-  # Read containers.env in a subshell: `set -a` exports everything it defines,
-  # and Compose gives the process environment precedence over every --env-file.
-  # Leaking those exports silently overrode the image tags this script wrote to
-  # generated.env -- including the SBSA tag swap, which appeared to succeed
-  # while Compose kept deploying the default tags.
-  (
-    set -a
-    # shellcheck disable=SC1091
-    source "${deployment_directory}/containers.env"
-    set +a
-    echo "[INFO] Managed container registry: ${VSS_CONTAINER_REGISTRY}"
-    echo "[INFO] Managed container tag:      ${VSS_CONTAINER_TAG}"
-  )
+  export_managed_container_channel "${deployment_directory}"
+  echo "[INFO] Managed container registry: ${VSS_CONTAINER_REGISTRY}"
+  echo "[INFO] Managed container tag:      ${VSS_CONTAINER_TAG}"
 
   # -f disables Compose's default file discovery, so the base file must be named
   # explicitly alongside any overlay.

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -917,6 +917,34 @@ else
 fi
 rm -f "${_out_compose_env_order}" "${_err_compose_env_order}"
 
+# GHCR acceptance passes VSS_CONTAINER_TAG without VSS_CONTAINER_REGISTRY.
+# state_up must export the registry from containers.env so compose does not
+# fall back to nvstaging/nvidia inline defaults.
+_out_ghcr_channel="$(mktemp)"
+_err_ghcr_channel="$(mktemp)"
+unset VSS_CONTAINER_REGISTRY
+export VSS_CONTAINER_TAG=pr-ghcr-channel-test
+cd "${REPO_ROOT}"
+set +e
+timeout "${TEST_TIMEOUT}" "$DEV_PROFILE" up -p base -i 127.0.0.1 -d > "${_out_ghcr_channel}" 2> "${_err_ghcr_channel}"
+_ghcr_channel_exit=$?
+set -e
+unset VSS_CONTAINER_TAG
+if [[ ${_ghcr_channel_exit} -ne 0 ]]; then
+  echo "FAIL: dry-run with VSS_CONTAINER_TAG only exited ${_ghcr_channel_exit}"
+  ((TESTS_FAILED++)) || true
+elif ! grep -Fq "ghcr.io/nvidia-ai-blueprints/vss/vss-agent:pr-ghcr-channel-test" "${_out_ghcr_channel}"; then
+  echo "FAIL: resolved compose images should use GHCR when only VSS_CONTAINER_TAG is exported"
+  ((TESTS_FAILED++)) || true
+elif grep -Fq "nvcr.io/nvstaging/vss-core/vss-agent:pr-ghcr-channel-test" "${_out_ghcr_channel}"; then
+  echo "FAIL: resolved compose images should not use nvstaging when GHCR acceptance tag is set"
+  ((TESTS_FAILED++)) || true
+else
+  echo "PASS: resolved compose images use GHCR registry when VSS_CONTAINER_TAG is exported"
+  ((TESTS_PASSED++)) || true
+fi
+rm -f "${_out_ghcr_channel}" "${_err_ghcr_channel}"
+
 # Search: RT-VLM (vss-rtvi-vlm) is always deployed because it serves both the critic and
 # video_understanding. It is activated via the explicit "rtvi-vlm" compose profile (no vlm_
 # NIM profile) and the agent is wired to it with VLM_NAME_SLUG=none, VLM_MODEL_TYPE=rtvi,


### PR DESCRIPTION
Fixes the `test-base` / `test-alerts-verification` / `test-alerts-realtime` / `test-search` failures on #1892. Targets `feat/search-hw-support` so it can be merged straight into that branch; the diff here is one commit.

## The failure

The reported symptom was a missing UI E2E report:

```
[publish-results] No UI E2E results found, checked: ['/results/vss-ui-results/base/ui-e2e-results-base.json', ...]
```

That is a consequence, not the cause. Playwright never ran because `docker compose up` failed ~7s in, in [pipeline 65800023](https://gitlab-master.nvidia.com/metromind/ci-vss-oss/-/pipelines/65800023):

```
Error response from daemon: manifest for nvcr.io/nvstaging/vss-core/vss-agent:pr-1892-85e61e48d4a2 not found: manifest unknown
```

| job | first missing manifest |
|---|---|
| [test-base](https://gitlab-master.nvidia.com/metromind/ci-vss-oss/-/jobs/422114734) | `nvcr.io/nvstaging/vss-core/vss-agent:pr-1892-…` |
| [test-alerts-verification](https://gitlab-master.nvidia.com/metromind/ci-vss-oss/-/jobs/422118256) / [test-alerts-realtime](https://gitlab-master.nvidia.com/metromind/ci-vss-oss/-/jobs/422118281) | `nvcr.io/nvidia/vss-core/vss-vios-sensor:pr-1892-…` |
| [test-search](https://gitlab-master.nvidia.com/metromind/ci-vss-oss/-/jobs/422118263) | `nvcr.io/nvstaging/vss-core/sdr-mw-l:pr-1892-…` |

The tag itself is fine — the candidate set is published on GHCR, and `setup-eval-overrides.sh` verified it (`GHCR acceptance: ghcr.io/nvidia-ai-blueprints/vss:pr-1892-85e61e48d4a2`). The registry is what was wrong: an NGC repository with a GHCR PR tag is a coordinate that cannot exist.

## Cause

`7326af58` moved the `containers.env` read in `state_up()` into a subshell, correctly, to stop `set -a` from exporting `VSS_RT_CV_TAG` / `VSS_RT_EMBED_TAG` / `VSS_RT_VLM_TAG` defaults over the values the script had just written to `generated.env` (the SBSA swap silently no-opping).

`VSS_CONTAINER_REGISTRY` was collateral. GitHub sends `VSS_CONTAINER_TAG` when it triggers acceptance, but not the registry — the registry has always come from `containers.env`. With the whole file confined to a subshell, compose interpolation saw the PR tag from the job environment and no registry, so it fell through to the inline `${...:-nvcr.io/nvstaging/vss-core}` / `nvcr.io/nvidia/vss-core` defaults.

`eval-warehouse-bp-wh-2d` passed in the same pipeline because `blueprint-deploy.sh` still sources `containers.env` in the parent shell, so it pulled `ghcr.io/nvidia-ai-blueprints/vss/vss-agent:pr-1892-…` and deployed normally.

## Change

`export_managed_container_channel()` still reads `containers.env` in a subshell, and now promotes exactly two variables — `VSS_CONTAINER_REGISTRY` and `VSS_CONTAINER_TAG` — into `state_up`'s environment. Both are already `${VAR:-default}` in `containers.env`, so an externally supplied value is preserved rather than overwritten. Per-image tags stay out of the environment, which is what `7326af58` was protecting, so `generated.env` remains authoritative for the SBSA swap.

## Test plan

- [x] New case in `deploy/docker/test-scripts/test-dev-profile.sh` reproduces the CI environment: `VSS_CONTAINER_TAG` exported with `VSS_CONTAINER_REGISTRY` unset, then asserts the resolved compose images contain `ghcr.io/nvidia-ai-blueprints/vss/vss-agent:<tag>` and *not* the `nvstaging` coordinate. It fails on the parent commit and passes here.
- [x] Full `test-dev-profile.sh` suite passes, including the existing `generated.env search selects SBSA RT Embed tag` case that pins the behaviour `7326af58` fixed.
- [ ] Re-run GHCR acceptance on #1892 and confirm the four developer-profile jobs deploy and produce `ui-e2e-results-*.json`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d.
- [x] New or existing tests cover these changes.
- [x] No secrets, API keys, or credentials committed.