### PR TITLE
Fix/qwen3 omni audio in video kwargs

### DIFF
--- a/services/rtvi/rt-vlm/docker/Dockerfile
+++ b/services/rtvi/rt-vlm/docker/Dockerfile
@@ -346,6 +346,11 @@ COPY src/scripts/install_codecs_nonroot.sh /opt/nvidia/rtvi/
 RUN --mount=type=bind,source=docker,target=/tmp/rtvi-src/docker \
     python3 /tmp/rtvi-src/docker/rtvi_vlm/patches/apply_vllm_arch_patch.py
 
+# Transformers 5 makes Parakeet's base configuration a dataclass. vLLM's
+# positional required subclass fields must be keyword-only to remain valid.
+RUN --mount=type=bind,source=docker,target=/tmp/rtvi-src/docker \
+    python3 /tmp/rtvi-src/docker/rtvi_vlm/patches/apply_vllm_parakeet_transformers5_patch.py
+
 # Qwen3-Omni's nightly processor incorrectly assumes every video item has
 # use_audio_in_video, including video-only requests.
 RUN --mount=type=bind,source=docker,target=/tmp/rtvi-src/docker \

--- a/services/rtvi/rt-vlm/docker/Dockerfile
+++ b/services/rtvi/rt-vlm/docker/Dockerfile
@@ -346,6 +346,11 @@ COPY src/scripts/install_codecs_nonroot.sh /opt/nvidia/rtvi/
 RUN --mount=type=bind,source=docker,target=/tmp/rtvi-src/docker \
     python3 /tmp/rtvi-src/docker/rtvi_vlm/patches/apply_vllm_arch_patch.py
 
+# Qwen3-Omni's nightly processor incorrectly assumes every video item has
+# use_audio_in_video, including video-only requests.
+RUN --mount=type=bind,source=docker,target=/tmp/rtvi-src/docker \
+    python3 /tmp/rtvi-src/docker/rtvi_vlm/patches/apply_vllm_qwen3_omni_audio_patch.py
+
 # EVS++ is shipped as prebuilt architecture-specific extensions below. Do not
 # copy its Python overlay into this public build; install the compiled modules
 # directly and retain the independent tensor-IPC patch.

--- a/services/rtvi/rt-vlm/docker/rtvi_vlm/patches/apply_vllm_parakeet_transformers5_patch.py
+++ b/services/rtvi/rt-vlm/docker/rtvi_vlm/patches/apply_vllm_parakeet_transformers5_patch.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/services/rtvi/rt-vlm/docker/rtvi_vlm/patches/apply_vllm_parakeet_transformers5_patch.py
+++ b/services/rtvi/rt-vlm/docker/rtvi_vlm/patches/apply_vllm_parakeet_transformers5_patch.py
@@ -1,5 +1,17 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Make vLLM's Parakeet config compatible with Transformers 5 dataclasses."""
 

