### PR TITLE
feat(vss-build-vision-ai): support warehouse mv3dt and auto-calibrati…

### DIFF
--- a/skills/vss-build-vision-ai/SKILL.md
+++ b/skills/vss-build-vision-ai/SKILL.md
@@ -102,7 +102,8 @@ Reached from Q1 → industry blueprint, or when the request names warehouse
 directly. Expand the selected variant's service list verbatim — warehouse is
 variant selection, not composition, so there is no delta path. Read
 [`references/profiles/warehouse.md`](references/profiles/warehouse.md) before
-asking, and apply its Hard constraints while asking, not after.
+asking, and apply its Hard constraints while asking, not after. Apply any build
+requirements its **Profile Service Set** states.
 
 Up to four single-select questions, each inside the four-option cap. Describe
 each option from warehouse.md's **Profile Service Set** table; do not restate

--- a/skills/vss-build-vision-ai/SKILL.md
+++ b/skills/vss-build-vision-ai/SKILL.md
@@ -104,27 +104,34 @@ variant selection, not composition, so there is no delta path. Read
 [`references/profiles/warehouse.md`](references/profiles/warehouse.md) before
 asking, and apply its Hard constraints while asking, not after.
 
-Up to three single-select questions, each inside the four-option cap. Describe
+Up to four single-select questions, each inside the four-option cap. Describe
 each option from warehouse.md's **Profile Service Set** table; do not restate
 its service lists here, or this table drifts from the one that is authoritative:
 
 | Question | Options |
 |---|---|
-| **Q2w-mode** — *"Which warehouse perception mode?"* | `2d` (RT-DETR) · `3d` (Sparse4D, depth-aware) |
+| **Q2w-mode** — *"Which warehouse mode?"* | `2d` (RT-DETR) · `3d` (Sparse4D, depth-aware) · `mv3dt` (multi-view 3D tracking, BEV fusion) · `auto-calibration` (produce a calibration) |
 | **Q2w-profile** — *"Which deployment variant?"* | `bp_wh` · `bp_wh_kafka` · `bp_wh_redis` |
 | **Q2w-size** — *"Minimal or extended?"* | Extended · Minimal |
+| **Q2w-dataset** — *"Which sample dataset?"* | `nv-warehouse-4cams` · `warehouse-loading-dock-3cams-synthetic` · `warehouse-4cams-20mx20m-synthetic` |
 
 Filter the remaining options rather than validating the answers afterwards.
 Both filters below are warehouse.md's to state; it is the source of truth for
 why, and this list only says when to apply them:
 
-- **Omit `bp_wh` from Q2w-profile when Q2w-mode is `3d`** — Hard constraints:
+- **Omit `bp_wh` from Q2w-profile unless Q2w-mode is `2d`** — Hard constraints:
   `bp_wh` is 2D-only. Leaving it selectable turns an impossible deployment into
   a late runtime failure.
+- **Skip Q2w-profile and Q2w-size entirely when Q2w-mode is `auto-calibration`** —
+  that mode pairs only with `bp_wh_auto_calib` and has a single list, so both
+  answers are forced.
 - **Skip Q2w-size entirely for `bp_wh`** — the Profile Service Set table lists
   no minimal variant for it.
-- Set `SAMPLE_VIDEO_DATASET` and `NUM_STREAMS` from the chosen variant, not from
-  the Foundation default; the dataset ↔ variant pairing is a Hard constraint.
+- **Ask Q2w-dataset for every mode, including `auto-calibration`.** Dataset and
+  mode are independent — all three ship calibration for `2d`, `3d` and `mv3dt`,
+  and auto-calibration needs to know which dataset it is calibrating. Set
+  `NUM_STREAMS` to the chosen dataset's camera count (4 / 3 / 4); that is the
+  Hard constraint that survives, and there is no dataset ↔ variant pairing rule.
 
 The answers select exactly one `COMPOSE_PROFILES_WH_*` list. Record its name in
 `FOUNDATION_VARIANT`, expand it verbatim into `COMPOSE_PROFILES`, and continue

--- a/skills/vss-build-vision-ai/references/data-directory.md
+++ b/skills/vss-build-vision-ai/references/data-directory.md
@@ -129,7 +129,10 @@ done
 # 0 streams with every container healthy, so fail here rather than at runtime.
 # ---------------------------------------------------------------------------
 case ",$COMPOSE_PROFILES," in
-  *,nvstreamer-2d,*|*,nvstreamer-3d,*)
+  # Every warehouse mode, not just 2d/3d: mv3dt and auto-calibration consume the
+  # same bundle. Enumerated rather than globbed -- nvstreamer-alerts/-base/-lvs/
+  # -video are developer profiles with a different data layout and no playback/.
+  *,nvstreamer-2d,*|*,nvstreamer-3d,*|*,nvstreamer-mv3dt,*|*,nvstreamer-amc,*)
     DATASET="$(sed -n 's/^SAMPLE_VIDEO_DATASET=//p' "$ENV_FILE" | tr -d '"')"
     wh_fail=0
     for d in videos models playback data_log; do
@@ -188,14 +191,15 @@ volumes.
 
 For `warehouse`, **`${VSS_DATA_DIR}` is not a directory you create — it *is* the
 extracted app-data bundle.** Point it at `<extract>/vss-warehouse-app-data`, the
-inner directory holding `videos/`, `playback/`, `models/` and `data_log/`.
+inner directory holding `videos/`, `playback/`, and `data_log/`.
 
 The whole bundle is a **read-only input**: `mkdir` cannot substitute for missing
 content, and an empty `videos/` turns a clear "no app data" failure into a
 zero-streams symptom. Treat it as a **blocking presence check**, not part of the
 `required=()` list above — run it *before* any `docker compose up`.
 
