### PR TITLE
Transfer deploy profile evals to build vision ai

### DIFF
--- a/.github/skill-eval/adapters/vss-build-vision-ai/generate.py
+++ b/.github/skill-eval/adapters/vss-build-vision-ai/generate.py
@@ -100,7 +100,7 @@ DEFAULT_PLATFORM = "RTXPRO6000BW"
 PREAMBLE = (
     "You are running inside a non-interactive evaluation harness. "
     "You are pre-authorized to deploy prerequisites autonomously — "
-    "do not pause to ask for confirmation on `/vss-deploy-profile` or any other "
+    "do not pause to ask for confirmation on `/vss-build-vision-ai` or any other "
     "setup action the trial requires."
 )
 

--- a/.github/skill-eval/adapters/vss-build-vision-ai/generate.py
+++ b/.github/skill-eval/adapters/vss-build-vision-ai/generate.py
@@ -100,8 +100,10 @@ DEFAULT_PLATFORM = "RTXPRO6000BW"
 PREAMBLE = (
     "You are running inside a non-interactive evaluation harness. "
     "You are pre-authorized to deploy prerequisites autonomously — "
-    "do not pause to ask for confirmation on `/vss-build-vision-ai` or any other "
-    "setup action the trial requires."
+    "do not pause to ask for confirmation on `/vss-deploy-profile` or any other "
+    "setup action the trial requires. For this adapter, the deployment skill "
+    "under test is `/vss-build-vision-ai`; do not invoke `/vss-deploy-profile` "
+    "unless a spec explicitly asks for it."
 )
 
 GENERIC_JUDGE = Path(__file__).resolve().parents[2] / "verifiers" / "generic_judge.py"

--- a/skills/vss-build-vision-ai/SKILL.md
+++ b/skills/vss-build-vision-ai/SKILL.md
@@ -15,6 +15,20 @@ metadata:
 
 **Two ways in:** **guided intake** (state an open intent like "build a vision agent" / "add vision capabilities" and the skill walks you through capability selection) or **prompt-driven** (name the capability or profile directly). Both land on the same routing and composition flow.
 
+## Do Not Use This Skill For
+
+- Operating an already-running deployment: search, summarize, VIOS, alerts,
+  reports, and video Q&A requests should route to the matching operations skill
+  after `vss configure` has recorded the deployment origin.
+- Deploying a single standalone microservice such as RT-VLM, RT-CV, RT-Embed,
+  VIOS, Video Analytics API, or Alert Bridge by itself. Use the matching
+  `skills/deployment/vss-deploy-*` or setup skill instead.
+- Helm/Kubernetes deployment, notebook-only deployment, model benchmarking, or
+  low-level service development. This skill owns Docker Compose stock profiles,
+  the warehouse industry profile, and delta build artifacts under `_builds/`.
+- Unsupported industry profiles such as `smartcities`; `warehouse` is the only
+  supported industry Foundation.
+
 ## References
 
 - [`references/composition.md`](references/composition.md) — delta-profile rules, Foundation selection, build artifact contract, resolution, and validation.

