### PR TITLE
chore(rtvi-cv): update libmsda_fp16 prebuilts for x86/aarch64/sbsa

### DIFF
--- a/services/rtvi/rt-cv/prebuilts/aarch64/libmsda_fp16.so
+++ b/services/rtvi/rt-cv/prebuilts/aarch64/libmsda_fp16.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a2af81d69e8c8df6ff1ba6fac16efbfe5ecaed9b8ddcc388a85a460926301186
-size 2156712
+oid sha256:373ee235f3df005b4b64a3947febcdf7bade50dae611a91c9cea1a2fa5cd4afc
+size 6482168

--- a/services/rtvi/rt-cv/prebuilts/sbsa/libmsda_fp16.so
+++ b/services/rtvi/rt-cv/prebuilts/sbsa/libmsda_fp16.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:20300d027c0f278a89c06ef8e830024d73539c66c748d867aa6e7a27719eac83
+oid sha256:d00c413e7b71f3550e03737930dc2acac3e91c47bc372462dc831a5caf47deb7
 size 2156712

--- a/services/rtvi/rt-cv/prebuilts/x86/libmsda_fp16.so
+++ b/services/rtvi/rt-cv/prebuilts/x86/libmsda_fp16.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0a92c2a6ae127d78749942ba7b2c45a6344d28e1353848b8d3167eed71aecf4d
-size 5739416
+oid sha256:b8fb7715b40821653fa7a0f0e85fc0c5fa1788697e0b9dc384d8d47d5d6a5248
+size 5747608


### PR DESCRIPTION
## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.

Bug https://nvbugspro.nvidia.com/bug/6676344