### PR TITLE
feat(video-analytics-api): add STREAM_TYPE environment variable for K…

### DIFF
--- a/deploy/docker/services/analytics/video-analytics-api/compose.yml
+++ b/deploy/docker/services/analytics/video-analytics-api/compose.yml
@@ -26,6 +26,8 @@ services:
           - vss-video-analytics-api
     ports:
       - ${VIDEO_ANALYTICS_API_HOST_PORT:-8081}:8081
+    environment:
+      STREAM_TYPE: ${STREAM_TYPE:-kafka}
     volumes:
       - $VSS_APPS_DIR/services/analytics/video-analytics-api/configs/vss-video-analytics-api-config.json:/opt/mdx/vss-video-analytics-api/configs/vss-video-analytics-api-config.json
       - $VSS_DATA_DIR/data_log/vss_video_analytics_api:/web-api-app/files

--- a/deploy/helm/services/analytics/charts/video-analytics-api/templates/deployment.yaml
+++ b/deploy/helm/services/analytics/charts/video-analytics-api/templates/deployment.yaml
@@ -74,6 +74,9 @@ spec:
             - index.js
             - --config
             - /opt/mdx/vss-video-analytics-api/configs/vss-video-analytics-api-config.json
+          env:
+            - name: STREAM_TYPE
+              value: {{ .Values.streamType | quote }}
           volumeMounts:
             - name: config
               mountPath: /opt/mdx/vss-video-analytics-api/configs/vss-video-analytics-api-config.json

--- a/deploy/helm/services/analytics/charts/video-analytics-api/values.yaml
+++ b/deploy/helm/services/analytics/charts/video-analytics-api/values.yaml
@@ -21,6 +21,7 @@ image:
   tag: "develop-latest"
   pullPolicy: IfNotPresent
 replicas: 1
+streamType: "kafka"
 
 kafkaBrokers: ""   # default: kafka-kafka:9092 (<release>-kafka-kafka:9092 if global.useReleaseNamePrefix)
 elasticsearchNode: ""   # default: http://<release>-elasticsearch:9200

--- a/services/analytics/video-analytics-api/src/app/initializers/server.js
+++ b/services/analytics/video-analytics-api/src/app/initializers/server.js
@@ -28,6 +28,7 @@ const elasticErrors = mdx.Utils.Elasticsearch.getElasticErrors();
 const morgan = require('morgan');
 const winston = require('winston');
 const FILE_UPLOAD_DIRECTORY = path.join(__dirname, '../files');