-When `COMPOSE_PROFILES` contains an `nvstreamer-2d` or `nvstreamer-3d` key,
+When `COMPOSE_PROFILES` contains a warehouse nvstreamer key — `nvstreamer-2d`,
+`nvstreamer-3d`, `nvstreamer-mv3dt` or `nvstreamer-amc` (auto-calibration) —
 verify before deploying:
 
 ```bash

--- a/skills/vss-build-vision-ai/references/profiles/warehouse.md
+++ b/skills/vss-build-vision-ai/references/profiles/warehouse.md
@@ -5,9 +5,8 @@ end to end: what the Foundation is made of, what constrains it, how a build is
 resolved, and how the result is reached and verified. The rest of the skill's
 machinery applies unchanged by reference — see Build and resolve below.
 
-`overrides.env` defines further service lists; only the nine below are
-supported. The others are out of scope for this skill — do not compose or deploy
-them.
+`overrides.env` defines further service lists; the fourteen `COMPOSE_PROFILES_WH_*`
+lists below are supported. The others are out of scope for this skill — do not compose or deploy them.
 
 **Warehouse is variant selection, not composition.** Pick the one
 `COMPOSE_PROFILES_WH_*` list that `MODE` + `BP_PROFILE` + size identify, expand
@@ -49,7 +48,7 @@ Resolve block below instead.
 Authoritative source:
 `deploy/docker/industry-profiles/warehouse-operations/overrides.env`. Select one
 list by variant; expand it verbatim into `COMPOSE_PROFILES` and record its name
-in `FOUNDATION_VARIANT`. Nine of the file's lists are in scope:
+in `FOUNDATION_VARIANT`. Fourteen of the file's lists are in scope:
 
 | `MODE` | `BP_PROFILE` | Extended list | Minimal list |
 |---|---|---|---|
@@ -58,6 +57,20 @@ in `FOUNDATION_VARIANT`. Nine of the file's lists are in scope:
 | `2d` | `bp_wh_redis` | `…_WH_REDIS_2D` | `…_WH_REDIS_2D_MINIMAL` |
 | `3d` | `bp_wh_kafka` | `…_WH_KAFKA_3D` | `…_WH_KAFKA_3D_MINIMAL` |
 | `3d` | `bp_wh_redis` | `…_WH_REDIS_3D` | `…_WH_REDIS_3D_MINIMAL` |
+| `mv3dt` | `bp_wh_kafka` | `…_WH_KAFKA_MV3DT` | `…_WH_KAFKA_MV3DT_MINIMAL` |
+| `mv3dt` | `bp_wh_redis` | `…_WH_REDIS_MV3DT` | `…_WH_REDIS_MV3DT_MINIMAL` |
+| `auto-calibration` | `bp_wh_auto_calib` | `COMPOSE_PROFILES_WH_AUTO_CALIB` | — |
+
+`mv3dt` is multi-view 3D tracking with BEV fusion — the same analytics shape as
+`3d`, fed by a multi-camera tracker rather than single-view Sparse4D.
+
+**`auto-calibration` is a mode, not a size or a broker choice.** It pairs only
+with `BP_PROFILE=bp_wh_auto_calib`, and it *produces* a calibration for the chosen
+dataset instead of consuming a shipped one — so no `warehouse-auto-calibration-app`
+tree exists and the calibration-presence rule below does not apply to it. It also
+ships **without SDRC**: `init-dirs`, `render-config`, `wdm-env-from-config`,
+`wait-for-redis` and `sdr-controller` are absent by design, so the infrastructure
+floor for this mode is the common set only.
 
 Extended adds ELK, `vss-video-analytics-api`, `vss-haproxy-ingress`,
 `import-calibration-output-container-<mode>`, and monitoring (`dcgm-exporter`,
@@ -115,15 +128,16 @@ config` — `scripts/validate_warehouse_env.py` checks them before deploy.
 
 | Constraint | Symptom if violated |
 |---|---|
-| `MODE` must be `2d` or `3d`, and `BP_PROFILE` one of `bp_wh`, `bp_wh_kafka`, `bp_wh_redis` | routes to a service list this skill does not support |
+| `MODE` must be `2d`, `3d`, `mv3dt` or `auto-calibration`, and `BP_PROFILE` one of `bp_wh`, `bp_wh_kafka`, `bp_wh_redis`, `bp_wh_auto_calib` | routes to a service list this skill does not support |
 | `BP_PROFILE=bp_wh` is 2D-only | unsupported combination |
+| `BP_PROFILE=bp_wh_auto_calib` pairs only with `MODE=auto-calibration`, and vice versa | routes to a list that is not the one selected |
 | `BP_PROFILE=bp_wh` is rejected on `IGX-THOR` and `DGX-SPARK` | configurator refuses |
 | `HARDWARE_PROFILE=DGX-SPARK` requires an `sbsa` `VSS_RT_CV_TAG` | configurator refuses |
 | `LLM_MODE=local` requires `services/nim/<LLM_NAME_SLUG>/hw-<HARDWARE_PROFILE>.env` | compose dies with a bare "no such file" |
-| Dataset ↔ variant: `nv-warehouse-4cams` only with `bp_wh`+`2d` (4 streams); `warehouse-loading-dock-3cams-synthetic` with 2D kafka/redis (3); `warehouse-4cams-20mx20m-synthetic` with `3d` (4) | short stream count with every container healthy |
+| `NUM_STREAMS` must equal the dataset's camera count: `nv-warehouse-4cams` 4, `warehouse-loading-dock-3cams-synthetic` 3, `warehouse-4cams-20mx20m-synthetic` 4. **Dataset and mode are independent** — every shipped dataset now carries calibration for `2d`, `3d` and `mv3dt`, so any dataset pairs with any analytics mode | short stream count with every container healthy |
 | `STREAM_TYPE=redis` iff `BP_PROFILE=bp_wh_redis` | no metadata reaches the broker |
 | A custom `SAMPLE_VIDEO_DATASET` has no checked-in `calibration.json` | Docker creates a directory where a file is expected; perception emits nothing |
