### PR TITLE
Fix Files API timestamps without milliseconds

### DIFF
--- a/services/rtvi/rt-vlm/src/api_models/file.py
+++ b/services/rtvi/rt-vlm/src/api_models/file.py
@@ -71,7 +71,7 @@ class FileInfo(CommonBaseModel):
             "If provided, this offsets the frame times in the response. "
             "If not provided, the frame times will be relative to the start of the file."
         ),
-        min_length=24,
+        min_length=20,
         max_length=24,
         examples=["2024-06-09T18:32:11.123Z"],
         pattern=TIMESTAMP_PATTERN,

--- a/services/rtvi/rt-vlm/src/server/rtvi_vlm_server.py
+++ b/services/rtvi/rt-vlm/src/server/rtvi_vlm_server.py
@@ -1682,7 +1682,7 @@ class RTVIServer:
                         "If provided, this offsets the frame times in the response. "
                         "If not provided, the frame times will be relative to the start of the file."
                     ),
-                    min_length=24,
+                    min_length=20,
                     max_length=24,
                     examples=["2024-06-09T18:32:11.123Z"],
                     pattern=TIMESTAMP_PATTERN,

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_rtvi_vlm_server.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_rtvi_vlm_server.py
@@ -351,6 +351,30 @@ class TestFileEndpoints:
         assert data["object"] == "list"
         assert isinstance(data["data"], list)
 
+    def test_list_files_accepts_creation_time_without_milliseconds(
+        self, test_client, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(rtvi_vlm_server, "_SKIP_INPUT_MEDIA_VERIFICATION", False)
+        media_path = tmp_path / "clip.mp4"
+        media_path.write_bytes(b"test-video")
+        add_response = test_client.post(
+            f"{API_PREFIX}/files",
+            files={
+                "filename": (None, str(media_path)),
+                "purpose": (None, "vision"),
+                "media_type": (None, "video"),
+                "creation_time": (None, "2025-01-15T10:00:00Z"),
+            },
+        )
+        assert add_response.status_code == 200
+        asset_id = add_response.json()["id"]
+
+        response = test_client.get(f"{API_PREFIX}/files?purpose=vision")
+
+        assert response.status_code == 200
+        assert response.json()["data"][0]["id"] == asset_id
+        assert response.json()["data"][0]["creation_time"] == "2025-01-15T10:00:00Z"
+
     def test_add_file_missing_params(self, test_client):
         """Test adding file with missing parameters"""
         response = test_client.post(f"{API_PREFIX}/files")


### PR DESCRIPTION
## Summary

- accept RFC3339 `creation_time` values with either second or millisecond precision in Files API requests and responses
- add an endpoint regression test covering upload followed by `GET /v1/files?purpose=vision`

## Root cause

The existing timestamp regex and validator allow both `2025-01-15T10:00:00Z` and `2025-01-15T10:00:00.000Z`, but the Files API fields required exactly 24 characters. Assets carrying a valid second-precision timestamp therefore caused FastAPI response validation to return HTTP 500 from the list endpoint.

This fixes QVS test 129493 from the referenced functional run. It is a separate defect found in the same aggregate log and does not address NVBug 6706112 (`_thread.RLock` serialization during livestream inference).

## Testing

Tested on the leased B200 host with `nvcr.io/nvstaging/vss-core/vss-rt-vlm:3.3.0-26.08.2`:

- regression test against released source: fails as expected with HTTP 422
- regression test against patched source: passes
- `TestFileEndpoints`: 7 passed
- repository pre-commit checks: passed

A broader `test_rtvi_vlm_server.py` run also exposed unrelated existing CV endpoint failures and a hanging integration shutdown test; no failures were in `TestFileEndpoints`.
