### PR TITLE
fix(skill): prefer canonical standalone compose

### DIFF
--- a/skills/deployment/vss-deploy-dense-captioning/SKILL.md
+++ b/skills/deployment/vss-deploy-dense-captioning/SKILL.md
@@ -82,14 +82,14 @@ Always follow this sequence. Never skip the dry-run.
 ```bash
 # 1. Use deploy/docker/services/rtvi/rtvi-vlm/rtvi-vlm-docker-compose.yml
 #    directly with the rtvi-vlm profile.
-# 2. Derive RTVI_VLM_IMAGE_TAG from that canonical file.
+# 2. Derive VSS_RT_VLM_TAG from that canonical file.
 # 3. Only if Compose rejects its optional undefined depends_on peers, create a
 #    scratch normalized copy and strip that block; never choose a stale copy first.
 # 4. Create a gitignored rtvi-vlm.env with the required RT-VLM values.
 # 5. Prepare host bind paths such as $VSS_DATA_DIR/data_log/vst/clip_storage.
 #    Use `sudo -n` for ownership fixes; if passwordless sudo is unavailable,
 #    stop and ask the host owner to run the printed command manually.
-# 6. docker compose --env-file rtvi-vlm.env -f rtvi-vlm-docker-compose.yml config --quiet
+# 6. docker compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" --profile rtvi-vlm config --quiet
 # 7. docker pull the exact RT-VLM image tag.
 # 8. docker compose ... up -d rtvi-vlm, wait for ready, then smoke test.
 ```
@@ -117,6 +117,10 @@ privileged ownership or Docker operation, use the non-interactive guard in
 prefer plain `docker`; otherwise use `sudo -n docker`; if `sudo -n` fails, stop
 with the exact manual command for the host owner instead of retrying with
 interactive sudo or weakening permissions.
+
+When wiring RT-VLM to Kafka, ELK, VIOS, or sibling model services, read
+[`references/integrate-rt-vlm.md`](references/integrate-rt-vlm.md) for the
+current integration contract and Compose variable mappings.
 
 If `docker pull` fails with a containerd snapshotter/unpack error on Docker 28+,
 apply the `/etc/docker/daemon.json` `containerd-snapshotter=false` fix in the

--- a/skills/deployment/vss-deploy-dense-captioning/SKILL.md
+++ b/skills/deployment/vss-deploy-dense-captioning/SKILL.md
@@ -17,7 +17,7 @@ For standalone RT-VLM deployment:
 - Docker, Docker Compose, NVIDIA Container Toolkit, and a visible GPU.
 - NGC registry credentials in `$NGC_CLI_API_KEY` for `docker login nvcr.io`,
   image pulls, and local NGC model/artifact downloads.
-- `curl`, `jq`, and any writable working directory for the standalone compose copy.
+- `curl`, `jq`, the current VSS checkout, and a writable directory for standalone env/state.
 
 For API calls against an existing service:
 - Running RT-VLM service reachable at `$BASE_URL`.
@@ -72,18 +72,19 @@ If the user asks for standalone RT-VLM dense captioning, or no VSS profile is
 already running, use the standalone RT-VLM flow in
 [`references/deploy-rt-vlm-service.md`](references/deploy-rt-vlm-service.md)
 before calling the API. This follows the same compose-centric pattern as
-`vss-deploy-profile`: gather context, run preflights, work from a local copy,
-dry-run with `docker compose config`, review, deploy, then wait for health.
+`vss-deploy-profile`: gather context, run preflights, validate the canonical
+checked-in Compose file first, review, deploy, then wait for health.
 
 ## Standalone Deployment Flow
 
 Always follow this sequence. Never skip the dry-run.
 
 ```bash
-# 1. Copy deploy/docker/services/rtvi/rtvi-vlm/rtvi-vlm-docker-compose.yml
-#    into any writable standalone working directory.
-# 2. Derive RTVI_VLM_IMAGE_TAG from that compose copy.
-# 3. Strip the standalone-only dangling depends_on block from the copy.
+# 1. Use deploy/docker/services/rtvi/rtvi-vlm/rtvi-vlm-docker-compose.yml
+#    directly with the rtvi-vlm profile.
+# 2. Derive RTVI_VLM_IMAGE_TAG from that canonical file.
+# 3. Only if Compose rejects its optional undefined depends_on peers, create a
+#    scratch normalized copy and strip that block; never choose a stale copy first.
 # 4. Create a gitignored rtvi-vlm.env with the required RT-VLM values.
 # 5. Prepare host bind paths such as $VSS_DATA_DIR/data_log/vst/clip_storage.
 #    Use `sudo -n` for ownership fixes; if passwordless sudo is unavailable,
@@ -103,12 +104,12 @@ docker compose version
 docker run --rm --gpus all nvidia/cuda:12.4.0-base-ubuntu22.04 nvidia-smi
 ```
 
-For standalone single-file deployments, do not run the raw
-`deploy/docker/services/rtvi/rtvi-vlm/rtvi-vlm-docker-compose.yml` directly: it
-contains `depends_on` references to sibling VLM/NIM services that are only
-defined in the full VSS/met-blueprints compose project. The standalone reference
-shows how to copy the compose file, derive the current image tag from it, strip
-the `depends_on` block, and validate the result before `up`.
+For standalone single-file deployments, start with the canonical
+`deploy/docker/services/rtvi/rtvi-vlm/rtvi-vlm-docker-compose.yml` and the
+`rtvi-vlm` profile. Do not select an existing modified copy. If Compose reports
+undefined optional `depends_on` peers, the standalone reference permits one
+scratch normalized copy sourced from that exact file; use it only after recording
+that validation failure, then validate it before `up`.
 
 For agent-driven validation, never let `sudo` prompt interactively. Before any
 privileged ownership or Docker operation, use the non-interactive guard in

--- a/skills/deployment/vss-deploy-dense-captioning/evals/evals.json
+++ b/skills/deployment/vss-deploy-dense-captioning/evals/evals.json
@@ -3,11 +3,11 @@
     "id": "dense-captioning-standalone-deploy",
     "question": "Deploy standalone RT-VLM dense captioning and verify the service is ready for API calls.",
     "expected_skill": "vss-deploy-dense-captioning",
-    "ground_truth": "Loads vss-deploy-dense-captioning, follows the standalone RT-VLM deploy reference, uses a writable compose copy, selects the correct RT-VLM image tag for the platform, validates compose before starting rtvi-vlm, verifies readiness/models/OpenAPI on the configured port, and avoids the full VSS profile flow.",
+    "ground_truth": "Loads vss-deploy-dense-captioning, follows the standalone RT-VLM deploy reference, starts from the canonical checked-in compose and creates a writable normalized copy only for known undefined optional peers, selects the correct RT-VLM image tag for the platform, validates compose before starting rtvi-vlm, verifies readiness/models/OpenAPI on the configured port, and avoids the full VSS profile flow.",
     "expected_behavior": [
       "Loads vss-deploy-dense-captioning rather than vss-deploy-profile.",
-      "Copies the RT-VLM compose into a writable standalone directory before editing it.",
-      "Derives RTVI_VLM_IMAGE_TAG from the compose default and chooses the -sbsa variant only for Spark, GB10, or SBSA-class hosts.",
+      "Uses the canonical checked-in RT-VLM compose directly and creates a writable normalized copy only after validation reports known undefined optional peers.",
+      "Derives VSS_RT_VLM_TAG from the compose default and chooses the -sbsa variant only for Spark, GB10, or SBSA-class hosts.",
       "Runs docker compose config before starting rtvi-vlm and checks /v1/health/ready, /v1/models, and /openapi.json after startup.",
       "Keeps NGC_CLI_API_KEY and RTVI_VLM_API_KEY out of logs and final responses."
     ]

--- a/skills/deployment/vss-deploy-dense-captioning/references/deploy-rt-vlm-service.md
+++ b/skills/deployment/vss-deploy-dense-captioning/references/deploy-rt-vlm-service.md
@@ -80,7 +80,7 @@ docker run --rm --gpus all nvidia/cuda:12.4.0-base-ubuntu22.04 nvidia-smi
 export NGC_CLI_API_KEY="<YOUR_NGC_KEY>"
 echo "$NGC_CLI_API_KEY" | docker login nvcr.io -u '$oauthtoken' --password-stdin
 
