### PR TITLE
chore(agent): bump distroless python base to 3.13-v4.1.2

### DIFF
--- a/.github/osrb/inventory.csv
+++ b/.github/osrb/inventory.csv
@@ -1231,7 +1231,6 @@ date-fns,2.30.0,MIT,services/ui,node,lockfile,services/ui/package-lock.json,runt
 date-fns,2.30.0,MIT,services/vios,node,lockfile,services/vios/ui/vios-ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 date-fns,4.4.0,MIT,services/ui,node,lockfile,services/ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 date-fns-jalali,4.1.0-0,MIT,services/ui,node,lockfile,services/ui/package-lock.json,runtime,no,no,no,declared-manifest,None
-debian,bookworm,UNKNOWN,services/agent,container,container,services/agent/docker/Dockerfile,runtime,no,no,yes,container-base,Unknown
 debug,2.6.9,MIT,services/analytics/video-analytics-api,node,lockfile,services/analytics/video-analytics-api/src/app/package-lock.json;services/analytics/video-analytics-api/test/package-lock.json,runtime,no,no,no,declared-manifest,None
 debug,3.2.7,MIT,services/ui,node,lockfile,services/ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 debug,4.4.3,MIT,services/analytics/video-analytics-api,node,lockfile,services/analytics/video-analytics-api/src/web-api-core/package-lock.json;services/analytics/video-analytics-api/test/package-lock.json,runtime,no,no,no,declared-manifest,None
@@ -2193,7 +2192,6 @@ libjsoncpp25,UNKNOWN,UNKNOWN,services/vios,deb,container,services/vios/cicd_file
 libldap2-dev,UNKNOWN,UNKNOWN,services/vios,deb,container,services/vios/cicd_files/x86_64/devel/Dockerfile.devel,runtime,no,no,yes,container-apt,Unknown
 liblua5.2-dev,UNKNOWN,UNKNOWN,services/sdrc,deb,container,services/sdrc/envoy/Dockerfile.wdm-router,runtime,no,no,yes,container-apt,Unknown
 libluajit-5.1-dev,UNKNOWN,UNKNOWN,services/sdrc,deb,container,services/sdrc/envoy/Dockerfile.wdm-router,runtime,no,no,yes,container-apt,Unknown
-liblzma5,UNKNOWN,UNKNOWN,services/agent,deb,container,services/agent/docker/Dockerfile,runtime,no,no,yes,container-apt,Unknown
 libnccl2,UNKNOWN,UNKNOWN,deploy,deb,container,deploy/docker/services/infra/Dockerfiles/elasticsearch-gpu.Dockerfile,runtime,no,no,yes,container-apt,Unknown
 libopencv-dev,UNKNOWN,UNKNOWN,services/vios,deb,container,services/vios/cicd_files/x86_64/devel/Dockerfile.devel,runtime,no,no,yes,container-apt,Unknown
 libopus-dev,UNKNOWN,UNKNOWN,services/vios,deb,container,services/vios/test/bdd_tests/Dockerfile,runtime,no,no,yes,container-apt,Unknown
@@ -2214,8 +2212,6 @@ libsqlite3-0,UNKNOWN,UNKNOWN,services/vios,deb,container,services/vios/cicd_file
 libsqlite3-dev,UNKNOWN,UNKNOWN,services/vios,deb,container,services/vios/cicd_files/x86_64/devel/Dockerfile.devel,runtime,no,no,yes,container-apt,Unknown
 libssl-dev,UNKNOWN,UNKNOWN,services/alert,deb,container,services/alert/Dockerfile,runtime,no,no,yes,container-apt,Unknown
 libssl-dev,UNKNOWN,UNKNOWN,services/vios,deb,container,services/vios/cicd_files/x86_64/devel/Dockerfile.devel,runtime,no,no,yes,container-apt,Unknown
-libssl3_3.0.20-1~deb12u2_amd64.deb,UNKNOWN,UNKNOWN,services/agent,source,container,services/agent/docker/Dockerfile,runtime,no,no,no,build-fetch,Unknown
-libssl3_3.0.20-1~deb12u2_arm64.deb,UNKNOWN,UNKNOWN,services/agent,source,container,services/agent/docker/Dockerfile,runtime,no,no,no,build-fetch,Unknown
 libssl3t64,UNKNOWN,UNKNOWN,services/vios,deb,container,services/vios/cicd_files/aarch64/Dockerfile.base,runtime,no,no,yes,container-apt,Unknown
 libswresample-dev,UNKNOWN,UNKNOWN,services/vios,deb,container,services/vios/test/bdd_tests/Dockerfile,runtime,no,no,yes,container-apt,Unknown
 libswscale-dev,UNKNOWN,UNKNOWN,services/vios,deb,container,services/vios/test/bdd_tests/Dockerfile,runtime,no,no,yes,container-apt,Unknown
