### PR TITLE
feat(skill): support warehouse mv3dt in build-vision-ai 

### DIFF
--- a/skills/vss-build-vision-ai/SKILL.md
+++ b/skills/vss-build-vision-ai/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vss-build-vision-ai
 description: >-
-  Add agent-ready vision capabilities — dense captioning, detection, search, alerting, summarization — to an agent or application through a customizable, self-contained vision stack built on the NVIDIA VSS Blueprint. Use this skill when a developer or agent wants to give their app vision: pick capabilities via guided intake ("build a vision agent", "add vision capabilities") or describe them in natural language ("create a profile for streaming dense captioning", "add agentic search to my base deployment", "deploy warehouse 3d"). Route, compose, configure, and deploy stock base, alerts, LVS, search developer profiles, or the warehouse industry profile and lean custom combinations expressed as delta overlays using one current developer profile as the Foundation.
+  Add agent-ready vision capabilities — dense captioning, detection, search, alerting, summarization — to an agent or application through a customizable, self-contained vision stack built on the NVIDIA VSS Blueprint. Use this skill when a developer or agent wants to give their app vision: pick capabilities via guided intake ("build a vision agent", "add vision capabilities") or describe them in natural language ("create a profile for streaming dense captioning", "add agentic search to my base deployment", "deploy warehouse MV3DT"). Route, compose, configure, and deploy stock base, alerts, LVS, search developer profiles, or the warehouse industry profile and lean custom combinations expressed as delta overlays using one current developer profile as the Foundation.
 license: Apache-2.0
 metadata:
   version: "3.2.0"
@@ -62,7 +62,7 @@ Ask via `AskUserQuestion` (single-select). Generate or deploy **nothing** until 
 **Q1 — Starting point.** *"How would you like to start?"*
 
 - **Deploy a pre-built developer workflow** *(recommended for a first run / quickstart)* — Choose from a ready-made, validated VSS developer profile. Fastest path to a running system; no composition needed. Deploys as-is; you can customize it afterward. → **Q2a**
-- **Deploy a pre-built industry blueprint** — Warehouse multi-camera perception (2D RT-DETR or 3D Sparse4D) with behavior analytics. Deployed as-is. → **Q2w**
+- **Deploy a pre-built industry blueprint** — Warehouse multi-camera perception (2D RT-DETR, 3D Sparse4D, or MV3DT) with behavior analytics. Deployed as-is. → **Q2w**
 - **Build a custom configuration** — pick the specific vision capabilities you need and let the skill compose the smallest delta overlay for them. → **Q2b**
 
 ### Mode: Pre-built workflow (quickstart)
@@ -103,7 +103,7 @@ its service lists here, or this table drifts from the one that is authoritative:
 
 | Question | Options |
 |---|---|
-| **Q2w-mode** — *"Which warehouse perception mode?"* | `2d` (RT-DETR) · `3d` (Sparse4D, depth-aware) |
+| **Q2w-mode** — *"Which warehouse perception mode?"* | `2d` (RT-DETR) · `3d` (Sparse4D, depth-aware) · `mv3dt` (multi-view 3D tracking) |
 | **Q2w-profile** — *"Which deployment variant?"* | `bp_wh` · `bp_wh_kafka` · `bp_wh_redis` |
 | **Q2w-size** — *"Minimal or extended?"* | Extended · Minimal |
 
@@ -111,7 +111,7 @@ Filter the remaining options rather than validating the answers afterwards.
 Both filters below are warehouse.md's to state; it is the source of truth for
 why, and this list only says when to apply them:
 
-- **Omit `bp_wh` from Q2w-profile when Q2w-mode is `3d`** — Hard constraints:
+- **Omit `bp_wh` from Q2w-profile when Q2w-mode is `3d` or `mv3dt`** — Hard constraints:
   `bp_wh` is 2D-only. Leaving it selectable turns an impossible deployment into
   a late runtime failure.
 - **Skip Q2w-size entirely for `bp_wh`** — the Profile Service Set table lists

