### PR TITLE
fix(helm): Fix Helm storage ingress rewrite matching

### DIFF
--- a/deploy/helm/developer-profiles/dev-profile-alerts/vss-ingress-example-rewrites.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/vss-ingress-example-rewrites.yaml
@@ -32,8 +32,8 @@ metadata:
   namespace: <NAMESPACE>
   annotations:
     haproxy.org/path-rewrite: |
-      /storage/(.*) /vst/storage/\1
-      /storage /vst/storage
+      ^/storage/(.*) /vst/storage/\1
+      ^/storage /vst/storage
       /va-mcp/(.*) /\1
       /va-mcp /
       /alert-bridge/(.*) /\1

--- a/deploy/helm/developer-profiles/dev-profile-base/vss-ingress-example-rewrites.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-base/vss-ingress-example-rewrites.yaml
@@ -32,8 +32,8 @@ metadata:
   namespace: <NAMESPACE>
   annotations:
     haproxy.org/path-rewrite: |
-      /storage/(.*) /vst/storage/\1
-      /storage /vst/storage
+      ^/storage/(.*) /vst/storage/\1
+      ^/storage /vst/storage
       /rtvi-vlm/(.*) /\1
       /rtvi-vlm /
       /phoenix/(.*) /\1

--- a/deploy/helm/developer-profiles/dev-profile-lvs/vss-ingress-example-rewrites.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/vss-ingress-example-rewrites.yaml
@@ -32,8 +32,8 @@ metadata:
   namespace: <NAMESPACE>
   annotations:
     haproxy.org/path-rewrite: |
-      /storage/(.*) /vst/storage/\1
-      /storage /vst/storage
+      ^/storage/(.*) /vst/storage/\1
+      ^/storage /vst/storage
       /elasticsearch/(.*) /\1
       /elasticsearch /
       /rtvi-vlm/(.*) /\1

--- a/deploy/helm/scripts/verify-ingress-routes.py
+++ b/deploy/helm/scripts/verify-ingress-routes.py
@@ -179,9 +179,10 @@ def check_profile(profile: str, rows: list[dict], verbose: bool) -> list[str]:
                 if path in strips:
                     mounted_strip.add(path)
                     to = "" if row["rewrite"] == "strip" else row["rewrite"]
+                    anchor = "^" if row.get("anchored", False) else ""
                     for src, want in (
-                        (f"{path}/(.*)", f"{to}/\\1"),
-                        (path, to or "/"),
+                        (f"{anchor}{path}/(.*)", f"{to}/\\1"),
+                        (f"{anchor}{path}", to or "/"),
                     ):
                         got = rewrites.get(src)
                         if got is None:
@@ -193,7 +194,9 @@ def check_profile(profile: str, rows: list[dict], verbose: bool) -> list[str]:
                                 f"{profile}: {src!r} rewrites to {got!r}, table says {want!r}"
                             )
 
-        surplus = {src.replace("/(.*)", "") for src in rewrites} - mounted_strip
+        surplus = {
+            src.removeprefix("^").replace("/(.*)", "") for src in rewrites
+        } - mounted_strip
         if surplus:
             fails.append(f"{profile}: rewritten but not mounted: {sorted(surplus)}")
 

--- a/deploy/helm/services/common/templates/_ingress-routes.tpl
+++ b/deploy/helm/services/common/templates/_ingress-routes.tpl
@@ -40,6 +40,7 @@
     rewrite  none  -> forwarded with the prefix intact
              strip -> prefix removed before the backend sees it
              /x    -> prefix replaced with /x
+    anchored prepend ^ to the HAProxy rewrite source when true
 
   Ordering is the rendered order: /api/chat before /api, and the UI catch-all
   last. The HAProxy controller matches longest-prefix regardless, but keeping
@@ -93,6 +94,7 @@
   path: /storage
   pathType: Prefix
   rewrite: /vst/storage
+  anchored: true
 - key: va-mcp
   path: /va-mcp
   pathType: Prefix
@@ -211,8 +213,9 @@ true
 {{- $rw := $row.rewrite | default "none" }}
 {{- if and $b.service (ne $rw "none") }}
 {{- $to := ternary "" $rw (eq $rw "strip") }}
-{{ $row.path }}/(.*) {{ $to }}/\1
-{{ $row.path }} {{ $to | default "/" }}
+{{- $anchor := ternary "^" "" ($row.anchored | default false) }}
+{{ $anchor }}{{ $row.path }}/(.*) {{ $to }}/\1
+{{ $anchor }}{{ $row.path }} {{ $to | default "/" }}
 {{- end }}
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
### Summary

Anchor the shared HAProxy `/storage` rewrite rules so they only match paths beginning with `/storage`.

Previously, the unanchored rule could also match `/storage` within unrelated API paths. For example, an NVStreamer request:

```text
/api/v1/storage/file
```

could be rewritten incorrectly as:

```text
/api/v1/vst/storage/file
```

This caused video uploads through the NVStreamer ingress to return 404.

### Changes

- Mark the shared `/storage` route as anchored.
- Generate these HAProxy rewrite rules:

```text
^/storage/(.*) /vst/storage/\1
^/storage /vst/storage
```

- Update ingress route verification to support anchored rules.
- Update the alerts, base, and LVS example ingress manifests.

Only `/storage` is anchored. All other ingress rewrite rules remain unchanged.

### Impact

Valid VST media paths continue to work:

```text
/storage/<path> → /vst/storage/<path>
```

Unrelated paths containing `storage` are no longer modified:

```text
/api/v1/storage/file
/vst/api/v1/storage/file
```

The shared rule is rendered by the alerts, base, LVS, and search developer profiles. No service code, internal Kubernetes service URL, storage data, or Docker deployment is changed.

### Validation

- Ran `helm lint` for the alerts real-time profile.
- Ran the ingress route verifier across base, alerts, LVS, and search.
- Verified all 22 ingress mounts and six disabled-component cases.
- Confirmed generated example manifests are current.
- Validated a Playwright video upload through the NVStreamer ingress.
- Confirmed NVStreamer received `POST /api/v1/storage/file` without unintended rewriting.
- Verified RTSP stream creation and cleanup succeeded.