### PR TITLE
fix(ci): read created GHCR alias digest from buildx metadata, never the fresh tag

### DIFF
--- a/.github/scripts/advance_ghcr_alias.py
+++ b/.github/scripts/advance_ghcr_alias.py
@@ -43,6 +43,7 @@ import json
 import re
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
@@ -235,6 +236,28 @@ def command_runner(command: list[str]) -> str:
     return result.stdout.strip()
 
 
+def created_digest(metadata_file: Path) -> str:
+    """Digest of the manifest ``imagetools create`` just wrote, read from its
+    ``--metadata-file`` output (``containerimage.descriptor.digest``).
+
+    This is a local file produced by the create itself, so it is immune to the
+    registry's read-after-write lag. Fails closed: a create that succeeded but
+    left no usable metadata broke the buildx contract, and reporting a digest
+    we did not observe would misrepresent what was published."""
+    try:
+        metadata = json.loads(metadata_file.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            f"imagetools create left no usable metadata at {metadata_file}: {exc}"
+        ) from exc
+    digest = str((metadata.get("containerimage.descriptor") or {}).get("digest") or "")
+    if not DIGEST_RE.fullmatch(digest):
+        raise RuntimeError(
+            f"imagetools create metadata carries no valid digest: {digest!r}"
+        )
+    return digest
+
+
 def advance(update: AliasUpdate, runner: Runner = command_runner) -> None:
     if update.digest:
         # Verify the SOURCE (content tag) before creating the alias so that we
@@ -262,35 +285,32 @@ def advance(update: AliasUpdate, runner: Runner = command_runner) -> None:
                 f"{update.name}: content tag digest {source_digest!r} != release-set {update.digest!r}"
             )
 