--- a/skills/vss-build-vision-ai/references/data-directory.md
+++ b/skills/vss-build-vision-ai/references/data-directory.md
@@ -86,7 +86,7 @@ esac
 
 # Warehouse perception writes its detector ONNX into models/ at ds-start phase 0.
 case ",$COMPOSE_PROFILES," in
-  *,perception-2d,*|*,perception-3d,*)
+  *,perception-2d,*|*,perception-3d,*|*,vss-rtvi-cv-mv3dt,*)
     required+=(models)
     ;;
 esac
@@ -129,7 +129,7 @@ done
 # 0 streams with every container healthy, so fail here rather than at runtime.
 # ---------------------------------------------------------------------------
 case ",$COMPOSE_PROFILES," in
-  *,nvstreamer-2d,*|*,nvstreamer-3d,*)
+  *,nvstreamer-2d,*|*,nvstreamer-3d,*|*,nvstreamer-mv3dt,*)
     DATASET="$(sed -n 's/^SAMPLE_VIDEO_DATASET=//p' "$ENV_FILE" | tr -d '"')"
     wh_fail=0
     for d in videos models playback data_log; do
@@ -195,7 +195,8 @@ content, and an empty `videos/` turns a clear "no app data" failure into a
 zero-streams symptom. Treat it as a **blocking presence check**, not part of the
 `required=()` list above — run it *before* any `docker compose up`.
 
-When `COMPOSE_PROFILES` contains an `nvstreamer-2d` or `nvstreamer-3d` key,
+When `COMPOSE_PROFILES` contains an `nvstreamer-2d`, `nvstreamer-3d`, or
+`nvstreamer-mv3dt` key,
 verify before deploying:
 
 ```bash

--- a/skills/vss-build-vision-ai/references/profiles/warehouse.md
+++ b/skills/vss-build-vision-ai/references/profiles/warehouse.md
@@ -5,7 +5,7 @@ end to end: what the Foundation is made of, what constrains it, how a build is
 resolved, and how the result is reached and verified. The rest of the skill's
 machinery applies unchanged by reference — see Build and resolve below.
 
-`overrides.env` defines further service lists; only the nine below are
+`overrides.env` defines further service lists; only the thirteen below are
 supported. The others are out of scope for this skill — do not compose or deploy
 them.
 
@@ -36,8 +36,9 @@ Resolve block below instead.
 
 ## Capabilities and routing cues
 
-- Multi-camera warehouse perception — RT-DETR (2D) or Sparse4D (3D) — with
-  behavior analytics over ROI, tripwire, and proximity events.
+- Multi-camera warehouse perception — RT-DETR (2D), Sparse4D (3D), or MV3DT
+  multi-view 3D tracking — with behavior analytics over ROI, tripwire, and
+  proximity events.
 - Choose for warehouse, loading-dock, forklift/pallet, or depth-aware
   multi-camera requests. Do **not** choose it for generic detection or search —
   `search` is the developer Foundation for those.
@@ -49,7 +50,7 @@ Resolve block below instead.
 Authoritative source:
 `deploy/docker/industry-profiles/warehouse-operations/overrides.env`. Select one
 list by variant; expand it verbatim into `COMPOSE_PROFILES` and record its name
-in `FOUNDATION_VARIANT`. Nine of the file's lists are in scope:
+in `FOUNDATION_VARIANT`. Thirteen of the file's lists are in scope:
 
 | `MODE` | `BP_PROFILE` | Extended list | Minimal list |
 |---|---|---|---|
@@ -58,6 +59,8 @@ in `FOUNDATION_VARIANT`. Nine of the file's lists are in scope:
 | `2d` | `bp_wh_redis` | `…_WH_REDIS_2D` | `…_WH_REDIS_2D_MINIMAL` |
 | `3d` | `bp_wh_kafka` | `…_WH_KAFKA_3D` | `…_WH_KAFKA_3D_MINIMAL` |
 | `3d` | `bp_wh_redis` | `…_WH_REDIS_3D` | `…_WH_REDIS_3D_MINIMAL` |
+| `mv3dt` | `bp_wh_kafka` | `…_WH_KAFKA_MV3DT` | `…_WH_KAFKA_MV3DT_MINIMAL` |
+| `mv3dt` | `bp_wh_redis` | `…_WH_REDIS_MV3DT` | `…_WH_REDIS_MV3DT_MINIMAL` |
 
 Extended adds ELK, `vss-video-analytics-api`, `vss-haproxy-ingress`,
 `import-calibration-output-container-<mode>`, and monitoring (`dcgm-exporter`,
@@ -70,12 +73,12 @@ of these.
 
 ## Capability owners present
 
-`<mode>` is `2d` or `3d`; the suffix is on the compose *service* name only
+`<mode>` is `2d`, `3d`, or `mv3dt`; the suffix is on the compose *service* name only
 ([`../services/vios.md`](../services/vios.md)).
 
 | Owner | Service profile keys |
 |---|---|
-| RT-CV | `perception-2d` / `perception-3d`; 3D additionally requires `ds-configurator-3d` |
+| RT-CV | `perception-2d` / `perception-3d`; 3D additionally requires `ds-configurator-3d`; MV3DT uses `vss-rtvi-cv-mv3dt`, `vss-rtvi-cv-bev-fusion`, and `mosquitto` |
 | Behavior Analytics | `vss-behavior-analytics-<mode>` |
 | Configurator | `bp-configurator-<mode>`, `bp-configurator-<mode>-init` |
 | ELK | `kafka`, `kafka-topic-init-container`, `redis`, `broker-health-check`, `elasticsearch`, `elasticsearch-init-container`, `kibana`, `logstash`, `kibana-init-container-<mode>` |
@@ -115,15 +118,15 @@ config` — `scripts/validate_warehouse_env.py` checks them before deploy.
 
 | Constraint | Symptom if violated |
 |---|---|
