### PR TITLE
fix(skills): align NvStreamer references with shared layout

### DIFF
--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -1405,6 +1405,7 @@ done
 _nvstreamer_base_compose="${REPO_ROOT}/deploy/docker/services/nvstreamer/base.yml"
 _nvstreamer_shared_compose="${REPO_ROOT}/deploy/docker/services/nvstreamer/compose.yml"
 _nvstreamer_vios_compose="${REPO_ROOT}/deploy/docker/services/vios/streamprocessing/docker-compose.yaml"
+_nvstreamer_infra_compose="${REPO_ROOT}/deploy/docker/services/infra/compose.yml"
 if ! grep -Eq '^  nvstreamer-base:' "${_nvstreamer_base_compose}"; then
   echo "FAIL: shared NVStreamer base Compose should define nvstreamer-base"
   ((_split_failed++)) || true
@@ -1464,12 +1465,20 @@ if grep -Fq 'file: base.yml' "${_nvstreamer_skill_reference}" || grep -Fq '"your
   echo "FAIL: VIOS integration skill should select the shared NVStreamer profile instead of copying its Compose definition"
   ((_split_failed++)) || true
 fi
-if ! grep -Fq 'COMPOSE_PROFILES=<existing-profile-list>,nvstreamer-alerts' "${_nvstreamer_skill_reference}"; then
-  echo "FAIL: VIOS integration skill should select the shared nvstreamer-alerts profile"
+if ! grep -Fq 'COMPOSE_PROFILES=<existing-profile-list>,kafka,kafka-topic-init-container,broker-health-check,nvstreamer-alerts' "${_nvstreamer_skill_reference}"; then
+  echo "FAIL: VIOS integration skill should select the complete NvStreamer and broker profile set"
   ((_split_failed++)) || true
 fi
 if ! grep -A4 -E '^  vios-apt-cache-init:' "${_nvstreamer_vios_compose}" | grep -Fq '"nvstreamer-alerts"'; then
   echo "FAIL: vios-apt-cache-init should activate with the nvstreamer-alerts profile"
+  ((_split_failed++)) || true
+fi
+if ! grep -A6 -E '^  broker-health-check:' "${_nvstreamer_infra_compose}" | grep -Fq 'profiles: ["broker-health-check"]'; then
+  echo "FAIL: broker-health-check should retain its documented Compose profile"
+  ((_split_failed++)) || true
+fi
+if ! grep -A8 -E '^  kafka-topic-init-container:' "${_nvstreamer_infra_compose}" | grep -Fq 'profiles: ["kafka-topic-init-container"]'; then
+  echo "FAIL: Kafka topic initialization should retain its documented Compose profile"
   ((_split_failed++)) || true
 fi
 if [[ ${_split_failed} -eq 0 ]]; then

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -1404,6 +1404,7 @@ for _spec in "${_shared_service_env_specs[@]}"; do
 done
 _nvstreamer_base_compose="${REPO_ROOT}/deploy/docker/services/nvstreamer/base.yml"
 _nvstreamer_shared_compose="${REPO_ROOT}/deploy/docker/services/nvstreamer/compose.yml"
+_nvstreamer_vios_compose="${REPO_ROOT}/deploy/docker/services/vios/streamprocessing/docker-compose.yaml"
 if ! grep -Eq '^  nvstreamer-base:' "${_nvstreamer_base_compose}"; then
   echo "FAIL: shared NVStreamer base Compose should define nvstreamer-base"
   ((_split_failed++)) || true
@@ -1457,6 +1458,18 @@ if grep -Fq 'deploy/docker/developer-profiles/dev-profile-alerts/compose.yml' "$
 fi
 if grep -Fq './nvstreamer/configs/' "${_nvstreamer_skill_reference}"; then
   echo "FAIL: VIOS integration skill should not use retired profile-local NVStreamer config mounts"