-# Run the Step 0a tag-selection snippet in the standalone copy flow below, then
+# Run the Step 0a tag-selection snippet against the canonical compose below, then
 # verify pull access for the exact image this compose will use.
 : "${RTVI_VLM_IMAGE_TAG:?Run Step 0a below to set RTVI_VLM_IMAGE_TAG first}"
 docker pull "nvcr.io/nvstaging/vss-core/vss-rt-vlm:${RTVI_VLM_IMAGE_TAG}"
@@ -369,8 +369,9 @@ volumes:
 ## 12. Deployment Flow
 
 This mirrors the compose-centric workflow used by the VSS deploy-profile skill:
-work from a local copy, build a deploy-specific `rtvi-vlm.env`, dry-run, review, deploy, and
-wait for health. Always follow this sequence. Never skip the dry-run.
+start from the canonical checked-in compose, build a deploy-specific `rtvi-vlm.env`,
+dry-run, review, deploy, and wait for health. Only create a normalized scratch copy
+after Compose specifically rejects undefined optional peers. Never skip the dry-run.
 
 This compose declares **6 blueprint profiles**. Service will NOT start under
 plain `docker compose up` — `--profile <name>` is required.
@@ -387,23 +388,18 @@ plain `docker compose up` — `--profile <name>` is required.
 Generic VLM workflow → `rtvi-vlm`.
 
 ```bash
-# Step 0. Get compose (copy from checkout, or fetch the same path from VSS_REF)
-# Keep the checked-in compose read-only; mutate only this standalone copy.
+# Step 0. Select the canonical checked-in compose. Do not start from an existing copy.
 : "${RTVI_DEPLOY_DIR:?Set RTVI_DEPLOY_DIR to any writable standalone working directory, e.g. /tmp/rtvi_deploy}"
 mkdir -p "$RTVI_DEPLOY_DIR" && cd "$RTVI_DEPLOY_DIR"
-VSS_CHECKOUT="${VSS_CHECKOUT:-}"
-if [ -n "$VSS_CHECKOUT" ] && [ -f "$VSS_CHECKOUT/deploy/docker/services/rtvi/rtvi-vlm/rtvi-vlm-docker-compose.yml" ]; then
-  cp "$VSS_CHECKOUT/deploy/docker/services/rtvi/rtvi-vlm/rtvi-vlm-docker-compose.yml" .
-else
-  VSS_REF="${VSS_REF:-e9caf1593ffcd4964426c3e481c2f05f880d2d58}" # validated 26.05.4 compose
-  wget -q -O rtvi-vlm-docker-compose.yml \
-    "https://raw.githubusercontent.com/NVIDIA-AI-Blueprints/video-search-and-summarization/${VSS_REF}/deploy/docker/services/rtvi/rtvi-vlm/rtvi-vlm-docker-compose.yml"
-fi
+: "${VSS_CHECKOUT:?Set VSS_CHECKOUT to the current VSS repository checkout}"
+CANONICAL_COMPOSE="$VSS_CHECKOUT/deploy/docker/services/rtvi/rtvi-vlm/rtvi-vlm-docker-compose.yml"
+[ -f "$CANONICAL_COMPOSE" ] || { echo "Canonical RT-VLM compose not found: $CANONICAL_COMPOSE" >&2; exit 1; }
+COMPOSE_FILE="$CANONICAL_COMPOSE"
 
 # Step 0a. Derive the compose default tag, then select the platform variant.
 #          Spark/GB10/SBSA requires the -sbsa tag.
 #          x86_64 and Tegra-based Jetson/AGX/IGX Thor use the normal multiarch tag.
-COMPOSE_DEFAULT_TAG=$(sed -nE 's/.*RTVI_VLM_IMAGE_TAG:-([^}]+).*/\1/p' rtvi-vlm-docker-compose.yml | head -n1)
+COMPOSE_DEFAULT_TAG=$(sed -nE 's/.*RTVI_VLM_IMAGE_TAG:-([^}]+).*/\1/p' "$CANONICAL_COMPOSE" | head -n1)
 : "${COMPOSE_DEFAULT_TAG:?Could not derive RTVI_VLM_IMAGE_TAG default}"
 RTVI_VLM_IMAGE_TAG="${RTVI_VLM_IMAGE_TAG:-$COMPOSE_DEFAULT_TAG}"
 RTVI_VLM_BASE_TAG="${RTVI_VLM_IMAGE_TAG%-sbsa}"
@@ -425,42 +421,8 @@ fi
 echo "Platform: $ARCH → image tag: $VLM_TAG"
 export VSS_DATA_DIR="${VSS_DATA_DIR:-$RTVI_DEPLOY_DIR/vss-data}"
 
-# Step 0b. Standalone fix — recent Docker Compose rejects `depends_on`
-#          references to sibling NIMs that aren't defined in this single-file
-#          project, even with `required: false`. Strip the depends_on block for
-#          standalone deploys. Use yq if available (handles YAML correctly),
-#          otherwise fall back to a small stdlib-only Python edit of this known
-#          compose file:
-if command -v yq >/dev/null; then
-  yq -i 'del(.services.rtvi-vlm.depends_on)' rtvi-vlm-docker-compose.yml
-else
-  python3 - <<'PY'
-from pathlib import Path
-
-p = Path("rtvi-vlm-docker-compose.yml")
-out = []
-skip = False
-base_indent = 4
-for line in p.read_text().splitlines():
-    stripped = line.lstrip()
-    indent = len(line) - len(stripped)
-    if not skip and line.startswith("    depends_on:"):
-        skip = True
-        continue
-    if skip:
-        if stripped and indent <= base_indent:
-            skip = False
-            out.append(line)
-        continue
-    out.append(line)
-p.write_text("\n".join(out) + "\n")
-PY
-fi
-#     Verify it's gone before Compose validates the project:
-if grep -q 'depends_on' rtvi-vlm-docker-compose.yml; then
-  echo "standalone compose still contains depends_on; remove it before up" >&2
-  exit 1
-fi
+# Step 0b. Keep COMPOSE_FILE pointed at the canonical file. Step 3 owns the
+#          one permitted fallback and records the exact validation failure first.
 
 # Step 1. Config — set model vars per §11 (Options A–E)
 #
@@ -528,9 +490,42 @@ if ! sudo -n chown -R 1001:1001 "$CLIP_STORAGE_DIR"; then
   exit 1
 fi
 
-# Step 3. Validate the standalone compose before creating containers.
-docker_cmd compose --env-file rtvi-vlm.env -f rtvi-vlm-docker-compose.yml \
-  --profile rtvi-vlm config --quiet
+# Step 3. Validate the canonical compose before creating containers. Only the
+# known optional-peer failure permits a normalized scratch copy.
+if ! COMPOSE_ERROR=$(docker_cmd compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" \
+  --profile rtvi-vlm config --quiet 2>&1); then
+  case "$COMPOSE_ERROR" in
+    *"depends on undefined service"*)
+      printf '%s\n' "$COMPOSE_ERROR" >&2
+      COMPOSE_FILE="$RTVI_DEPLOY_DIR/rtvi-vlm-docker-compose.yml"
+      cp "$CANONICAL_COMPOSE" "$COMPOSE_FILE"
+      python3 - "$COMPOSE_FILE" <<'PY'
+from pathlib import Path
+import sys
+
+p = Path(sys.argv[1])
+out = []
+skip = False
+for line in p.read_text().splitlines():
+    stripped = line.lstrip()
+    indent = len(line) - len(stripped)
+    if not skip and line.startswith("    depends_on:"):
+        skip = True
+        continue
+    if skip:
+        if stripped and indent <= 4:
+            skip = False
+            out.append(line)
+        continue
+    out.append(line)
+p.write_text("\n".join(out) + "\n")
+PY
+      docker_cmd compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" \
+        --profile rtvi-vlm config --quiet
+      ;;
+    *) printf '%s\n' "$COMPOSE_ERROR" >&2; exit 1 ;;
+  esac
+fi
 
 # Step 4. NGC auth. Pipe the key from the user shell; do not rely on sudo
 # preserving environment variables.
@@ -541,7 +536,7 @@ printf '%s' "$NGC_CLI_API_KEY" | docker_cmd login nvcr.io -u '$oauthtoken' --pas
 docker_cmd pull "nvcr.io/nvstaging/vss-core/vss-rt-vlm:${VLM_TAG}"
 
 # Step 6. Bring up — plain `up` (no profile) starts nothing
-docker_cmd compose --env-file rtvi-vlm.env -f rtvi-vlm-docker-compose.yml \
+docker_cmd compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" \
   --profile rtvi-vlm up -d
 
 # Step 7. Wait for healthy — start_period is 1200s (20 MIN) on first boot.
@@ -563,27 +558,27 @@ curl -f "http://localhost:${RTVI_VLM_PORT}/v1/health/ready"
 
 ## 13. Dry Run
 
-Run dry-runs from the standalone working directory after §12 Step 0b has stripped
-the dangling `depends_on` block. The raw checked-in compose is valid only inside
-the full VSS/met-blueprints multi-file project where sibling services exist.
+Run dry-runs from the standalone working directory with the `COMPOSE_FILE` selected
+by §12 Step 3. It remains the canonical checked-in file unless Compose produced the
+specific undefined-optional-peer error and the flow created a normalized scratch copy.
 
 ```bash
 cd "${RTVI_DEPLOY_DIR:?Set RTVI_DEPLOY_DIR to your standalone working directory}"
 
 # Resolved compose (audit; --no-interpolate keeps ${VAR} literal — no secrets leaked)