--- a/skills/vss-build-vision-ai/eval/profile_stock_alerts_cv_runtime_harbor.json
+++ b/skills/vss-build-vision-ai/eval/profile_stock_alerts_cv_runtime_harbor.json
@@ -1,0 +1,34 @@
+{
+  "skills": [
+    "vss-build-vision-ai"
+  ],
+  "profile": "stock-alerts-cv",
+  "resources": {
+    "platforms": {
+      "RTXPRO6000BW": {
+        "gpu_count": 2
+      }
+    }
+  },
+  "env": "A 2x RTX PRO 6000 Blackwell host with Docker, NVIDIA Container Toolkit, NGC credentials, and the VSS repository at `{{repo_root}}`. This eval transfers the old vss-deploy-profile alerts CV-verification deployment coverage to Build Vision AI.",
+  "expects": [
+    {
+      "query": "Use `/vss-build-vision-ai` to deploy the stock VSS **alerts** pre-built developer workflow in `2d_cv` mode on `{{platform}}` from `{{repo_root}}`. Keep the alerts CV-verification service set unchanged, write the build artifacts under `_builds/stock-alerts-cv/`, validate the resolved Compose file, deploy it end-to-end, and leave the deployment running for readiness checks.",
+      "checks": [
+        "`{{repo_root}}/_builds/stock-alerts-cv/override.env` exists and declares `FOUNDATION=alerts`, `MODE=2d_cv`, and the full effective `COMPOSE_PROFILES`.",
+        "The effective service set matches the stock alerts `2d_cv` profile and includes RT-CV perception, behavior analytics, alert bridge, RT-VLM verification, Video Analytics API, VIOS, Agent, UI, Phoenix, ingress, Elasticsearch/Kafka/Kibana/Logstash, and one LLM profile token without adding an invented `stock-alerts-cv` or aggregate profile key.",
+        "`{{repo_root}}/_builds/stock-alerts-cv/compose.yml` includes the root `deploy/docker/compose.yml`, and the build directory contains `override.env`, `compose.yml`, and `resolved.yml`.",
+        "The deployment is launched directly from `_builds/stock-alerts-cv/resolved.yml` after validation.",
+        "`curl -sf --max-time 15 http://localhost:8000/health` returns exit 0 (Agent REST API responsive).",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0 (Agent backend).",
+        "`docker ps --format '{{.Names}}' | grep -qx redis` returns exit 0 (shared cache/message peer).",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-rtvi-cv` returns exit 0 (RT-CV perception).",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-behavior-analytics` returns exit 0 (rule-based alert generation on CV output).",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-alert-bridge` returns exit 0 (routes CV-generated alerts to VLM verifier).",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-vios-nvstreamer` returns exit 0 (video ingestion source).",
+        "`curl -sf --max-time 15 http://localhost:${RTVI_CV_HOST_PORT:-9010}/api/v1/ready` returns exit 0 and reports `ready-info.ds-ready=YES`.",
+        "The agent does not invoke `/vss-deploy-profile` or `scripts/dev-profile.sh`."
+      ]
+    }
+  ]
+}

--- a/skills/vss-build-vision-ai/eval/profile_stock_alerts_cv_runtime_harbor.json
+++ b/skills/vss-build-vision-ai/eval/profile_stock_alerts_cv_runtime_harbor.json
@@ -10,7 +10,7 @@
       }
     }
   },