--- a/services/rtvi/rt-vlm/docker/rtvi_vlm/patches/apply_vllm_parakeet_transformers5_patch.py
+++ b/services/rtvi/rt-vlm/docker/rtvi_vlm/patches/apply_vllm_parakeet_transformers5_patch.py
@@ -1,0 +1,54 @@
+######################################################################################################
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+######################################################################################################
+
+"""Make vLLM's Parakeet config compatible with Transformers 5 dataclasses."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+VLLM_ROOT = Path(os.environ.get("VLLM_ROOT", "/usr/local/lib/python3.12/dist-packages/vllm"))
+TARGET = VLLM_ROOT / "transformers_utils/configs/parakeet.py"
+IMPORT = "from dataclasses import dataclass, field"
+ORIGINAL_IMPORT = "from dataclasses import dataclass"
+FIELDS = (
+    "llm_hidden_size",
+    "projection_hidden_size",
+    "projection_bias",
+    "sampling_rate",
+)
+
+
+def apply_patch() -> None:
+    content = TARGET.read_text(encoding="utf-8")
+    if IMPORT not in content:
+        if ORIGINAL_IMPORT not in content:
+            raise RuntimeError(f"PATCH ANCHOR NOT FOUND in {TARGET}: {ORIGINAL_IMPORT!r}")
+        content = content.replace(ORIGINAL_IMPORT, IMPORT, 1)
+
+    changed = False
+    for name in FIELDS:
+        original = f"    {name}: " + ("bool" if name == "projection_bias" else "int")
+        replacement = original + " = field(kw_only=True)"
+        if replacement in content:
+            continue
+        if original not in content:
+            raise RuntimeError(f"PATCH ANCHOR NOT FOUND in {TARGET}: {original!r}")
+        content = content.replace(original, replacement, 1)
+        changed = True
+
+    if not changed:
+        print("  ✓ Parakeet Transformers 5 patch already applied, skipping.")
+        return
+    TARGET.write_text(content, encoding="utf-8")
+    print("  ✓ Parakeet config supports Transformers 5 dataclass inheritance")
+
+
+if __name__ == "__main__":
+    print("Applying vLLM Parakeet Transformers 5 compatibility patch...")
+    apply_patch()
+    print("Done.")

--- a/services/rtvi/rt-vlm/docker/rtvi_vlm/patches/apply_vllm_parakeet_transformers5_patch.py
+++ b/services/rtvi/rt-vlm/docker/rtvi_vlm/patches/apply_vllm_parakeet_transformers5_patch.py
@@ -1,7 +1,5 @@
-######################################################################################################
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-######################################################################################################
 
 """Make vLLM's Parakeet config compatible with Transformers 5 dataclasses."""
 

--- a/services/rtvi/rt-vlm/docker/rtvi_vlm/patches/apply_vllm_parakeet_transformers5_patch.py
+++ b/services/rtvi/rt-vlm/docker/rtvi_vlm/patches/apply_vllm_parakeet_transformers5_patch.py
@@ -1,6 +1,6 @@
 ######################################################################################################
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+# SPDX-License-Identifier: Apache-2.0
 ######################################################################################################
 
 """Make vLLM's Parakeet config compatible with Transformers 5 dataclasses."""

--- a/services/rtvi/rt-vlm/docker/rtvi_vlm/patches/apply_vllm_qwen3_omni_audio_patch.py
+++ b/services/rtvi/rt-vlm/docker/rtvi_vlm/patches/apply_vllm_qwen3_omni_audio_patch.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/services/rtvi/rt-vlm/docker/rtvi_vlm/patches/apply_vllm_qwen3_omni_audio_patch.py
+++ b/services/rtvi/rt-vlm/docker/rtvi_vlm/patches/apply_vllm_qwen3_omni_audio_patch.py
@@ -1,7 +1,5 @@
-######################################################################################################
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-######################################################################################################
 
 """Patch vLLM's Qwen3-Omni video-only processor compatibility bug.
 

--- a/services/rtvi/rt-vlm/docker/rtvi_vlm/patches/apply_vllm_qwen3_omni_audio_patch.py
+++ b/services/rtvi/rt-vlm/docker/rtvi_vlm/patches/apply_vllm_qwen3_omni_audio_patch.py
@@ -1,6 +1,6 @@
 ######################################################################################################
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+# SPDX-License-Identifier: Apache-2.0
 ######################################################################################################
 
 """Patch vLLM's Qwen3-Omni video-only processor compatibility bug.