@@ -2572,7 +2568,6 @@ nvcr.io/nvidia/deepstream,rtvi_ds9.1plus-triton,UNKNOWN,services/rtvi/rt-cv,cont
 nvcr.io/nvidia/distroless/node,22-v4.1.2,UNKNOWN,services/analytics/video-analytics-api,container,container,services/analytics/video-analytics-api/docker/Dockerfile,runtime,no,no,yes,container-base,Unknown
 nvcr.io/nvidia/distroless/node,22-v4.1.2,UNKNOWN,services/ui,container,container,services/ui/Dockerfile,runtime,no,no,yes,container-base,Unknown
 nvcr.io/nvidia/distroless/node,22-v4.1.2-dev,UNKNOWN,services/ui,container,container,services/ui/Dockerfile,runtime,no,no,yes,container-base,Unknown
-nvcr.io/nvidia/distroless/python,3.13-v4.1.2,UNKNOWN,services/agent,container,container,services/agent/docker/Dockerfile,runtime,no,no,yes,container-base,Unknown
 nvcr.io/nvidia/distroless/python,3.13-v4.0.5,UNKNOWN,services/configurators/vss-rt-config-adaptor,container,container,services/configurators/vss-rt-config-adaptor/docker/Dockerfile,runtime,no,no,yes,container-base,Unknown
 nvcr.io/nvidia/distroless/python,3.13-v4.0.5,UNKNOWN,services/rtvi/rt-cv-3d/rt-cv-bev-fusion,container,container,services/rtvi/rt-cv-3d/rt-cv-bev-fusion/Dockerfiles/measurement-fusion.Dockerfile,runtime,no,no,yes,container-base,Unknown
 nvcr.io/nvidia/distroless/python,3.13-v4.0.5,UNKNOWN,services/rtvi/rt-cv-3d/rt-cv-config-init,container,container,services/rtvi/rt-cv-3d/rt-cv-config-init/Dockerfiles/mv3dt-config-init.Dockerfile,runtime,no,no,yes,container-base,Unknown
@@ -2581,6 +2576,7 @@ nvcr.io/nvidia/distroless/python,3.13-v4.0.8,UNKNOWN,services/alert,container,co
 nvcr.io/nvidia/distroless/python,3.13-v4.0.8,UNKNOWN,services/video-summarization,container,container,services/video-summarization/docker/Dockerfile,runtime,no,no,yes,container-base,Unknown
 nvcr.io/nvidia/distroless/python,3.13-v4.0.9,UNKNOWN,services/analytics/behavior-analytics,container,container,services/analytics/behavior-analytics/docker/Dockerfile,runtime,no,no,yes,container-base,Unknown
 nvcr.io/nvidia/distroless/python,3.13-v4.1.1,UNKNOWN,services/configurators/vss-configurator,container,container,services/configurators/vss-configurator/docker/Dockerfile,runtime,no,no,yes,container-base,Unknown
+nvcr.io/nvidia/distroless/python,3.13-v4.1.2,UNKNOWN,services/agent,container,container,services/agent/docker/Dockerfile,runtime,no,no,yes,container-base,Unknown
 nvcr.io/nvidia/k8s/dcgm-exporter,4.2.0-4.1.0-ubuntu22.04,UNKNOWN,services/rtvi/rt-embed,container,compose,services/rtvi/rt-embed/docker/compose.yaml,runtime,no,no,yes,container-image,Unknown
 nvcr.io/nvidia/k8s/dcgm-exporter,4.2.0-4.1.0-ubuntu22.04,UNKNOWN,services/rtvi/rt-vlm,container,compose,services/rtvi/rt-vlm/docker/compose.yaml,runtime,no,no,yes,container-image,Unknown
 nvcr.io/nvidia/pytorch,26.03-py3,UNKNOWN,services/rtvi/rt-embed,container,container,services/rtvi/rt-embed/docker/Dockerfile,runtime,no,no,yes,container-base,Unknown
@@ -3856,7 +3852,6 @@ werkzeug,3.0.3,BSD License,services/alert,python,manifest,services/alert/require
 werkzeug,3.1.8,BSD-3-Clause,services/configurators/vss-configurator,python,lockfile,services/configurators/vss-configurator/uv.lock,runtime,no,no,no,declared-manifest,None
 werkzeug,3.1.8,BSD-3-Clause,services/configurators/vss-rt-config-adaptor,python,lockfile,services/configurators/vss-rt-config-adaptor/uv.lock,runtime,no,no,no,declared-manifest,None
 werkzeug,3.1.8,BSD-3-Clause,services/sdrc,python,lockfile;manifest,services/sdrc/pyproject.toml;services/sdrc/uv.lock,runtime,no,no,no,declared-manifest,None
