### PR TITLE
fix(agent-ui): stop Alerts sidebar render loop on VLM Verified toggle

### DIFF
--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/__tests__/components/AlertsComponent.sidebarControls.test.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/__tests__/components/AlertsComponent.sidebarControls.test.tsx
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Regression guard for the render loop behind the "VLM Verified toggle crashes
+ * the Alerts view" bug.
+ *
+ * When the controls live in the host app's left sidebar, AlertsComponent hands
+ * its memoized controls JSX up through `onControlsReady` from an effect and the
+ * host stores it in state. If any input to that memo has a fresh identity every
+ * render, the effect refires on every render, the host re-renders, and the cycle
+ * never settles — in the browser it burns CPU until a synchronously-updating
+ * child (the Kaizen VLM verdict Select) turns it into React error #185.
+ *
+ * These tests use the real hooks, so an unstable handler identity resurfaces
+ * here as a bounded-push assertion failure instead of a hung suite.
+ */
+
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import { AlertsComponent } from '../../lib-src/AlertsComponent';
+
+const alertsData: any = {
+  apiUrl: 'http://api.test/video-analytics-api',
+  vstApiUrl: 'http://api.test/vst/api',
+  alertsApiUrl: 'http://api.test/alert-bridge/api/v1',
+  maxResults: 100,
+  pageSize: 20,
+  defaultTimeWindow: 10,
+  defaultAutoRefreshInterval: 1000,
+  // Matches a deployment with NEXT_PUBLIC_ALERTS_TAB_VERIFIED_FLAG_DEFAULT=false,
+  // where the verdict Select mounts only once the toggle is switched on.
+  defaultVlmVerified: false,
+  maxSearchTimeLimit: 0,
+  enableRealtimeAlerts: true,
+  enableCvAlertsVerification: true,
+};
+
+/** Beyond this many pushes the controls are not settling; stop feeding the cycle. */
+const PUSH_BUDGET = 25;
+
+const incident = (index: number) => ({
+  Id: `alert-${index}`,
+  timestamp: '2026-01-01T00:00:00.000Z',
+  end: '2026-01-01T00:00:05.000Z',
+  sensorId: `Camera-${index}`,
+  category: 'Loitering',
+  analyticsModule: { info: { triggerModules: 'Motion' }, description: 'desc' },
+});
+
+let pushCount = 0;
+
+/** Stands in for the host app's sidebar (apps/.../Home.tsx + ModeControlsSection). */
+const SidebarHost: React.FC = () => {
+  const [handlers, setHandlers] = React.useState<any>(null);
+  const onControlsReady = React.useCallback((next: any) => {
+    pushCount += 1;
+    if (pushCount > PUSH_BUDGET) return;
+    setHandlers((prev: any) =>
+      prev && prev.controlsComponent === next.controlsComponent ? prev : next,
+    );
+  }, []);
+
+  return (
+    <div>
+      <aside data-testid="sidebar">{handlers?.controlsComponent}</aside>
+      <AlertsComponent
+        theme="dark"
+        isActive
+        alertsData={alertsData}
+        renderControlsInLeftSidebar
+        onControlsReady={onControlsReady}
+      />
+    </div>
+  );
+};
+
+const settle = (milliseconds: number) =>
+  act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, milliseconds));
+  });
+
+beforeEach(() => {
+  pushCount = 0;
+  global.fetch = jest.fn(async (url: unknown) => {
+    if (String(url).includes('/v1/sensor/list')) {
+      return {
+        ok: true,
+        json: async () => [{ name: 'Camera-1', sensorId: 'Camera-1', state: 'online' }],
+      } as any;
+    }
+    return { ok: true, json: async () => ({ incidents: [incident(1), incident(2)] }) } as any;
+  }) as any;
+});
+
+describe('AlertsComponent sidebar controls', () => {
+  it('stops pushing controls to the host once mounted', async () => {
+    await act(async () => {
+      render(<SidebarHost />);
+    });
+    await settle(1200);
+
+    expect(pushCount).toBeLessThanOrEqual(PUSH_BUDGET);
+  });
+
+  it('settles after VLM Verified is toggled on', async () => {
+    await act(async () => {
+      render(<SidebarHost />);
+    });
+    await settle(1200);
+
+    const toggle = screen.getByTestId('vlm-verified-toggle');
+    expect(toggle.getAttribute('aria-checked')).toBe('false');
+
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
+    await settle(1200);
+
+    expect(pushCount).toBeLessThanOrEqual(PUSH_BUDGET);
+    expect(screen.getByTestId('vlm-verified-toggle').getAttribute('aria-checked')).toBe('true');
+    expect(screen.getByTestId('vlm-verdict-select')).toBeTruthy();
+  });
+});

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/__tests__/hooks/useAutoRefresh.test.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/__tests__/hooks/useAutoRefresh.test.ts
@@ -220,6 +220,19 @@ describe('useAutoRefresh', () => {
     expect(onRefresh).toHaveBeenCalledTimes(2);
   });
 
