### PR TITLE
fix(nvstreamer): leave Helm server_domain_name empty

### DIFF
--- a/deploy/helm/services/vios/charts/vios-nvstreamer/configs/vst-config.json
+++ b/deploy/helm/services/vios/charts/vios-nvstreamer/configs/vst-config.json
@@ -1,7 +1,7 @@
 {
   "network": {
     "http_port": "31000",
-    "server_domain_name": "__SERVER_DOMAIN_NAME__",
+    "server_domain_name": "",
     "stunurl_list": [
       "stun.l.google.com:19302",
       "stun1.l.google.com:19302"


### PR DESCRIPTION
## Summary
- Set `server_domain_name` in the nvstreamer Helm `vst-config.json` to `""` instead of the `__SERVER_DOMAIN_NAME__` placeholder.
- This change will allow nvstreamer pod's discovery via pod ip rather than service IP which was causing issue in warehouse deployment. This will solve the issue of streamprocessing not able to access RTSP streams from nvstreamer.