-  "env": "A 2x RTX PRO 6000 Blackwell host with Docker, NVIDIA Container Toolkit, NGC credentials, and the VSS repository at `{{repo_root}}`. This eval transfers the old vss-deploy-profile alerts CV-verification deployment coverage to Build Vision AI.",
+  "env": "A 2x RTX PRO 6000 Blackwell host with Docker, NVIDIA Container Toolkit, NGC credentials, and the VSS repository at `{{repo_root}}`. This eval transfers the old vss-deploy-profile alerts CV-verification deployment coverage to Build Vision AI. Coverage boundary: this is stock alerts `2d_cv` deployment/readiness parity only; the existing `profile_at_1_alert_verification` eval remains the deeper alert-verification round-trip and Elasticsearch/Kafka verdict test.",
   "expects": [
     {
       "query": "Use `/vss-build-vision-ai` to deploy the stock VSS **alerts** pre-built developer workflow in `2d_cv` mode on `{{platform}}` from `{{repo_root}}`. Keep the alerts CV-verification service set unchanged, write the build artifacts under `_builds/stock-alerts-cv/`, validate the resolved Compose file, deploy it end-to-end, and leave the deployment running for readiness checks.",

--- a/skills/vss-build-vision-ai/eval/profile_stock_alerts_vlm_runtime_harbor.json
+++ b/skills/vss-build-vision-ai/eval/profile_stock_alerts_vlm_runtime_harbor.json
@@ -24,7 +24,7 @@
         "`docker ps --format '{{.Names}}' | grep -qx redis` returns exit 0 (shared cache/message peer).",
         "`docker ps --format '{{.Names}}' | grep -qx vss-rtvi-vlm` returns exit 0 (continuous VLM processor).",
         "`docker ps --format '{{.Names}}' | grep -qx vss-vios-nvstreamer` returns exit 0 (video ingestion source).",
-        "`! docker ps --format '{{.Names}}' | grep -qx vss-rtvi-cv` returns exit 0 (real-time mode does not run the CV perception pipeline).",
+        "`docker ps --format '{{.Names}}' | awk '$0 == \"vss-rtvi-cv\" { found=1 } END { exit found ? 1 : 0 }'` returns exit 0 (real-time mode does not run the CV perception pipeline).",
         "`curl -sf --max-time 15 http://localhost:8018/v1/health/ready` returns exit 0 (RT-VLM ready).",
         "The agent does not invoke `/vss-deploy-profile` or `scripts/dev-profile.sh`."
       ]

--- a/skills/vss-build-vision-ai/eval/profile_stock_alerts_vlm_runtime_harbor.json
+++ b/skills/vss-build-vision-ai/eval/profile_stock_alerts_vlm_runtime_harbor.json
@@ -1,0 +1,33 @@
+{
+  "skills": [
+    "vss-build-vision-ai"
+  ],
+  "profile": "stock-alerts-vlm",
+  "resources": {
+    "platforms": {
+      "RTXPRO6000BW": {
+        "gpu_count": 2
+      }
+    }
+  },
+  "env": "A 2x RTX PRO 6000 Blackwell host with Docker, NVIDIA Container Toolkit, NGC credentials, and the VSS repository at `{{repo_root}}`. This eval transfers the old vss-deploy-profile alerts VLM real-time deployment coverage to Build Vision AI.",
+  "expects": [
+    {
+      "query": "Use `/vss-build-vision-ai` to deploy the stock VSS **alerts** pre-built developer workflow in `2d_vlm` mode on `{{platform}}` from `{{repo_root}}`. Keep the alerts real-time VLM service set unchanged, write the build artifacts under `_builds/stock-alerts-vlm/`, validate the resolved Compose file, deploy it end-to-end, and leave the deployment running for readiness checks.",
+      "checks": [
+        "`{{repo_root}}/_builds/stock-alerts-vlm/override.env` exists and declares `FOUNDATION=alerts`, `MODE=2d_vlm`, and the full effective `COMPOSE_PROFILES`.",
+        "The effective service set matches the stock alerts `2d_vlm` profile and includes continuous RT-VLM, alert bridge, Video Analytics API, VIOS, Agent, UI, Phoenix, ingress, Elasticsearch/Kafka/Kibana/Logstash, and one LLM profile token without adding RT-CV, behavior analytics, an invented `stock-alerts-vlm`, or an aggregate profile key.",
+        "`{{repo_root}}/_builds/stock-alerts-vlm/compose.yml` includes the root `deploy/docker/compose.yml`, and the build directory contains `override.env`, `compose.yml`, and `resolved.yml`.",
+        "The deployment is launched directly from `_builds/stock-alerts-vlm/resolved.yml` after validation.",
+        "`curl -sf --max-time 15 http://localhost:8000/health` returns exit 0 (Agent REST API responsive).",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0 (Agent backend).",
+        "`docker ps --format '{{.Names}}' | grep -qx redis` returns exit 0 (shared cache/message peer).",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-rtvi-vlm` returns exit 0 (continuous VLM processor).",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-vios-nvstreamer` returns exit 0 (video ingestion source).",
+        "`! docker ps --format '{{.Names}}' | grep -qx vss-rtvi-cv` returns exit 0 (real-time mode does not run the CV perception pipeline).",
+        "`curl -sf --max-time 15 http://localhost:8018/v1/health/ready` returns exit 0 (RT-VLM ready).",
+        "The agent does not invoke `/vss-deploy-profile` or `scripts/dev-profile.sh`."
+      ]
+    }
+  ]
+}

--- a/skills/vss-build-vision-ai/eval/profile_stock_alerts_vlm_runtime_harbor.json
+++ b/skills/vss-build-vision-ai/eval/profile_stock_alerts_vlm_runtime_harbor.json
@@ -10,7 +10,7 @@
       }
     }
   },