-| `MODE=3d` on a `…_MINIMAL` list has no Elasticsearch | `mdx-bev` never persisted; BEV output unverifiable |
+| `MODE=3d` or `mv3dt` on a `…_MINIMAL` list has no Elasticsearch | `mdx-bev` never persisted; BEV output unverifiable |
 
 ### Remote VLM is exposed but not wired (Docker path)
 
@@ -159,14 +173,21 @@ checked-in `calibration.json` that Compose bind-mounts by path:
 warehouse-<mode>-app/calibration/sample-data/${SAMPLE_VIDEO_DATASET}/calibration.json
 ```
 
-All three shipped datasets carry one. 3D mounts it three ways — behavior
-analytics reads `/resources/calibration.json`, `ds-configurator-3d` and
+All three shipped datasets carry one **for each of `2d`, `3d` and `mv3dt`**, which
+is why dataset and mode are chosen independently. 3D mounts it three ways —
+behavior analytics reads `/resources/calibration.json`, `ds-configurator-3d` and
 perception read `/opt/data/ds-configurator/calibration.json`. Nothing is staged
 under `$VSS_DATA_DIR`.
 
 Only a **custom** dataset needs a calibration run — produced by
-`vss-generate-video-calibration` — dropped at the path above under its dataset
-name. `scripts/validate_warehouse_env.py` fails the build when it is missing.
+`vss-generate-video-calibration`, or by a `MODE=auto-calibration` build — dropped
+at the path above under its dataset name.
+`scripts/validate_warehouse_env.py` fails the build when it is missing.
+
+`MODE=auto-calibration` is the exception to this whole section: it is the run that
+*produces* a calibration, so it has no `warehouse-auto-calibration-app` tree and the
+presence check is skipped for it. Pick the dataset you intend to calibrate and match
+`NUM_STREAMS` to it, exactly as for an analytics mode.
 
 `import-calibration-output-container-<mode>` (extended lists only) imports
 calibration into the analytics store; it does not produce calibration.

--- a/skills/vss-build-vision-ai/references/profiles/warehouse.md
+++ b/skills/vss-build-vision-ai/references/profiles/warehouse.md
@@ -72,6 +72,27 @@ ships **without SDRC**: `init-dirs`, `render-config`, `wdm-env-from-config`,
 `wait-for-redis` and `sdr-controller` are absent by design, so the infrastructure
 floor for this mode is the common set only.
 
+**Auto-calibration build requirements.** In `override.env`, restore the
+direct-VST defaults — `overrides.env` sets the SDRC trio for `2d`/`3d`/`mv3dt`,
+and a later env layer can only override a variable, not un-set it:
+
+```text
+VST_USE_SDRC=false
+VST_NGINX_MODE=vst
+STREAM_PROCESSOR_MODULE_ENDPOINT=http://vss-vios-streamprocessing:30001
+```
+
+Create the project store before `up` — it is not in the repo, and the container
+writes to it as uid 1000:
+
+```bash
+mkdir -p "$VSS_APPS_DIR/services/auto-calibration/projects"
+chmod 0777 "$VSS_APPS_DIR/services/auto-calibration/projects"
+```
+
+**VGGT is optional — nothing to do.** `VGGT available: False` in the logs is
+expected, not a failure: the weight is gated on HuggingFace, so the service may falls back to base AMC.
+
 Extended adds ELK, `vss-video-analytics-api`, `vss-haproxy-ingress`,
 `import-calibration-output-container-<mode>`, and monitoring (`dcgm-exporter`,
 `prometheus`, `grafana`, `node-exporter`, `cadvisor`). Minimal lists carry none
@@ -351,8 +372,11 @@ browser-reachable origin that rewrites paths to internal services. The
 | Video Analytics API | `<HOST_IP>:8081` (`VIDEO_ANALYTICS_API_HOST_PORT`) | same |
 | Grafana | `<HOST_IP>:35000` (`GRAFANA_HOST_PORT`) | `bp_wh`, or extended Kafka/Redis; no ingress route |
 | VSS Agent, Phoenix | `<HOST_IP>:8000`, `<HOST_IP>:6006` | `bp_wh` only; prefer `/api` and `/phoenix` |
+| Auto-calibration API | `<HOST_IP>:8010/docs` (`VSS_AUTO_CALIBRATION_HOST_PORT`) | `auto-calibration` only; no ingress route |
+| Auto-calibration UI | `<HOST_IP>:5000` (`VSS_AUTO_CALIBRATION_UI_HOST_PORT`) | `auto-calibration` only; no ingress route |
 
-Nothing listens on `8001` — there is no VST MCP container.
+Nothing listens on `8001` — there is no VST MCP container. On `auto-calibration`
+nothing listens on `10000` either: that mode deploys no `sdr-controller`.
 
 > **A wrong `Host` header looks like "every path 404s".** HAProxy first denies
 > any request whose `Host` is not in its `known_host` ACL — `VSS_PUBLIC_HOST`,
@@ -401,6 +425,24 @@ curl -sf "http://${HOST_IP}:8000/health"                   # bp_wh only
 > Endpoint quirks that read as a dead service are in
 > [`../services/elk.md`](../services/elk.md); routes that never answer are in
 > Access points above.
+
+### `MODE=auto-calibration` readiness
+
+This mode deploys no `vss-rtvi-cv` and processes no streams, so the liveness
+check above does not apply. Use instead:
+
+```bash
+curl -sf -o /dev/null -w '%{http_code}\n' "http://${HOST_IP}:8010/docs"   # API  -> 200
+curl -sf -o /dev/null -w '%{http_code}\n' "http://${HOST_IP}:5000/"       # UI   -> 200
+docker inspect -f '{{.RestartCount}} {{.State.Health.Status}}' vss-auto-calibration
+docker logs --since 60s vss-auto-calibration 2>&1 | grep -c "Failed to persist project state"
+```
+
+Expect `200`, `200`, `0 healthy`, and a count of **0** — the last probe is what
+confirms the `projects/` mount is writable.
+
+`/docs` is the endpoint that answers; `/openapi.json`, `/v1/health` and `/health`
+return **404** on this image.
 
 ## Sources
 

--- a/skills/vss-build-vision-ai/references/profiles/warehouse.md
+++ b/skills/vss-build-vision-ai/references/profiles/warehouse.md
@@ -99,9 +99,7 @@ Extended adds ELK, `vss-video-analytics-api`, `vss-haproxy-ingress`,
 `prometheus`, `grafana`, `node-exporter`, `cadvisor`). Minimal lists carry none
 of these.
 
-> `MINIMAL_PROFILE` and `ELASTICSEARCH_MODE` are **dead knobs** on this path —
-> read only by `blueprint-deploy.sh` and the launchable, never by the compose
-> stack. Size is selected *only* by which list `COMPOSE_PROFILES` points at.
+> Size is selected *only* by which list `COMPOSE_PROFILES` points at.
 
 ## Capability owners present
 
@@ -161,30 +159,17 @@ config` — `scripts/validate_warehouse_env.py` checks them before deploy.
 | A custom `SAMPLE_VIDEO_DATASET` has no checked-in `calibration.json` | Docker creates a directory where a file is expected; perception emits nothing |
 | `MODE=3d` or `mv3dt` on a `…_MINIMAL` list has no Elasticsearch | `mdx-bev` never persisted; BEV output unverifiable |
 
