### PR TITLE
Fix(docs)/tegra deploy instructions

### DIFF
--- a/docs/agent-workflow-alert-verification.mdx
+++ b/docs/agent-workflow-alert-verification.mdx
@@ -154,11 +154,11 @@ HARDWARE_PROFILE=H100
 ```ini
 HARDWARE_PROFILE=H100
 MODE=2d_cv
-LLM_MODE=local
 LLM_DEVICE_ID=1
-VLM_MODE=local
 VLM_DEVICE_ID=2 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
 RT_VLM_DEVICE_ID=2 # Must match VLM_DEVICE_ID
+LLM_MODE=local
+VLM_MODE=local
 ```
 </Tab>
 <Tab title="Remote LLM">
@@ -214,26 +214,17 @@ RTVI_VLM_MODEL_PATH=none
 </Tab>
 <Tab title="GB300">
 <Tabs>
-<Tab title="Shared GPU">
-
-```ini
-HARDWARE_PROFILE=GB300
-VSS_RT_CV_TAG=develop-latest-sbsa
-VSS_RT_VLM_TAG=develop-latest-sbsa
-```
-</Tab>
-<Tab title="Dedicated GPU">
+<Tab title="Default">
 
 ```ini
 HARDWARE_PROFILE=GB300
 MODE=2d_cv
+LLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+RT_CV_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+RT_VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
 VSS_RT_CV_TAG=develop-latest-sbsa
 VSS_RT_VLM_TAG=develop-latest-sbsa
-LLM_MODE=local
-LLM_DEVICE_ID=1
-VLM_MODE=local
-VLM_DEVICE_ID=2 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
-RT_VLM_DEVICE_ID=2 # Must match VLM_DEVICE_ID
 ```
 </Tab>
 <Tab title="Remote LLM">
@@ -241,6 +232,9 @@ RT_VLM_DEVICE_ID=2 # Must match VLM_DEVICE_ID
 ```ini
 HARDWARE_PROFILE=GB300
 MODE=2d_cv
+RT_CV_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+RT_VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
 VSS_RT_CV_TAG=develop-latest-sbsa
 VSS_RT_VLM_TAG=develop-latest-sbsa
 LLM_MODE=remote
@@ -255,6 +249,9 @@ LLM_MODEL_TYPE=<nim-or-openai>
 ```ini
 HARDWARE_PROFILE=GB300
 MODE=2d_cv
+LLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+RT_CV_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+RT_VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
 VSS_RT_CV_TAG=develop-latest-sbsa
 VSS_RT_VLM_TAG=develop-latest-sbsa
 VLM_MODE=remote
@@ -273,6 +270,8 @@ RTVI_VLM_MODEL_PATH=none
 ```ini
 HARDWARE_PROFILE=GB300
 MODE=2d_cv
+RT_CV_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+RT_VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
 VSS_RT_CV_TAG=develop-latest-sbsa
 VSS_RT_VLM_TAG=develop-latest-sbsa
 LLM_MODE=remote
@@ -307,11 +306,11 @@ MODE=2d_cv
 ```ini
 HARDWARE_PROFILE=RTXPRO6000BW
 MODE=2d_cv
-LLM_MODE=local
 LLM_DEVICE_ID=1
-VLM_MODE=local
 VLM_DEVICE_ID=2 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
 RT_VLM_DEVICE_ID=2 # Must match VLM_DEVICE_ID
+LLM_MODE=local
+VLM_MODE=local
 ```
 </Tab>
 <Tab title="Remote LLM">
@@ -393,11 +392,11 @@ LLM_MODEL_TYPE=<nim-or-openai>
 ```ini
 HARDWARE_PROFILE=L40S
 MODE=2d_cv
-LLM_MODE=local
 LLM_DEVICE_ID=1
-VLM_MODE=local
 VLM_DEVICE_ID=2 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
 RT_VLM_DEVICE_ID=2 # Must match VLM_DEVICE_ID
+LLM_MODE=local
+VLM_MODE=local
 ```
 </Tab>
 <Tab title="Remote LLM">
@@ -451,7 +450,7 @@ RTVI_VLM_MODEL_PATH=none
 </Tab>
 </Tabs>
 </Tab>
-<Tab title="SPARK">
+<Tab title="DGX-SPARK">
 <Tabs>
 <Tab title="Remote LLM">
 See [VSS-Agent-Customization-configure-llm ](/vss/vision-agent/vss-agents/agent-customization/customize-models/configure-the-llm) for remote LLM endpoint options.
@@ -459,9 +458,12 @@ See [VSS-Agent-Customization-configure-llm ](/vss/vision-agent/vss-agents/agent-
 ```ini
 HARDWARE_PROFILE=DGX-SPARK
 MODE=2d_cv