-| `MODE` must be `2d` or `3d`, and `BP_PROFILE` one of `bp_wh`, `bp_wh_kafka`, `bp_wh_redis` | routes to a service list this skill does not support |
+| `MODE` must be `2d`, `3d`, or `mv3dt`, and `BP_PROFILE` one of `bp_wh`, `bp_wh_kafka`, `bp_wh_redis` | routes to a service list this skill does not support |
 | `BP_PROFILE=bp_wh` is 2D-only | unsupported combination |
 | `BP_PROFILE=bp_wh` is rejected on `IGX-THOR` and `DGX-SPARK` | configurator refuses |
 | `HARDWARE_PROFILE=DGX-SPARK` requires an `sbsa` `VSS_RT_CV_TAG` | configurator refuses |
 | `LLM_MODE=local` requires `services/nim/<LLM_NAME_SLUG>/hw-<HARDWARE_PROFILE>.env` | compose dies with a bare "no such file" |
-| Dataset ↔ variant: `nv-warehouse-4cams` only with `bp_wh`+`2d` (4 streams); `warehouse-loading-dock-3cams-synthetic` with 2D kafka/redis (3); `warehouse-4cams-20mx20m-synthetic` with `3d` (4) | short stream count with every container healthy |
+| Dataset ↔ variant: `nv-warehouse-4cams` only with `bp_wh`+`2d` (4 streams); `warehouse-loading-dock-3cams-synthetic` with 2D kafka/redis (3); `warehouse-4cams-20mx20m-synthetic` with `3d` or `mv3dt` (4) | short stream count with every container healthy |
 | `STREAM_TYPE=redis` iff `BP_PROFILE=bp_wh_redis` | no metadata reaches the broker |
 | A custom `SAMPLE_VIDEO_DATASET` has no checked-in `calibration.json` | Docker creates a directory where a file is expected; perception emits nothing |
-| `MODE=3d` on a `…_MINIMAL` list has no Elasticsearch | `mdx-bev` never persisted; BEV output unverifiable |
+| `MODE=3d` or `MODE=mv3dt` on a `…_MINIMAL` list has no Elasticsearch | `mdx-bev` never persisted; BEV output unverifiable |
 
 ### Remote VLM is exposed but not wired (Docker path)
 