-wget,UNKNOWN,UNKNOWN,services/agent,deb,container,services/agent/docker/Dockerfile,runtime,no,no,yes,container-apt,Unknown
 wget,UNKNOWN,UNKNOWN,services/rtvi/rt-embed,deb,container,services/rtvi/rt-embed/docker/Dockerfile,runtime,no,no,yes,container-apt,Unknown
 wget,UNKNOWN,UNKNOWN,services/vios,deb,container,services/vios/cicd_files/aarch64/devel/Dockerfile,runtime,no,no,yes,container-apt,Unknown
 whatwg-encoding,3.1.1,MIT,services/ui,node,lockfile,services/ui/package-lock.json,runtime,no,no,no,declared-manifest,None

--- a/.github/osrb/inventory.csv
+++ b/.github/osrb/inventory.csv
@@ -2572,7 +2572,7 @@ nvcr.io/nvidia/deepstream,rtvi_ds9.1plus-triton,UNKNOWN,services/rtvi/rt-cv,cont
 nvcr.io/nvidia/distroless/node,22-v4.1.2,UNKNOWN,services/analytics/video-analytics-api,container,container,services/analytics/video-analytics-api/docker/Dockerfile,runtime,no,no,yes,container-base,Unknown
 nvcr.io/nvidia/distroless/node,22-v4.1.2,UNKNOWN,services/ui,container,container,services/ui/Dockerfile,runtime,no,no,yes,container-base,Unknown
 nvcr.io/nvidia/distroless/node,22-v4.1.2-dev,UNKNOWN,services/ui,container,container,services/ui/Dockerfile,runtime,no,no,yes,container-base,Unknown
-nvcr.io/nvidia/distroless/python,3.13-v3.1.10,UNKNOWN,services/agent,container,container,services/agent/docker/Dockerfile,runtime,no,no,yes,container-base,Unknown
+nvcr.io/nvidia/distroless/python,3.13-v4.1.2,UNKNOWN,services/agent,container,container,services/agent/docker/Dockerfile,runtime,no,no,yes,container-base,Unknown
 nvcr.io/nvidia/distroless/python,3.13-v4.0.5,UNKNOWN,services/configurators/vss-rt-config-adaptor,container,container,services/configurators/vss-rt-config-adaptor/docker/Dockerfile,runtime,no,no,yes,container-base,Unknown
 nvcr.io/nvidia/distroless/python,3.13-v4.0.5,UNKNOWN,services/rtvi/rt-cv-3d/rt-cv-bev-fusion,container,container,services/rtvi/rt-cv-3d/rt-cv-bev-fusion/Dockerfiles/measurement-fusion.Dockerfile,runtime,no,no,yes,container-base,Unknown
 nvcr.io/nvidia/distroless/python,3.13-v4.0.5,UNKNOWN,services/rtvi/rt-cv-3d/rt-cv-config-init,container,container,services/rtvi/rt-cv-3d/rt-cv-config-init/Dockerfiles/mv3dt-config-init.Dockerfile,runtime,no,no,yes,container-base,Unknown

--- a/services/agent/docker/Dockerfile
+++ b/services/agent/docker/Dockerfile
@@ -94,32 +94,11 @@ RUN rm -rf /vss-agent/.venv/lib/python3.13/site-packages/cv2 \
            -o -name 'libde265*.so*' -o -name 'libopenh264*.so*' -o -name 'libkvazaar*.so*' \
        \) -delete 2>/dev/null || true
 
