### PR TITLE
test(deploy): empty-but-set GHCR registry; do not export container tag

### DIFF
--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -1506,9 +1506,19 @@ function export_managed_container_channel() {
   # generated.env -- including the SBSA tag swap, which appeared to succeed
   # while Compose kept deploying the default tags.
   #
-  # GHCR acceptance only exports VSS_CONTAINER_TAG. Export the shared registry
-  # and tag pair here so compose does not fall back to nvstaging/nvidia inline
-  # defaults while still leaving per-image tag overrides in generated.env.
+  # Promote only VSS_CONTAINER_REGISTRY. ci-vss-oss forwards
+  # -e VSS_CONTAINER_REGISTRY="${VSS_CONTAINER_REGISTRY:-}", so the compose
+  # process sees the registry empty-but-set. Compose interpolates that empty
+  # value through nested NGC fallbacks in containers.env; bash ${VAR:-default}
+  # treats empty as unset, which is why sourcing this file in the parent shell
+  # rewrote the registry to GHCR. Export the resolved registry so compose sees
+  # a real GHCR coordinate.
+  #
+  # Do not export VSS_CONTAINER_TAG. GHCR acceptance already injects the tag
+  # into the process environment. Promoting containers.env's resolved default
+  # would shadow any tag in overrides.env / generated.env, because Compose
+  # gives the process environment precedence over every --env-file. Assign the
+  # resolved tag in this shell only so the INFO line can print it.
   eval "$(
     (
       set -a
@@ -1516,7 +1526,7 @@ function export_managed_container_channel() {
       source "${deployment_directory}/containers.env"
       set +a
       printf 'export VSS_CONTAINER_REGISTRY=%q\n' "${VSS_CONTAINER_REGISTRY}"
-      printf 'export VSS_CONTAINER_TAG=%q\n' "${VSS_CONTAINER_TAG}"
+      printf 'VSS_CONTAINER_TAG=%q\n' "${VSS_CONTAINER_TAG}"
     )
   )"
 }

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -917,30 +917,55 @@ else
 fi
 rm -f "${_out_compose_env_order}" "${_err_compose_env_order}"
 
-# GHCR acceptance passes VSS_CONTAINER_TAG without VSS_CONTAINER_REGISTRY.
-# state_up must export the registry from containers.env so compose does not
-# fall back to nvstaging/nvidia inline defaults.
+# ci-vss-oss forwards -e VSS_CONTAINER_REGISTRY="${VSS_CONTAINER_REGISTRY:-}"
+# so compose sees an empty-but-set registry, not an unset one. That empty
+# value is interpolated through nested NGC fallbacks in containers.env
+# (unset would still resolve GHCR via Compose ${VAR:-default}). Restore the
+# prior environment so later tests in this suite are unaffected.
 _out_ghcr_channel="$(mktemp)"
 _err_ghcr_channel="$(mktemp)"
-unset VSS_CONTAINER_REGISTRY
-export VSS_CONTAINER_TAG=pr-ghcr-channel-test
+_ghcr_had_registry=0
+_ghcr_saved_registry=""
+_ghcr_had_tag=0
+_ghcr_saved_tag=""
+if [[ -n "${VSS_CONTAINER_REGISTRY+x}" ]]; then
+  _ghcr_had_registry=1
+  _ghcr_saved_registry="${VSS_CONTAINER_REGISTRY}"
+fi
+if [[ -n "${VSS_CONTAINER_TAG+x}" ]]; then
+  _ghcr_had_tag=1
+  _ghcr_saved_tag="${VSS_CONTAINER_TAG}"
+fi
+export VSS_CONTAINER_REGISTRY=
+export VSS_CONTAINER_TAG=pr-ghcr-empty-registry-test
 cd "${REPO_ROOT}"
 set +e
 timeout "${TEST_TIMEOUT}" "$DEV_PROFILE" up -p base -i 127.0.0.1 -d > "${_out_ghcr_channel}" 2> "${_err_ghcr_channel}"
 _ghcr_channel_exit=$?
 set -e