+  it('keeps toggleEnabled identity stable across renders', () => {
+    const onRefresh = jest.fn();
+    const { result, rerender } = renderHook(() =>
+      useAutoRefresh({ onRefresh, defaultInterval: 1000 })
+    );
+
+    // AlertsComponent feeds this into the memoized sidebar controls JSX it pushes
+    // to its host from an effect; a fresh function per render loops that push.
+    const first = result.current.toggleEnabled;
+    rerender();
+    expect(result.current.toggleEnabled).toBe(first);
+  });
+
   it('continues auto-refresh chain when onRefresh throws', async () => {
     const onRefresh = jest.fn()
       .mockRejectedValueOnce(new Error('Network error'))

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/hooks/useAutoRefresh.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/hooks/useAutoRefresh.ts
@@ -8,7 +8,7 @@
  * when the page is refreshed or the browser tab is closed.
  */
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 
 /**
  * Configuration options for the useAutoRefresh hook
@@ -156,9 +156,13 @@ export const useAutoRefresh = ({
     saveToStorage(STORAGE_KEY_INTERVAL, intervalValue);
   }, [intervalValue, hydrated]);
 
-  const toggleEnabled = () => {
+  // Stable identity: this is a dependency of the memoized sidebar controls JSX,
+  // which AlertsComponent pushes to its parent from an effect. A fresh function
+  // every render makes that JSX new every render, so the effect refires, the
+  // parent re-renders, and the cycle never settles.
+  const toggleEnabled = useCallback(() => {
     setIsEnabled(prev => !prev);
-  };
+  }, []);
 
   return {
     isEnabled,


### PR DESCRIPTION
## Problem

nvbug 6715260

Alerts Tab → View Alerts → turning **VLM Verified** on crashes the tab with a
client-side exception (minified React error #185, *Maximum update depth
exceeded*). Reproduces on a deployment with
`NEXT_PUBLIC_ALERTS_TAB_VERIFIED_FLAG_DEFAULT=false`, where the toggle starts
off and the VLM verdict `Select` is mounted by the click.

## Root cause

`useAutoRefresh` returned a new `toggleEnabled` closure on every render:

```ts
const toggleEnabled = () => { setIsEnabled(prev => !prev); };
```

`AlertsComponent` passes it into the `useMemo`'d `AlertsSidebarControls` JSX and
hands that element to the host app through `onControlsReady` (the controls are
rendered by `Home`'s left sidebar via `ModeControlsSection`). So:

1. unstable `toggleAutoRefresh` → new `controlsComponent` element every render
2. the `onControlsReady` effect depends on `controlsComponent` → refires
3. `Home` stores the new element in state → re-renders → `AlertsComponent`
   re-renders (the tab elements are rebuilt inline, not memoized) → back to 1

The cycle never settles. It went unnoticed because React only *warns* about
nested passive updates in development and drops the check entirely in
production builds — so it just burned CPU. Turning VLM Verified on mounts the
Kaizen verdict `Select`, whose Ariakit store updates synchronously inside that
cascade; that path *does* trip React's nested sync-update limit, which throws
and unmounts the tab.

Diagnostic detail: the reported stack lands in the Ariakit store's
`setState`/parent-sync recursion in `441.44f5188132225676.js`, which is the
symptom rather than the cause.

## Fix

Memoize `toggleEnabled` so the controls JSX is stable and the push to the host
settles. One-line behavioural change; the auto-refresh semantics are untouched.

## Tests

- `useAutoRefresh` — asserts `toggleEnabled` keeps its identity across renders.
- New `AlertsComponent.sidebarControls.test.tsx` — mounts `AlertsComponent`
  with `renderControlsInLeftSidebar` behind a host harness that mirrors
  `Home.tsx`, and asserts the controls stop being pushed, both on mount and
  after the VLM Verified toggle. The harness caps the pushes it accepts, so a
  regression fails the assertion instead of hanging the suite (verified: with
  the fix reverted these fail at 29 and 34 pushes; before the cap the suite hung
  indefinitely).

Full alerts suite: 238 tests across 21 suites pass; `tsc --noEmit` clean.