-# Security patch stage - download patched runtime libraries
-# CVE-2025-69419, CVE-2025-69420, CVE-2025-15467: Upgrade libssl3 to 3.0.20-1~deb12u2
-# CVE-2026-34743: Upgrade liblzma5 to 5.4.1-1+deb12u1
-# (bumped from 3.0.19-1~deb12u2, which Debian rotated out of the security pool — the
-#  pinned URL started returning 404 and broke the image build).
-FROM debian:bookworm AS security-patches
-ARG TARGETARCH
-
-# Download the patched libssl3 package for the target architecture
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends wget ca-certificates liblzma5 && \
-    mkdir -p /patches && \
-    dpkg --compare-versions "$(dpkg-query -W -f='${Version}' liblzma5)" ge "5.4.1-1+deb12u1" && \
-    dpkg-query -s liblzma5 > /patches/liblzma5.status && \
-    cp /var/lib/dpkg/info/liblzma5*.md5sums /patches/liblzma5.md5sums && \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        wget --max-redirect=0 -O /patches/libssl3.deb https://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl3_3.0.20-1~deb12u2_amd64.deb; \
-    elif [ "$TARGETARCH" = "arm64" ]; then \
-        wget --max-redirect=0 -O /patches/libssl3.deb https://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl3_3.0.20-1~deb12u2_arm64.deb; \
-    fi && \
-    cd /patches && \
-    dpkg-deb -x libssl3.deb /patches/libssl3-extracted && \
-    rm -rf /var/lib/apt/lists/*
-
 # Runtime stage - using NVIDIA distroless production image (supports AMD64 and ARM64)
-FROM nvcr.io/nvidia/distroless/python:3.13-v3.1.10 AS runtime
+# 3.13-v4.1.2 is the latest NGC tag (Debian 13 / OpenSSL 3.5.7, Go 1.26.6). The prior
+# bookworm security-patches stage is removed: it targeted Debian 12 libssl3/liblzma5 and
+# must not be overlaid onto the v4 base.
+FROM nvcr.io/nvidia/distroless/python:3.13-v4.1.2 AS runtime
 ARG USER_ID=1000
 ARG GROUP_ID=1000
 ARG TARGETPLATFORM
@@ -144,21 +123,6 @@ RUN ["/usr/local/bin/python3", "-c", "import os; os.remove('/tmp/cleanup_vulnera
 # libssl3.so/libcrypto.so shared libraries, not the CLI tool. This eliminates Grype
 # findings for CVE-2025-15467, CVE-2025-69419, CVE-2025-69420, CVE-2025-69421 etc.
 RUN ["/usr/local/bin/python3", "-c", "import os; os.path.exists('/usr/bin/openssl') and os.remove('/usr/bin/openssl')"]
-
-# Copy patched OpenSSL libraries to fix CVE-2025-69419, CVE-2025-69420, CVE-2025-15467
-# These replace the base image libssl3 with 3.0.19-1~deb12u2
-# Copy directly to architecture-specific paths where the runtime image expects them
-COPY --from=security-patches /patches/libssl3-extracted/usr/lib/*-linux-gnu*/libssl.so.* /usr/lib/x86_64-linux-gnu/
-COPY --from=security-patches /patches/libssl3-extracted/usr/lib/*-linux-gnu*/libssl.so.* /usr/lib/aarch64-linux-gnu/
-COPY --from=security-patches /patches/libssl3-extracted/usr/lib/*-linux-gnu*/libcrypto.so.* /usr/lib/x86_64-linux-gnu/
-COPY --from=security-patches /patches/libssl3-extracted/usr/lib/*-linux-gnu*/libcrypto.so.* /usr/lib/aarch64-linux-gnu/
-
-# Replace liblzma and its package metadata so runtime scanners identify the
-# patched Debian package rather than the vulnerable distroless-base version.
-COPY --from=security-patches /usr/lib/*-linux-gnu*/liblzma.so.* /usr/lib/x86_64-linux-gnu/
-COPY --from=security-patches /usr/lib/*-linux-gnu*/liblzma.so.* /usr/lib/aarch64-linux-gnu/
-COPY --from=security-patches /patches/liblzma5.status /var/lib/dpkg/status.d/liblzma5
-COPY --from=security-patches /patches/liblzma5.md5sums /var/lib/dpkg/status.d/liblzma5.md5sums
 
 # Copy application without any dev needs
 COPY --from=builder --chown=root:root --chmod=0555 /vss-agent/.venv /vss-agent/.venv


### PR DESCRIPTION
## Summary
- Bump `vss-agent` runtime from `nvcr.io/nvidia/distroless/python:3.13-v3.1.10` to **`3.13-v4.1.2`** (latest available on NGC).
- Remove the Debian 12 `security-patches` overlay for `libssl3` / `liblzma5`; the v4 base is Debian 13 with OpenSSL 3.5.7 and must not be downgraded.
- Update OSRB inventory for the new base image tag.

**Why:** the distroless helpers (`sleep`, `shelless_ulimit`) in v3.1.x are built with **go1.26.4**, which triggers 10 Go stdlib CVE findings in `govulncheck` / nSpect ahead of the Sept 10 global VEX removal. **v4.1.2** ships **go1.26.6** (`govulncheck -mode=binary` clean).

## Test plan
- [ ] CI builds `vss-agent` image successfully
- [ ] Container starts and `/health` responds on a dev profile
- [ ] Re-scan image with `govulncheck` on `/usr/bin/sleep` (expect no stdlib findings)
- [ ] Confirm nSpect stdlib findings clear after image rebuild/promotion