+  ((_split_failed++)) || true
+fi
+if grep -Fq 'file: base.yml' "${_nvstreamer_skill_reference}" || grep -Fq '"your-profile-flag"' "${_nvstreamer_skill_reference}"; then
+  echo "FAIL: VIOS integration skill should select the shared NVStreamer profile instead of copying its Compose definition"
+  ((_split_failed++)) || true
+fi
+if ! grep -Fq 'COMPOSE_PROFILES=<existing-profile-list>,nvstreamer-alerts' "${_nvstreamer_skill_reference}"; then
+  echo "FAIL: VIOS integration skill should select the shared nvstreamer-alerts profile"
+  ((_split_failed++)) || true
+fi
+if ! grep -A4 -E '^  vios-apt-cache-init:' "${_nvstreamer_vios_compose}" | grep -Fq '"nvstreamer-alerts"'; then
+  echo "FAIL: vios-apt-cache-init should activate with the nvstreamer-alerts profile"
   ((_split_failed++)) || true
 fi
 if [[ ${_split_failed} -eq 0 ]]; then

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -1451,6 +1451,14 @@ if grep -Fq 'deploy/docker/developer-profiles/dev-profile-alerts/nvstreamer/conf
   echo "FAIL: VIOS integration skill should not reference the retired profile-specific NVStreamer config"
   ((_split_failed++)) || true
 fi
+if grep -Fq 'deploy/docker/developer-profiles/dev-profile-alerts/compose.yml' "${_nvstreamer_skill_reference}"; then
+  echo "FAIL: VIOS integration skill should not cite the retired profile-specific NVStreamer service"
+  ((_split_failed++)) || true
+fi
+if grep -Fq './nvstreamer/configs/' "${_nvstreamer_skill_reference}"; then
+  echo "FAIL: VIOS integration skill should not use retired profile-local NVStreamer config mounts"
+  ((_split_failed++)) || true
+fi
 if [[ ${_split_failed} -eq 0 ]]; then
   echo "PASS: developer profile env split keeps profile-specific override-layer values isolated"
   ((TESTS_PASSED++)) || true

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -1421,32 +1421,36 @@ if grep -Eq '(developer-profiles|industry-profiles)/' "${_nvstreamer_shared_comp
   echo "FAIL: shared NVStreamer Compose should not reference blueprint directories"
   ((_split_failed++)) || true
 fi