-  "env": "A 2x RTX PRO 6000 Blackwell host with Docker, NVIDIA Container Toolkit, NGC credentials, and the VSS repository at `{{repo_root}}`. This eval transfers the old vss-deploy-profile alerts VLM real-time deployment coverage to Build Vision AI.",
+  "env": "A 2x RTX PRO 6000 Blackwell host with Docker, NVIDIA Container Toolkit, NGC credentials, and the VSS repository at `{{repo_root}}`. This eval transfers the old vss-deploy-profile alerts VLM real-time deployment coverage to Build Vision AI. Coverage boundary: this is the stock alerts `2d_vlm` runtime parity check and specifically guards the real-time VLM variant where RT-CV and behavior analytics must stay absent.",
   "expects": [
     {
       "query": "Use `/vss-build-vision-ai` to deploy the stock VSS **alerts** pre-built developer workflow in `2d_vlm` mode on `{{platform}}` from `{{repo_root}}`. Keep the alerts real-time VLM service set unchanged, write the build artifacts under `_builds/stock-alerts-vlm/`, validate the resolved Compose file, deploy it end-to-end, and leave the deployment running for readiness checks.",

--- a/skills/vss-build-vision-ai/eval/profile_stock_base_runtime_harbor.json
+++ b/skills/vss-build-vision-ai/eval/profile_stock_base_runtime_harbor.json
@@ -1,0 +1,33 @@
+{
+  "skills": [
+    "vss-build-vision-ai"
+  ],
+  "profile": "stock-base",
+  "resources": {
+    "platforms": {
+      "RTXPRO6000BW": {
+        "gpu_count": 1
+      }
+    }
+  },
+  "env": "A stock RTX PRO 6000 Blackwell host with Docker, NVIDIA Container Toolkit, NGC credentials, and the VSS repository at `{{repo_root}}`. This eval transfers the old vss-deploy-profile base deployment coverage to Build Vision AI.",
+  "expects": [
+    {
+      "query": "Use `/vss-build-vision-ai` to deploy the stock VSS **base** pre-built developer workflow on `{{platform}}` from `{{repo_root}}`. Keep the base profile's authoritative service set unchanged, write the build artifacts under `_builds/stock-base/`, validate the resolved Compose file, deploy it end-to-end, and leave the deployment running for readiness checks.",
+      "checks": [
+        "`{{repo_root}}/_builds/stock-base/override.env` exists and declares `FOUNDATION=base` and the full effective `COMPOSE_PROFILES`.",
+        "The effective service set matches the stock base profile and includes `vss-agent`, `vss-ui`, `phoenix`, `redis`, `vss-haproxy-ingress`, VIOS services, one LLM profile token, and `rtvi-vlm` without adding an invented `stock-base` or aggregate profile key.",
+        "`{{repo_root}}/_builds/stock-base/compose.yml` includes the root `deploy/docker/compose.yml`, and the build directory contains `override.env`, `compose.yml`, and `resolved.yml`.",
+        "The deployment is launched directly from `_builds/stock-base/resolved.yml` after validation.",
+        "`curl -sf --max-time 15 http://localhost:8000/health` returns exit 0 (Agent REST API responsive).",
+        "`curl -sf --max-time 15 http://localhost:3000/` returns exit 0 (Agent UI responsive).",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0.",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-agent-ui` returns exit 0.",
+        "`docker ps --format '{{.Names}}' | grep -qx redis` returns exit 0.",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-vios-postgres` returns exit 0.",
+        "`docker ps --format '{{.Names}}' | grep -qx phoenix` returns exit 0.",
+        "The agent does not invoke `/vss-deploy-profile` or `scripts/dev-profile.sh`."
+      ]
+    }
+  ]
+}

--- a/skills/vss-build-vision-ai/eval/profile_stock_base_runtime_harbor.json
+++ b/skills/vss-build-vision-ai/eval/profile_stock_base_runtime_harbor.json
@@ -10,7 +10,7 @@
       }
     }
   },
-  "env": "A stock RTX PRO 6000 Blackwell host with Docker, NVIDIA Container Toolkit, NGC credentials, and the VSS repository at `{{repo_root}}`. This eval transfers the old vss-deploy-profile base deployment coverage to Build Vision AI.",
+  "env": "A stock RTX PRO 6000 Blackwell host with Docker, NVIDIA Container Toolkit, NGC credentials, and the VSS repository at `{{repo_root}}`. This eval transfers the old vss-deploy-profile base deployment coverage to Build Vision AI. Coverage boundary: no existing Build Vision AI eval validates a stock base runtime deployment with the base profile's Agent, UI, Redis, VIOS, Phoenix, LLM, and RT-VLM service set left unchanged.",
   "expects": [
     {
       "query": "Use `/vss-build-vision-ai` to deploy the stock VSS **base** pre-built developer workflow on `{{platform}}` from `{{repo_root}}`. Keep the base profile's authoritative service set unchanged, write the build artifacts under `_builds/stock-base/`, validate the resolved Compose file, deploy it end-to-end, and leave the deployment running for readiness checks.",

--- a/skills/vss-build-vision-ai/eval/profile_stock_lvs_runtime_harbor.json
+++ b/skills/vss-build-vision-ai/eval/profile_stock_lvs_runtime_harbor.json
@@ -10,7 +10,7 @@
       }
     }
   },
-  "env": "A stock RTX PRO 6000 Blackwell host with Docker, NVIDIA Container Toolkit, NGC credentials, and the VSS repository at `{{repo_root}}`. This eval transfers the old vss-deploy-profile LVS deployment coverage to Build Vision AI.",
+  "env": "A stock RTX PRO 6000 Blackwell host with Docker, NVIDIA Container Toolkit, NGC credentials, and the VSS repository at `{{repo_root}}`. This eval transfers the old vss-deploy-profile LVS deployment coverage to Build Vision AI. Coverage boundary: this is stock LVS deployment/readiness parity with the profile service set unchanged; it does not replace the `an-1` LVS API build eval or the `an-1-runtime` stored-video summarization round-trip, which exercise a custom LVS build shape and API behavior.",
   "expects": [
     {
       "query": "Use `/vss-build-vision-ai` to deploy the stock VSS **lvs** pre-built developer workflow on `{{platform}}` from `{{repo_root}}`. Keep the lvs profile's authoritative service set unchanged, write the build artifacts under `_builds/stock-lvs/`, validate the resolved Compose file, deploy it end-to-end, and leave the deployment running for readiness checks.",

--- a/skills/vss-build-vision-ai/eval/profile_stock_lvs_runtime_harbor.json
+++ b/skills/vss-build-vision-ai/eval/profile_stock_lvs_runtime_harbor.json
@@ -1,0 +1,34 @@
+{
+  "skills": [
+    "vss-build-vision-ai"
+  ],
+  "profile": "stock-lvs",
+  "resources": {
+    "platforms": {
+      "RTXPRO6000BW": {
+        "gpu_count": 1
+      }
+    }
+  },
+  "env": "A stock RTX PRO 6000 Blackwell host with Docker, NVIDIA Container Toolkit, NGC credentials, and the VSS repository at `{{repo_root}}`. This eval transfers the old vss-deploy-profile LVS deployment coverage to Build Vision AI.",
+  "expects": [
+    {
+      "query": "Use `/vss-build-vision-ai` to deploy the stock VSS **lvs** pre-built developer workflow on `{{platform}}` from `{{repo_root}}`. Keep the lvs profile's authoritative service set unchanged, write the build artifacts under `_builds/stock-lvs/`, validate the resolved Compose file, deploy it end-to-end, and leave the deployment running for readiness checks.",
+      "checks": [
+        "`{{repo_root}}/_builds/stock-lvs/override.env` exists and declares `FOUNDATION=lvs` and the full effective `COMPOSE_PROFILES`.",
+        "The effective service set matches the stock lvs profile and includes `lvs-server`, `rtvi-vlm`, Elasticsearch/Kafka/Kibana/Logstash, VIOS, Agent, UI, Phoenix, ingress, and one LLM profile token without adding an invented `stock-lvs` or aggregate profile key.",
+        "`{{repo_root}}/_builds/stock-lvs/compose.yml` includes the root `deploy/docker/compose.yml`, and the build directory contains `override.env`, `compose.yml`, and `resolved.yml`.",
+        "The deployment is launched directly from `_builds/stock-lvs/resolved.yml` after validation.",
+        "`curl -sf --max-time 15 http://localhost:8000/health` returns exit 0 (Agent REST API responsive).",
+        "`curl -sf --max-time 15 http://localhost:3000/` returns exit 0 (Agent UI responsive).",
+        "`curl -sf --max-time 15 http://localhost:38111/v1/ready` returns exit 0 (LVS API responsive).",
+        "`curl -sf --max-time 15 http://localhost:8018/v1/health/ready` returns exit 0 (RT-VLM ready).",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0.",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-agent-ui` returns exit 0.",
+        "`docker ps --format '{{.Names}}' | grep -qx redis` returns exit 0.",
+        "`docker ps --format '{{.Names}}' | grep -qx phoenix` returns exit 0.",
+        "The agent does not invoke `/vss-deploy-profile` or `scripts/dev-profile.sh`."
+      ]
+    }
+  ]
+}

--- a/skills/vss-build-vision-ai/eval/profile_stock_search_runtime_harbor.json
+++ b/skills/vss-build-vision-ai/eval/profile_stock_search_runtime_harbor.json
@@ -10,7 +10,7 @@
       }
     }
   },