--- a/services/rtvi/rt-vlm/docker/rtvi_vlm/patches/apply_vllm_qwen3_omni_audio_patch.py
+++ b/services/rtvi/rt-vlm/docker/rtvi_vlm/patches/apply_vllm_qwen3_omni_audio_patch.py
@@ -1,0 +1,40 @@
+######################################################################################################
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+######################################################################################################
+
+"""Patch vLLM's Qwen3-Omni video-only processor compatibility bug.
+
+The affected vLLM nightly unconditionally indexes ``use_audio_in_video`` in
+the per-video multimodal fields, although that field is absent for normal
+video-only requests. Treat a missing field as ``False``, matching the
+Qwen2.5-Omni processor's handling.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+VLLM_ROOT = Path(os.environ.get("VLLM_ROOT", "/usr/local/lib/python3.12/dist-packages/vllm"))
+TARGET = VLLM_ROOT / "model_executor/models/qwen3_omni_moe_thinker.py"
+UNSAFE = 'if item and item["use_audio_in_video"].data:'
+SAFE = 'if item and item.get("use_audio_in_video") and item["use_audio_in_video"].data:'
+
+
+def apply_patch() -> None:
+    content = TARGET.read_text(encoding="utf-8")
+    if SAFE in content:
+        print("  ✓ Qwen3-Omni audio patch already applied, skipping.")
+        return
+    if UNSAFE not in content:
+        raise RuntimeError(f"PATCH ANCHOR NOT FOUND in {TARGET}: {UNSAFE!r}")
+    TARGET.write_text(content.replace(UNSAFE, SAFE, 1), encoding="utf-8")
+    print("  ✓ Qwen3-Omni video-only requests tolerate missing audio flag")
+
+
+if __name__ == "__main__":
+    print("Applying vLLM Qwen3-Omni audio-in-video compatibility patch...")
+    apply_patch()
+    print("Done.")

--- a/services/rtvi/rt-vlm/docker/rtvi_vlm/patches/apply_vllm_qwen3_omni_audio_patch.py
+++ b/services/rtvi/rt-vlm/docker/rtvi_vlm/patches/apply_vllm_qwen3_omni_audio_patch.py
@@ -1,5 +1,17 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Patch vLLM's Qwen3-Omni video-only processor compatibility bug.
 

--- a/services/rtvi/rt-vlm/src/models/vllm_compatible/vllm_compatible_model.py
+++ b/services/rtvi/rt-vlm/src/models/vllm_compatible/vllm_compatible_model.py
@@ -596,6 +596,7 @@ _QWEN3VL_ARCHS = frozenset(
         "Qwen3VLMoeForConditionalGeneration",
     }
 )
+_QWEN3_OMNI_ARCHS = frozenset({"Qwen3OmniMoeForConditionalGeneration"})
 _COSMOS3_DIFFUSERS_ARCHS = frozenset({"Cosmos3ForConditionalGeneration"})
 _COSMOS3_EDGE_ARCHS = frozenset(
     {
@@ -850,6 +851,25 @@ def _build_video_message_content(query_text, vlm_model_type, model_architecture)
     ):
         return [video, text]
     return [text, video]
+
+
+def _default_mm_processor_kwargs(
+    vlm_model_type: str,
+    model_architecture: str,
+    has_audio: bool,
+) -> dict:
+    """Return model-required multimodal processor arguments.
+
+    Qwen3-Omni's vLLM processor unconditionally reads
+    ``use_audio_in_video`` for every video item. Supplying ``False`` for a
+    video-only request is therefore required, not merely an audio opt-in.
+    """
+    kwargs = {}
+    if vlm_model_type == "cosmos-reason1":
+        kwargs["chain_of_thought"] = True
+    if model_architecture in _QWEN3_OMNI_ARCHS:
+        kwargs["use_audio_in_video"] = has_audio
+    return kwargs
 
 
 def _uses_cosmos3_vllm_plugin(model_architecture: str) -> bool:
@@ -3717,10 +3737,11 @@ class VllmCompatible(BaseVlmModel):
                 logger.warning("Audio processing returned None — audio will NOT be sent to model")
 
         # Prepare LLM inputs
-        base_mm_processor_kwargs = {}
-
-        if self._vlm_model_type == "cosmos-reason1":
-            base_mm_processor_kwargs["chain_of_thought"] = True
+        base_mm_processor_kwargs = _default_mm_processor_kwargs(
+            self._vlm_model_type,
+            self._model_architecture,
+            has_audio,
+        )
 
         # Merge user-provided mm_processor_kwargs from request
         mm_processor_kwargs = _merge_mm_processor_kwargs(

--- a/services/rtvi/rt-vlm/src/utils/asset_manager.py
+++ b/services/rtvi/rt-vlm/src/utils/asset_manager.py
@@ -341,21 +341,6 @@ class Asset:
         self._sensor_name = sensor_name
         self._camera_id = camera_id
 
-    def __getstate__(self):
-        """Make assets safe to send to decoder subprocesses.
-
-        Live-stream setup passes an Asset through a multiprocessing command
-        queue. The lifecycle lock protects only the parent AssetManager and is
-        not picklable, so omit it from the transport copy.
-        """
-        state = self.__dict__.copy()
-        state.pop("_lifecycle_lock", None)
-        return state
-
-    def __setstate__(self, state):
-        self.__dict__.update(state)
-        self._lifecycle_lock = RLock()
-
     @classmethod
     def fromdir(cls, asset_dir):
         with open(os.path.join(asset_dir, "info.json")) as f:

--- a/services/rtvi/rt-vlm/src/utils/asset_manager.py
+++ b/services/rtvi/rt-vlm/src/utils/asset_manager.py
@@ -341,6 +341,21 @@ class Asset:
         self._sensor_name = sensor_name
         self._camera_id = camera_id
 
+    def __getstate__(self):
+        """Make assets safe to send to decoder subprocesses.
+
+        Live-stream setup passes an Asset through a multiprocessing command
+        queue. The lifecycle lock protects only the parent AssetManager and is
+        not picklable, so omit it from the transport copy.
+        """
+        state = self.__dict__.copy()
+        state.pop("_lifecycle_lock", None)
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._lifecycle_lock = RLock()
+
     @classmethod
     def fromdir(cls, asset_dir):
         with open(os.path.join(asset_dir, "info.json")) as f:

--- a/services/rtvi/rt-vlm/tests/model/vllm_compatible/test_input_error_handling.py
+++ b/services/rtvi/rt-vlm/tests/model/vllm_compatible/test_input_error_handling.py
@@ -191,6 +191,29 @@ def test_video_message_content_preserves_model_prompt_order(architecture, expect
     assert [item["type"] for item in content] == expected_types
 
 
+def test_qwen3_omni_video_requests_always_set_use_audio_in_video():
+    """vLLM's Qwen3-Omni processor indexes this field even without audio."""
+    no_audio = vllm_compatible_model._default_mm_processor_kwargs(
+        "vllm-compatible", "Qwen3OmniMoeForConditionalGeneration", False
+    )
+    with_audio = vllm_compatible_model._default_mm_processor_kwargs(
+        "vllm-compatible", "Qwen3OmniMoeForConditionalGeneration", True
+    )
+
+    assert no_audio == {"use_audio_in_video": False}
+    assert with_audio == {"use_audio_in_video": True}
+
+
+def test_requested_mm_processor_kwargs_can_override_qwen3_omni_default():
+    base = vllm_compatible_model._default_mm_processor_kwargs(
+        "vllm-compatible", "Qwen3OmniMoeForConditionalGeneration", False
+    )
+
+    assert vllm_compatible_model._merge_mm_processor_kwargs(
+        base, {"use_audio_in_video": True}
+    ) == {"use_audio_in_video": True}
+
+
 @pytest.mark.parametrize(
     "vllm_error",
     [

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_vllm_parakeet_transformers5_patch.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_vllm_parakeet_transformers5_patch.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_vllm_parakeet_transformers5_patch.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_vllm_parakeet_transformers5_patch.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Regression tests for the vLLM Parakeet Transformers 5 build patch."""
 
 from __future__ import annotations

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_vllm_parakeet_transformers5_patch.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_vllm_parakeet_transformers5_patch.py
@@ -1,0 +1,50 @@
+"""Regression tests for the vLLM Parakeet Transformers 5 build patch."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+PATCH_PATH = (
+    Path(__file__).parents[2]
+    / "docker/rtvi_vlm/patches/apply_vllm_parakeet_transformers5_patch.py"
+)
+
+
+def _load_patch_module():
+    spec = importlib.util.spec_from_file_location("parakeet_patch", PATCH_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parakeet_patch_makes_subclass_fields_keyword_only(tmp_path, monkeypatch):
+    target = tmp_path / "transformers_utils/configs/parakeet.py"
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        "from dataclasses import dataclass\n\n"
+        "class ParakeetConfig:\n"
+        "    llm_hidden_size: int\n"
+        "    projection_hidden_size: int\n"
+        "    projection_bias: bool\n"
+        "    projection_eps: float = 1e-5\n"
+        "    sampling_rate: int\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("VLLM_ROOT", str(tmp_path))
+    patch = _load_patch_module()
+
+    patch.apply_patch()
+    patch.apply_patch()
+
+    assert target.read_text(encoding="utf-8") == (
+        "from dataclasses import dataclass, field\n\n"
+        "class ParakeetConfig:\n"
+        "    llm_hidden_size: int = field(kw_only=True)\n"
+        "    projection_hidden_size: int = field(kw_only=True)\n"
+        "    projection_bias: bool = field(kw_only=True)\n"
+        "    projection_eps: float = 1e-5\n"
+        "    sampling_rate: int = field(kw_only=True)\n"
+    )

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_vllm_parakeet_transformers5_patch.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_vllm_parakeet_transformers5_patch.py
@@ -1,5 +1,17 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Regression tests for the vLLM Parakeet Transformers 5 build patch."""
 

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_vllm_qwen3_omni_audio_patch.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_vllm_qwen3_omni_audio_patch.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_vllm_qwen3_omni_audio_patch.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_vllm_qwen3_omni_audio_patch.py
@@ -1,0 +1,40 @@
+######################################################################################################
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+######################################################################################################
+
+"""Regression coverage for the Qwen3-Omni vLLM compatibility patch."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+PATCH_PATH = (
+    Path(__file__).parents[2]
+    / "docker/rtvi_vlm/patches/apply_vllm_qwen3_omni_audio_patch.py"
+)
+
+
+def _load_patch_module():
+    spec = importlib.util.spec_from_file_location("qwen3_omni_audio_patch", PATCH_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_qwen3_omni_patch_makes_audio_flag_optional(tmp_path, monkeypatch):
+    target = tmp_path / "model_executor/models/qwen3_omni_moe_thinker.py"
+    target.parent.mkdir(parents=True)
+    target.write_text('if item and item["use_audio_in_video"].data:\n', encoding="utf-8")
+    monkeypatch.setenv("VLLM_ROOT", str(tmp_path))
+    patch = _load_patch_module()
+
+    patch.apply_patch()
+    patch.apply_patch()
+
+    assert target.read_text(encoding="utf-8") == (
+        'if item and item.get("use_audio_in_video") and item["use_audio_in_video"].data:\n'
+    )

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_vllm_qwen3_omni_audio_patch.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_vllm_qwen3_omni_audio_patch.py
@@ -1,7 +1,5 @@
-######################################################################################################
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-######################################################################################################
 
 """Regression coverage for the Qwen3-Omni vLLM compatibility patch."""
 

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_vllm_qwen3_omni_audio_patch.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_vllm_qwen3_omni_audio_patch.py
@@ -1,5 +1,17 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Regression coverage for the Qwen3-Omni vLLM compatibility patch."""
 

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_vllm_qwen3_omni_audio_patch.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_vllm_qwen3_omni_audio_patch.py
@@ -1,6 +1,6 @@
 ######################################################################################################
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+# SPDX-License-Identifier: Apache-2.0
 ######################################################################################################
 
 """Regression coverage for the Qwen3-Omni vLLM compatibility patch."""


### PR DESCRIPTION
## Summary

Fixes native-audio VLM compatibility for Qwen3-Omni and Nemotron Omni models when using the vLLM-compatible backend.

## Related NVBugs

- [B] 6712429: [VLM 3.3.0] Audio summarization fails with Qwen3-Omni-30B-A3B-Instruct
- [B] 6710950: [VLM 3.3.0] Deployment fails Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8

## Changes

- Patch the Qwen3-Omni vLLM processor path so video requests without the optional `use_audio_in_video` field do not raise `KeyError`.
- Patch vLLM Parakeet configuration dataclasses for Transformers 5 compatibility, allowing Nemotron Omni model architecture inspection and initialization.

## Validation

Built the local RT-VLM image and ran real-GPU Jensen AI Summit video caption requests with native audio enabled (`enable_audio: true`) for:

- Qwen/Qwen3-Omni-30B-A3B-Instruct
- nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8
- nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16
- nvidia/Nemotron-Nano-V3-Omni-GA0420-FP8

All four returned captions. Server logs confirmed `Audio stream found.` and `Audio pipeline finished for chunk: 0`; Qwen logs additionally confirmed `use_audio_in_video: True` while generating with video frames.

## Checklist

- [x] Commits are DCO signed off.
- [x] Real-GPU native-audio validation completed for all four models.
- [x] No secrets, API keys, or credentials committed.