### PR TITLE
[NVBug 6706112] fix(rtvi-vlm): keep live stream assets picklable

### DIFF
--- a/services/rtvi/rt-vlm/src/utils/asset_manager.py
+++ b/services/rtvi/rt-vlm/src/utils/asset_manager.py
@@ -341,6 +341,15 @@ class Asset:
         self._sensor_name = sensor_name
         self._camera_id = camera_id
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state.pop("_lifecycle_lock", None)
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._lifecycle_lock = RLock()
+
     @classmethod
     def fromdir(cls, asset_dir):
         with open(os.path.join(asset_dir, "info.json")) as f:

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_asset_gc_concurrency.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_asset_gc_concurrency.py
@@ -3,6 +3,8 @@
 
 import asyncio
 import os
+import pickle
+from multiprocessing.reduction import ForkingPickler
 from threading import Event, Thread
 
 import pytest
@@ -18,6 +20,36 @@ def _asset(tmp_path, asset_id):
     path = asset_dir / "video.mp4"
     path.touch()
     return Asset(asset_id, str(path), "vision", "video", str(asset_dir))
+
+
+def test_live_asset_command_payload_is_picklable(tmp_path):
+    asset = Asset(
+        "live",
+        "rtsp://example.com/live",
+        "vision",
+        "video",
+        str(tmp_path),
+        username="user",
+        password="password",
+        sensor_name="sensor",
+        camera_id="camera",
+    )
+
+    payload = pickle.loads(
+        ForkingPickler.dumps({"command": "start-live-stream", "asset": asset})
+    )
+    restored = payload["asset"]
+
+    assert restored.asset_id == asset.asset_id
+    assert restored.path == asset.path
+    assert restored.username == asset.username
+    assert restored.password == asset.password
+    assert restored.sensor_name == asset.sensor_name
+    assert restored.camera_id == asset.camera_id
+    restored.lock()
+    assert restored.use_count == 1
+    restored.unlock()
+    assert restored.use_count == 0
 
 
 def test_age_out_uses_stable_asset_snapshot(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- omit the process-local `Asset._lifecycle_lock` when serializing an asset for decoder commands
- recreate the lock when the asset is deserialized in the decoder process
- cover the exact `start-live-stream` payload with `multiprocessing.reduction.ForkingPickler`

## Root cause

An `RLock` was added to `Asset`, while live-stream startup continued to pass the complete asset through a `multiprocessing.Queue`. The queue feeder cannot pickle the lock, so `start-live-stream` never reaches the decoder and the caller waits indefinitely for a response.

## Verification

Verified on NVIDIA B200 with Cosmos3 Nano Reasoner NVFP4.

- single stream with four concurrent prompts: 4/4 requests returned HTTP 200 and produced SSE captions
- four streams with four concurrent prompts each: 16/16 requests passed per round across four rounds
- total: 68/68 requests produced captions
- zero `RLock` serialization errors and zero tracebacks
- RTVI remained ready after every round