-PERCEPTION_DOCKERFILE_PREFIX=EDGE-
+RT_CV_DEVICE_ID=0
+VLM_DEVICE_ID=0
+RT_VLM_DEVICE_ID=0
 VSS_RT_CV_TAG=develop-latest-sbsa
 VSS_RT_VLM_TAG=develop-latest-sbsa
+PERCEPTION_DOCKERFILE_PREFIX=EDGE-
 RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.4
 LLM_MODE=remote
 LLM_NAME_SLUG=none
@@ -480,6 +482,9 @@ See [VSS-Agent-Customization-configure-llm ](/vss/vision-agent/vss-agents/agent-
 ```ini
 HARDWARE_PROFILE=IGX-THOR
 MODE=2d_cv
+RT_CV_DEVICE_ID=0 # Adjust to the Thor GPU ID reported by nvidia-smi.
+VLM_DEVICE_ID=0 # Adjust to the Thor GPU ID reported by nvidia-smi.
+RT_VLM_DEVICE_ID=0 # Adjust to the Thor GPU ID reported by nvidia-smi.
 PERCEPTION_DOCKERFILE_PREFIX=EDGE-
 VLM_AS_VERIFIER_CONFIG_FILE_PREFIX=EDGE-LOCAL-VLM-
 LLM_MODE=remote
@@ -499,6 +504,9 @@ See [VSS-Agent-Customization-configure-llm ](/vss/vision-agent/vss-agents/agent-
 ```ini
 HARDWARE_PROFILE=AGX-THOR
 MODE=2d_cv
+RT_CV_DEVICE_ID=0 # Adjust to the Thor GPU ID reported by nvidia-smi.
+VLM_DEVICE_ID=0 # Adjust to the Thor GPU ID reported by nvidia-smi.
+RT_VLM_DEVICE_ID=0 # Adjust to the Thor GPU ID reported by nvidia-smi.
 PERCEPTION_DOCKERFILE_PREFIX=EDGE-
 VLM_AS_VERIFIER_CONFIG_FILE_PREFIX=EDGE-LOCAL-VLM-
 LLM_MODE=remote
@@ -530,11 +538,11 @@ VLM_ENV_FILE=/path/to/vlm.env
 ```ini
 HARDWARE_PROFILE=OTHER
 MODE=2d_cv
-LLM_MODE=local
 LLM_DEVICE_ID=1
-VLM_MODE=local
 VLM_DEVICE_ID=2 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
 RT_VLM_DEVICE_ID=2 # Must match VLM_DEVICE_ID
+LLM_MODE=local
+VLM_MODE=local
 LLM_ENV_FILE=/path/to/llm.env
 VLM_ENV_FILE=/path/to/vlm.env
 ```

--- a/docs/agent-workflow-lvs.mdx
+++ b/docs/agent-workflow-lvs.mdx
@@ -243,11 +243,11 @@ HARDWARE_PROFILE=H100
 
 ```ini
 HARDWARE_PROFILE=H100
-LLM_MODE=local
 LLM_DEVICE_ID=0
-VLM_MODE=local
 VLM_DEVICE_ID=1 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
 RT_VLM_DEVICE_ID=1 # Must match VLM_DEVICE_ID
+LLM_MODE=local
+VLM_MODE=local
 ```
 </Tab>
 <Tab title="Remote LLM">
@@ -300,27 +300,25 @@ RTVI_VLM_MODEL_PATH=none
 </Tab>
 <Tab title="GB300">
 <Tabs>
-<Tab title="Shared GPU">
+<Tab title="Default">
 
 ```ini
 HARDWARE_PROFILE=GB300
-```
-</Tab>
-<Tab title="Dedicated GPU">
-
-```ini
-HARDWARE_PROFILE=GB300
-LLM_MODE=local
-LLM_DEVICE_ID=0
-VLM_MODE=local
-VLM_DEVICE_ID=1 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
-RT_VLM_DEVICE_ID=1 # Must match VLM_DEVICE_ID
+LLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+RT_VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+VSS_RT_VLM_TAG=develop-latest-sbsa
+VSS_VIDEO_SUMMARIZATION_TAG=develop-latest-sbsa
 ```
 </Tab>
 <Tab title="Remote LLM">
 
 ```ini
 HARDWARE_PROFILE=GB300
+VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+RT_VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+VSS_RT_VLM_TAG=develop-latest-sbsa
+VSS_VIDEO_SUMMARIZATION_TAG=develop-latest-sbsa
 LLM_MODE=remote
 LLM_NAME_SLUG=none
 LLM_BASE_URL=https://<llm-endpoint-without-v1>
@@ -332,6 +330,10 @@ LLM_MODEL_TYPE=<nim-or-openai>
 
 ```ini
 HARDWARE_PROFILE=GB300
+LLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+RT_VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+VSS_RT_VLM_TAG=develop-latest-sbsa
+VSS_VIDEO_SUMMARIZATION_TAG=develop-latest-sbsa
 VLM_MODE=remote
 VLM_NAME_SLUG=none
 VLM_BASE_URL=https://<vlm-endpoint-without-v1>
@@ -347,6 +349,9 @@ RTVI_VLM_MODEL_PATH=none
 
 ```ini
 HARDWARE_PROFILE=GB300
+RT_VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+VSS_RT_VLM_TAG=develop-latest-sbsa
+VSS_VIDEO_SUMMARIZATION_TAG=develop-latest-sbsa
 LLM_MODE=remote
 LLM_NAME_SLUG=none
 LLM_BASE_URL=https://<llm-endpoint-without-v1>
@@ -377,11 +382,11 @@ HARDWARE_PROFILE=RTXPRO6000BW
 
 ```ini
 HARDWARE_PROFILE=RTXPRO6000BW
-LLM_MODE=local
 LLM_DEVICE_ID=0
-VLM_MODE=local
 VLM_DEVICE_ID=1 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
 RT_VLM_DEVICE_ID=1 # Must match VLM_DEVICE_ID
+LLM_MODE=local
+VLM_MODE=local
 ```
 </Tab>
 <Tab title="Remote LLM">
@@ -438,11 +443,11 @@ RTVI_VLM_MODEL_PATH=none
 
 ```ini
 HARDWARE_PROFILE=L40S
-LLM_MODE=local
 LLM_DEVICE_ID=0
-VLM_MODE=local
 VLM_DEVICE_ID=1 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
 RT_VLM_DEVICE_ID=1 # Must match VLM_DEVICE_ID
+LLM_MODE=local
+VLM_MODE=local
 ```
 </Tab>
 <Tab title="Remote LLM">
@@ -509,11 +514,11 @@ VLM_ENV_FILE=/path/to/vlm.env
 
 ```ini
 HARDWARE_PROFILE=OTHER
-LLM_MODE=local
 LLM_DEVICE_ID=0
-VLM_MODE=local
 VLM_DEVICE_ID=1 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
 RT_VLM_DEVICE_ID=1 # Must match VLM_DEVICE_ID
+LLM_MODE=local
+VLM_MODE=local
 LLM_ENV_FILE=/path/to/llm.env
 VLM_ENV_FILE=/path/to/vlm.env
 ```

--- a/docs/agent-workflow-rt-alert.mdx
+++ b/docs/agent-workflow-rt-alert.mdx
@@ -296,12 +296,12 @@ COMPOSE_PROFILES=${COMPOSE_PROFILES_VLM}
 ```ini
 HARDWARE_PROFILE=H100
 MODE=2d_vlm
-ALERT_AGENT_ALWAYS_ON=true
-LLM_MODE=local
 LLM_DEVICE_ID=1
-VLM_MODE=local
 VLM_DEVICE_ID=2 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
 RT_VLM_DEVICE_ID=2 # Must match VLM_DEVICE_ID
+ALERT_AGENT_ALWAYS_ON=true
+LLM_MODE=local
+VLM_MODE=local
 COMPOSE_PROFILES=${COMPOSE_PROFILES_VLM}
 ```
 </Tab>
@@ -323,31 +323,18 @@ COMPOSE_PROFILES=${COMPOSE_PROFILES_VLM}
 </Tab>
 <Tab title="GB300">
 <Tabs>
-<Tab title="Shared GPU">
+<Tab title="Default">
 
 ```ini
 HARDWARE_PROFILE=GB300
 MODE=2d_vlm
+LLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+RT_VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
 VSS_RT_CV_TAG=develop-latest-sbsa
 VSS_RT_VLM_TAG=develop-latest-sbsa
 ALERT_AGENT_ALWAYS_ON=true
 RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.4
-COMPOSE_PROFILES=${COMPOSE_PROFILES_VLM}
-```
-</Tab>
-<Tab title="Dedicated GPU">
-
-```ini
-HARDWARE_PROFILE=GB300
-MODE=2d_vlm
-VSS_RT_CV_TAG=develop-latest-sbsa
-VSS_RT_VLM_TAG=develop-latest-sbsa
-ALERT_AGENT_ALWAYS_ON=true
-LLM_MODE=local
-LLM_DEVICE_ID=1
-VLM_MODE=local
-VLM_DEVICE_ID=2 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
-RT_VLM_DEVICE_ID=2 # Must match VLM_DEVICE_ID
 COMPOSE_PROFILES=${COMPOSE_PROFILES_VLM}
 ```
 </Tab>
@@ -356,6 +343,8 @@ COMPOSE_PROFILES=${COMPOSE_PROFILES_VLM}
 ```ini
 HARDWARE_PROFILE=GB300
 MODE=2d_vlm
+VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+RT_VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
 VSS_RT_CV_TAG=develop-latest-sbsa
 VSS_RT_VLM_TAG=develop-latest-sbsa
 ALERT_AGENT_ALWAYS_ON=true
@@ -386,12 +375,12 @@ COMPOSE_PROFILES=${COMPOSE_PROFILES_VLM}
 ```ini
 HARDWARE_PROFILE=RTXPRO6000BW
 MODE=2d_vlm
-ALERT_AGENT_ALWAYS_ON=true
-LLM_MODE=local
 LLM_DEVICE_ID=1
-VLM_MODE=local
 VLM_DEVICE_ID=2 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
 RT_VLM_DEVICE_ID=2 # Must match VLM_DEVICE_ID
+ALERT_AGENT_ALWAYS_ON=true
+LLM_MODE=local
+VLM_MODE=local
 COMPOSE_PROFILES=${COMPOSE_PROFILES_VLM}
 ```
 </Tab>
@@ -441,12 +430,12 @@ COMPOSE_PROFILES=${COMPOSE_PROFILES_VLM}
 ```ini
 HARDWARE_PROFILE=L40S
 MODE=2d_vlm
-ALERT_AGENT_ALWAYS_ON=true
-LLM_MODE=local
 LLM_DEVICE_ID=1
-VLM_MODE=local
 VLM_DEVICE_ID=2 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
 RT_VLM_DEVICE_ID=2 # Must match VLM_DEVICE_ID
+ALERT_AGENT_ALWAYS_ON=true
+LLM_MODE=local
+VLM_MODE=local
 COMPOSE_PROFILES=${COMPOSE_PROFILES_VLM}
 ```
 </Tab>
@@ -466,7 +455,7 @@ COMPOSE_PROFILES=${COMPOSE_PROFILES_VLM}
 </Tab>
 </Tabs>
 </Tab>
-<Tab title="SPARK">
+<Tab title="DGX-SPARK">
 <Tabs>
 <Tab title="Remote LLM">
 See [VSS-Agent-Customization-configure-llm ](/vss/vision-agent/vss-agents/agent-customization/customize-models/configure-the-llm) for remote LLM endpoint options.
@@ -474,9 +463,11 @@ See [VSS-Agent-Customization-configure-llm ](/vss/vision-agent/vss-agents/agent-
 ```ini
 HARDWARE_PROFILE=DGX-SPARK
 MODE=2d_vlm
-PERCEPTION_DOCKERFILE_PREFIX=EDGE-
+VLM_DEVICE_ID=0
+RT_VLM_DEVICE_ID=0
 VSS_RT_CV_TAG=develop-latest-sbsa
 VSS_RT_VLM_TAG=develop-latest-sbsa
+PERCEPTION_DOCKERFILE_PREFIX=EDGE-
 RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.4
 ALERT_AGENT_ALWAYS_ON=true
 LLM_MODE=remote
@@ -497,6 +488,8 @@ See [VSS-Agent-Customization-configure-llm ](/vss/vision-agent/vss-agents/agent-
 ```ini
 HARDWARE_PROFILE=IGX-THOR
 MODE=2d_vlm
+VLM_DEVICE_ID=0 # Adjust to the Thor GPU ID reported by nvidia-smi.
+RT_VLM_DEVICE_ID=0 # Adjust to the Thor GPU ID reported by nvidia-smi.
 PERCEPTION_DOCKERFILE_PREFIX=EDGE-
 VLM_AS_VERIFIER_CONFIG_FILE_PREFIX=EDGE-LOCAL-VLM-
 ALERT_AGENT_ALWAYS_ON=true
@@ -518,6 +511,8 @@ See [VSS-Agent-Customization-configure-llm ](/vss/vision-agent/vss-agents/agent-
 ```ini
 HARDWARE_PROFILE=AGX-THOR
 MODE=2d_vlm
+VLM_DEVICE_ID=0 # Adjust to the Thor GPU ID reported by nvidia-smi.
+RT_VLM_DEVICE_ID=0 # Adjust to the Thor GPU ID reported by nvidia-smi.
 PERCEPTION_DOCKERFILE_PREFIX=EDGE-
 VLM_AS_VERIFIER_CONFIG_FILE_PREFIX=EDGE-LOCAL-VLM-
 ALERT_AGENT_ALWAYS_ON=true
@@ -554,12 +549,12 @@ COMPOSE_PROFILES=${COMPOSE_PROFILES_VLM}
 ```ini
 HARDWARE_PROFILE=OTHER
 MODE=2d_vlm
-ALERT_AGENT_ALWAYS_ON=true
-LLM_MODE=local
 LLM_DEVICE_ID=1
-VLM_MODE=local
 VLM_DEVICE_ID=2 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
 RT_VLM_DEVICE_ID=2 # Must match VLM_DEVICE_ID
+ALERT_AGENT_ALWAYS_ON=true
+LLM_MODE=local
+VLM_MODE=local
 LLM_ENV_FILE=/path/to/llm.env
 VLM_ENV_FILE=/path/to/vlm.env
 COMPOSE_PROFILES=${COMPOSE_PROFILES_VLM}

--- a/docs/agent-workflow-search.mdx
+++ b/docs/agent-workflow-search.mdx
@@ -204,11 +204,11 @@ HARDWARE_PROFILE=H100
 
 ```ini
 HARDWARE_PROFILE=H100
-LLM_MODE=local
 LLM_DEVICE_ID=2
-VLM_MODE=local
 VLM_DEVICE_ID=3 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
 RT_VLM_DEVICE_ID=3 # Must match VLM_DEVICE_ID
+LLM_MODE=local
+VLM_MODE=local
 ```
 </Tab>
 <Tab title="Remote LLM">
@@ -265,29 +265,32 @@ RTVI_VLM_MODEL_PATH=none
 <Tab title="GB300">
 <Tabs>
 <Tab title="Default">
-3 GPUs. LLM shares a base GPU; VLM gets a dedicated GPU.
+Use the GB300 GPU for all local services. On a DGX Station, confirm its ID with `nvidia-smi` because it may be GPU 0 or 1.
 
 ```ini
 HARDWARE_PROFILE=GB300
-```
-</Tab>
-<Tab title="Dedicated GPU">
-4 GPUs. Both LLM and VLM get dedicated GPUs. To use the default layout (3 GPUs, LLM shared), omit both device ID flags.
-
-```ini
-HARDWARE_PROFILE=GB300
-LLM_MODE=local
-LLM_DEVICE_ID=2
-VLM_MODE=local
-VLM_DEVICE_ID=3 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
-RT_VLM_DEVICE_ID=3 # Must match VLM_DEVICE_ID
+LLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+RT_CV_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+RT_EMBED_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+RT_VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+VSS_RT_CV_TAG=develop-latest-sbsa
+VSS_RT_EMBED_TAG=develop-latest-sbsa
+VSS_RT_VLM_TAG=develop-latest-sbsa
 ```
 </Tab>
 <Tab title="Remote LLM">
-3 GPUs. VLM gets a dedicated GPU; LLM is offloaded.
+The VLM uses the GB300 GPU; the LLM is offloaded.
 
 ```ini
 HARDWARE_PROFILE=GB300
+RT_CV_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+RT_EMBED_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+RT_VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+VSS_RT_CV_TAG=develop-latest-sbsa
+VSS_RT_EMBED_TAG=develop-latest-sbsa
+VSS_RT_VLM_TAG=develop-latest-sbsa
 LLM_MODE=remote
 LLM_NAME_SLUG=none
 LLM_BASE_URL=https://<llm-endpoint-without-v1>
@@ -296,10 +299,17 @@ LLM_MODEL_TYPE=<nim-or-openai>
 ```
 </Tab>
 <Tab title="Remote VLM">
-2 GPUs. LLM time-shares with base service GPUs.
+The LLM uses the GB300 GPU; the VLM is offloaded.
 
 ```ini
 HARDWARE_PROFILE=GB300
+LLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+RT_CV_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+RT_EMBED_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+RT_VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+VSS_RT_CV_TAG=develop-latest-sbsa
+VSS_RT_EMBED_TAG=develop-latest-sbsa
+VSS_RT_VLM_TAG=develop-latest-sbsa
 VLM_MODE=remote
 VLM_NAME_SLUG=none
 VLM_BASE_URL=https://<vlm-endpoint-without-v1>
@@ -316,6 +326,12 @@ RTVI_VLM_MODEL_PATH=none
 
 ```ini
 HARDWARE_PROFILE=GB300
+RT_CV_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+RT_EMBED_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+RT_VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+VSS_RT_CV_TAG=develop-latest-sbsa
+VSS_RT_EMBED_TAG=develop-latest-sbsa
+VSS_RT_VLM_TAG=develop-latest-sbsa
 LLM_MODE=remote
 LLM_NAME_SLUG=none
 LLM_BASE_URL=https://<llm-endpoint-without-v1>
@@ -348,11 +364,11 @@ HARDWARE_PROFILE=RTXPRO6000BW
 
 ```ini
 HARDWARE_PROFILE=RTXPRO6000BW
-LLM_MODE=local
 LLM_DEVICE_ID=2
-VLM_MODE=local
 VLM_DEVICE_ID=3 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
 RT_VLM_DEVICE_ID=3 # Must match VLM_DEVICE_ID
+LLM_MODE=local
+VLM_MODE=local
 ```
 </Tab>
 <Tab title="Remote LLM">
@@ -413,11 +429,11 @@ RTVI_VLM_MODEL_PATH=none
 
 ```ini
 HARDWARE_PROFILE=L40S
-LLM_MODE=local
 LLM_DEVICE_ID=2
-VLM_MODE=local
 VLM_DEVICE_ID=3 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
 RT_VLM_DEVICE_ID=3 # Must match VLM_DEVICE_ID
+LLM_MODE=local
+VLM_MODE=local
 ```
 </Tab>
 <Tab title="Remote LLM">
@@ -425,14 +441,14 @@ RT_VLM_DEVICE_ID=3 # Must match VLM_DEVICE_ID
 
 ```ini
 HARDWARE_PROFILE=L40S
+VLM_DEVICE_ID=2 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
+RT_VLM_DEVICE_ID=2 # Must match VLM_DEVICE_ID
 LLM_MODE=remote
 LLM_NAME_SLUG=none
 LLM_BASE_URL=https://<llm-endpoint-without-v1>
 LLM_NAME=<llm-model-id-from-v1-models>
 LLM_MODEL_TYPE=<nim-or-openai>
 VLM_MODE=local
-VLM_DEVICE_ID=2 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
-RT_VLM_DEVICE_ID=2 # Must match VLM_DEVICE_ID
 ```
 </Tab>
 <Tab title="Remote VLM">
@@ -440,8 +456,8 @@ RT_VLM_DEVICE_ID=2 # Must match VLM_DEVICE_ID
 
 ```ini
 HARDWARE_PROFILE=L40S
-LLM_MODE=local
 LLM_DEVICE_ID=2
+LLM_MODE=local
 VLM_MODE=remote
 VLM_NAME_SLUG=none
 VLM_BASE_URL=https://<vlm-endpoint-without-v1>
@@ -493,11 +509,11 @@ LLM_ENV_FILE=/path/to/llm.env
 
 ```ini
 HARDWARE_PROFILE=OTHER
-LLM_MODE=local
 LLM_DEVICE_ID=2
-VLM_MODE=local
 VLM_DEVICE_ID=3 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
 RT_VLM_DEVICE_ID=3 # Must match VLM_DEVICE_ID
+LLM_MODE=local
+VLM_MODE=local
 LLM_ENV_FILE=/path/to/llm.env
 ```
 </Tab>

--- a/docs/edge-deployment.mdx
+++ b/docs/edge-deployment.mdx
@@ -111,6 +111,8 @@ docker compose -f compose.yml \
    # developer-profiles/dev-profile-base/user-overrides.env
    HARDWARE_PROFILE=DGX-SPARK
    VSS_RT_VLM_TAG=develop-latest-sbsa
+   VLM_DEVICE_ID=0
+   RT_VLM_DEVICE_ID=0
    RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.7
    LLM_MODE=remote
    LLM_NAME_SLUG=none
@@ -133,6 +135,10 @@ In this case, you can skip running the vLLM container entirely, as the blueprint
 # Free up GPU for a full blueprint deployment first:
 # docker stop nemotron-edge && docker rm nemotron-edge
 HARDWARE_PROFILE=DGX-SPARK
+VSS_RT_VLM_TAG=develop-latest-sbsa
+LLM_DEVICE_ID=0
+VLM_DEVICE_ID=0
+RT_VLM_DEVICE_ID=0
 LLM_MODE=local
 LLM_NAME=nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8
 LLM_NAME_SLUG=nemotron-nano
@@ -172,6 +178,8 @@ must be tuned to coexist.
    ```ini
    # developer-profiles/dev-profile-base/user-overrides.env
    HARDWARE_PROFILE=AGX-THOR # Set IGX-THOR on IGX hardware.
+   VLM_DEVICE_ID=0 # Adjust to the Thor GPU ID reported by nvidia-smi.
+   RT_VLM_DEVICE_ID=0 # Adjust to the Thor GPU ID reported by nvidia-smi.
    RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.35
    LLM_MODE=remote
    LLM_NAME_SLUG=none
@@ -191,6 +199,9 @@ In this case, you can skip running the vLLM container entirely, as the blueprint
 # Free up GPU for a full blueprint deployment first:
 # docker stop nemotron-edge && docker rm nemotron-edge
 HARDWARE_PROFILE=AGX-THOR # Set IGX-THOR on IGX hardware.
+LLM_DEVICE_ID=0 # Adjust to the Thor GPU ID reported by nvidia-smi.
+VLM_DEVICE_ID=0 # Adjust to the Thor GPU ID reported by nvidia-smi.
+RT_VLM_DEVICE_ID=0 # Adjust to the Thor GPU ID reported by nvidia-smi.
 # To choose a local model, set LLM_NAME and LLM_NAME_SLUG in this file.
 ```
 

--- a/docs/prerequisites.mdx
+++ b/docs/prerequisites.mdx
@@ -282,7 +282,7 @@ The following tables show the number of GPUs needed for each development profile
 | [dev-profile-search ](/vss/vision-agent/agent-workflows/search) <sup>2</sup> | 4 | 3 | 3 | 2 |
 
 </Tab>
-<Tab title="SPARK">
+<Tab title="DGX-SPARK">
 
 | **Profile** | **Remote LLM** |
 | --- | --- |

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -202,11 +202,11 @@ HARDWARE_PROFILE=H100
 
 ```ini
 HARDWARE_PROFILE=H100
-LLM_MODE=local
 LLM_DEVICE_ID=0
-VLM_MODE=local
 VLM_DEVICE_ID=1 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
 RT_VLM_DEVICE_ID=1 # Must match VLM_DEVICE_ID
+LLM_MODE=local
+VLM_MODE=local
 ```
 </Tab>
 <Tab title="Remote LLM">
@@ -259,27 +259,23 @@ RTVI_VLM_MODEL_PATH=none
 </Tab>
 <Tab title="GB300">
 <Tabs>
-<Tab title="Shared GPU">
+<Tab title="Default">
 
 ```ini
 HARDWARE_PROFILE=GB300
-```
-</Tab>
-<Tab title="Dedicated GPU">
-
-```ini
-HARDWARE_PROFILE=GB300
-LLM_MODE=local
-LLM_DEVICE_ID=0
-VLM_MODE=local
-VLM_DEVICE_ID=1 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
-RT_VLM_DEVICE_ID=1 # Must match VLM_DEVICE_ID
+LLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+RT_VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+VSS_RT_VLM_TAG=develop-latest-sbsa
 ```
 </Tab>
 <Tab title="Remote LLM">
 
 ```ini
 HARDWARE_PROFILE=GB300
+VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+RT_VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+VSS_RT_VLM_TAG=develop-latest-sbsa
 LLM_MODE=remote
 LLM_NAME_SLUG=none
 LLM_BASE_URL=https://<llm-endpoint-without-v1>
@@ -291,6 +287,9 @@ LLM_MODEL_TYPE=<nim-or-openai>
 
 ```ini
 HARDWARE_PROFILE=GB300
+LLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+RT_VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+VSS_RT_VLM_TAG=develop-latest-sbsa
 VLM_MODE=remote
 VLM_NAME_SLUG=none
 VLM_BASE_URL=https://<vlm-endpoint-without-v1>
@@ -306,6 +305,8 @@ RTVI_VLM_MODEL_PATH=none
 
 ```ini
 HARDWARE_PROFILE=GB300
+RT_VLM_DEVICE_ID=0 # Adjust to the GB300 GPU ID reported by nvidia-smi.
+VSS_RT_VLM_TAG=develop-latest-sbsa
 LLM_MODE=remote
 LLM_NAME_SLUG=none
 LLM_BASE_URL=https://<llm-endpoint-without-v1>
@@ -336,11 +337,11 @@ HARDWARE_PROFILE=RTXPRO6000BW
 
 ```ini
 HARDWARE_PROFILE=RTXPRO6000BW
-LLM_MODE=local
 LLM_DEVICE_ID=0
-VLM_MODE=local
 VLM_DEVICE_ID=1 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
 RT_VLM_DEVICE_ID=1 # Must match VLM_DEVICE_ID
+LLM_MODE=local
+VLM_MODE=local
 ```
 </Tab>
 <Tab title="Remote LLM">
@@ -397,11 +398,11 @@ RTVI_VLM_MODEL_PATH=none
 
 ```ini
 HARDWARE_PROFILE=L40S
-LLM_MODE=local
 LLM_DEVICE_ID=0
-VLM_MODE=local
 VLM_DEVICE_ID=1 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
 RT_VLM_DEVICE_ID=1 # Must match VLM_DEVICE_ID
+LLM_MODE=local
+VLM_MODE=local
 ```
 </Tab>
 <Tab title="Remote LLM">
@@ -452,7 +453,7 @@ RTVI_VLM_MODEL_PATH=none
 </Tab>
 </Tabs>
 </Tab>
-<Tab title="SPARK">
+<Tab title="DGX-SPARK">
 <Tabs>
 <Tab title="Remote LLM">
 See [VSS-Agent-Customization-configure-llm ](/vss/vision-agent/vss-agents/agent-customization/customize-models/configure-the-llm) for remote LLM endpoint options,
@@ -460,6 +461,8 @@ and [edge-deployment](/vss/appendix/additional-deployments/edge-deployment) for 
 
 ```ini
 HARDWARE_PROFILE=DGX-SPARK
+VLM_DEVICE_ID=0
+RT_VLM_DEVICE_ID=0
 VSS_RT_VLM_TAG=develop-latest-sbsa
 RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.7
 LLM_MODE=remote
@@ -479,6 +482,8 @@ and [edge-deployment](/vss/appendix/additional-deployments/edge-deployment) for 
 
 ```ini
 HARDWARE_PROFILE=IGX-THOR
+VLM_DEVICE_ID=0 # Adjust to the Thor GPU ID reported by nvidia-smi.
+RT_VLM_DEVICE_ID=0 # Adjust to the Thor GPU ID reported by nvidia-smi.
 RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.35
 LLM_MODE=remote
 LLM_NAME_SLUG=none
@@ -497,6 +502,8 @@ and [edge-deployment](/vss/appendix/additional-deployments/edge-deployment) for 
 
 ```ini
 HARDWARE_PROFILE=AGX-THOR
+VLM_DEVICE_ID=0 # Adjust to the Thor GPU ID reported by nvidia-smi.
+RT_VLM_DEVICE_ID=0 # Adjust to the Thor GPU ID reported by nvidia-smi.
 RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.35
 LLM_MODE=remote
 LLM_NAME_SLUG=none
@@ -523,11 +530,11 @@ VLM_ENV_FILE=/path/to/vlm.env
 
 ```ini
 HARDWARE_PROFILE=OTHER
-LLM_MODE=local
 LLM_DEVICE_ID=0
-VLM_MODE=local
 VLM_DEVICE_ID=1 # Any non-shared GPU; differ from LLM_DEVICE_ID when the LLM is local
 RT_VLM_DEVICE_ID=1 # Must match VLM_DEVICE_ID
+LLM_MODE=local
+VLM_MODE=local
 LLM_ENV_FILE=/path/to/llm.env
 VLM_ENV_FILE=/path/to/vlm.env
 ```


### PR DESCRIPTION
## Summary

Improve deployment override documentation for GB300, DGX-SPARK, IGX-Thor, and AGX-Thor GPU selection and SBSA image tags.

## Plan

- Document explicit GPU IDs for each applicable runtime service.
- Remove unsupported dedicated-GPU layouts for GB300.
- Align SBSA tag overrides and hardware tab names.
- Normalize environment-variable ordering across deployment tabs.

## Related Issue

VIA-2725

## Changes

- Added GPU device-ID overrides for LLM, VLM, RT-VLM, RT-CV, and RT-Embed where applicable.- GB300 defaults to 0 with nvidia-smi guidance.
   - DGX-SPARK defaults to 0.
   - Thor examples default to 0 with Thor GPU nvidia-smi guidance.
- Removed GB300 dedicated-GPU tabs and retained default, remote-LLM, and remote-VLM configurations.
- Added profile-specific develop-latest-sbsa image tags for RT-CV, RT-VLM, RT-Embed, and video summarization.
- Removed RT_CV_DEVICE_ID from real-time alert examples because that mode does not deploy RT-CV.
- Renamed documentation tabs from SPARK to DGX-SPARK.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.