+const VALID_STREAM_TYPES = new Set(["kafka", "redis"]);
 const logger = winston.createLogger({
     format: winston.format.combine(
         winston.format.timestamp(),
@@ -101,6 +102,12 @@ module.exports = {
 
         const inSimulationMode = (bootstrapObjectMap.server.configs.get("inSimulationMode") === "true");
         cache.set("inSimulationMode", inSimulationMode);
+        const streamType = process.env.STREAM_TYPE || "kafka";
+        if (!VALID_STREAM_TYPES.has(streamType)) {
+            logger.error(`[APP ERROR] Invalid stream type: ${streamType}. Expected one of: kafka, redis.`);
+            process.exit(1);
+        }
+        logger.info(`[APP] Using ${streamType} stream type.`);
 
         const elastic = require('./elastic');
 
@@ -112,8 +119,9 @@ module.exports = {
                 "insertion-timestamp-pipeline"
             );
 
-            const kafka = require('./kafka');
-            if(kafka!=null){
+            if (streamType === "kafka") {
+                const kafka = require('./kafka');
+                if(kafka!=null){
                 logger.info('[KAFKA TOPIC] Waiting for required Kafka topics.');
                 await mdx.Utils.Kafka.waitForTopics(kafka.getAdminClient());
 
@@ -143,6 +151,7 @@ module.exports = {
                 mtmcObject.consumeAMRMessages(kafka, amrConfig).catch(error=>{
                     throw(error);
                 });
+                }
             }
 
             logger.info('[SERVER] Initializing routes');

--- a/skills/deployment/vss-setup-video-analytics-api/SKILL.md
+++ b/skills/deployment/vss-setup-video-analytics-api/SKILL.md
@@ -107,9 +107,9 @@ The compose-file edits, config options, deploy + verify commands, REST API endpo
 
 Use [`references/deploy-video-analytics-api-service.md`](references/deploy-video-analytics-api-service.md) for the REST endpoint table and runtime dependency notes.
 
-## Kafka-dependent features (runtime, requires `STREAM_TYPE=kafka` and a broker)
+## Kafka-dependent features (runtime, requires `STREAM_TYPE=kafka` and non-empty `kafka.brokers`)
 
-When `STREAM_TYPE=kafka` and Kafka is configured, the container does not become live until its broker and required topics are available. Once it is live, three additional capabilities are available:
+When `STREAM_TYPE=kafka` and `kafka.brokers` is non-empty, the container does not become live until those brokers and the required topics are available. Once it is live, three additional capabilities are available:
 
 ### Dynamic config
 

--- a/skills/deployment/vss-setup-video-analytics-api/SKILL.md
+++ b/skills/deployment/vss-setup-video-analytics-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vss-setup-video-analytics-api
-description: Use to deploy the vss-video-analytics-api REST service standalone with its Elasticsearch ingest-pipeline and, when configured, Kafka-topic readiness gates. Not for full warehouse deploy.
+description: Use to deploy the vss-video-analytics-api REST service standalone with its Elasticsearch ingest-pipeline, selectable Kafka/Redis stream type, and Kafka-topic readiness gates when Kafka is selected. Not for full warehouse deploy.
 license: Apache-2.0
 metadata:
   author: "NVIDIA Video Search and Summarization team"
@@ -10,7 +10,7 @@ metadata:
 ---
 ## Purpose
 
-Deploy the video-analytics-api REST service standalone with the user's chosen config and data-log bind. The service exposes port 8081 and `/livez` only after Elasticsearch, the `insertion-timestamp-pipeline`, and any configured Kafka topic requirements are ready.
+Deploy the video-analytics-api REST service standalone with the user's chosen config and data-log bind. The service exposes port 8081 and `/livez` only after Elasticsearch, the `insertion-timestamp-pipeline`, and, when `STREAM_TYPE=kafka`, the configured Kafka topic requirements are ready.
 
 ## Instructions
 
@@ -85,8 +85,9 @@ The full operational walkthrough — config-source options, data-log volume beha
    > rotate immediately.
 3. **Docker runtime** — Docker Engine **28.3.3** with Docker Compose plugin **v2.39.1+**. Verify with `docker --version` and `docker compose version`.
 4. **Elasticsearch and ingest pipeline** — the endpoint in `elasticsearch.node` must be reachable and contain `insertion-timestamp-pipeline`. Elasticsearch port availability alone is insufficient: the API deliberately waits for that pipeline before binding port 8081. When using the infra compose, start both `elasticsearch` and `elasticsearch-init-container`.
-5. **Kafka is optional only when disabled in the config.** With `kafka.brokers: []` or `null`, the API skips Kafka. With brokers configured, it waits before listening until `mdx-notification`, `mdx-amr`, and at least one `mdx-rtls*` topic exist. The service-shipped config enables Kafka, so choose either a broker-less config or provision those topics.
-6. **`$VSS_DATA_DIR` for the default compose.** The base compose bind-mounts `$VSS_DATA_DIR/data_log/vss_video_analytics_api` for multipart upload handling and file-backed assets such as calibration images. Set the directory to a writable host path and pre-create it, or remove that mount if image uploads are not needed.
+5. **`STREAM_TYPE`** — Compose passes this environment variable to the API. It accepts only `kafka` or `redis`; unset defaults to `kafka`, and any other value makes the API exit at startup. With `STREAM_TYPE=kafka`, the API waits for configured Kafka topics. With `STREAM_TYPE=redis`, it skips Kafka startup work and topic readiness gates; the API does not create a Redis client.
+6. **Kafka configuration when `STREAM_TYPE=kafka`.** With `kafka.brokers: []` or `null`, Kafka startup work is skipped. With brokers configured, the API waits before listening until `mdx-notification`, `mdx-amr`, and at least one `mdx-rtls*` topic exist. The service-shipped config enables Kafka, so provision those topics when selecting Kafka.
+7. **`$VSS_DATA_DIR` for the default compose.** The base compose bind-mounts `$VSS_DATA_DIR/data_log/vss_video_analytics_api` for multipart upload handling and file-backed assets such as calibration images. Set the directory to a writable host path and pre-create it, or remove that mount if image uploads are not needed.
 
 If any required prerequisite fails, surface the gap before going further.
 
@@ -94,10 +95,11 @@ If any required prerequisite fails, surface the gap before going further.
 
 Hand the user [`references/deploy-video-analytics-api-service.md`](references/deploy-video-analytics-api-service.md) and walk them through its steps in order:
 
-1. Choose a config — image-baked default, service-shipped, or custom.
-2. Decide whether a data-log volume is needed for file uploads.
-3. Confirm readiness dependencies — Elasticsearch plus `insertion-timestamp-pipeline`; and, if Kafka is configured, the required topics.
-4. Deploy + verify with `docker compose up` and health check.
+1. Choose `STREAM_TYPE`: `kafka` or `redis`; omit it only to use the Kafka default.
+2. Choose a config — image-baked default, service-shipped, or custom.
+3. Decide whether a data-log volume is needed for file uploads.
+4. Confirm readiness dependencies — Elasticsearch plus `insertion-timestamp-pipeline`; and, only for `STREAM_TYPE=kafka` with configured brokers, the required topics.
+5. Deploy + verify with `docker compose up` and health check.
 
 The compose-file edits, config options, deploy + verify commands, REST API endpoint table, and troubleshooting table all live in that reference — don't duplicate them here.
 
@@ -105,9 +107,9 @@ The compose-file edits, config options, deploy + verify commands, REST API endpo
 
 Use [`references/deploy-video-analytics-api-service.md`](references/deploy-video-analytics-api-service.md) for the REST endpoint table and runtime dependency notes.
 
-## Kafka-dependent features (runtime, requires broker)
+## Kafka-dependent features (runtime, requires `STREAM_TYPE=kafka` and a broker)
 
-When Kafka is configured, the container does not become live until its broker and required topics are available. Once it is live, three additional capabilities are available:
+When `STREAM_TYPE=kafka` and Kafka is configured, the container does not become live until its broker and required topics are available. Once it is live, three additional capabilities are available:
 
 ### Dynamic config
 
@@ -129,7 +131,7 @@ The API consumes real-time location (`mdx-rtls`) and AMR (`mdx-amr`) messages fr
 
 - If the user wants "the full stack" (UI / agent / perception): hand off to `vss-deploy-profile` with profile `warehouse` (or `alerts`). Don't run this skill in parallel.
 - If the user wants to deploy the analytics pipeline (behavior creation, incident detection): hand off to `vss-setup-behavior-analytics`.
-- If the user wants to publish a runtime config / calibration update through the REST API: confirm Kafka is reachable, then use the `/config` or calibration endpoints and point them at the behavior-analytics dynamic-update references for the consumer wire contract.
+- If the user wants to publish a runtime config / calibration update through the REST API: confirm `STREAM_TYPE=kafka` and Kafka are reachable, then use the `/config` or calibration endpoints and point them at the behavior-analytics dynamic-update references for the consumer wire contract.
 - If the user wants to understand the dynamic config / dynamic calibration wire contract from the **consumer** (behavior-analytics) side: point them at the `vss-setup-behavior-analytics` dynamic-config and dynamic-calibration references.
 - If the user wants to query or interact with the REST API endpoints: the deploy reference endpoint table covers what's available. For the full OpenAPI spec, see `src/app/specification/openapi.json` in the `video-analytics-api` repo.
 

--- a/skills/deployment/vss-setup-video-analytics-api/references/configuration.md
+++ b/skills/deployment/vss-setup-video-analytics-api/references/configuration.md
@@ -53,11 +53,17 @@ The video-analytics-api server loads a JSON config file at startup via the `--co
 | `rawIndex` | string | `"mdx-raw-*"` | Raw data index pattern. |
 | `retries` | number | `15` | Number of Elasticsearch connection retries before giving up. |
 
+### `STREAM_TYPE` environment variable
+
+| Variable | Allowed values | Default | What it controls |
+|---|---|---|---|
+| `STREAM_TYPE` | `kafka`, `redis` | `kafka` | Selects startup behavior. `kafka` enables configured Kafka readiness/workers; `redis` skips Kafka startup work. Invalid values make the server exit. |
+
 ### `kafka`
 
 | Field | Type | Default | What it controls |
 |---|---|---|---|
-| `brokers` | array of strings | `["localhost:9092"]` (service-shipped) / `[]` (image-baked) | Kafka broker addresses. Empty array or `null` disables Kafka entirely — no error, no retry loop. |
+| `brokers` | array of strings | `["localhost:9092"]` (service-shipped) / `[]` (image-baked) | Kafka broker addresses. With `STREAM_TYPE=kafka`, an empty array or `null` skips Kafka startup work. `STREAM_TYPE=redis` also skips Kafka startup work, regardless of this setting. |
 | `retries` | number or null | `null` | KafkaJS retry count. `null` uses KafkaJS defaults. |
 
 ## Config sources
@@ -108,5 +114,5 @@ Any absolute host path. Copy one of the above as a starting point and edit. Bind
 
 - Keep `server.configs[].value` as strings — the server parses types internally.
 - When running with `network_mode: "host"`, Elasticsearch and Kafka must also be on the host network.
-- Set `kafka.brokers` to an empty array `[]` to run without Kafka. The server starts normally; Kafka-dependent endpoints (dynamic config, dynamic calibration, RTLS/AMR) are simply unavailable.
+- `STREAM_TYPE` must be `kafka` or `redis`; when unset, it defaults to `kafka`. Select `redis` to skip Kafka startup work. For `kafka`, set `kafka.brokers` to `[]` to skip Kafka startup work. Kafka-dependent endpoints (dynamic config, dynamic calibration, RTLS/AMR) require `STREAM_TYPE=kafka` and configured brokers.
 - The `amrRetentionInSec` default is `"3"` in both the service-shipped config and the image-baked default.

--- a/skills/deployment/vss-setup-video-analytics-api/references/deploy-video-analytics-api-service.md
+++ b/skills/deployment/vss-setup-video-analytics-api/references/deploy-video-analytics-api-service.md
@@ -18,9 +18,10 @@ You only edit the existing service compose:
 ```
 
 1. **`command:`** — which config file the Node server loads at startup.
-2. **`volumes:`** — what config (required) and what data-log directory (optional) to mount.
+2. **`environment.STREAM_TYPE`:** — `kafka` or `redis`; omitted defaults to `kafka`.
+3. **`volumes:`** — what config (required) and what data-log directory (optional) to mount.
 
-Walk steps 1-3 below to decide each one; the bring-it-up command lives in [Deploy + verify](#deploy--verify) at the end. For a field-by-field JSON config reference, see the [Configuration Guide](configuration.md).
+Walk steps 1-4 below to decide each one; the bring-it-up command lives in [Deploy + verify](#deploy--verify) at the end. For a field-by-field JSON config reference, see the [Configuration Guide](configuration.md).
 
 ---
 
@@ -85,7 +86,25 @@ Top-level shape:
 
 ---
 
-## Step 2 — Data log volume
+## Step 2 — Select the stream type
+
+Compose passes `STREAM_TYPE` into the server:
+
+- `kafka` — the default when `STREAM_TYPE` is unset. With configured `kafka.brokers`, the server waits for Kafka topics and starts its Kafka workers.
+- `redis` — skips Kafka topic readiness and Kafka workers. It does not configure a Redis client; Elasticsearch-backed API endpoints remain available.
+
+Any other value is invalid and makes the server exit at startup. Set the value in Compose:
+
+```yaml
+services:
+  vss-video-analytics-api:
+    environment:
+      STREAM_TYPE: ${STREAM_TYPE:-kafka}
+```
+
+---
+
+## Step 3 — Data log volume
 
 The compose mounts a data-log directory for multipart upload handling and file-backed assets such as calibration images:
 
@@ -105,7 +124,7 @@ If you don't need image upload endpoints, you can drop this mount — the contai
 
 ---
 
-## Step 3 — Infrastructure dependencies
+## Step 4 — Infrastructure dependencies
 
 ### Elasticsearch (required)
 
@@ -125,16 +144,16 @@ Wait for ES to be healthy before starting the API:
 curl -sf http://localhost:9200/_cluster/health
 ```
 
-### Kafka (optional only when disabled)
+### Kafka (only for `STREAM_TYPE=kafka`)
 
-Kafka is optional only when `kafka.brokers` is empty or null in the config; then the server skips Kafka entirely.
+`STREAM_TYPE` accepts only `kafka` or `redis`; it defaults to `kafka` when unset. The Redis setting skips Kafka startup work and does not configure a Redis client. For the Kafka setting, empty or null `kafka.brokers` skips Kafka startup work.
 
 When brokers are configured and reachable, the API gains:
 - **Dynamic config** — produces/consumes config update notifications on `mdx-notification` (Kafka key `behavior-analytics-config`). This is how the UI pushes config changes to `behavior-analytics` through the API.
 - **Dynamic calibration** — produces calibration update notifications on `mdx-notification` (Kafka key `calibration`).
 - **RTLS / AMR** — consumes real-time location and AMR messages from `mdx-rtls` / `mdx-amr` topics and exposes them via REST.
 
-If brokers are configured, the server waits before listening until it can list topics and finds `mdx-notification`, `mdx-amr`, and at least one topic matching `^mdx-rtls.*`. Its logs identify the missing topic or failed topic-list request on each retry. If you want the API to run broker-less, set `kafka.brokers` to an empty array (`[]`) or `null`.
+With `STREAM_TYPE=kafka` and configured brokers, the server waits before listening until it can list topics and finds `mdx-notification`, `mdx-amr`, and at least one topic matching `^mdx-rtls.*`. Its logs identify the missing topic or failed topic-list request on each retry. To skip Kafka startup work, select `STREAM_TYPE=redis`, or select `STREAM_TYPE=kafka` with `kafka.brokers` set to an empty array (`[]`) or `null`.
 
 ---
 
@@ -205,7 +224,7 @@ While the ingest pipeline is absent, the API emits:
 {"message":"[ELASTICSEARCH] Ingest pipeline is not present.","pipelineId":"insertion-timestamp-pipeline"}
 ```
 
-The API checks once per second until the pipeline exists, then performs the same loop for configured Kafka requirements. This is expected when the API starts before its infrastructure; wait for `/livez` rather than treating the container's running state or Elasticsearch port 9200 as API readiness.
+The API checks once per second until the pipeline exists, then, only with `STREAM_TYPE=kafka` and configured brokers, performs the same loop for Kafka requirements. This is expected when the API starts before its infrastructure; wait for `/livez` rather than treating the container's running state or Elasticsearch port 9200 as API readiness.
 
 ## Teardown
 
@@ -222,7 +241,7 @@ For a multi-service teardown (broker, ES, etc.), use the `vss-deploy-profile` te
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | API never exposes `/livez`; logs say `Ingest pipeline is not present` | Elasticsearch is reachable but `insertion-timestamp-pipeline` has not been created. | Start or repair `elasticsearch-init-container`; verify with `curl -sf http://localhost:9200/_ingest/pipeline/insertion-timestamp-pipeline`. |
-| API never exposes `/livez`; logs say `Required Kafka topics are not present` | Kafka is enabled but one or more requirements are absent. | Create `mdx-notification`, `mdx-amr`, and a topic matching `mdx-rtls*`, or disable Kafka with `kafka.brokers: []`. |
+| API never exposes `/livez`; logs say `Required Kafka topics are not present` | `STREAM_TYPE=kafka` with configured brokers, but one or more requirements are absent. | Create `mdx-notification`, `mdx-amr`, and a topic matching `mdx-rtls*`; select `STREAM_TYPE=redis`; or set `kafka.brokers: []`. |
 | `[INPUT ERROR] Invalid path for bootstrap config file.` | The `--config` path doesn't exist inside the container. | Verify the volume mount target matches the `--config` flag path. Use an absolute path. |
 | Compose tries to mount `/data_log/vss_video_analytics_api` from the filesystem root | `$VSS_DATA_DIR` is unset while the default data-log bind mount is still present. | Export `VSS_DATA_DIR` to a writable host path and create `$VSS_DATA_DIR/data_log/vss_video_analytics_api`, or remove the `/web-api-app/files` mount if image uploads are not needed. |
 | `EADDRINUSE` | Port 8081 (or your configured port) is already in use. | Check with `ss -tlnp | grep :8081`. Stop the conflicting process or change `server.port` in the config. |

--- a/skills/deployment/vss-setup-video-analytics-api/skill-card.md
+++ b/skills/deployment/vss-setup-video-analytics-api/skill-card.md
@@ -1,5 +1,5 @@
 ## Description: <br>
-Use to deploy the vss-video-analytics-api REST service standalone with Elasticsearch ingest-pipeline and configured Kafka-topic readiness gates. Not for full warehouse deploy. <br>
+Use to deploy the vss-video-analytics-api REST service standalone with Elasticsearch ingest-pipeline, selectable Kafka/Redis stream type, and Kafka-topic readiness gates when Kafka is selected. Not for full warehouse deploy. <br>
 
 This skill is ready for commercial/non-commercial use. <br>
 


### PR DESCRIPTION
…afka/Redis selection

- Updated docker-compose configuration to include STREAM_TYPE environment variable, defaulting to 'kafka'.
- Enhanced server initialization to validate STREAM_TYPE and log the selected stream type.
- Updated documentation to reflect the new selectable stream type feature and its implications for Kafka and Redis usage.

This change allows users to choose between Kafka and Redis for stream processing, improving flexibility in deployment.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