-docker compose --env-file rtvi-vlm.env -f rtvi-vlm-docker-compose.yml \
+docker compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" \
   --profile rtvi-vlm config --no-interpolate
 
 # Validation only
-docker compose --env-file rtvi-vlm.env -f rtvi-vlm-docker-compose.yml \
+docker compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" \
   --profile rtvi-vlm config --quiet && echo "compose valid"
 
 # Create containers + pull + volumes, but don't start
-docker compose --env-file rtvi-vlm.env -f rtvi-vlm-docker-compose.yml \
+docker compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" \
   --profile rtvi-vlm up --no-start
 
 # Cleanup
-docker compose --env-file rtvi-vlm.env -f rtvi-vlm-docker-compose.yml down
+docker compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" --profile rtvi-vlm down
 ```
 
 > Note: compose uses `${VAR:+:path}` conditional-bind on `ASSET_STORAGE_DIR` and
@@ -664,9 +659,9 @@ once the service is up):
 | Volume mount error mentioning `data_log/vst/clip_storage` | `VSS_DATA_DIR` unset → malformed mount | Set `VSS_DATA_DIR`; pre-create the `data_log/vst/clip_storage` subtree |
 | `sudo -n chown` reports that a password is required or fails in an agent session | Host path ownership requires user privileges and passwordless sudo is unavailable | Ask the host owner to run `sudo chown -R 1001:1001 "$VSS_DATA_DIR/data_log/vst/clip_storage"`; do not use `chmod 777` |
 | `sudo -n docker ...` reports that a password is required | Docker requires elevated privileges, but the agent cannot satisfy an interactive sudo prompt | Prefer adding the user to the docker group, enable passwordless sudo for Docker, or have the host owner run the printed Docker command manually. Do not retry with interactive sudo. |
-| `service "X" depends on undefined service "Y": invalid compose project` | Recent Docker Compose rejects `depends_on` refs to sibling NIM services not defined in this single-file project — even with `required: false`. | Remove the `depends_on` block from the local compose copy (§12 step 0b). Only needed for standalone deploys without the full met-blueprints project. |
+| `service "X" depends on undefined service "Y": invalid compose project` | Recent Docker Compose rejects `depends_on` refs to sibling NIM services not defined in this single-file project — even with `required: false`. | After recording this failure against the canonical file, use the normalized scratch copy created by §12 Step 3. |
 | `docker compose pull` → `invalid compose project` | Same `depends_on` validation runs before pull | Use `docker pull nvcr.io/nvstaging/vss-core/vss-rt-vlm:<tag>` directly (§4) |
-| `docker compose pull --no-deps` → `unknown flag: --no-deps` | Compose 2.38 does not support `--no-deps` on `pull` | Use direct `docker pull` (§4), or strip `depends_on` and validate before `up` (§12 step 0b). |
+| `docker compose pull --no-deps` → `unknown flag: --no-deps` | Compose 2.38 does not support `--no-deps` on `pull` | Use direct `docker pull` (§4); Compose validation and its conditional fallback remain in §12 Step 3. |
 | `password is empty` on Docker login | `$NGC_CLI_API_KEY` is not set in the invoking shell, or a previous sudo shell dropped the environment | Export `NGC_CLI_API_KEY` in the user shell and pipe it through the §12 Docker wrapper: `printf '%s' "$NGC_CLI_API_KEY" \| docker_cmd login nvcr.io -u '$oauthtoken' --password-stdin` |
 | `unauthorized` on `docker compose pull` | Missing NGC auth or no org access | `docker login nvcr.io` with a key that has `nvidia/vss-core` access |
 | `Exited (1)` "Error: No GPUs were found" | Container can't see GPUs | Install NVIDIA Container Toolkit; `docker run --rm --gpus all nvidia/cuda:12.4.0-base-ubuntu22.04 nvidia-smi` must work |
@@ -737,8 +732,8 @@ docker compose --env-file rtvi-vlm.env -f rtvi-vlm-docker-compose.yml down --rmi
   validates all `depends_on` service references at project load time and rejects
   them with `invalid compose project` if the services aren't defined — regardless
   of `required: false`. For standalone deployments (no full met-blueprints
-  project), strip the `depends_on` block from the local compose copy (§12 step
-  0b). The `required: false` behavior works correctly only when running under
+  project), first record the canonical validation failure, then use §12 Step 3's
+  normalized scratch copy. The `required: false` behavior works correctly only when running under
   the full met-blueprints multi-file project where all sibling services are
   defined.
 - **`sudo docker` drops environment variables**: `NGC_CLI_API_KEY` and other

--- a/skills/deployment/vss-deploy-dense-captioning/references/deploy-rt-vlm-service.md
+++ b/skills/deployment/vss-deploy-dense-captioning/references/deploy-rt-vlm-service.md
@@ -3,16 +3,17 @@
 ## 1. Overview
 
 **Service**: `rtvi-vlm` (container name `vss-rtvi-vlm`)
-**Image (default multiarch: x86 / Jetson-Tegra / non-Spark non-SBSA)**: `nvcr.io/nvstaging/vss-core/vss-rt-vlm:3.3.0-26.08.2`
-**Image (Spark / GB10 / SBSA / Grace)**: `nvcr.io/nvstaging/vss-core/vss-rt-vlm:3.3.0-26.08.2-sbsa`
+**Image**: resolve it from the canonical Compose file; its standalone default is
+`ghcr.io/nvidia-ai-blueprints/vss/vss-rt-vlm:develop-latest`, and environment
+overrides may select a release registry/tag or the `-sbsa` platform variant.
 **Primary port**: `${RTVI_VLM_PORT}` → container `8000` (FastAPI REST, `/v1`)
 **Validated GPUs**: H100 · RTX PRO 6000 Blackwell · L40S · DGX SPARK · IGX Thor · AGX Thor
 
 Derive `<compose-default>` from the checked-out
 `deploy/docker/services/rtvi/rtvi-vlm/rtvi-vlm-docker-compose.yml` instead of
 hardcoding it in commands. The current compose default is
-`3.3.0-26.08.2`; Spark, GB10, and SBSA-class platforms append `-sbsa`. All other
-platforms use the normal multiarch tag.
+`develop-latest`; Spark, GB10, and SBSA-class platforms append `-sbsa`. All
+other platforms use the normal multiarch tag.
 
 Real-Time VLM is VSS's streaming vision-language inference service: RTSP decode →
 segmentation → VLM inference (vLLM) → Kafka publication (NvSchema protobuf).
@@ -52,10 +53,11 @@ live-authoritative schema — see §16.
 - **`VSS_DATA_DIR`** host path — compose bind-mounts
   `${VSS_DATA_DIR}/data_log/vst/clip_storage` with no default → mount breaks if unset
 - **Free port**: `${RTVI_VLM_PORT}` (whatever you pick)
-- **Outbound**: `nvcr.io`, `huggingface.co`, any remote NIM/OpenAI endpoints
+- **Outbound**: the Compose-resolved image registry (`ghcr.io` by default),
+  `nvcr.io`, `huggingface.co`, and any remote NIM/OpenAI endpoints
 
-> ⚠ **Profiles are mandatory.** Service declares **6 blueprint profiles**
-> (§12). Plain `docker compose up` starts **nothing** — pass `--profile <name>`.
+> ⚠ **Profiles are mandatory.** The standalone file declares only `rtvi-vlm`.
+> Plain `docker compose up` starts **nothing** — pass `--profile rtvi-vlm`.
 
 For standalone Kafka setup, use
 [`kafka-workflows.md`](kafka-workflows.md#standalone-kafka-listener-setup). This
@@ -80,10 +82,8 @@ docker run --rm --gpus all nvidia/cuda:12.4.0-base-ubuntu22.04 nvidia-smi
 export NGC_CLI_API_KEY="<YOUR_NGC_KEY>"
 echo "$NGC_CLI_API_KEY" | docker login nvcr.io -u '$oauthtoken' --password-stdin
 
-# Run the Step 0a tag-selection snippet against the canonical compose below, then
-# verify pull access for the exact image this compose will use.
-: "${RTVI_VLM_IMAGE_TAG:?Run Step 0a below to set RTVI_VLM_IMAGE_TAG first}"
-docker pull "nvcr.io/nvstaging/vss-core/vss-rt-vlm:${RTVI_VLM_IMAGE_TAG}"
+# Step 5 resolves and pulls the exact image selected by the canonical Compose
+# file after its environment and platform tag have been applied.
 ```
 
 > ⚠ **`docker compose pull` fails on standalone deployments** (recent Docker
@@ -133,11 +133,11 @@ Use the `rtvi-vlm.env` block in §12 as the starting point.
 
 | Compose line | Spec | Stateful? | `down -v` destroys? |
 |---|---|---|---|
-| 108 | `${ASSET_STORAGE_DIR:-/dummy}${ASSET_STORAGE_DIR:+:/tmp/assets}` (optional bind over tmpfs) | yes (if set) | yes (host bind) |
-| 109 | `${RTVI_VLM_HF_CACHE:-rtvi-hf-cache}:/tmp/huggingface` (named by default, multi-GB) | **yes** | **YES — multi-GB re-download** |
-| 110 | `${VSS_DATA_DIR}/data_log/vst/clip_storage:<container VST streamer video dir>` — **no default → required** | yes | yes (host bind) |
-| 111 | `${NGC_MODEL_CACHE:-rtvi-ngc-model-cache}:/opt/nvidia/rtvi/.rtvi/ngc_model_cache` (named) | **yes** | **YES — re-download weights** |
-| 112 | `${RTVI_VLM_LOG_DIR:-/dummy}${RTVI_VLM_LOG_DIR:+:/opt/nvidia/rtvi/log/rtvi/}` (optional bind) | no | no |
+| 173 | `${ASSET_STORAGE_DIR:-/dummy}${ASSET_STORAGE_DIR:+:/tmp/assets}` (optional bind over tmpfs) | yes (if set) | yes (host bind) |
+| 174 | `${RTVI_VLM_HF_CACHE:-rtvi-hf-cache}:/tmp/huggingface` (named by default, multi-GB) | **yes** | **YES — multi-GB re-download** |
+| 175 | `${VSS_DATA_DIR}/data_log/vst/clip_storage:<container VST streamer video dir>` — **no default → required** | yes | yes (host bind) |
+| 176 | `${NGC_MODEL_CACHE:-rtvi-ngc-model-cache}:/opt/nvidia/rtvi/.rtvi/ngc_model_cache` (named) | **yes** | **YES — re-download weights** |
+| 177 | `${RTVI_VLM_LOG_DIR:-/dummy}${RTVI_VLM_LOG_DIR:+:/opt/nvidia/rtvi/log/rtvi/}` (optional bind) | no | no |
 
 **Required host-path setup** — `VSS_DATA_DIR` is not optional. See the
 host-path setup step in the Quick-Start section below for the exact commands to
@@ -242,7 +242,7 @@ Kafka and Redis are **not bundled** — expected on host or in a sibling compose
 Set `RTVI_VLM_MODEL_TO_USE` in `rtvi-vlm.env` to select the backend. After any change:
 
 ```bash
-docker compose --env-file rtvi-vlm.env -f rtvi-vlm-docker-compose.yml \
+docker compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" \
   --profile rtvi-vlm up -d --force-recreate rtvi-vlm
 ```
 
@@ -373,19 +373,10 @@ start from the canonical checked-in compose, build a deploy-specific `rtvi-vlm.e
 dry-run, review, deploy, and wait for health. Only create a normalized scratch copy
 after Compose specifically rejects undefined optional peers. Never skip the dry-run.
 
-This compose declares **6 blueprint profiles**. Service will NOT start under
-plain `docker compose up` — `--profile <name>` is required.
-
-| Profile | Intended use |
-|---|---|
-| `bp_wh_2d` | Warehouse/base 2D profile |
-| `rtvi-vlm` | Alerts blueprint (2D, VLM-only) |
-| `bp_developer_alerts_2d_cv` | Alerts (2D + CV) |
-| `bp_developer_base_2d_IGX-THOR` | Base 2D on IGX Thor |
-| `bp_developer_base_2d_AGX-THOR` | Base 2D on AGX Thor |
-| `bp_developer_lvs_2d` | LVS 2D profile |
-
-Generic VLM workflow → `rtvi-vlm`.
+This standalone file declares one profile: `rtvi-vlm`. Additional blueprint
+profiles exist only in the full multi-file VSS Compose project. Plain
+`docker compose up` starts nothing; standalone deployment must pass
+`--profile rtvi-vlm`.
 
 ```bash
 # Step 0. Select the canonical checked-in compose. Do not start from an existing copy.
@@ -399,21 +390,21 @@ COMPOSE_FILE="$CANONICAL_COMPOSE"
 # Step 0a. Derive the compose default tag, then select the platform variant.
 #          Spark/GB10/SBSA requires the -sbsa tag.
 #          x86_64 and Tegra-based Jetson/AGX/IGX Thor use the normal multiarch tag.
-COMPOSE_DEFAULT_TAG=$(sed -nE 's/.*RTVI_VLM_IMAGE_TAG:-([^}]+).*/\1/p' "$CANONICAL_COMPOSE" | head -n1)
-: "${COMPOSE_DEFAULT_TAG:?Could not derive RTVI_VLM_IMAGE_TAG default}"
-RTVI_VLM_IMAGE_TAG="${RTVI_VLM_IMAGE_TAG:-$COMPOSE_DEFAULT_TAG}"
-RTVI_VLM_BASE_TAG="${RTVI_VLM_IMAGE_TAG%-sbsa}"
+COMPOSE_DEFAULT_TAG=$(sed -nE 's/.*VSS_RT_VLM_TAG:-([^}]+).*/\1/p' "$CANONICAL_COMPOSE" | head -n1)
+: "${COMPOSE_DEFAULT_TAG:?Could not derive VSS_RT_VLM_TAG default}"
+VSS_RT_VLM_TAG="${VSS_RT_VLM_TAG:-$COMPOSE_DEFAULT_TAG}"
+VSS_RT_VLM_BASE_TAG="${VSS_RT_VLM_TAG%-sbsa}"
 ARCH=$(uname -m)
 PROFILE=$(printf '%s' "${HARDWARE_PROFILE:-}" | tr '[:lower:]' '[:upper:]')
 if printf '%s' "$PROFILE" | grep -Eq 'DGX-SPARK|SPARK|GB10|SBSA'; then
-  VLM_TAG="${RTVI_VLM_BASE_TAG}-sbsa" # Spark / GB10 / SBSA
+  VLM_TAG="${VSS_RT_VLM_BASE_TAG}-sbsa" # Spark / GB10 / SBSA
 elif [ "$ARCH" = "x86_64" ]; then
-  VLM_TAG="$RTVI_VLM_BASE_TAG"
+  VLM_TAG="$VSS_RT_VLM_BASE_TAG"
 elif [ "$ARCH" = "aarch64" ]; then
   if grep -qi tegra /proc/cpuinfo 2>/dev/null || [ -f /etc/nv_tegra_release ]; then
-    VLM_TAG="$RTVI_VLM_BASE_TAG"        # Jetson / AGX Thor / IGX Thor (Tegra)
+    VLM_TAG="$VSS_RT_VLM_BASE_TAG"        # Jetson / AGX Thor / IGX Thor (Tegra)
   else
-    VLM_TAG="${RTVI_VLM_BASE_TAG}-sbsa" # SBSA server-ARM, including DGX Spark / GB10 / Grace
+    VLM_TAG="${VSS_RT_VLM_BASE_TAG}-sbsa" # SBSA server-ARM, including DGX Spark / GB10 / Grace
   fi
 else
   echo "Unsupported architecture: $ARCH" && exit 1
@@ -453,7 +444,7 @@ NGC_CLI_API_KEY=${NGC_CLI_API_KEY}
 RTVI_VLM_PORT=8018
 HOST_IP=${HOST_IP}
 VSS_DATA_DIR=${VSS_DATA_DIR}
-RTVI_VLM_IMAGE_TAG=${VLM_TAG}
+VSS_RT_VLM_TAG=${VLM_TAG}
 RT_VLM_DEVICE_ID=0
 # Model config (choose one option from §11):
 RTVI_VLM_MODEL_TO_USE=cosmos-reason3
@@ -504,9 +495,42 @@ from pathlib import Path
 import sys
 
 p = Path(sys.argv[1])
+allowed = {
+    "broker-health-check",
+    "cosmos-reason1-7b",
+    "cosmos-reason1-7b-shared-gpu",
+    "cosmos-reason2-8b",
+    "cosmos-reason2-8b-shared-gpu",
+    "cosmos3-reasoner",
+    "cosmos3-reasoner-shared-gpu",
+    "qwen3-vl-8b-instruct",
+    "qwen3-vl-8b-instruct-shared-gpu",
+}
+lines = p.read_text().splitlines()
+dependencies = {}
+in_block = False
+current = None
+for line in lines:
+    stripped = line.lstrip()
+    indent = len(line) - len(stripped)
+    if not in_block and line.startswith("    depends_on:"):
+        in_block = True
+        continue
+    if in_block and stripped and indent <= 4:
+        break
+    if in_block and indent == 6 and stripped.endswith(":"):
+        current = stripped[:-1]
+        dependencies[current] = False
+    elif in_block and current and indent == 8 and stripped == "required: false":
+        dependencies[current] = True
+
+unsafe = sorted(name for name, optional in dependencies.items() if name not in allowed or not optional)
+if not dependencies or unsafe:
+    raise SystemExit(f"Refusing to remove unknown or required dependencies: {unsafe or 'none found'}")
+
 out = []
 skip = False
-for line in p.read_text().splitlines():
+for line in lines:
     stripped = line.lstrip()
     indent = len(line) - len(stripped)
     if not skip and line.startswith("    depends_on:"):
@@ -532,8 +556,11 @@ fi
 : "${NGC_CLI_API_KEY:?Set NGC_CLI_API_KEY before docker login}"
 printf '%s' "$NGC_CLI_API_KEY" | docker_cmd login nvcr.io -u '$oauthtoken' --password-stdin
 
-# Step 5. Pull image directly (docker compose pull fails on standalone — see §4)
-docker_cmd pull "nvcr.io/nvstaging/vss-core/vss-rt-vlm:${VLM_TAG}"
+# Step 5. Resolve and pull the exact image selected by Compose.
+RTVI_VLM_IMAGE=$(docker_cmd compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" \
+  --profile rtvi-vlm config --images | awk 'NF { print; exit }')
+: "${RTVI_VLM_IMAGE:?Compose did not resolve an rtvi-vlm image}"
+docker_cmd pull "$RTVI_VLM_IMAGE"
 
 # Step 6. Bring up — plain `up` (no profile) starts nothing
 docker_cmd compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" \
@@ -546,8 +573,21 @@ docker_cmd compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" \
 #         Warm-cache restart (rtvi-hf-cache + rtvi-ngc-model-cache preserved across
 #         `down` without -v) completes in ~55 seconds. IN-1 reference reruns
 #         logged 54s and 56s in this window.
-until [ "$(docker_cmd compose --env-file rtvi-vlm.env -f rtvi-vlm-docker-compose.yml ps --format json rtvi-vlm \
-  | jq -r 'if length > 0 then ([.[].Health] | all(. == "healthy")) else false end')" = "true" ]; do
+HEALTH_DEADLINE=$((SECONDS + 1200))
+while true; do
+  if ! PS_JSON=$(docker_cmd compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" \
+    --profile rtvi-vlm ps --format json rtvi-vlm); then
+    echo "ERROR: failed to query rtvi-vlm health" >&2
+    exit 1
+  fi
+  if [ "$(printf '%s' "$PS_JSON" | jq -r 'if length > 0 then ([.[].Health] | all(. == "healthy")) else false end')" = "true" ]; then
+    break
+  fi
+  if (( SECONDS >= HEALTH_DEADLINE )); then
+    echo "ERROR: rtvi-vlm did not become healthy within 1200 seconds" >&2
+    docker_cmd logs --tail 200 vss-rtvi-vlm >&2 || true
+    exit 1
+  fi
   echo "waiting for rtvi-vlm… (~55s warm-cache, up to 20 minutes on first run)"
   sleep 15
 done
@@ -564,6 +604,7 @@ specific undefined-optional-peer error and the flow created a normalized scratch
 
 ```bash
 cd "${RTVI_DEPLOY_DIR:?Set RTVI_DEPLOY_DIR to your standalone working directory}"
+: "${COMPOSE_FILE:?Run §12 Step 0 first, or set COMPOSE_FILE to the canonical compose path}"
 
 # Resolved compose (audit; --no-interpolate keeps ${VAR} literal — no secrets leaked)
 docker compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" \
@@ -609,14 +650,14 @@ Healthy log signatures (`docker logs vss-rtvi-vlm`):
 ## 15. Logs & Status
 
 ```bash
-docker compose --env-file rtvi-vlm.env -f rtvi-vlm-docker-compose.yml ps
+docker compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" --profile rtvi-vlm ps
 
 # By container name (compose sets container_name: vss-rtvi-vlm)
 docker logs -f vss-rtvi-vlm
 
 # Or by service via compose
-docker compose --env-file rtvi-vlm.env -f rtvi-vlm-docker-compose.yml logs -f rtvi-vlm
-docker compose --env-file rtvi-vlm.env -f rtvi-vlm-docker-compose.yml logs --tail 200 --since 10m rtvi-vlm
+docker compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" --profile rtvi-vlm logs -f rtvi-vlm
+docker compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" --profile rtvi-vlm logs --tail 200 --since 10m rtvi-vlm
 
 docker stats vss-rtvi-vlm
 nvidia-smi dmon -s u
@@ -660,8 +701,8 @@ once the service is up):
 | `sudo -n chown` reports that a password is required or fails in an agent session | Host path ownership requires user privileges and passwordless sudo is unavailable | Ask the host owner to run `sudo chown -R 1001:1001 "$VSS_DATA_DIR/data_log/vst/clip_storage"`; do not use `chmod 777` |
 | `sudo -n docker ...` reports that a password is required | Docker requires elevated privileges, but the agent cannot satisfy an interactive sudo prompt | Prefer adding the user to the docker group, enable passwordless sudo for Docker, or have the host owner run the printed Docker command manually. Do not retry with interactive sudo. |
 | `service "X" depends on undefined service "Y": invalid compose project` | Recent Docker Compose rejects `depends_on` refs to sibling NIM services not defined in this single-file project — even with `required: false`. | After recording this failure against the canonical file, use the normalized scratch copy created by §12 Step 3. |
-| `docker compose pull` → `invalid compose project` | Same `depends_on` validation runs before pull | Use `docker pull nvcr.io/nvstaging/vss-core/vss-rt-vlm:<tag>` directly (§4) |
-| `docker compose pull --no-deps` → `unknown flag: --no-deps` | Compose 2.38 does not support `--no-deps` on `pull` | Use direct `docker pull` (§4); Compose validation and its conditional fallback remain in §12 Step 3. |
+| `docker compose pull` → `invalid compose project` | Same `depends_on` validation runs before pull | Resolve the exact image with `docker compose config --images`, then use direct `docker pull` (§12 Step 5). |
+| `docker compose pull --no-deps` → `unknown flag: --no-deps` | Compose 2.38 does not support `--no-deps` on `pull` | Use the resolved direct pull (§12 Step 5); Compose validation and its conditional fallback remain in Step 3. |
 | `password is empty` on Docker login | `$NGC_CLI_API_KEY` is not set in the invoking shell, or a previous sudo shell dropped the environment | Export `NGC_CLI_API_KEY` in the user shell and pipe it through the §12 Docker wrapper: `printf '%s' "$NGC_CLI_API_KEY" \| docker_cmd login nvcr.io -u '$oauthtoken' --password-stdin` |
 | `unauthorized` on `docker compose pull` | Missing NGC auth or no org access | `docker login nvcr.io` with a key that has `nvidia/vss-core` access |
 | `Exited (1)` "Error: No GPUs were found" | Container can't see GPUs | Install NVIDIA Container Toolkit; `docker run --rm --gpus all nvidia/cuda:12.4.0-base-ubuntu22.04 nvidia-smi` must work |
@@ -674,17 +715,17 @@ once the service is up):
 
 **Forward**:
 ```bash
-# rtvi-vlm.env: RTVI_VLM_IMAGE_TAG=<new-tag>
-docker compose --env-file rtvi-vlm.env -f rtvi-vlm-docker-compose.yml --profile <p> pull rtvi-vlm
-docker compose --env-file rtvi-vlm.env -f rtvi-vlm-docker-compose.yml --profile <p> up -d --force-recreate rtvi-vlm
+# rtvi-vlm.env: VSS_RT_VLM_TAG=<new-tag>
+docker compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" --profile rtvi-vlm pull rtvi-vlm
+docker compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" --profile rtvi-vlm up -d --force-recreate rtvi-vlm
 ```
 
 **Rollback**:
 ```bash
 # Record current tag first: `docker compose --env-file rtvi-vlm.env -f ... images rtvi-vlm`
-# rtvi-vlm.env: RTVI_VLM_IMAGE_TAG=<prior-tag>
-docker compose --env-file rtvi-vlm.env -f rtvi-vlm-docker-compose.yml --profile <p> pull rtvi-vlm
-docker compose --env-file rtvi-vlm.env -f rtvi-vlm-docker-compose.yml --profile <p> up -d --force-recreate rtvi-vlm
+# rtvi-vlm.env: VSS_RT_VLM_TAG=<prior-tag>
+docker compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" --profile rtvi-vlm pull rtvi-vlm
+docker compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" --profile rtvi-vlm up -d --force-recreate rtvi-vlm
 ```
 
 Named volumes survive both. Re-download only if `MODEL_PATH` changes.
@@ -693,15 +734,16 @@ Named volumes survive both. Re-download only if `MODEL_PATH` changes.
 
 ```bash
 cd "${RTVI_DEPLOY_DIR:?Set RTVI_DEPLOY_DIR to your standalone working directory}"
+: "${COMPOSE_FILE:?Run §12 Step 0 first, or set COMPOSE_FILE to the canonical compose path}"
 
 # Keep named volumes (model caches preserved)
-docker compose --env-file rtvi-vlm.env -f rtvi-vlm-docker-compose.yml --profile rtvi-vlm down
+docker compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" --profile rtvi-vlm down
 
 # WIPES model caches (20–80 GB re-download)
-docker compose --env-file rtvi-vlm.env -f rtvi-vlm-docker-compose.yml --profile rtvi-vlm down -v
+docker compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" --profile rtvi-vlm down -v
 
 # Remove locally-pulled image
-docker compose --env-file rtvi-vlm.env -f rtvi-vlm-docker-compose.yml down --rmi local
+docker compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" --profile rtvi-vlm down --rmi local
 
 # Optional host-side (do NOT rm $VSS_DATA_DIR — shared with other services)
 # rm -rf ./rtvi-assets ./rtvi-logs
@@ -722,7 +764,7 @@ docker compose --env-file rtvi-vlm.env -f rtvi-vlm-docker-compose.yml down --rmi
   cache volume can trigger a `torch_aot_compile` / `_Missing has no attribute
   _modules` warning and force a full vLLM recompile on first boot.
 - **Profiles are mandatory**: `docker compose up` without `--profile` starts
-  nothing. 6 profiles available — §12.
+  nothing. The standalone file supports only `--profile rtvi-vlm` — §12.
 - **`container_name: vss-rtvi-vlm` hardcoded** (line 22) — can't run two instances
   on the same host without editing. Second `up` fails with
   `Conflict. The container name "/vss-rtvi-vlm" is already in use`.

--- a/skills/deployment/vss-deploy-dense-captioning/references/deploy-rt-vlm-service.md
+++ b/skills/deployment/vss-deploy-dense-captioning/references/deploy-rt-vlm-service.md
@@ -508,40 +508,40 @@ allowed = {
 }
 lines = p.read_text().splitlines()
 dependencies = {}
-in_block = False
+try:
+    service_start = lines.index("  rtvi-vlm:")
+except ValueError as exc:
+    raise SystemExit("Refusing to normalize: rtvi-vlm service not found") from exc
+service_end = next(
+    (i for i in range(service_start + 1, len(lines))
+     if lines[i].strip() and len(lines[i]) - len(lines[i].lstrip()) <= 2),
+    len(lines),
+)
+try:
+    depends_start = lines.index("    depends_on:", service_start + 1, service_end)
+except ValueError as exc:
+    raise SystemExit("Refusing to normalize: rtvi-vlm depends_on block not found") from exc
+depends_end = next(
+    (i for i in range(depends_start + 1, service_end)
+     if lines[i].strip() and len(lines[i]) - len(lines[i].lstrip()) <= 4),
+    service_end,
+)
+
 current = None
-for line in lines:
+for line in lines[depends_start + 1:depends_end]:
     stripped = line.lstrip()
     indent = len(line) - len(stripped)
-    if not in_block and line.startswith("    depends_on:"):
-        in_block = True
-        continue
-    if in_block and stripped and indent <= 4:
-        break
-    if in_block and indent == 6 and stripped.endswith(":"):
+    if indent == 6 and stripped.endswith(":"):
         current = stripped[:-1]
         dependencies[current] = False
-    elif in_block and current and indent == 8 and stripped == "required: false":
+    elif current and indent == 8 and stripped == "required: false":
         dependencies[current] = True
 
 unsafe = sorted(name for name, optional in dependencies.items() if name not in allowed or not optional)
 if not dependencies or unsafe:
     raise SystemExit(f"Refusing to remove unknown or required dependencies: {unsafe or 'none found'}")
 
-out = []
-skip = False
-for line in lines:
-    stripped = line.lstrip()
-    indent = len(line) - len(stripped)
-    if not skip and line.startswith("    depends_on:"):
-        skip = True
-        continue
-    if skip:
-        if stripped and indent <= 4:
-            skip = False
-            out.append(line)
-        continue
-    out.append(line)
+out = lines[:depends_start] + lines[depends_end:]
 p.write_text("\n".join(out) + "\n")
 PY
       docker_cmd compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" \

--- a/skills/deployment/vss-deploy-dense-captioning/references/integrate-rt-vlm.md
+++ b/skills/deployment/vss-deploy-dense-captioning/references/integrate-rt-vlm.md
@@ -108,10 +108,10 @@ The host-side variable names that the compose interpolates differ from the canon
 | `RTVI_VLM_PORT` | Host REST API port (rewrites to container `8000`) | strict (`${RTVI_VLM_PORT?}`) | **Yes** |
 | `HOST_IP` | Interpolated into `KAFKA_BOOTSTRAP_SERVERS=${HOST_IP}:9092`; no fallback | — | **Yes (effective)** |
 | `VSS_DATA_DIR` | Bind-mount root for VST clip storage `${VSS_DATA_DIR}/data_log/vst/clip_storage` | — | **Yes** |
-| `NGC_CLI_API_KEY` / `RTVI_VLM_API_KEY` | rewrites to `NGC_API_KEY` + `VIA_VLM_API_KEY` — image pull + NIM auth | — | **Yes** |
+| `NGC_CLI_API_KEY` / `RTVI_VLM_API_KEY` | rewrites to `NGC_API_KEY` + `VIA_VLM_API_KEY` for model download and NIM auth | — | **Yes** |
 | `HF_TOKEN` | Gated HuggingFace pulls (Qwen3-VL, Cosmos3) | — | conditional |
 | `RTVI_VLM_MODEL_TO_USE` → `VLM_MODEL_TO_USE` | Backend selector: `openai-compat` (default), `cosmos-reason1`, `cosmos-reason2`, `cosmos-reason3`, `vllm-compatible`, `custom` | `openai-compat` | **Yes** |
-| `RTVI_VLM_MODEL_PATH` → `MODEL_PATH` | NGC/git path to model when not `openai-compat`. **Override to `:1208-fp8-static-kv8` for cosmos-reason2 to match VSS docs / NIM siblings — compose default `:hf-1208` is a different quant.** | `ngc:nim/nvidia/cosmos-reason2-8b:hf-1208` (compose) / `ngc:nim/nvidia/cosmos-reason2-8b:0303-fp8-dynamic-kv8` (rst sample) | conditional |
+| `RTVI_VLM_MODEL_PATH` → `MODEL_PATH` | NGC/git path to the model when not `openai-compat`; override it only when selecting a different backend/model. | `ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final` | conditional |
 | `RT_VLM_DEVICE_ID` | GPU `device_ids` entry (breaks `RTVI_VLM_*` pattern by design — fixed by upstream compose) | `0` | optional |
 | `RTVI_VLM_NVIDIA_VISIBLE_DEVICES` → `NVIDIA_VISIBLE_DEVICES` | GPU visibility | `all` | optional |
 | `KAFKA_ENABLED` | Toggle Kafka output | `true` | optional |
@@ -120,10 +120,10 @@ The host-side variable names that the compose interpolates differ from the canon
 | `RTVI_VLM_ERROR_BUS` → `ERROR_BUS` | Error-output broker type | `kafka` | optional; empty disables errors |
 | `RTVI_VLM_KAFKA_INCIDENT_TOPIC` → `KAFKA_INCIDENT_TOPIC` | Incident topic | `mdx-vlm-incidents` | optional |
 | `KAFKA_BOOTSTRAP_SERVERS` | Broker address | `${HOST_IP}:9092` (host-net) or `kafka:9092` (compose-net) | **Yes (effective)** |
-| `ERROR_MESSAGE_TOPIC` | Error topic | `mdx-vlm-errors` | optional |
+| `RTVI_VLM_ERROR_MESSAGE_TOPIC` → `ERROR_MESSAGE_TOPIC` | Error topic | `vision-llm-errors` | optional |
 | `VIA_VLM_ENDPOINT` (host: `RTVI_VLM_ENDPOINT`) | Remote OpenAI-compat backend URL when `VLM_MODEL_TO_USE=openai-compat` | — | conditional |
 | `VIA_VLM_OPENAI_MODEL_DEPLOYMENT_NAME` (host: `VLM_NAME`) | Remote model deployment name | — | conditional |
-| `RTVI_VLM_IMAGE_TAG` | Compose image-tag override; pick platform-correct tag (`3.3.0-26.08.2` for x86/Tegra; `3.3.0-26.08.2-sbsa` for SBSA Grace/Spark). **Resolve the live default from `dev-profile-base/.env` — do NOT hardcode; the tag stream moves (was `3.2.0-26.04.1`, is `3.3.0-26.08.2` as of 2026-06-02).** | `3.3.0-26.08.2` (per `dev-profile-base/.env`) | optional |
+| `VSS_RT_VLM_TAG` | Compose image-tag override; append `-sbsa` only for SBSA Grace/Spark. Resolve the standalone default from the canonical RT-VLM Compose file; the full VSS project may override it through `deploy/docker/containers.env`. | `develop-latest` (standalone Compose) | optional |
 
 ## Network Requirements
 
@@ -141,12 +141,12 @@ The host-side variable names that the compose interpolates differ from the canon
 
 - **Endpoint rename (3.2.0 breaking change).** `/v1/generate_captions_alerts` was renamed to `/v1/generate_captions`. 3.1.0-era clients break — update before deployment. Source: `real-time-vlm.rst` § Breaking Changes.
 - **Duplicate stream/camera IDs now 409.** Re-adding a stream with the same ID returns HTTP 409 (`DuplicateStreamId` / `DuplicateCameraId`) instead of silently overwriting. Idempotent registration code must remove first or handle 409. Source: `real-time-vlm.rst` § Breaking Changes (lines 99–102).
-- **`depends_on.required: false` is NOT enough on recent Docker Compose.** The live compose declares **8** sibling-NIM `depends_on` peers, all `required: false`: `cosmos-reason1-7b`, `cosmos-reason1-7b-shared-gpu`, `cosmos-reason2-8b`, `cosmos-reason2-8b-shared-gpu`, `cosmos3-reasoner`, `cosmos3-reasoner-shared-gpu`, `qwen3-vl-8b-instruct`, `qwen3-vl-8b-instruct-shared-gpu` (plus `broker-health-check`, which IS defined when ELK is present and is kept). (Verified live 2026-06-02 — earlier revisions of this doc listed only the cosmos-reason1/2 + qwen3 trio and omitted `cosmos3-reasoner` ± `-shared-gpu`; the upstream peer set has grown.) Recent Compose still validates these refs at project-load time and rejects standalone deploys with `invalid compose project`. A consumer deploying rtvi-vlm standalone must strip whichever NIM peers are undefined in its include graph (all 8 for an in-process backend); the generalized rule "strip any undefined `required:false` peer" is robust to the set changing. Source: `deploy-rt-vlm-service.md` §20 + §4.
-- **Profiles are mandatory.** The upstream rtvi-vlm compose declares 6 compose profiles (`bp_wh_2d`, `bp_developer_alerts_2d_vlm`, `bp_developer_alerts_2d_cv`, `bp_developer_base_2d_IGX-THOR`, `bp_developer_base_2d_AGX-THOR`, `bp_developer_lvs_2d`). `docker compose up` without `--profile` starts **nothing**. A standalone deploy must add its chosen compose-profile flag to the `profiles:` list of its compose copy.
+- **`depends_on.required: false` is NOT enough on recent Docker Compose.** The live compose declares eight sibling-NIM peers plus `broker-health-check`, all `required: false`. Recent Compose still rejects undefined peers during standalone project loading. Follow the guarded fallback in `deploy-rt-vlm-service.md`: normalize only after canonical validation fails, and only when every dependency matches the documented optional-peer allowlist. Reject unknown or required dependencies instead of hiding a Compose regression.
+- **Profiles are mandatory.** The standalone RT-VLM Compose file declares only `rtvi-vlm`; additional blueprint profiles come from the full VSS include graph. Standalone deployment must pass `--profile rtvi-vlm`.
 - **Single-instance.** `container_name: vss-rtvi-vlm` is hardcoded in the upstream compose. A second instance on the same host fails with `Conflict. The container name "/vss-rtvi-vlm" is already in use`. Source: `deploy-rt-vlm-service.md` §20.
 - **NvSchema protobuf must align with Logstash descriptors.** The producer (RT-VLM) and the consumer (Logstash) must agree on the `nv.VisionLLM` and `nv.Incident` proto schema. The shared source-of-truth is the descriptor pair at `deploy/docker/services/infra/elk/pb_definitions/descriptors/{schema.desc, ext.desc}`. Schema drift on one side without the other causes Logstash to write empty/default-valued documents to ES without raising. Source: `integrate-elk.md` § Known Integration Constraints.
 - **Caption topic must be `mdx-vlm-captions` (resolved in VSS 3.2).** VSS 3.2 added the `mdx-lvs` Logstash pipeline (`pipelines/kafka/mdx-lvs-logstash.conf`) that subscribes to `mdx-vlm-captions` and indexes captions into ES using via-ctx-rag's `add_summary` shape (indices named `<collection>_<id>`, not `mdx-vlm-*` date indices). Use `RTVI_VLM_MESSAGE_BUS=kafka` and `RTVI_VLM_MESSAGE_BUS_TOPIC=mdx-vlm-captions` so captions reach ES without any Logstash config patching. Source: live verification 2026-05-23, `met-blueprint-docs/real-time-vlm.rst`, `mdx-lvs-logstash.conf`.
-- **MODEL_PATH tag divergence (must override).** Compose default is `ngc:nim/nvidia/cosmos-reason2-8b:hf-1208` but the VSS-docs-matching tag is `:1208-fp8-static-kv8` (the rst sample uses `:0303-fp8-dynamic-kv8`). These tags are NOT interchangeable on a live cache — different quant produces different torch_aot_compile cache hashes. Source: `deploy-rt-vlm-service.md` §20 third bullet.
+- **MODEL_PATH follows the canonical Compose default.** Standalone deployment uses `ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final` unless the selected backend/model explicitly requires another artifact. Different quantizations are not interchangeable in an existing compile cache.
 - **VOD vs. RTSP timestamp differ.** File uploads (VOD) carry chunk-relative epoch timestamps; if the upload `timestamp` query param is unset, caption docs land in the `mdx-vlm-1970-01-01` ES index. RTSP streams carry wall-clock NTP timestamps and land in the correct date-named index. Affects Kibana dashboards — time picker must include 1970 for VOD-driven captions. Source: `EXAMPLE-PROMPTS.md` § P-006-S1 known edge cases.
 - **Jetson Thor / DGX Spark instability at 8+ vision tokens.** Documented platform issue. Cap streams ≤2 or drop input resolution. Source: `real-time-vlm.rst` § (search "Jetson Thor") + `deploy-rt-vlm-service.md` §9.
 - **First-boot cold-start is 20 minutes.** Model weight download + vLLM warmup + CUDA graph capture fills the `start_period: 1200s`. Warm-cache restart is ~55 s. Pre-warn operators not to kill as "stuck." Source: `real-time-vlm.rst` § Sample docker-compose.yml (line 393).
@@ -154,21 +154,19 @@ The host-side variable names that the compose interpolates differ from the canon
 
 ## Example Compose Snippet
 
-Minimal IN-1-relevant block. Full upstream compose is at `deploy/docker/services/rtvi/rtvi-vlm/rtvi-vlm-docker-compose.yml`; a standalone deploy patches a copy (never the upstream tree). Sourced from `real-time-vlm.rst` § Sample docker-compose.yml (lines 272–397) — abbreviated to the IN-1 minimum.
+Minimal standalone-relevant block. The canonical source is `deploy/docker/services/rtvi/rtvi-vlm/rtvi-vlm-docker-compose.yml`; use it directly unless canonical validation requires the guarded normalized copy described in `deploy-rt-vlm-service.md`.
 
 ```yaml
 services:
   rtvi-vlm:
-    image: nvcr.io/nvstaging/vss-core/vss-rt-vlm:${RTVI_VLM_IMAGE_TAG:-3.3.0-26.08.2}   # resolve tag from dev-profile-base/.env; registry is nvstaging in 3.2.0
+    image: ${VSS_RT_VLM_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-rt-vlm}:${VSS_RT_VLM_TAG:-develop-latest}
     container_name: vss-rtvi-vlm
     shm_size: '16gb'
     runtime: nvidia
     user: "1001:1001"
     ports:
       - "${RTVI_VLM_PORT?}:8000"
-    profiles:
-      - <your-profile-flag>   # add your deployment's compose-profile flag
-      # ... existing upstream profiles preserved
+    profiles: ["rtvi-vlm"]
     volumes:
       - "${RTVI_VLM_HF_CACHE:-rtvi-hf-cache}:/tmp/huggingface"
       - "${VSS_DATA_DIR}/data_log/vst/clip_storage:/home/vst/vst_release/streamer_videos"
@@ -176,15 +174,15 @@ services:
     environment:
       NGC_API_KEY: "${NGC_CLI_API_KEY:-}"
       HF_TOKEN: "${HF_TOKEN:-}"
-      VLM_MODEL_TO_USE: "${RTVI_VLM_MODEL_TO_USE:-cosmos-reason2}"
-      MODEL_PATH: "${RTVI_VLM_MODEL_PATH:-ngc:nim/nvidia/cosmos-reason2-8b:1208-fp8-static-kv8}"
+      VLM_MODEL_TO_USE: "${RTVI_VLM_MODEL_TO_USE:-openai-compat}"
+      MODEL_PATH: "${RTVI_VLM_MODEL_PATH:-ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final}"
       KAFKA_ENABLED: "true"
       MESSAGE_BUS: "${RTVI_VLM_MESSAGE_BUS:-kafka}"
       MESSAGE_BUS_TOPIC: "${RTVI_VLM_MESSAGE_BUS_TOPIC:-mdx-vlm-captions}"
       ERROR_BUS: "${RTVI_VLM_ERROR_BUS:-kafka}"
       KAFKA_INCIDENT_TOPIC: "${RTVI_VLM_KAFKA_INCIDENT_TOPIC:-mdx-vlm-incidents}"
       KAFKA_BOOTSTRAP_SERVERS: "${HOST_IP}:9092"
-      ERROR_MESSAGE_TOPIC: "${ERROR_MESSAGE_TOPIC:-mdx-events}"
+      ERROR_MESSAGE_TOPIC: "${RTVI_VLM_ERROR_MESSAGE_TOPIC:-vision-llm-errors}"
     deploy:
       resources:
         reservations:

--- a/skills/deployment/vss-deploy-dense-captioning/references/kafka-workflows.md
+++ b/skills/deployment/vss-deploy-dense-captioning/references/kafka-workflows.md
@@ -295,7 +295,7 @@ done
 The RT-VLM compose maps `RTVI_VLM_KAFKA_BOOTSTRAP_SERVERS` to the container-side `KAFKA_BOOTSTRAP_SERVERS`, defaulting to `kafka:29092`. Set the prefixed host variable in `rtvi-vlm.env` before recreating RT-VLM when using an external broker.
 
 ```bash
-docker compose --env-file rtvi-vlm.env -f rtvi-vlm-docker-compose.yml \
+docker compose --env-file rtvi-vlm.env -f "$COMPOSE_FILE" \
   --profile rtvi-vlm up -d --force-recreate rtvi-vlm
 ```
 


### PR DESCRIPTION
## Summary

Make standalone RT-VLM deployment start from the canonical checked-in Compose file and `rtvi-vlm` profile, while keeping the documented fallback narrow and fail-closed.

## Related Issue

[NVBug 6701686](https://nvbugswb.nvidia.com/NVBugs5/redir.aspx?url=/6701686)

## Changes

- Use #1913-compatible `VSS_RT_VLM_TAG` naming.
- Resolve the exact image through Compose instead of hardcoding a registry.
- Carry `$COMPOSE_FILE` through validation, health, logs, upgrade, and cleanup.
- Normalize only the known optional dependency allowlist; reject unknown or required dependencies.
- Bound health polling and surface Compose failures.
- Correct standalone profile, model, topic, and evaluation contracts.
- Reject stale pre-modified Compose copies.

## Validation

- Agent Skills Playbook compliance: PASS (0 errors, 0 warnings)
- Skill quick validation: PASS
- Deployment shell block: `bash -n` PASS
- Dependency normalizer: canonical positive case PASS; unknown and required dependency rejection PASS
- Eval JSON and `git diff --check`: PASS
- Pre-commit secret scan, SPDX, and DCO hooks: PASS
- Live Docker Compose resolution: deferred to CI because Docker CLI is unavailable on the local host

## Checklist
- [x] I am familiar with the contributing guidelines.
- [x] Pre-commit hooks ran locally.
- [x] Every commit is DCO signed off.
- [x] Existing evaluation coverage was aligned with the canonical-first behavior.
- [x] Documentation is updated.
- [x] No secrets, API keys, or credentials committed.