-  "env": "A 2x RTX PRO 6000 Blackwell host with Docker, NVIDIA Container Toolkit, NGC credentials, remote VLM credentials/endpoints supplied by the harness, and the VSS repository at `{{repo_root}}`. This eval transfers the old vss-deploy-profile search deployment coverage to Build Vision AI.",
+  "env": "A 2x RTX PRO 6000 Blackwell host with Docker, NVIDIA Container Toolkit, NGC credentials, remote VLM credentials/endpoints supplied by the harness, and the VSS repository at `{{repo_root}}`. This eval transfers the old vss-deploy-profile search deployment coverage to Build Vision AI. Coverage boundary: this is the stock search runtime parity check with Agent/UI retained and RT-VLM kept as a remote-backed proxy; it is distinct from the headless `profile_search_standalone_harbor` and combined alerts/search composition evals.",
   "expects": [
     {
       "query": "Use `/vss-build-vision-ai` to deploy the stock VSS **search** pre-built developer workflow on this two-GPU `{{platform}}` host from `{{repo_root}}`. Use the current `search` developer profile unchanged as the Foundation, write artifacts under `_builds/stock-search/`, override the default local RT-VLM backend to use the configured remote VLM endpoint while keeping local `vss-rtvi-vlm` as the OpenAI-compatible proxy, validate the resolved Compose file, deploy it end-to-end, and leave the deployment running.",

--- a/skills/vss-build-vision-ai/eval/profile_stock_search_runtime_harbor.json
+++ b/skills/vss-build-vision-ai/eval/profile_stock_search_runtime_harbor.json
@@ -1,0 +1,35 @@
+{
+  "skills": [
+    "vss-build-vision-ai"
+  ],
+  "profile": "stock-search",
+  "resources": {
+    "platforms": {
+      "RTXPRO6000BW": {
+        "gpu_count": 2
+      }
+    }
+  },
+  "env": "A 2x RTX PRO 6000 Blackwell host with Docker, NVIDIA Container Toolkit, NGC credentials, remote VLM credentials/endpoints supplied by the harness, and the VSS repository at `{{repo_root}}`. This eval transfers the old vss-deploy-profile search deployment coverage to Build Vision AI.",
+  "expects": [
+    {
+      "query": "Use `/vss-build-vision-ai` to deploy the stock VSS **search** pre-built developer workflow on this two-GPU `{{platform}}` host from `{{repo_root}}`. Use the current `search` developer profile unchanged as the Foundation, write artifacts under `_builds/stock-search/`, override the default local RT-VLM backend to use the configured remote VLM endpoint while keeping local `vss-rtvi-vlm` as the OpenAI-compatible proxy, validate the resolved Compose file, deploy it end-to-end, and leave the deployment running.",
+      "checks": [
+        "`{{repo_root}}/_builds/stock-search/override.env` exists and declares `FOUNDATION=search` and the full effective `COMPOSE_PROFILES`.",
+        "The effective service set matches the stock search profile and includes RT-CV, RT-Embed, RT-VLM proxy, Elasticsearch/Kafka/Kibana/Logstash, VIOS, Agent, UI, Phoenix, ingress, and one LLM profile token without adding an invented `stock-search` or aggregate profile key.",
+        "`{{repo_root}}/_builds/stock-search/compose.yml` includes the root `deploy/docker/compose.yml`, and the build directory contains `override.env`, `compose.yml`, and `resolved.yml`.",
+        "The deployment is launched directly from `_builds/stock-search/resolved.yml` after validation.",
+        "`curl -sf --max-time 15 http://localhost:8000/health` returns exit 0 (Agent REST API responsive).",
+        "`curl -sf --max-time 15 http://localhost:3000/` returns exit 0 (Agent UI responsive).",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0.",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-agent-ui` returns exit 0.",
+        "`docker ps --format '{{.Names}}' | grep -qx redis` returns exit 0.",
+        "`docker ps --format '{{.Names}}' | grep -qx phoenix` returns exit 0.",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-rtvi-vlm` returns exit 0.",
+        "`curl -sf --max-time 15 http://localhost:8018/v1/models` returns exit 0 (search RT-VLM proxy responsive).",
+        "The deployed search configuration uses `VLM_MODEL_TYPE=rtvi`, `VLM_NAME_SLUG=none`, `VLM_MODE=remote`, `RTVI_VLM_MODEL_TO_USE=openai-compat`, and `RTVI_VLM_MODEL_PATH=none`.",
+        "The agent does not invoke `/vss-deploy-profile` or `scripts/dev-profile.sh`."
+      ]
+    }
+  ]
+}

--- a/skills/vss-build-vision-ai/eval/profile_stock_warehouse_2d_agent_runtime_harbor.json
+++ b/skills/vss-build-vision-ai/eval/profile_stock_warehouse_2d_agent_runtime_harbor.json
@@ -1,0 +1,41 @@
+{
+  "skills": [
+    "vss-build-vision-ai"
+  ],
+  "profile": "stock-warehouse-2d-agent",
+  "resources": {
+    "platforms": {
+      "RTXPRO6000BW": {
+        "gpu_count": 2
+      }
+    }
+  },
+  "env": "A 2x RTX PRO 6000 Blackwell host with Docker, NVIDIA Container Toolkit, NGC credentials, remote LLM credentials/endpoints supplied by the harness, the VSS repository at `{{repo_root}}`, and access to `nvidia/vss-warehouse/vss-warehouse-app-data:3.2.0`. This eval transfers the old vss-deploy-profile warehouse agent deployment coverage to Build Vision AI.",
+  "expects": [
+    {
+      "query": "Use `/vss-build-vision-ai` to deploy the stock VSS **warehouse** agents variant with `MODE=2d` and `BP_PROFILE=bp_wh` on `{{platform}}` from `{{repo_root}}`. Use a remote LLM endpoint. Get the App Data from `nvidia/vss-warehouse/vss-warehouse-app-data:3.2.0`, write build artifacts under `_builds/stock-warehouse-2d-agent/`, expand the warehouse `COMPOSE_PROFILES_WH_2D` service list verbatim, validate the resolved Compose file, deploy it end-to-end, and leave the deployment running.",
+      "checks": [
+        "`{{repo_root}}/_builds/stock-warehouse-2d-agent/override.env` exists and declares `FOUNDATION=warehouse`, `FOUNDATION_VARIANT=COMPOSE_PROFILES_WH_2D`, `MODE=2d`, `BP_PROFILE=bp_wh`, and the full expanded effective `COMPOSE_PROFILES`.",
+        "The effective service set matches the warehouse `COMPOSE_PROFILES_WH_2D` list verbatim and includes the agent/UI warehouse stack, RT-CV 2D perception, behavior analytics, alert bridge, Video Analytics API, VIOS, Kafka, Elasticsearch/Kibana/Logstash, ingress, RT-VLM, and one remote LLM profile token without adding an invented `stock-warehouse-2d-agent` or aggregate profile key.",
+        "`{{repo_root}}/_builds/stock-warehouse-2d-agent/compose.yml` includes the root `deploy/docker/compose.yml`, and the build directory contains `override.env`, `configurator.env`, `compose.yml`, and `resolved.yml`.",
+        "The warehouse app-data gate confirms `${VSS_DATA_DIR}` points at the supplied warehouse app-data bundle before deployment.",
+        "The deployment is launched directly from `_builds/stock-warehouse-2d-agent/resolved.yml` after validation.",
+        "`curl -sf --max-time 15 http://localhost:8000/health` returns exit 0 (Agent REST API responsive).",
+        "`curl -sf --max-time 15 http://localhost:3000/` returns exit 0 (Agent UI responsive).",
+        "`curl -sf --max-time 15 http://localhost:8081/livez` returns exit 0 (Video Analytics API health endpoint responsive).",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0.",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-agent-ui` returns exit 0.",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-rtvi-cv` returns exit 0 (RT-DETR DeepStream perception).",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-rtvi-vlm` returns exit 0 (VLM verifier for this warehouse variant).",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-alert-bridge` returns exit 0.",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-behavior-analytics` returns exit 0.",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-video-analytics-api` returns exit 0.",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-vios-nvstreamer` returns exit 0.",
+        "`docker ps --format '{{.Names}}' | grep -qx kafka` returns exit 0.",
+        "`{{repo_root}}/_builds/stock-warehouse-2d-agent/override.env` declares `LLM_MODE=remote` and `LLM_NAME_SLUG=none`, so no local LLM container is started.",
+        "`docker ps --format '{{.Names}}' | grep -qxE 'nemotron-3\\.5-lightning-30b-a3b|nvidia-nemotron-nano-9b-v2-fp8'` returns exit 1 (remote LLM mode must not start a local LLM container).",
+        "The agent does not invoke `/vss-deploy-profile` or `scripts/dev-profile.sh`."
+      ]
+    }
+  ]
+}

--- a/skills/vss-build-vision-ai/eval/profile_stock_warehouse_2d_agent_runtime_harbor.json
+++ b/skills/vss-build-vision-ai/eval/profile_stock_warehouse_2d_agent_runtime_harbor.json
@@ -10,7 +10,7 @@
       }
     }
   },