-unset VSS_CONTAINER_TAG
+if [[ ${_ghcr_had_registry} -eq 1 ]]; then
+  export VSS_CONTAINER_REGISTRY="${_ghcr_saved_registry}"
+else
+  unset VSS_CONTAINER_REGISTRY
+fi
+if [[ ${_ghcr_had_tag} -eq 1 ]]; then
+  export VSS_CONTAINER_TAG="${_ghcr_saved_tag}"
+else
+  unset VSS_CONTAINER_TAG
+fi
+_ghcr_agent_ok="ghcr.io/nvidia-ai-blueprints/vss/vss-agent:pr-ghcr-empty-registry-test"
+_ghcr_agent_ngc="nvcr.io/nvstaging/vss-core/vss-agent:pr-ghcr-empty-registry-test"
 if [[ ${_ghcr_channel_exit} -ne 0 ]]; then
-  echo "FAIL: dry-run with VSS_CONTAINER_TAG only exited ${_ghcr_channel_exit}"
+  echo "FAIL: dry-run with empty VSS_CONTAINER_REGISTRY exited ${_ghcr_channel_exit}"
   ((TESTS_FAILED++)) || true
-elif ! grep -Fq "ghcr.io/nvidia-ai-blueprints/vss/vss-agent:pr-ghcr-channel-test" "${_out_ghcr_channel}"; then
-  echo "FAIL: resolved compose images should use GHCR when only VSS_CONTAINER_TAG is exported"
+elif ! grep -Fq "${_ghcr_agent_ok}" "${_out_ghcr_channel}"; then
+  echo "FAIL: resolved vss-agent should be ${_ghcr_agent_ok} when VSS_CONTAINER_REGISTRY is empty-but-set"
   ((TESTS_FAILED++)) || true
-elif grep -Fq "nvcr.io/nvstaging/vss-core/vss-agent:pr-ghcr-channel-test" "${_out_ghcr_channel}"; then
-  echo "FAIL: resolved compose images should not use nvstaging when GHCR acceptance tag is set"
+elif grep -Fq "${_ghcr_agent_ngc}" "${_out_ghcr_channel}"; then
+  echo "FAIL: resolved vss-agent should not be ${_ghcr_agent_ngc} when VSS_CONTAINER_REGISTRY is empty-but-set"
   ((TESTS_FAILED++)) || true
 else
-  echo "PASS: resolved compose images use GHCR registry when VSS_CONTAINER_TAG is exported"
+  echo "PASS: resolved vss-agent uses GHCR when VSS_CONTAINER_REGISTRY is empty-but-set"
   ((TESTS_PASSED++)) || true
 fi
 rm -f "${_out_ghcr_channel}" "${_err_ghcr_channel}"


### PR DESCRIPTION
## Summary

Follow-up to merged #1971 (`7ade1c67f`). This PR does **not** replay that code fix; it tightens the regression test and removes an unsafe extra export.

**Base:** `develop`, not `feat/search-hw-support`. That feature branch was the head of #1892, which merged to `develop` and is no longer on origin. `deploy/docker/scripts/dev-profile.sh` and `deploy/docker/test-scripts/test-dev-profile.sh` on current `develop` match `7ade1c67f` for these files, so the delta is the same two-file change.

1. Replace the weak `unset VSS_CONTAINER_REGISTRY` case with the empty-but-set condition that ci-vss-oss actually forwards.
2. Stop **exporting** `VSS_CONTAINER_TAG` from `export_managed_container_channel()`. Promoting it reintroduces the silent process-environment override that `7326af58` eliminated: Compose gives the process environment precedence over every `--env-file`, so `containers.env`'s resolved default (`develop-latest`) beats any tag in `overrides.env` / `generated.env`. GHCR acceptance already injects the tag; only `VSS_CONTAINER_REGISTRY` arrives empty-but-set and needs promoting. The `[INFO] Managed container tag:` line still prints via a non-exported assignment.

## Registry precedence (unset / empty / real)