-    runner(
-        [
-            "docker",
-            "buildx",
-            "imagetools",
-            "create",
-            "--tag",
-            update.target,
-            update.source,
-        ]
-    )
-
-    if not update.digest:
-        # Reuse-pinned entries record no digest. The source was content
-        # addressed, so there is nothing to compare against -- report what the
-        # alias resolved to after creation.
-        observed = runner(
+    # The created digest comes from the buildx metadata file, never from
+    # inspecting the fresh target tag: GHCR reads are eventually consistent
+    # right after a write, so a post-create inspect can return the old
+    # manifest (or 404) and fail a retag that actually succeeded.
+    with tempfile.TemporaryDirectory(prefix="ghcr-alias-") as scratch:
+        metadata_file = Path(scratch) / "create-metadata.json"
+        runner(
             [
                 "docker",
                 "buildx",
                 "imagetools",
-                "inspect",
+                "create",
+                "--metadata-file",
+                str(metadata_file),
+                "--tag",
                 update.target,
-                "--format",
-                "{{json .Manifest}}",
+                update.source,
             ]
         )
-        digest = str(json.loads(observed).get("digest") or "")
-        print(f"[ghcr-alias] {update.name}: {update.target} -> {digest}")
+        digest = created_digest(metadata_file)
+
+    # No comparison against the release-set digest here: when the source is a
+    # single-platform manifest, imagetools create wraps it in a fresh index,
+    # so the created digest legitimately differs from the source manifest
+    # digest. Correctness is asserted before the write, on the stable source.
+    print(f"[ghcr-alias] {update.name}: {update.target} -> {digest}")
 
 
 def main() -> int:

--- a/.github/scripts/test_advance_ghcr_alias.py
+++ b/.github/scripts/test_advance_ghcr_alias.py
@@ -196,46 +196,74 @@ class AdvanceTest(unittest.TestCase):
     def _update(self):
         return alias_plan(release_set(), "develop-abc123abc123", ALL_CONTENT)[0]
 
+    def _digestless_update(self):
+        data = release_set()
+        for image in data["images"]:
+            if image["image"].startswith("ghcr.io/"):
+                image["digest"] = None
+        return alias_plan(data, "develop-abc123abc123", ALL_CONTENT)[0]
+
+    @staticmethod
+    def _runner(commands, source_digest=DIGEST, write_metadata=True):
+        """Fake runner that records commands and honours --metadata-file the
+        way buildx does: the created digest is written to the file named in
+        the create command, never returned on stdout."""
+
+        def runner(command: list[str]) -> str:
+            commands.append(command)
+            if "create" in command:
+                if write_metadata:
+                    path = Path(command[command.index("--metadata-file") + 1])
+                    path.write_text(
+                        json.dumps({"containerimage.descriptor": {"digest": DIGEST}})
+                    )
+                return ""
+            return json.dumps({"digest": source_digest})
+
+        return runner
+
     def test_verifies_source_before_creating_alias(self):
         """Inspect the SOURCE (stable content tag) before creating the alias,
         not the TARGET after -- GHCR eventual consistency makes post-create
         inspect of the new tag unreliable."""
         commands: list[list[str]] = []
-
-        def runner(command: list[str]) -> str:
-            commands.append(command)
-            return json.dumps({"digest": DIGEST}) if "inspect" in command else ""
-
-        advance(self._update(), runner)
+        advance(self._update(), self._runner(commands))
         # First call: inspect the SOURCE content tag.
         self.assertEqual(commands[0][3], "inspect")
         self.assertTrue(commands[0][4].endswith(f":tree-{TREE}"))
-        # Second call: create the alias.
+        # Second call: create the alias, reporting its result via metadata.
         self.assertEqual(commands[1][3], "create")
+        self.assertIn("--metadata-file", commands[1])
         # No third call -- we do not inspect the target after creation.
         self.assertEqual(len(commands), 2)
 
     def test_advance_rejects_digest_drift(self):
         """Source digest != release-set digest → refuse to create the alias."""
-        def runner(command: list[str]) -> str:
-            return json.dumps({"digest": MIRROR_DIGEST}) if "inspect" in command else ""
-
+        commands: list[list[str]] = []
         with self.assertRaisesRegex(RuntimeError, "content tag digest"):
-            advance(self._update(), runner)
+            advance(self._update(), self._runner(commands, source_digest=MIRROR_DIGEST))
+        self.assertEqual(len(commands), 1)  # refused before any create
 
-    def test_digestless_entry_reports_the_resolved_digest(self):
-        """Reuse-pinned entries record no digest; the source was content
-        addressed, so there is nothing to assert against."""
-        data = release_set()
-        for image in data["images"]:
-            if image["image"].startswith("ghcr.io/"):
-                image["digest"] = None
-        update = alias_plan(data, "develop-abc123abc123", ALL_CONTENT)[0]
+    def test_digestless_entry_never_inspects_the_target(self):
+        """Regression: reuse-pinned entries record no digest, and the created
+        digest must come from the buildx metadata file -- a post-create
+        inspect of the fresh tag races GHCR's read-after-write consistency
+        and fails runs whose retag actually succeeded."""
+        commands: list[list[str]] = []
+        advance(self._digestless_update(), self._runner(commands))
+        # Exactly one registry-writing call and no inspect of anything.
+        self.assertEqual(len(commands), 1)
+        self.assertEqual(commands[0][3], "create")
+        self.assertIn("--metadata-file", commands[0])
+        self.assertNotIn("inspect", [part for c in commands for part in c])
 
-        def runner(command: list[str]) -> str:
-            return json.dumps({"digest": DIGEST}) if "inspect" in command else ""
-
-        advance(update, runner)  # must not raise
+    def test_missing_create_metadata_fails_closed(self):
+        """A create that succeeds but writes no metadata broke the buildx
+        contract; reporting an unobserved digest would misrepresent the
+        publish."""
+        commands: list[list[str]] = []
+        with self.assertRaisesRegex(RuntimeError, "no usable metadata"):
+            advance(self._digestless_update(), self._runner(commands, write_metadata=False))
 
 
 class TreeSourceTest(unittest.TestCase):


### PR DESCRIPTION
## Why

The digestless (reuse-pinned) path in `advance_ghcr_alias.py` inspected the **target tag immediately after** `imagetools create`. GHCR reads are eventually consistent right after a write, so that inspect can return the old manifest (or 404) and fail a run whose retag actually succeeded — the flake this PR removes.

## What

`docker buildx imagetools create` reports the created manifest digest itself via [`--metadata-file`](https://docs.docker.com/reference/cli/docker/buildx/imagetools/create/#write-create-result-metadata-to-a-file---metadata-file) (`containerimage.descriptor.digest`) — a local file immune to registry read-after-write lag. The script now:

- **keeps** the pre-create SOURCE (content-tag) verification when the release set records an expected digest — unchanged;
- creates every alias with `--metadata-file` and reads the resulting digest from the metadata;
- **never inspects the newly created target tag**;
- fails the run if create leaves no usable metadata, rather than reporting a digest it did not observe.

The created digest is deliberately **not** compared against the release-set digest: when the source is a single-platform manifest, `imagetools create` wraps it in a fresh index, so the created digest legitimately differs from the source manifest digest (an earlier draft had this comparison; Codex review flagged it as a false-failure source and it was removed). Correctness is asserted **before** the write, on the stable source.

## Tests

- New regression test `test_digestless_entry_never_inspects_the_target`: digestless/reused entries issue exactly one `create` call and **zero** `inspect` calls.
- New fail-closed test for the missing-metadata path.
- Fake runner now honours `--metadata-file` the way buildx does (digest written to the file, not stdout).
- `python3 .github/scripts/test_advance_ghcr_alias.py` → **25/25 pass**; ruff clean.

## Not in scope (follow-up candidate)

Carrying a prior digest forward on reused release-set entries: `release_set.py` builds reuse-pinned entries from the committed compose pins, which are tag-only — a digest would have to come from the previous release set or a registry read, a design question rather than a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