-  "env": "A 2x RTX PRO 6000 Blackwell host with Docker, NVIDIA Container Toolkit, NGC credentials, remote LLM credentials/endpoints supplied by the harness, the VSS repository at `{{repo_root}}`, and access to `nvidia/vss-warehouse/vss-warehouse-app-data:3.2.0`. This eval transfers the old vss-deploy-profile warehouse agent deployment coverage to Build Vision AI.",
+  "env": "A 2x RTX PRO 6000 Blackwell host with Docker, NVIDIA Container Toolkit, NGC credentials, remote LLM credentials/endpoints supplied by the harness, the VSS repository at `{{repo_root}}`, and access to `nvidia/vss-warehouse/vss-warehouse-app-data:3.2.0`. This eval transfers the old vss-deploy-profile warehouse agent deployment coverage to Build Vision AI. Coverage boundary: this is runtime deployment/readiness parity for the stock warehouse `MODE=2d`, `BP_PROFILE=bp_wh` agent variant; it is distinct from `profile_wh_2_2d_agent_chat`, which is a build-only warehouse contract check and does not deploy.",
   "expects": [
     {
       "query": "Use `/vss-build-vision-ai` to deploy the stock VSS **warehouse** agents variant with `MODE=2d` and `BP_PROFILE=bp_wh` on `{{platform}}` from `{{repo_root}}`. Use a remote LLM endpoint. Get the App Data from `nvidia/vss-warehouse/vss-warehouse-app-data:3.2.0`, write build artifacts under `_builds/stock-warehouse-2d-agent/`, expand the warehouse `COMPOSE_PROFILES_WH_2D` service list verbatim, validate the resolved Compose file, deploy it end-to-end, and leave the deployment running.",


### PR DESCRIPTION
## Summary

## Plan

## Related Issue
[VIA-2534](https://jirasw.nvidia.com/browse/VIA-2534)

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
