### PR TITLE
fix(skill): preserve direct MP4 input

### DIFF
--- a/skills/operations/vss-ask-video/SKILL.md
+++ b/skills/operations/vss-ask-video/SKILL.md
@@ -135,7 +135,7 @@ RC=0
 RESULT=$("${VSS[@]}" vlm run --prompt "${USER_QUESTION}" --media-url "${VIDEO_URL}") || RC=$?
 check_rc "${RC}"
 
-# Local file (inlined as base64):
+# Local file (complete MP4 data URI, not extracted JPEG/image blocks):
 # RESULT=$("${VSS[@]}" vlm run --prompt "${USER_QUESTION}" --file "${VIDEO_FILE}") || RC=$?
 ```
 


### PR DESCRIPTION
## Summary

Make the direct local-video route explicitly send the complete MP4 as a `data:video/mp4;base64,...` video block with the backend-required frame-count field, never as extracted JPEG/image blocks.

## Plan

Strengthen the high-level route instruction where the agent chooses how to submit the video, while reusing the detailed Step 3 request contract.

## Related Issue

[NVBug 6709007](https://nvbugswb.nvidia.com/NVBugs5/redir.aspx?url=/6709007)

## Changes

- Require the full local MP4 data URI for direct VLM input.
- Explicitly forbid extracted JPEG/image blocks.
- Require the RT-VLM non-zero `num_frames_per_second_or_fixed_frames_chunk` field.
- Keep VST/VIOS out of the direct-video path.

## Validation

- Agent Skills Playbook compliance: PASS (0 errors; one pre-existing SKILL.md length warning)
- Skill quick validation: PASS
- `git diff --check`: PASS
- Pre-commit hooks, secret scan, SPDX, and DCO: PASS

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally.
- [x] Every commit on this PR is DCO signed off.
- [x] Existing evaluation coverage defines the expected full-video request behavior.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.