@@ -161,8 +164,9 @@ warehouse-<mode>-app/calibration/sample-data/${SAMPLE_VIDEO_DATASET}/calibration
 
 All three shipped datasets carry one. 3D mounts it three ways — behavior
 analytics reads `/resources/calibration.json`, `ds-configurator-3d` and
-perception read `/opt/data/ds-configurator/calibration.json`. Nothing is staged
-under `$VSS_DATA_DIR`.
+perception read `/opt/data/ds-configurator/calibration.json`. MV3DT uses its
+mode-specific calibration and camera configuration under
+`warehouse-mv3dt-app`. Nothing is staged under `$VSS_DATA_DIR`.
 
 Only a **custom** dataset needs a calibration run — produced by
 `vss-generate-video-calibration` — dropped at the path above under its dataset
@@ -358,8 +362,10 @@ unchanged. Warehouse additionally needs a **liveness** check — every container
 can be `Up` while zero streams are processed:
 
 ```bash
-docker logs --since 60s vss-rtvi-cv 2>&1 | grep -aE "stream_name" | tail -8
-docker logs --since 60s vss-rtvi-cv 2>&1 | grep -a "Active sources" | tail -1
+RT_CV_CONTAINER=vss-rtvi-cv             # MODE=2d or MODE=3d
+# RT_CV_CONTAINER=vss-rtvi-cv-mv3dt     # MODE=mv3dt
+docker logs --since 60s "$RT_CV_CONTAINER" 2>&1 | grep -aE "stream_name" | tail -8
+docker logs --since 60s "$RT_CV_CONTAINER" 2>&1 | grep -a "Active sources" | tail -1
 ```
 
 Expect one `stream_name` line per source at roughly source framerate, and an
@@ -386,7 +392,7 @@ curl -sf "http://${HOST_IP}:8000/health"                   # bp_wh only
 - `deploy/docker/industry-profiles/warehouse-operations/.env`
 - `deploy/docker/industry-profiles/warehouse-operations/overrides.env`
 - `deploy/docker/industry-profiles/warehouse-operations/compose.yml`
-- `deploy/docker/industry-profiles/warehouse-operations/warehouse-{2d,3d}-app/`
+- `deploy/docker/industry-profiles/warehouse-operations/warehouse-{2d,3d,mv3dt}-app/`
 - `deploy/docker/industry-profiles/warehouse-operations/blueprint-configurator/blueprint_config.yml`
 - `deploy/docker/services/infra/compose-no-turn-tcp-relay.yml`
 - `deploy/docker/services/infra/haproxy/haproxy.cfg.template`

--- a/skills/vss-build-vision-ai/references/readiness.md
+++ b/skills/vss-build-vision-ai/references/readiness.md
@@ -106,10 +106,11 @@ output; on a warehouse `MODE=3d` build it stays flat at `0` forever while the
 stack is perfectly healthy, so snapshotting it reports a dead data plane on a
 working deployment. There is no universal topic to poll:
 
-| Build | Perception topic | Analytics topics |
+| Build | Data-plane topic(s) | Analytics topics |
 |---|---|---|
 | Warehouse `MODE=2d`, Alerts, Search (RT-CV 2D) | `mdx-raw` | `mdx-behavior`, `mdx-incidents` |