-### Remote VLM is exposed but not wired (Docker path)
+### Remote VLM is not supported (Docker path)
 
-`VLM_MODE=remote` looks supported and is not. `blueprint-deploy.sh
---use-remote-vlm` (2D + `bp_wh` only) sets `VLM_BASE_URL`,
-`RTVI_VLM_ENDPOINT=${VLM_BASE_URL}/v1` and `RTVI_VLM_MODEL_PATH=none`, but it
-never switches the two selectors that decide which backend serves the request:
+Warehouse uses the integrated RTVI VLM, which runs locally only, so `VLM_MODE`
+and `VLM_NAME_SLUG` stay `none` — `scripts/validate_warehouse_env.py` enforces
+it. The supported remote configuration is **remote LLM with local RT-VLM**
+(`LLM_MODE=remote`, `LLM_BASE_URL` without a trailing `/v1`).
 
-| Knob | Warehouse default | Remote needs | Set by `--use-remote-vlm`? |
-|---|---|---|---|
-| `RTVI_VLM_MODEL_TO_USE` | `cosmos-reason3` | `openai-compat` | no |
-| `VLM_MODEL_TYPE` | `rtvi` | non-`rtvi` | only if `--vlm-model-type` is passed explicitly |
-
-Both live in `industry-profiles/warehouse-operations/overrides.env`. The result
-is a deployment that starts cleanly and keeps routing through the local RT-VLM
-proxy against a model path of `none`. The same backend-selection bug was fixed
-for **Helm only** in
-[NVIDIA-AI-Blueprints/video-search-and-summarization#1501](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/1501);
-the Docker warehouse path was not updated, and no warehouse end-to-end run has
-validated remote VLM — the validated remote configuration is **remote LLM with
-local RT-VLM**, which is unaffected and remains supported.
-
-`scripts/validate_warehouse_env.py` therefore rejects any non-`none` `VLM_MODE`
-or `VLM_NAME_SLUG`. Lift that rule only once the Docker path sets both
-selectors.
+Setting `VLM_MODE=remote` looks plausible and is not wired: the Docker path never
+switches `RTVI_VLM_MODEL_TO_USE` (`cosmos-reason3`) or `VLM_MODEL_TYPE` (`rtvi`),
+so the deployment starts cleanly and keeps routing through the local RT-VLM
+against a model path of `none`.
 
 ### Calibration is already in the repo
 

--- a/skills/vss-build-vision-ai/references/profiles/warehouse.md
+++ b/skills/vss-build-vision-ai/references/profiles/warehouse.md
@@ -103,15 +103,16 @@ of these.
 
 ## Capability owners present
 
-`<mode>` is `2d` or `3d`; the suffix is on the compose *service* name only
-([`../services/vios.md`](../services/vios.md)).
+`<mode>` is `2d`, `3d` or `mv3dt`; the suffix is on the compose *service* name
+only ([`../services/vios.md`](../services/vios.md)).
 
 | Owner | Service profile keys |
 |---|---|
-| RT-CV | `perception-2d` / `perception-3d`; 3D additionally requires `ds-configurator-3d` |
+| RT-CV | `perception-2d` / `perception-3d`; 3D additionally requires `ds-configurator-3d`. **`mv3dt` does not follow the `perception-<mode>` pattern**: it is two services, `vss-rtvi-cv-mv3dt` (per-camera tracking) and `vss-rtvi-cv-bev-fusion` (multi-view merge) |
 | Behavior Analytics | `vss-behavior-analytics-<mode>` |
-| Configurator | `bp-configurator-<mode>`, `bp-configurator-<mode>-init` |
+| Configurator | `bp-configurator-<mode>`, `bp-configurator-<mode>-init` — `mv3dt` has no `-init` |
 | ELK | `kafka`, `kafka-topic-init-container`, `redis`, `broker-health-check`, `elasticsearch`, `elasticsearch-init-container`, `kibana`, `logstash`, `kibana-init-container-<mode>` |
+| MQTT | `mosquitto` — **`mv3dt` lists only**; no 2d/3d list carries it (`MQTT_HOST_PORT` 1883) |
 | VIOS | `nvstreamer-<mode>`, `sensor-ms-<mode>`, `streamprocessing-ms-<mode>`, `centralizedb`, `vst-ingress`, `sdr-controller`, `turnserver`, `turnserver-init`, `init-dirs`, `render-config`, `wdm-env-from-config`, `wait-for-redis`, `sensor-bp-wait-bp-configurator` |
 | Video Analytics API | `vss-video-analytics-api`, `import-calibration-output-container-<mode>` |
 | Ingress | `vss-haproxy-ingress` |
@@ -397,6 +398,13 @@ Expect one `stream_name` line per source at roughly source framerate, and an
 active-source count equal to `NUM_STREAMS`. Do **not** `grep -i fps` —
 DeepStream's only line containing that string is a valueless header, so it
 reports success regardless.
+
+On `mv3dt` the perception container is `vss-rtvi-cv-mv3dt`, and `mdx-bev` comes
+from a second service, `vss-rtvi-cv-bev-fusion` — check it is `healthy` too.
+**`mv3dt` publishes `mdx-raw` as well as `mdx-bev`** (per-camera tracks and the
+fused result), unlike `3d`. First output can take several minutes; a
+`vss-vios-ingress` restart count in the low teens while `sdr-controller` comes up
+is normal, provided it settles to `healthy`.
 
 HTTP probes, when the selected list ships them:
 

--- a/skills/vss-build-vision-ai/references/profiles/warehouse.md
+++ b/skills/vss-build-vision-ai/references/profiles/warehouse.md
@@ -66,12 +66,13 @@ in `FOUNDATION_VARIANT`. The lists in scope are:
 `3d`, fed by a multi-camera tracker rather than single-view Sparse4D.
 
 **`auto-calibration` is a mode, not a size or a broker choice.** It pairs only
-with `BP_PROFILE=bp_wh_auto_calib`, and it *produces* a calibration for the chosen
-dataset instead of consuming a shipped one — so no `warehouse-auto-calibration-app`
-tree exists and the calibration-presence rule below does not apply to it. It also
-ships **without SDRC**: `init-dirs`, `render-config`, `wdm-env-from-config`,
-`wait-for-redis` and `sdr-controller` are absent by design, so the infrastructure
-floor for this mode is the common set only.
+with `BP_PROFILE=bp_wh_auto_calib`. It writes a calibration rather than reading
+one, so the calibration-presence rule below does not apply, and there is no
+`warehouse-auto-calibration-app` tree for a mode-embedded path to point at. It
+runs no perception and no broker, so `STREAM_TYPE` does not apply either. It
+ships without the SDRC chain — `init-dirs`, `render-config`,
+`wdm-env-from-config`, `wait-for-redis`, `sdr-controller` — so its
+infrastructure floor is the common set only.
 
 **Auto-calibration build requirements.** In `override.env`, restore the
 direct-VST defaults — `overrides.env` sets the SDRC trio for `2d`/`3d`/`mv3dt`,
@@ -110,7 +111,7 @@ only ([`../services/vios.md`](../services/vios.md)).
 |---|---|
 | RT-CV | `perception-2d` / `perception-3d`; 3D additionally requires `ds-configurator-3d`. **`mv3dt` does not follow the `perception-<mode>` pattern**: it is two services, `vss-rtvi-cv-mv3dt` (per-camera tracking) and `vss-rtvi-cv-bev-fusion` (multi-view merge) |
 | Behavior Analytics | `vss-behavior-analytics-<mode>` |
-| Configurator | `bp-configurator-<mode>`, `bp-configurator-<mode>-init` — `mv3dt` has no `-init` |
+| Configurator | `bp-configurator-<mode>` |
 | ELK | `kafka`, `kafka-topic-init-container`, `redis`, `broker-health-check`, `elasticsearch`, `elasticsearch-init-container`, `kibana`, `logstash`, `kibana-init-container-<mode>` |
 | MQTT | `mosquitto` — **`mv3dt` lists only**; no 2d/3d list carries it (`MQTT_HOST_PORT` 1883) |
 | VIOS | `nvstreamer-<mode>`, `sensor-ms-<mode>`, `streamprocessing-ms-<mode>`, `centralizedb`, `vst-ingress`, `sdr-controller`, `turnserver`, `turnserver-init`, `init-dirs`, `render-config`, `wdm-env-from-config`, `wait-for-redis`, `sensor-bp-wait-bp-configurator` |
@@ -353,7 +354,7 @@ browser-reachable origin that rewrites paths to internal services. The
 |---|---|---|
 | NvStreamer UI | `<HOST_IP>:31000` (`NVSTREAMER_HTTP_HOST_PORT`) | all variants; no ingress route |
 | VST UI | `<HOST_IP>:30888/vst/` (`VST_INGRESS_HOST_PORT`) | all variants; prefer `/vst/` via ingress |
-| SDR controller | `<HOST_IP>:10000` (`SDRC_PROXY_HOST_PORT`) | all variants |
+| SDR controller | `<HOST_IP>:10000` (`SDRC_PROXY_HOST_PORT`); also publishes 5003, 8011, 9902 | all except `auto-calibration`, which deploys none |
 | Elasticsearch | `<HOST_IP>:9200` (`ELASTICSEARCH_HOST_PORT`) | `bp_wh`, or extended Kafka/Redis |
 | Kibana | `<HOST_IP>:5601/kibana` (`KIBANA_HOST_PORT`) | same — served under `/kibana` either way |
 | Video Analytics API | `<HOST_IP>:8081` (`VIDEO_ANALYTICS_API_HOST_PORT`) | same |
@@ -362,8 +363,7 @@ browser-reachable origin that rewrites paths to internal services. The
 | Auto-calibration API | `<HOST_IP>:8010/docs` (`VSS_AUTO_CALIBRATION_HOST_PORT`) | `auto-calibration` only; no ingress route |
 | Auto-calibration UI | `<HOST_IP>:5000` (`VSS_AUTO_CALIBRATION_UI_HOST_PORT`) | `auto-calibration` only; no ingress route |
 
-Nothing listens on `8001` — there is no VST MCP container. On `auto-calibration`
-nothing listens on `10000` either: that mode deploys no `sdr-controller`.
+Nothing listens on `8001` — there is no VST MCP container.
 
 > **A wrong `Host` header looks like "every path 404s".** HAProxy first denies
 > any request whose `Host` is not in its `known_host` ACL — `VSS_PUBLIC_HOST`,

--- a/skills/vss-build-vision-ai/references/profiles/warehouse.md
+++ b/skills/vss-build-vision-ai/references/profiles/warehouse.md
@@ -5,8 +5,9 @@ end to end: what the Foundation is made of, what constrains it, how a build is
 resolved, and how the result is reached and verified. The rest of the skill's
 machinery applies unchanged by reference — see Build and resolve below.
 
-`overrides.env` defines further service lists; the fourteen `COMPOSE_PROFILES_WH_*`
-lists below are supported. The others are out of scope for this skill — do not compose or deploy them.
+`overrides.env` defines further service lists; the `COMPOSE_PROFILES_WH_*` lists
+in the table below are supported. The others are out of scope for this skill —
+do not compose or deploy them.
 
 **Warehouse is variant selection, not composition.** Pick the one
 `COMPOSE_PROFILES_WH_*` list that `MODE` + `BP_PROFILE` + size identify, expand
@@ -48,7 +49,7 @@ Resolve block below instead.
 Authoritative source:
 `deploy/docker/industry-profiles/warehouse-operations/overrides.env`. Select one
 list by variant; expand it verbatim into `COMPOSE_PROFILES` and record its name
-in `FOUNDATION_VARIANT`. Fourteen of the file's lists are in scope:
+in `FOUNDATION_VARIANT`. The lists in scope are:
 
 | `MODE` | `BP_PROFILE` | Extended list | Minimal list |
 |---|---|---|---|

--- a/skills/vss-build-vision-ai/references/services/configurator.md
+++ b/skills/vss-build-vision-ai/references/services/configurator.md
@@ -4,13 +4,13 @@
 
 | Capability | Canonical service profile keys | Foundation |
 |---|---|---|
-| Stream and hardware configuration rendering | `bp-configurator-<mode>`, `bp-configurator-<mode>-init` | `warehouse` |
+| Stream and hardware configuration rendering | `bp-configurator-<mode>` | `warehouse` |
 
-`<mode>` is `2d` or `3d`; both use the container name `vss-configurator`.
+`<mode>` is `2d`, `3d` or `mv3dt`; all use the container name `vss-configurator`.
 
-> **`bp-configurator-<mode>-init` renders no config.** Despite the name it is a
-> one-shot **broker readiness gate**: it polls Kafka/Redis and exits `0`. An
-> `Exited (0)` is success.
+> The broker readiness gate is a separate key, `broker-health-check` — a one-shot
+> that polls Kafka/Redis and exits `0`, which perception and analytics wait on via
+> `service_completed_successfully`. An `Exited (0)` is success.
 
 ## Required peers
 

--- a/skills/vss-build-vision-ai/scripts/validate_resolved_yml.py
+++ b/skills/vss-build-vision-ai/scripts/validate_resolved_yml.py
@@ -38,6 +38,7 @@ FILE_TARGET_SUFFIXES = {
 }
 GENERATED_BIND_NAMES = {".wdm-env"}
 NGC_TRIGGER = re.compile(r"nvcr\.io/|(?<![\w.-])ngc:")
+NGC_MODEL_REF = re.compile(r"(?<![\w.-])ngc:")
 NGC_SECRET_KEYS = ("NGC_API_KEY", "NGC_CLI_API_KEY")
 
 
@@ -112,9 +113,10 @@ def secret_errors(document: dict[str, Any], extra_required: set[str]) -> list[st
                     "time — set it and regenerate resolved.yml"
                 )
 
-    if ngc_required and not (seen["NGC_API_KEY"] or seen["NGC_CLI_API_KEY"]):
+    ngc_model_ref = any(NGC_MODEL_REF.search(value) for _, value in walk_strings(document))
+    if ngc_model_ref and not (seen["NGC_API_KEY"] or seen["NGC_CLI_API_KEY"]):
         errors.append(
-            "resolved model references NGC-gated artifacts (nvcr.io/ or ngc:) but no "
+            "resolved model references an ngc: model path but no "
             "NGC_API_KEY/NGC_CLI_API_KEY is wired into any service environment"
         )
     for key in extra_required:

--- a/skills/vss-build-vision-ai/scripts/validate_warehouse_env.py
+++ b/skills/vss-build-vision-ai/scripts/validate_warehouse_env.py
@@ -23,21 +23,20 @@ import sys
 from pathlib import Path
 
 
-# (dataset, allowed (mode, bp_profile) pairs, expected NUM_STREAMS)
+# (dataset -> expected NUM_STREAMS). Dataset and mode are independent: every
+# shipped dataset now carries calibration for 2d, 3d and mv3dt, and
+# overrides.env states it outright ("so dataset and mode can be chosen
+# independently"). blueprint_config.yml agrees -- its only dataset rule is that
+# NUM_STREAMS matches the camera count. Calibration presence is still checked
+# per (dataset, mode) further down, which is what actually constrains a pairing.
 DATASETS = {
-    "nv-warehouse-4cams": ({("2d", "bp_wh")}, 4),
-    "warehouse-loading-dock-3cams-synthetic": (
-        {("2d", "bp_wh_kafka"), ("2d", "bp_wh_redis")},
-        3,
-    ),
-    "warehouse-4cams-20mx20m-synthetic": (
-        {("3d", "bp_wh_kafka"), ("3d", "bp_wh_redis")},
-        4,
-    ),
+    "nv-warehouse-4cams": 4,
+    "warehouse-loading-dock-3cams-synthetic": 3,
+    "warehouse-4cams-20mx20m-synthetic": 4,
 }
 
-MODES = {"2d", "3d"}
-BP_PROFILES = {"bp_wh", "bp_wh_kafka", "bp_wh_redis"}
+MODES = {"2d", "3d", "mv3dt", "auto-calibration"}
+BP_PROFILES = {"bp_wh", "bp_wh_kafka", "bp_wh_redis", "bp_wh_auto_calib"}
 
 # The service lists this skill supports, keyed by the (MODE, BP_PROFILE) pair
 # that selects them. overrides.env defines others; selecting one of those is a
@@ -68,6 +67,18 @@ VARIANT_MATRIX = {
         "COMPOSE_PROFILES_WH_REDIS_3D",
         "COMPOSE_PROFILES_WH_REDIS_3D_MINIMAL",
     },
+    ("mv3dt", "bp_wh_kafka"): {
+        "COMPOSE_PROFILES_WH_KAFKA_MV3DT",
+        "COMPOSE_PROFILES_WH_KAFKA_MV3DT_MINIMAL",
+    },
+    ("mv3dt", "bp_wh_redis"): {
+        "COMPOSE_PROFILES_WH_REDIS_MV3DT",
+        "COMPOSE_PROFILES_WH_REDIS_MV3DT_MINIMAL",
+    },
+    # auto-calibration is its own MODE, not a bp_profile layered onto 2d/3d/mv3dt:
+    # it produces a calibration instead of consuming a shipped one, and there is
+    # exactly one list for it.
+    ("auto-calibration", "bp_wh_auto_calib"): {"COMPOSE_PROFILES_WH_AUTO_CALIB"},
 }
 
 IN_SCOPE_VARIANTS = {v for variants in VARIANT_MATRIX.values() for v in variants}