-_nvstreamer_service_definition_specs=(
-  "nvstreamer-alerts:deploy/docker/developer-profiles/dev-profile-alerts/compose.yml deploy/docker/industry-profiles/smartcities/compose.yml"
-  "nvstreamer-lvs:deploy/docker/developer-profiles/dev-profile-lvs/compose.yml"
-  "nvstreamer-2d-fusion:deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/compose.yml"
-  "nvstreamer-2d:deploy/docker/industry-profiles/warehouse-operations/warehouse-2d-app/warehouse-2d-app.yml"
-  "nvstreamer-3d:deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/warehouse-3d-app.yml"
-  "nvstreamer-mv3dt:deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/warehouse-mv3dt-app.yml"
+_nvstreamer_shared_services=(
+  nvstreamer-alerts
+  nvstreamer-lvs
+  nvstreamer-2d-fusion
+  nvstreamer-2d
+  nvstreamer-3d
+  nvstreamer-mv3dt
 )
-for _spec in "${_nvstreamer_service_definition_specs[@]}"; do
-  _service="${_spec%%:*}"
-  _expected_definition_paths="${_spec#*:}"
-  _expected_definition_count="$(wc -w <<< "${_expected_definition_paths}")"
-  _definition_count="$(grep -R -E --include='*.yml' --include='*.yaml' "^  ${_service}:" \
-    "${REPO_ROOT}/deploy/docker/developer-profiles" \
-    "${REPO_ROOT}/deploy/docker/industry-profiles" | wc -l)"
-  if [[ "${_definition_count}" -ne "${_expected_definition_count}" ]]; then
-    echo "FAIL: ${_service} should have ${_expected_definition_count} blueprint-owned Compose definition(s) (found ${_definition_count})"
+for _service in "${_nvstreamer_shared_services[@]}"; do
+  if ! grep -Eq "^  ${_service}:" "${_nvstreamer_shared_compose}"; then
+    echo "FAIL: shared NVStreamer Compose should define ${_service}"
     ((_split_failed++)) || true
   fi
-  for _definition_path in ${_expected_definition_paths}; do
-    if ! grep -Eq "^  ${_service}:" "${REPO_ROOT}/${_definition_path}"; then
-      echo "FAIL: ${_service} definition missing from ${_definition_path}"
-      ((_split_failed++)) || true
-    fi
-  done
 done
+if grep -R -E --include='*.yml' --include='*.yaml' \
+  '^  (nvstreamer-alerts|nvstreamer-lvs|nvstreamer-2d-fusion|nvstreamer-2d|nvstreamer-3d|nvstreamer-mv3dt):' \
+  "${REPO_ROOT}/deploy/docker/developer-profiles" \
+  "${REPO_ROOT}/deploy/docker/industry-profiles" >/dev/null; then
+  echo "FAIL: blueprint Compose files should not redefine shared NVStreamer services"
+  ((_split_failed++)) || true
+fi
+_nvstreamer_skill_reference="${REPO_ROOT}/skills/operations/vss-manage-video-io-storage/references/integrate-vios-service.md"
+if ! grep -Fq 'deploy/docker/services/nvstreamer/configs/vst-config.json' "${_nvstreamer_skill_reference}"; then
+  echo "FAIL: VIOS integration skill should reference the shared NVStreamer config"
+  ((_split_failed++)) || true
+fi
+if grep -Fq 'deploy/docker/developer-profiles/dev-profile-alerts/nvstreamer/configs/vst-config.json' "${_nvstreamer_skill_reference}"; then
+  echo "FAIL: VIOS integration skill should not reference the retired profile-specific NVStreamer config"
+  ((_split_failed++)) || true
+fi
 if [[ ${_split_failed} -eq 0 ]]; then
   echo "PASS: developer profile env split keeps profile-specific override-layer values isolated"
   ((TESTS_PASSED++)) || true

--- a/skills/operations/vss-manage-video-io-storage/references/integrate-vios-service.md
+++ b/skills/operations/vss-manage-video-io-storage/references/integrate-vios-service.md
@@ -57,7 +57,7 @@ ${VSS_DATA_DIR}/videos/<profile-name>/*.mp4   (sample files on host disk)
         └─► WebRTC playback on 31000
 ```
 
-Use when the user explicitly asks to serve sample files or OOBE clips over RTSP, or asks for a deployment without external camera dependencies. **No sensor/add call required** — NvStreamer auto-publishes everything in the watched directory. Source: `deploy/docker/developer-profiles/dev-profile-alerts/compose.yml` § `nvstreamer-alerts` + `deploy/docker/developer-profiles/dev-profile-alerts/nvstreamer/configs/vst-config.json`.
+Use when the user explicitly asks to serve sample files or OOBE clips over RTSP, or asks for a deployment without external camera dependencies. **No sensor/add call required** — NvStreamer auto-publishes everything in the watched directory. Source: `deploy/docker/services/nvstreamer/compose.yml` § `nvstreamer-alerts` + `deploy/docker/services/nvstreamer/configs/vst-config.json`.
 
 For video ingestion into the natural-language search workflow, use [`vss-search-archive`](../../vss-search-archive/SKILL.md) instead. Search ingestion must go through the VSS agent-backed file or RTSP ingest routes so the source is wired into RTVI-CV, RTVI-Embed, and Elasticsearch; a bare VIOS upload or NvStreamer publish only stores / serves the video and does not create search embeddings.
 

--- a/skills/operations/vss-manage-video-io-storage/references/integrate-vios-service.md
+++ b/skills/operations/vss-manage-video-io-storage/references/integrate-vios-service.md
@@ -252,7 +252,7 @@ component_services:
   **Endpoint (consumed downstream):** `rtsp://${HOST_IP}:30554/live/<sensorId>` — the VIOS live proxy of the registered NvStreamer stream.
   **Sequence:** stage a sample video into `${VSS_DATA_DIR}/videos/<build-name>/` → NvStreamer auto-discovers it (`sensorId == streamId == name == filename-stem`) → `GET http://${HOST_IP}:31000/vst/api/v1/sensor/<stem>/streams` returns `.[0].url` = `rtsp://${HOST_IP}:315xx/nvstream/…` (read the port from the API — do NOT construct it) → `POST http://${HOST_IP}:30888/vst/api/v1/sensor/add` with `{"sensorUrl":"<that-url>"}` (field is `sensorUrl`, NOT `url`) → VIOS re-publishes at `rtsp://${HOST_IP}:30554/live/<sensorId>` → feed THAT (using `${HOST_IP}`, not `localhost` — Finding 12) to RT-VLM `POST :8018/v1/streams/add`.
   **Trigger:** validation-harness only — the build-vision-ai skill emits NvStreamer when the capability has a live/streaming path and no real camera/RTSP URL was supplied. NvStreamer is NOT a `sensor_topology` variant and NOT in this doc's `component_services:` block. Allow ~5 s after staging for the streams list to populate; retry with backoff.
-  Source: `vss-build-vision-ai/references/validation-harness.md § 4` + `references/nvstreamer-api-reference.md § Canonical workflow: NvStreamer → VIOS handoff` + `deploy/docker/developer-profiles/dev-profile-alerts/compose.yml § nvstreamer-alerts`.
+  Source: `vss-build-vision-ai/references/validation-harness.md § 4` + `references/nvstreamer-api-reference.md § Canonical workflow: NvStreamer → VIOS handoff` + `deploy/docker/services/nvstreamer/compose.yml § nvstreamer-alerts`.
 
 - **Method:** RTSP recorded-replay playback (VOD)
   **Endpoint:** `rtsp://<host>:30564/vod/<sensorId>`
@@ -434,22 +434,25 @@ services:
 
 (Full upstream definitions live in `deploy/docker/services/vios/{foundational,initiator,streamprocessing}/docker-compose.yaml` + `deploy/docker/services/infra/sdrc/docker-compose.yaml`. Container names use the canonical `vss-vios-*` form, NOT the legacy `*-dev` form. The deprecated `services/vios/sdr/streamprocessing/` tree has been removed — streamprocessing now lives directly under `services/vios/streamprocessing/`, with the legacy `envoy.yaml` + `sdr-config/` bind sources gone.)
 
-For Topology B (NvStreamer file-driven), use this service shape instead of `vss-vios-sensor`:
+For Topology B (NvStreamer file-driven), reuse the centralized `nvstreamer-alerts` service from `deploy/docker/services/nvstreamer/compose.yml` instead of defining a profile-local service. Add the consuming deployment's profile flag to a patched copy:
 
 ```yaml
-  vss-vios-nvstreamer:         # developer-profiles/dev-profile-alerts/compose.yml § nvstreamer-alerts
-    image: nvcr.io/nvstaging/vss-core/vss-vios-nvstreamer:${NVSTREAMER_IMAGE_TAG}
-    profiles: [..., <your-profile-flag>]
-    network_mode: host
-    environment:
-      ADAPTOR: streamer          # NvStreamer mode — auto-scans video_path for files
-      HTTP_PORT: ${NVSTREAMER_HTTP_PORT}   # default 31000; RTSP server defaults to 31554
+# deploy/docker/services/nvstreamer/compose.yml
+services:
+  nvstreamer-alerts:
+    extends:
+      file: base.yml
+      service: nvstreamer-base
+    profiles: !override ["nvstreamer-alerts", "your-profile-flag"]
     volumes:
-      - ./nvstreamer/configs/vst-config.json:${VST_CONTAINER_ROOT}/configs/vst_config.json
-      - ./nvstreamer/configs/vst-storage.json:${VST_CONTAINER_ROOT}/configs/vst_storage.json
-      - ${VSS_DATA_DIR}/videos/<profile-name>:${VST_CONTAINER_ROOT}/streamer_videos
-      - ${VSS_DATA_DIR}/data_log/nvstreamer/vst_data:${VST_CONTAINER_ROOT}/vst_data
+      - ${NVSTREAMER_ALERTS_VIDEO_DIR:-${NVSTREAMER_VIDEO_DIR:-${VSS_DATA_DIR}}/videos/dev-profile-alerts}:/home/vst/vst_release/streamer_videos
+      - ${VSS_DATA_DIR}/data_log/nvstreamer/vst_data:/home/vst/vst_release/vst_data
+    depends_on:
+      broker-health-check:
+        condition: service_completed_successfully
 ```
+
+The image, ports, environment, and configuration mounts are inherited from `deploy/docker/services/nvstreamer/base.yml`. By default, the configuration files come from `${VSS_APPS_DIR}/services/nvstreamer/configs`; set `NVSTREAMER_CONFIG_DIR` only when the deployment requires a custom `vst-config.json`.
 
 Both topologies emit the same `camera_streaming` Kafka/Redis event downstream.
 

--- a/skills/operations/vss-manage-video-io-storage/references/integrate-vios-service.md
+++ b/skills/operations/vss-manage-video-io-storage/references/integrate-vios-service.md
@@ -434,25 +434,14 @@ services:
 
 (Full upstream definitions live in `deploy/docker/services/vios/{foundational,initiator,streamprocessing}/docker-compose.yaml` + `deploy/docker/services/infra/sdrc/docker-compose.yaml`. Container names use the canonical `vss-vios-*` form, NOT the legacy `*-dev` form. The deprecated `services/vios/sdr/streamprocessing/` tree has been removed — streamprocessing now lives directly under `services/vios/streamprocessing/`, with the legacy `envoy.yaml` + `sdr-config/` bind sources gone.)
 
-For Topology B (NvStreamer file-driven), reuse the centralized `nvstreamer-alerts` service from `deploy/docker/services/nvstreamer/compose.yml` instead of defining a profile-local service. Add the consuming deployment's profile flag to a patched copy:
+For Topology B (NvStreamer file-driven), reuse the centralized `nvstreamer-alerts` service from `deploy/docker/services/nvstreamer/compose.yml` instead of copying or patching its service definition. Add the existing `nvstreamer-alerts` profile to the consuming deployment and launch from the top-level `deploy/docker/compose.yml`:
 
-```yaml
-# deploy/docker/services/nvstreamer/compose.yml
-services:
-  nvstreamer-alerts:
-    extends:
-      file: base.yml
-      service: nvstreamer-base
-    profiles: !override ["nvstreamer-alerts", "your-profile-flag"]
-    volumes:
-      - ${NVSTREAMER_ALERTS_VIDEO_DIR:-${NVSTREAMER_VIDEO_DIR:-${VSS_DATA_DIR}}/videos/dev-profile-alerts}:/home/vst/vst_release/streamer_videos
-      - ${VSS_DATA_DIR}/data_log/nvstreamer/vst_data:/home/vst/vst_release/vst_data
-    depends_on:
-      broker-health-check:
-        condition: service_completed_successfully
+```dotenv
+COMPOSE_PROFILES=<existing-profile-list>,nvstreamer-alerts
+NVSTREAMER_ALERTS_VIDEO_DIR=${VSS_DATA_DIR}/videos/<profile-name>
 ```
 
-The image, ports, environment, and configuration mounts are inherited from `deploy/docker/services/nvstreamer/base.yml`. By default, the configuration files come from `${VSS_APPS_DIR}/services/nvstreamer/configs`; set `NVSTREAMER_CONFIG_DIR` only when the deployment requires a custom `vst-config.json`.
+The image, ports, environment, and configuration mounts are inherited from `deploy/docker/services/nvstreamer/base.yml`. By default, the configuration files come from `${VSS_APPS_DIR}/services/nvstreamer/configs`; set `NVSTREAMER_CONFIG_DIR` only when the deployment requires a custom `vst-config.json`. The shared `vios-apt-cache-init` dependency carries the same `nvstreamer-alerts` profile, so selecting this existing profile activates both services.
 
 Both topologies emit the same `camera_streaming` Kafka/Redis event downstream.
 

--- a/skills/operations/vss-manage-video-io-storage/references/integrate-vios-service.md
+++ b/skills/operations/vss-manage-video-io-storage/references/integrate-vios-service.md
@@ -434,14 +434,15 @@ services:
 
 (Full upstream definitions live in `deploy/docker/services/vios/{foundational,initiator,streamprocessing}/docker-compose.yaml` + `deploy/docker/services/infra/sdrc/docker-compose.yaml`. Container names use the canonical `vss-vios-*` form, NOT the legacy `*-dev` form. The deprecated `services/vios/sdr/streamprocessing/` tree has been removed — streamprocessing now lives directly under `services/vios/streamprocessing/`, with the legacy `envoy.yaml` + `sdr-config/` bind sources gone.)
 
-For Topology B (NvStreamer file-driven), reuse the centralized `nvstreamer-alerts` service from `deploy/docker/services/nvstreamer/compose.yml` instead of copying or patching its service definition. Add the existing `nvstreamer-alerts` profile to the consuming deployment and launch from the top-level `deploy/docker/compose.yml`:
+For Topology B (NvStreamer file-driven), reuse the centralized `nvstreamer-alerts` service from `deploy/docker/services/nvstreamer/compose.yml` instead of copying or patching its service definition. For the default Kafka-backed deployment, add the complete NvStreamer and broker dependency profile set and launch from the top-level `deploy/docker/compose.yml`:
 
 ```dotenv
-COMPOSE_PROFILES=<existing-profile-list>,nvstreamer-alerts
+STREAM_TYPE=kafka
+COMPOSE_PROFILES=<existing-profile-list>,kafka,kafka-topic-init-container,broker-health-check,nvstreamer-alerts
 NVSTREAMER_ALERTS_VIDEO_DIR=${VSS_DATA_DIR}/videos/<profile-name>
 ```
 
-The image, ports, environment, and configuration mounts are inherited from `deploy/docker/services/nvstreamer/base.yml`. By default, the configuration files come from `${VSS_APPS_DIR}/services/nvstreamer/configs`; set `NVSTREAMER_CONFIG_DIR` only when the deployment requires a custom `vst-config.json`. The shared `vios-apt-cache-init` dependency carries the same `nvstreamer-alerts` profile, so selecting this existing profile activates both services.
+The image, ports, environment, and configuration mounts are inherited from `deploy/docker/services/nvstreamer/base.yml`. By default, the configuration files come from `${VSS_APPS_DIR}/services/nvstreamer/configs`; set `NVSTREAMER_CONFIG_DIR` only when the deployment requires a custom `vst-config.json`. The shared `vios-apt-cache-init` dependency carries the same `nvstreamer-alerts` profile and activates automatically. `broker-health-check` is separately profile-gated, so it must be selected explicitly together with Kafka and `kafka-topic-init-container`, which creates the topics that the health check waits for. The standard Alerts profile lists already include this complete set.
 
 Both topologies emit the same `camera_streaming` Kafka/Redis event downstream.
 


### PR DESCRIPTION
## Description
Fixes [NvBug 6710641](https://nvbugs/6710641).
- Update the VIOS integration skill to reference the centralized NvStreamer Compose file and VST configuration.
- Align the developer-profile regression test with the shared NvStreamer service ownership introduced by the layout change.
- Guard against profile-specific service redefinitions and the retired skill path.

## Validation

- Focused NvStreamer path and service contract: 24 checks passed.
- `bash -n deploy/docker/test-scripts/test-dev-profile.sh`
- `git diff --check`
- Applicable pre-commit hooks passed for the changed files (`trufflehog` was skipped because its Go environment could not be installed in the sandbox).

The complete `test-dev-profile.sh` suite was not run locally because Docker Compose is unavailable on this macOS host.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco) compliant.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.