-| Warehouse `MODE=3d` (Sparse4D / MV3DT) | `mdx-bev` | `mdx-behavior`, `mdx-incidents` |
+| Warehouse `MODE=3d` (Sparse4D) | `mdx-bev` | `mdx-behavior`, `mdx-incidents` |
+| Warehouse `MODE=mv3dt` | `mdx-raw`, then fused `mdx-bev` | `mdx-behavior`, `mdx-incidents` |
 
 Confirm rather than assume: `kafka-topics --bootstrap-server localhost:29092
 --list` shows every topic the build created (a warehouse stack creates ~20

--- a/skills/vss-build-vision-ai/references/sizing.md
+++ b/skills/vss-build-vision-ai/references/sizing.md
@@ -132,27 +132,30 @@ but "does this hardware support the count this dataset requires".
 `blueprint_config.yml` is authoritative for that ceiling. `HARDWARE_PROFILE`
 selects the section; `MODE` selects the row:
 
-| `HARDWARE_PROFILE` | `2d` | `3d` |
-|---|---:|---:|
-| H100 | 77 | 19 |
-| RTXPRO6000BW | 52 | 21 |
-| RTXPRO6000BW-SE | 47 | 20 |
-| L40S | 29 | 10 |
-| RTXA6000ADA | 28 | 8 |
-| RTXPRO4500BW | 20 | 9 |
-| RTXA6000 | 15 | **4** |
-| L4 | 9 | **3** |
-| IGX-THOR | 9 | 8 |
-| DGX-SPARK | 7 | 7 |
+| `HARDWARE_PROFILE` | `2d` | `3d` | `mv3dt` |
+|---|---:|---:|---:|
+| H100 | 77 | 19 | 61 |
+| RTXPRO6000BW | 52 | 21 | 39 |
+| RTXPRO6000BW-SE | 47 | 20 | 39 |
+| L40S | 29 | 10 | 23 |
+| RTXA6000ADA | 28 | 8 | 22 |
+| RTXPRO4500BW | 20 | 9 | — |
+| RTXA6000 | 15 | **4** | **4** |
+| L4 | 9 | **3** | 7 |
+| IGX-THOR | 9 | 8 | 7 |
+| DGX-SPARK | 7 | 7 | 7 |
 
 Check the dataset's stream count against the cell before deploying:
 
 - `nv-warehouse-4cams` (2D `bp_wh`) — 4 streams. Fits every profile.
 - `warehouse-loading-dock-3cams-synthetic` (2D kafka/redis) — 3 streams. Fits
   every profile.
-- `warehouse-4cams-20mx20m-synthetic` (3D) — 4 streams. **Exceeds `L4` (3).**
-  Exactly saturates `RTXA6000` (4), which leaves no margin for a second workload
-  on that GPU.
+- `warehouse-4cams-20mx20m-synthetic` (3D or MV3DT) — 4 streams. In 3D it
+  **exceeds `L4` (3)**. It exactly saturates `RTXA6000` (4) in either mode,
+  which leaves no margin for a second workload on that GPU.
+
+`RTXPRO4500BW` has no MV3DT tuning entry in `blueprint_config.yml`; do not infer
+a stream ceiling for that combination.
 
 `NUM_STREAMS` is an input and is never rewritten — the file-count prerequisite
 that would recompute it from the video directory is `enabled: false` in every
@@ -206,7 +209,7 @@ integrated RT-VLM at an external endpoint):
 
 | Variant | GPU consumers | Layout |
 |---|---|---|
-| `bp_wh_kafka` / `bp_wh_redis`, `2d` or `3d` | RT-CV only | Everything else is CPU-bound (ELK, VIOS, analytics). One GPU at `RT_CV_DEVICE_ID=0` is the whole budget. |
+| `bp_wh_kafka` / `bp_wh_redis`, `2d`, `3d`, or `mv3dt` | RT-CV only | Everything else, including MV3DT BEV Fusion, is CPU-bound (ELK, VIOS, analytics). One GPU at `RT_CV_DEVICE_ID=0` is the whole budget. |
 | `bp_wh`, `2d` | RT-CV, integrated RT-VLM, LLM NIM | Stock layout is `RT_CV_DEVICE_ID=0`, `RT_VLM_DEVICE_ID=1`, `LLM_DEVICE_ID=2`. With fewer GPUs, place RT-CV first (fixed footprint) and apply the RT-VLM placement rules above; a remote LLM removes the third consumer entirely. |
 
 Headless warehouse perception is far lighter than a VLM profile — a measured

--- a/skills/vss-build-vision-ai/scripts/validate_warehouse_env.py
+++ b/skills/vss-build-vision-ai/scripts/validate_warehouse_env.py
@@ -31,12 +31,17 @@ DATASETS = {
         3,
     ),
     "warehouse-4cams-20mx20m-synthetic": (
-        {("3d", "bp_wh_kafka"), ("3d", "bp_wh_redis")},
+        {
+            ("3d", "bp_wh_kafka"),
+            ("3d", "bp_wh_redis"),
+            ("mv3dt", "bp_wh_kafka"),
+            ("mv3dt", "bp_wh_redis"),
+        },
         4,
     ),
 }
 