@@ -75,17 +86,24 @@ IN_SCOPE_VARIANTS = {v for variants in VARIANT_MATRIX.values() for v in variants
 # Services every warehouse list carries that no capability names. The
 # forward-closure prune in composition.md must not remove them.
 INFRA_FLOOR = [
-    "init-dirs",
-    "render-config",
-    "wdm-env-from-config",
-    "wait-for-redis",
-    "sdr-controller",
     "centralizedb",
     "vst-ingress",
     "sensor-bp-wait-bp-configurator",
     "turnserver-init",
     "turnserver",
     "redis",
+]
+
+# The SDRC chain rides on top of the common floor for the analytics modes.
+# MODE=auto-calibration deliberately ships without it -- overrides.env: "2d/3d/mv3dt
+# warehouse profiles use SDRC. MODE=auto-calibration has no sdr-controller" -- so
+# requiring these of the auto-calibration list would reject a correct build.
+SDRC_FLOOR = [
+    "init-dirs",
+    "render-config",
+    "wdm-env-from-config",
+    "wait-for-redis",
+    "sdr-controller",
 ]
 
 ASSIGN = re.compile(r"^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=(.*)$")
@@ -95,7 +113,7 @@ ASSIGN = re.compile(r"^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=(.*)$")
 # a 2D detector in a 3D build resolves cleanly, boots healthy, and publishes to the
 # wrong topic -- 2D writes mdx-raw while vss-behavior-analytics-3d reads mdx-bev, so
 # analytics silently sees nothing.
-MODE_TOKEN = re.compile(r"(?:^|-)(2d|3d)(?:-|$)")
+MODE_TOKEN = re.compile(r"(?:^|-)(2d|3d|mv3dt)(?:-|$)")
 
 
 def strip_value(value: str) -> str:
@@ -282,11 +300,21 @@ def check(env: dict[str, str], repo: Path, foundation_dir: Path) -> list[str]:
                 "different broker than the runtime expects"
             )
 