| Process environment | Compose interpolation of nested fallbacks in `containers.env` | Result with GHCR-only PR tag |
| --- | --- | --- |
| `VSS_CONTAINER_REGISTRY` **unset** | `${VAR:-default}` uses the GHCR default | GHCR (the weak #1971 test; never the bug) |
| `VSS_CONTAINER_REGISTRY` **empty-but-set** (`-e VSS_CONTAINER_REGISTRY="${VSS_CONTAINER_REGISTRY:-}"`) | empty wins; nested NGC fallbacks fire | `nvcr.io/nvstaging/vss-core/…:<pr-tag>` without the registry export |
| `VSS_CONTAINER_REGISTRY` set to GHCR | uses that value | GHCR |

Bash `${VAR:-default}` treats empty as unset; Compose does not. Parent-shell sourcing therefore looked fine while `docker compose --env-file` did not.

## Tag export shadowing (merged #1971 vs this PR)

Sentinel `VSS_CONTAINER_TAG=sentinel-from-generated` in `dev-profile-base/overrides.env` (copied to `generated.env`):

| Build | Resolved `vss-agent` |
| --- | --- |
| Merged #1971 (exports registry **and** tag) | `ghcr.io/nvidia-ai-blueprints/vss/vss-agent:develop-latest` — sentinel silently ignored |
| Unpatched (subshell only) | `…:sentinel-from-generated` — sentinel honored, CI registry case still broken |
| This PR (registry-only export) | `…:sentinel-from-generated` — sentinel honored **and** empty-but-set registry fixed |

## Verified discrimination (dry-run only)

Empty-but-set registry + `VSS_CONTAINER_TAG=pr-ghcr-empty-registry-test`:

- unpatched PR-1892 head → `nvcr.io/nvstaging/vss-core/vss-agent:pr-ghcr-empty-registry-test` (FAIL)
- with registry export (and this PR) → `ghcr.io/nvidia-ai-blueprints/vss/vss-agent:pr-ghcr-empty-registry-test` (PASS)

Literal suite assertion:

`PASS: resolved vss-agent uses GHCR when VSS_CONTAINER_REGISTRY is empty-but-set`

Local dry-run on this branch (`NGC_CLI_API_KEY=test-key-for-dry-run`, `SKIP_HARDWARE_CHECK=true`, `dev-profile.sh up … -d`; still runs `docker compose config --images`; **no deploy**):

1. Empty-but-set GHCR: `ghcr.io/nvidia-ai-blueprints/vss/vss-agent:pr-ghcr-empty-registry-test`; no `nvcr.io/nvstaging` / `nvcr.io/nvidia/vss-core` with that tag. INFO still prints registry + tag.
2. Sentinel in `overrides.env`: `ghcr.io/nvidia-ai-blueprints/vss/vss-agent:sentinel-from-generated` (not `develop-latest`). Tracked `overrides.env` restored afterwards.
3. SBSA intact: `up -p alerts -H DGX-SPARK -m real-time -d` resolved `ghcr.io/nvidia-ai-blueprints/vss/vss-rt-vlm:develop-latest-sbsa`. After `export_managed_container_channel()`, `env | grep '^VSS_RT_'` is empty; `VSS_CONTAINER_TAG` is not exported.

A **ci-vss-oss acceptance re-run is still required** to prove the four previously failing jobs green.

## Pre-existing suite failures (not this PR)

`deploy/docker/test-scripts/test-dev-profile.sh` is **not** green on this base. Roughly 20 cases already fail independently of this change (for example `generated.env search selects SBSA RT Embed tag` fails because `--use-sbsa-images` is not implemented in that script). This PR neither causes nor fixes those.

## Test plan

- [ ] `git diff develop...HEAD --stat` is only `dev-profile.sh` and `test-dev-profile.sh`
- [ ] Dry-run empty-but-set registry case
- [ ] Dry-run sentinel tag in `overrides.env` still wins
- [ ] Dry-run alerts + DGX-SPARK still resolves SBSA RT-VLM tag; no `VSS_RT_*` process-env leak
- [ ] Re-run ci-vss-oss GHCR acceptance