-MODES = {"2d", "3d"}
+MODES = {"2d", "3d", "mv3dt"}
 BP_PROFILES = {"bp_wh", "bp_wh_kafka", "bp_wh_redis"}
 
 # The service lists this skill supports, keyed by the (MODE, BP_PROFILE) pair
@@ -68,6 +73,14 @@ VARIANT_MATRIX = {
         "COMPOSE_PROFILES_WH_REDIS_3D",
         "COMPOSE_PROFILES_WH_REDIS_3D_MINIMAL",
     },
+    ("mv3dt", "bp_wh_kafka"): {
+        "COMPOSE_PROFILES_WH_KAFKA_MV3DT",
+        "COMPOSE_PROFILES_WH_KAFKA_MV3DT_MINIMAL",
+    },
+    ("mv3dt", "bp_wh_redis"): {
+        "COMPOSE_PROFILES_WH_REDIS_MV3DT",
+        "COMPOSE_PROFILES_WH_REDIS_MV3DT_MINIMAL",
+    },
 }
 
 IN_SCOPE_VARIANTS = {v for variants in VARIANT_MATRIX.values() for v in variants}
@@ -95,7 +108,7 @@ ASSIGN = re.compile(r"^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=(.*)$")
 # a 2D detector in a 3D build resolves cleanly, boots healthy, and publishes to the
 # wrong topic -- 2D writes mdx-raw while vss-behavior-analytics-3d reads mdx-bev, so
 # analytics silently sees nothing.
-MODE_TOKEN = re.compile(r"(?:^|-)(2d|3d)(?:-|$)")
+MODE_TOKEN = re.compile(r"(?:^|-)(2d|3d|mv3dt)(?:-|$)")
 
 
 def strip_value(value: str) -> str:
@@ -283,9 +296,9 @@ def check(env: dict[str, str], repo: Path, foundation_dir: Path) -> list[str]:
             )
 
     # 1/3. bp_wh is 2d-only.
-    if bp == "bp_wh" and mode == "3d":
+    if bp == "bp_wh" and mode in {"3d", "mv3dt"}:
         errors.append(
-            "BP_PROFILE=bp_wh is unsupported with MODE=3d "
+            f"BP_PROFILE=bp_wh is unsupported with MODE={mode} "
             "(agents run in 2d only); use bp_wh_kafka or bp_wh_redis"
         )
 
@@ -474,9 +487,9 @@ def check(env: dict[str, str], repo: Path, foundation_dir: Path) -> list[str]:
                 "vss-generate-video-calibration, or use a shipped sample dataset"
             )
 
-    if mode == "3d" and variant.endswith("_MINIMAL"):
+    if mode in {"3d", "mv3dt"} and variant.endswith("_MINIMAL"):
         warnings.append(
-            "MODE=3d on a _MINIMAL list deploys no Elasticsearch, so the "
+            f"MODE={mode} on a _MINIMAL list deploys no Elasticsearch, so the "
             "mdx-bev index is never persisted and BEV output cannot be verified"
         )
 


### PR DESCRIPTION
## Summary

Add Warehouse MV3DT support to the `vss-build-vision-ai` skill using the existing Warehouse blueprint and Compose profiles.

## Plan

- Add MV3DT to the Warehouse workflow selection.
- Reuse the existing Kafka and Redis Warehouse MV3DT variants.
- Extend validation, data checks, sizing, and readiness guidance.
- Avoid changes to deployment or Compose definitions.

## Changes

- Added `mv3dt` to the Warehouse perception-mode selection.
- Added Kafka/Redis extended and minimal MV3DT variants.
- Updated Warehouse environment validation for MV3DT.
- Updated app-data, calibration, sizing, and readiness guidance.
- Verified all four MV3DT variants and Compose service resolution.
- No new files or deployment configuration changes.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.