-    # 1/3. bp_wh is 2d-only.
-    if bp == "bp_wh" and mode == "3d":
+    # 1/3. bp_wh is 2d-only, and bp_wh_auto_calib is auto-calibration-only.
+    if bp == "bp_wh" and mode and mode != "2d":
         errors.append(
-            "BP_PROFILE=bp_wh is unsupported with MODE=3d "
+            f"BP_PROFILE=bp_wh is unsupported with MODE={mode} "
             "(agents run in 2d only); use bp_wh_kafka or bp_wh_redis"
+        )
+    if bp == "bp_wh_auto_calib" and mode and mode != "auto-calibration":
+        errors.append(
+            f"BP_PROFILE=bp_wh_auto_calib requires MODE=auto-calibration, got MODE={mode}. "
+            "There is one auto-calibration list (COMPOSE_PROFILES_WH_AUTO_CALIB); it is not "
+            "a variant of the 2d/3d/mv3dt lists"
+        )
+    if mode == "auto-calibration" and bp and bp != "bp_wh_auto_calib":
+        errors.append(
+            f"MODE=auto-calibration requires BP_PROFILE=bp_wh_auto_calib, got {bp!r}"
         )
 
     # 2. bp_wh 2d is rejected on edge platforms.
@@ -320,12 +348,7 @@ def check(env: dict[str, str], repo: Path, foundation_dir: Path) -> list[str]:
         if dataset not in DATASETS:
             warnings.append(f"SAMPLE_VIDEO_DATASET={dataset!r} is not a known sample dataset")
         else:
-            allowed, streams = DATASETS[dataset]
-            if mode and bp and (mode, bp) not in allowed:
-                errors.append(
-                    f"SAMPLE_VIDEO_DATASET={dataset!r} is not valid for "
-                    f"MODE={mode} + BP_PROFILE={bp}"
-                )
+            streams = DATASETS[dataset]
             actual = env.get("NUM_STREAMS", "")
             if actual and actual != str(streams):
                 errors.append(
@@ -338,7 +361,7 @@ def check(env: dict[str, str], repo: Path, foundation_dir: Path) -> list[str]:
     stream_type = env.get("STREAM_TYPE", "")
     if bp == "bp_wh_redis" and stream_type != "redis":
         errors.append(f"BP_PROFILE=bp_wh_redis requires STREAM_TYPE=redis, got {stream_type!r}")
-    if bp in {"bp_wh", "bp_wh_kafka"} and stream_type not in {"", "kafka"}:
+    if bp in {"bp_wh", "bp_wh_kafka", "bp_wh_auto_calib"} and stream_type not in {"", "kafka"}:
         errors.append(f"BP_PROFILE={bp} requires STREAM_TYPE=kafka, got {stream_type!r}")
 
     # 6b. The selected broker must actually be in the service list. The env
@@ -443,7 +466,10 @@ def check(env: dict[str, str], repo: Path, foundation_dir: Path) -> list[str]:
             "FOUNDATION_VARIANT list into COMPOSE_PROFILES as a literal."
         )
     else:
-        missing = [s for s in INFRA_FLOOR if s not in profiles]
+        required_floor = list(INFRA_FLOOR)
+        if mode != "auto-calibration":
+            required_floor += SDRC_FLOOR
+        missing = [s for s in required_floor if s not in profiles]
         if missing:
             errors.append(
                 "COMPOSE_PROFILES is missing warehouse infrastructure services that no "
@@ -457,7 +483,10 @@ def check(env: dict[str, str], repo: Path, foundation_dir: Path) -> list[str]:
     # The shipped sample datasets already carry it, so nothing needs generating.
     # Only a custom dataset lacks it -- and a missing bind source makes Docker
     # create a directory where a file is expected.
-    if mode in MODES and dataset:
+    # MODE=auto-calibration is exempt: it *produces* a calibration for the chosen
+    # dataset rather than consuming a shipped one, and there is no
+    # warehouse-auto-calibration-app tree to look in.
+    if mode in MODES and mode != "auto-calibration" and dataset:
         calib = (
             repo
             / "deploy/docker/industry-profiles/warehouse-operations"

--- a/skills/vss-build-vision-ai/scripts/validate_warehouse_env.py
+++ b/skills/vss-build-vision-ai/scripts/validate_warehouse_env.py
@@ -109,11 +109,11 @@ SDRC_FLOOR = [
 ASSIGN = re.compile(r"^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=(.*)$")
 
 # Warehouse service keys carry the deployment mode as a token, e.g. perception-3d,
-# bp-configurator-2d-init, vss-behavior-analytics-3d. The token must agree with MODE:
+# bp-configurator-2d, vss-behavior-analytics-3d. The token must agree with MODE:
 # a 2D detector in a 3D build resolves cleanly, boots healthy, and publishes to the
 # wrong topic -- 2D writes mdx-raw while vss-behavior-analytics-3d reads mdx-bev, so
 # analytics silently sees nothing.
-MODE_TOKEN = re.compile(r"(?:^|-)(2d|3d|mv3dt)(?:-|$)")
+MODE_TOKEN = re.compile(r"(?:^|-)(2d|3d|mv3dt|auto-calibration)(?:-|$)")
 
 
 def strip_value(value: str) -> str:
@@ -361,7 +361,9 @@ def check(env: dict[str, str], repo: Path, foundation_dir: Path) -> list[str]:
     stream_type = env.get("STREAM_TYPE", "")
     if bp == "bp_wh_redis" and stream_type != "redis":
         errors.append(f"BP_PROFILE=bp_wh_redis requires STREAM_TYPE=redis, got {stream_type!r}")
-    if bp in {"bp_wh", "bp_wh_kafka", "bp_wh_auto_calib"} and stream_type not in {"", "kafka"}:
+    # bp_wh_auto_calib is deliberately absent: its list carries no kafka key and no
+    # perception, so it brokers no metadata and STREAM_TYPE does not apply.
+    if bp in {"bp_wh", "bp_wh_kafka"} and stream_type not in {"", "kafka"}:
         errors.append(f"BP_PROFILE={bp} requires STREAM_TYPE=kafka, got {stream_type!r}")
 
     # 6b. The selected broker must actually be in the service list. The env


### PR DESCRIPTION
…on modes

Warehouse scope goes from nine service lists to fourteen: the mv3dt kafka/redis pair with their _MINIMAL counterparts, and COMPOSE_PROFILES_WH_AUTO_CALIB.

auto-calibration is its own MODE, not a BP_PROFILE layered onto 2d/3d/mv3dt. It pairs only with bp_wh_auto_calib, and two of its properties would otherwise make a correct build fail validation:

- It ships without SDRC. overrides.env: "2d/3d/mv3dt warehouse profiles use SDRC. MODE=auto-calibration has no sdr-controller". INFRA_FLOOR is split so the SDRC chain (init-dirs, render-config, wdm-env-from-config, wait-for-redis, sdr-controller) is required only for the analytics modes.
- It produces a calibration rather than consuming a shipped one, and there is no warehouse-auto-calibration-app tree, so the calibration-presence check is skipped for it.

The dataset table drops its (mode, bp_profile) pairing set and keeps only the camera count. Every shipped dataset now carries calibration for 2d, 3d and mv3dt; overrides.env says so directly ("so dataset and mode can be chosen independently") and blueprint_config.yml's only remaining dataset rule is that NUM_STREAMS matches the count. Calibration presence is still checked per (dataset, mode), which is what actually constrains a pairing. Q2w gains a dataset question, since the dataset is no longer implied by the variant.

MODE_TOKEN also learns mv3dt. The mv3dt keys carry a -mv3dt suffix that the 2d|3d pattern matched nowhere, which silently disabled the mode-agreement check in both directions for those builds -- a stray perception-3d in an mv3dt list resolved and booted healthy while publishing to the wrong topic.

bp_wh's 2d-only guard now tests mode != "2d" rather than mode == "3d", so bp_wh + mv3dt is rejected rather than slipping through.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
