### PR TITLE
feat(video-analytics-api): add documentation for Video Analytics API …

### DIFF
--- a/skills/deployment/vss-setup-video-analytics-api/references/deploy-video-analytics-api-service.md
+++ b/skills/deployment/vss-setup-video-analytics-api/references/deploy-video-analytics-api-service.md
@@ -128,7 +128,7 @@ If you don't need image upload endpoints, you can drop this mount — the contai
 
 ### Elasticsearch (required)
 
-Elasticsearch-backed operations require the `insertion-timestamp-pipeline`. Ensure `elasticsearch-init-container` has created it; an open Elasticsearch port or a healthy cluster alone does not prove that the custom ingest pipeline exists. `/livez` is only a liveness response and does not check this prerequisite.
+The server waits for Elasticsearch and the `insertion-timestamp-pipeline` before it registers routes and binds port 8081. With `STREAM_TYPE=kafka` and configured brokers, it also waits for its required Kafka topics. Thus an unavailable `/livez` does not identify which bootstrap prerequisite is missing. An open Elasticsearch port or a healthy cluster alone does not prove that the custom ingest pipeline exists.
 
 Make sure the `elasticsearch.node` in your config matches the running ES instance. With `network_mode: "host"`, ES must also be on the host network.
 
@@ -181,7 +181,7 @@ The server auto-discovers controllers from `src/app/controllers/rest-apis/` and 
 | `/tracker` | Cross-sensor tracking: unique object counts and locations, full unique-object records with constituent behaviors, behavior locations matched to a global object, and last RTLS / AMR source record. |
 | `/clustering` | Retrieves sampled behavior clusters for a sensor and time range (`/clustering/behavior`); adds a label to a behavior cluster (`/clustering/add-label`). |
 
-Data-query endpoints require Elasticsearch, the `insertion-timestamp-pipeline`, matching indices, and data. Endpoints that use configured Kafka features require their topics. `/livez` reports only that its HTTP route is live; Endpoints that publish notifications (config, calibration) or expose RTLS / AMR streams also require Kafka.
+The API registers `/livez` only after its Elasticsearch ingest-pipeline check and, with configured Kafka, its topic check. Data-query endpoints additionally need matching Elasticsearch indices and data. Endpoints that publish notifications (config, calibration) or expose RTLS / AMR streams require Kafka.
 
 ---
 
@@ -224,7 +224,7 @@ While the ingest pipeline is absent, the API emits:
 {"message":"[ELASTICSEARCH] Ingest pipeline is not present.","pipelineId":"insertion-timestamp-pipeline"}
 ```
 
-Logs reporting a missing ingest pipeline or Kafka requirement identify a dependency that must be fixed for the affected API operations. A `/livez` response remains only a liveness signal; verify Elasticsearch, the pipeline, Kafka, and any required data independently for end-to-end readiness.
+The API checks once per second until the pipeline exists, then, only with `STREAM_TYPE=kafka` and configured brokers, performs the same loop for Kafka requirements. This is expected when the API starts before its infrastructure; wait for `/livez` to confirm route registration, then verify data availability separately.
 
 ## Teardown
 
@@ -240,12 +240,12 @@ For a multi-service teardown (broker, ES, etc.), use the `vss-deploy-profile` te
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| Logs say `Ingest pipeline is not present` | Elasticsearch is reachable but `insertion-timestamp-pipeline` has not been created. | Start or repair `elasticsearch-init-container`; verify with `curl -sf http://localhost:9200/_ingest/pipeline/insertion-timestamp-pipeline`. `/livez` can still return 200. |
-| Logs say `Required Kafka topics are not present` | `STREAM_TYPE=kafka` with configured brokers, but one or more requirements are absent. | Create `mdx-notification`, `mdx-amr`, and a topic matching `mdx-rtls*`; select `STREAM_TYPE=redis`; or set `kafka.brokers: []`. `/livez` can still return 200. |
+| API never exposes `/livez`; logs say `Ingest pipeline is not present` | Elasticsearch is reachable but `insertion-timestamp-pipeline` has not been created. | Start or repair `elasticsearch-init-container`; verify with `curl -sf http://localhost:9200/_ingest/pipeline/insertion-timestamp-pipeline`. |
+| API never exposes `/livez`; logs say `Required Kafka topics are not present` | `STREAM_TYPE=kafka` with configured brokers, but one or more requirements are absent. | Create `mdx-notification`, `mdx-amr`, and a topic matching `mdx-rtls*`; select `STREAM_TYPE=redis`; or set `kafka.brokers: []`. |
 | `[INPUT ERROR] Invalid path for bootstrap config file.` | The `--config` path doesn't exist inside the container. | Verify the volume mount target matches the `--config` flag path. Use an absolute path. |
 | Compose tries to mount `/data_log/vss_video_analytics_api` from the filesystem root | `$VSS_DATA_DIR` is unset while the default data-log bind mount is still present. | Export `VSS_DATA_DIR` to a writable host path and create `$VSS_DATA_DIR/data_log/vss_video_analytics_api`, or remove the `/web-api-app/files` mount if image uploads are not needed. |
 | `EADDRINUSE` | Port 8081 (or your configured port) is already in use. | Check with `ss -tlnp | grep :8081`. Stop the conflicting process or change `server.port` in the config. |
-| Container is running but port 8081 is unavailable | Host-port publication or a network path is unavailable. | Check the Compose port mapping and host network path. Dependency logs can explain unavailable API operations, but are independent of `/livez`. |
+| Container is running but port 8081 is unavailable | API is waiting for its Elasticsearch pipeline or configured Kafka requirements. | Read container logs for the missing readiness requirement; `/livez` returns 200 only after route registration. |
 | `/livez` returns 200 but data endpoints return empty results | Elasticsearch indices don't exist or have no data. | Check indices: `curl -s http://localhost:9200/_cat/indices?v \| grep mdx`. If empty, the upstream pipeline (behavior-analytics, perception) hasn't produced data yet. |
 | Config update via POST `/config` times out | The ACK from behavior-analytics didn't arrive within `configStatusTimeoutMs`. | Check that behavior-analytics is running and consuming from `mdx-notification`. Check the `configStatusTimeoutMs` value (default `30000`ms). |
 | Image won't run `docker exec -it ... sh` | Runtime is a **Node** image (`nvcr.io/nvidia/distroless/node:22-v4.0.7`) — no shell, but the `node` binary is present. | Use `docker logs <container>` for runtime output. To print a bind-mounted file (e.g. bootstrap config), use `docker exec <container> node -e '...'` — see below. Prefer reading the host-side mount path when the file is volume-bound. |

--- a/skills/deployment/vss-setup-video-analytics-api/references/deploy-video-analytics-api-service.md
+++ b/skills/deployment/vss-setup-video-analytics-api/references/deploy-video-analytics-api-service.md
@@ -201,8 +201,9 @@ mkdir -p "$VSS_DATA_DIR/data_log/vss_video_analytics_api"
 docker compose -f services/analytics/video-analytics-api/compose.yml up -d vss-video-analytics-api
 
 docker ps --filter "name=vss-video-analytics-api" --format '{{.Names}}\t{{.Status}}'
-# The Compose service sets container_name explicitly.
-docker logs -f vss-video-analytics-api
+# Compose auto-names the standalone container <project>-<service>-<index>; project defaults to
+# the compose file's parent dir, so the full name is:
+docker logs -f video-analytics-api-vss-video-analytics-api-1
 ```
 
 Healthy log lines include:
@@ -252,7 +253,7 @@ For a multi-service teardown (broker, ES, etc.), use the `vss-deploy-profile` te
 **Inspect a mounted config inside the container** (same path as `command: node index.js --config …`):
 
 ```bash
-docker exec vss-video-analytics-api node -e \
+docker exec video-analytics-api-vss-video-analytics-api-1 node -e \
   "const fs=require('fs'); const p='/opt/mdx/vss-video-analytics-api/configs/vss-video-analytics-api-config.json'; console.log(JSON.stringify(JSON.parse(fs.readFileSync(p,'utf8')), null, 2))"
 ```
 

--- a/skills/deployment/vss-setup-video-analytics-api/references/deploy-video-analytics-api-service.md
+++ b/skills/deployment/vss-setup-video-analytics-api/references/deploy-video-analytics-api-service.md
@@ -128,7 +128,7 @@ If you don't need image upload endpoints, you can drop this mount — the contai
 
 ### Elasticsearch (required)
 
-The server pings Elasticsearch on startup, then waits for the `insertion-timestamp-pipeline`. It does not bind port 8081 or make `/livez` available until both are ready. An open Elasticsearch port or a healthy cluster alone does not prove that the custom ingest pipeline exists.
+Elasticsearch-backed operations require the `insertion-timestamp-pipeline`. Ensure `elasticsearch-init-container` has created it; an open Elasticsearch port or a healthy cluster alone does not prove that the custom ingest pipeline exists. `/livez` is only a liveness response and does not check this prerequisite.
 
 Make sure the `elasticsearch.node` in your config matches the running ES instance. With `network_mode: "host"`, ES must also be on the host network.
 
@@ -181,7 +181,7 @@ The server auto-discovers controllers from `src/app/controllers/rest-apis/` and 
 | `/tracker` | Cross-sensor tracking: unique object counts and locations, full unique-object records with constituent behaviors, behavior locations matched to a global object, and last RTLS / AMR source record. |
 | `/clustering` | Retrieves sampled behavior clusters for a sensor and time range (`/clustering/behavior`); adds a label to a behavior cluster (`/clustering/add-label`). |
 
-The server must initialize against Elasticsearch, `insertion-timestamp-pipeline`, and any configured Kafka topics before `/livez` can return healthy. Data-query endpoints also need matching Elasticsearch indices and data. Endpoints that publish notifications (config, calibration) or expose RTLS / AMR streams also require Kafka.
+Data-query endpoints require Elasticsearch, the `insertion-timestamp-pipeline`, matching indices, and data. Endpoints that use configured Kafka features require their topics. `/livez` reports only that its HTTP route is live; Endpoints that publish notifications (config, calibration) or expose RTLS / AMR streams also require Kafka.
 
 ---
 
@@ -212,7 +212,7 @@ Healthy log lines include:
 {"timestamp":"...","level":"info","message":"[SERVER] Listening on port: 8081"}
 ```
 
-Verify the health endpoint:
+Verify the liveness endpoint:
 
 ```bash
 curl -sf http://localhost:8081/livez && echo "OK" || echo "DOWN"
@@ -224,7 +224,7 @@ While the ingest pipeline is absent, the API emits:
 {"message":"[ELASTICSEARCH] Ingest pipeline is not present.","pipelineId":"insertion-timestamp-pipeline"}
 ```
 
-The API checks once per second until the pipeline exists, then, only with `STREAM_TYPE=kafka` and configured brokers, performs the same loop for Kafka requirements. This is expected when the API starts before its infrastructure; wait for `/livez` rather than treating the container's running state or Elasticsearch port 9200 as API readiness.
+Logs reporting a missing ingest pipeline or Kafka requirement identify a dependency that must be fixed for the affected API operations. A `/livez` response remains only a liveness signal; verify Elasticsearch, the pipeline, Kafka, and any required data independently for end-to-end readiness.
 
 ## Teardown
 
@@ -240,12 +240,12 @@ For a multi-service teardown (broker, ES, etc.), use the `vss-deploy-profile` te
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| API never exposes `/livez`; logs say `Ingest pipeline is not present` | Elasticsearch is reachable but `insertion-timestamp-pipeline` has not been created. | Start or repair `elasticsearch-init-container`; verify with `curl -sf http://localhost:9200/_ingest/pipeline/insertion-timestamp-pipeline`. |
-| API never exposes `/livez`; logs say `Required Kafka topics are not present` | `STREAM_TYPE=kafka` with configured brokers, but one or more requirements are absent. | Create `mdx-notification`, `mdx-amr`, and a topic matching `mdx-rtls*`; select `STREAM_TYPE=redis`; or set `kafka.brokers: []`. |
+| Logs say `Ingest pipeline is not present` | Elasticsearch is reachable but `insertion-timestamp-pipeline` has not been created. | Start or repair `elasticsearch-init-container`; verify with `curl -sf http://localhost:9200/_ingest/pipeline/insertion-timestamp-pipeline`. `/livez` can still return 200. |
+| Logs say `Required Kafka topics are not present` | `STREAM_TYPE=kafka` with configured brokers, but one or more requirements are absent. | Create `mdx-notification`, `mdx-amr`, and a topic matching `mdx-rtls*`; select `STREAM_TYPE=redis`; or set `kafka.brokers: []`. `/livez` can still return 200. |
 | `[INPUT ERROR] Invalid path for bootstrap config file.` | The `--config` path doesn't exist inside the container. | Verify the volume mount target matches the `--config` flag path. Use an absolute path. |
 | Compose tries to mount `/data_log/vss_video_analytics_api` from the filesystem root | `$VSS_DATA_DIR` is unset while the default data-log bind mount is still present. | Export `VSS_DATA_DIR` to a writable host path and create `$VSS_DATA_DIR/data_log/vss_video_analytics_api`, or remove the `/web-api-app/files` mount if image uploads are not needed. |
 | `EADDRINUSE` | Port 8081 (or your configured port) is already in use. | Check with `ss -tlnp | grep :8081`. Stop the conflicting process or change `server.port` in the config. |
-| Container is running but port 8081 is unavailable | API is waiting for its Elasticsearch pipeline or configured Kafka requirements. | Read container logs for the missing readiness requirement; `/livez` returns 200 only after all gates pass. |
+| Container is running but port 8081 is unavailable | Host-port publication or a network path is unavailable. | Check the Compose port mapping and host network path. Dependency logs can explain unavailable API operations, but are independent of `/livez`. |
 | `/livez` returns 200 but data endpoints return empty results | Elasticsearch indices don't exist or have no data. | Check indices: `curl -s http://localhost:9200/_cat/indices?v \| grep mdx`. If empty, the upstream pipeline (behavior-analytics, perception) hasn't produced data yet. |
 | Config update via POST `/config` times out | The ACK from behavior-analytics didn't arrive within `configStatusTimeoutMs`. | Check that behavior-analytics is running and consuming from `mdx-notification`. Check the `configStatusTimeoutMs` value (default `30000`ms). |
 | Image won't run `docker exec -it ... sh` | Runtime is a **Node** image (`nvcr.io/nvidia/distroless/node:22-v4.0.7`) — no shell, but the `node` binary is present. | Use `docker logs <container>` for runtime output. To print a bind-mounted file (e.g. bootstrap config), use `docker exec <container> node -e '...'` — see below. Prefer reading the host-side mount path when the file is volume-bound. |

--- a/skills/deployment/vss-setup-video-analytics-api/references/deploy-video-analytics-api-service.md
+++ b/skills/deployment/vss-setup-video-analytics-api/references/deploy-video-analytics-api-service.md
@@ -201,9 +201,8 @@ mkdir -p "$VSS_DATA_DIR/data_log/vss_video_analytics_api"
 docker compose -f services/analytics/video-analytics-api/compose.yml up -d vss-video-analytics-api
 
 docker ps --filter "name=vss-video-analytics-api" --format '{{.Names}}\t{{.Status}}'
-# Compose auto-names the standalone container <project>-<service>-<index>; project defaults to
-# the compose file's parent dir, so the full name is:
-docker logs -f video-analytics-api-vss-video-analytics-api-1
+# The Compose service sets container_name explicitly.
+docker logs -f vss-video-analytics-api
 ```
 
 Healthy log lines include:
@@ -248,12 +247,12 @@ For a multi-service teardown (broker, ES, etc.), use the `vss-deploy-profile` te
 | Container is running but port 8081 is unavailable | API is waiting for its Elasticsearch pipeline or configured Kafka requirements. | Read container logs for the missing readiness requirement; `/livez` returns 200 only after route registration. |
 | `/livez` returns 200 but data endpoints return empty results | Elasticsearch indices don't exist or have no data. | Check indices: `curl -s http://localhost:9200/_cat/indices?v \| grep mdx`. If empty, the upstream pipeline (behavior-analytics, perception) hasn't produced data yet. |
 | Config update via POST `/config` times out | The ACK from behavior-analytics didn't arrive within `configStatusTimeoutMs`. | Check that behavior-analytics is running and consuming from `mdx-notification`. Check the `configStatusTimeoutMs` value (default `30000`ms). |
-| Image won't run `docker exec -it ... sh` | Runtime is a **Node** image (`nvcr.io/nvidia/distroless/node:22-v4.0.7`) — no shell, but the `node` binary is present. | Use `docker logs <container>` for runtime output. To print a bind-mounted file (e.g. bootstrap config), use `docker exec <container> node -e '...'` — see below. Prefer reading the host-side mount path when the file is volume-bound. |
+| Image won't run `docker exec -it ... sh` | Runtime is a **Node** image (`nvcr.io/nvidia/distroless/node:22-v4.1.2`) — no shell, but the `node` binary is present. | Use `docker logs <container>` for runtime output. To print a bind-mounted file (e.g. bootstrap config), use `docker exec <container> node -e '...'` — see below. Prefer reading the host-side mount path when the file is volume-bound. |
 
 **Inspect a mounted config inside the container** (same path as `command: node index.js --config …`):
 
 ```bash
-docker exec video-analytics-api-vss-video-analytics-api-1 node -e \
+docker exec vss-video-analytics-api node -e \
   "const fs=require('fs'); const p='/opt/mdx/vss-video-analytics-api/configs/vss-video-analytics-api-config.json'; console.log(JSON.stringify(JSON.parse(fs.readFileSync(p,'utf8')), null, 2))"
 ```
 

--- a/skills/vss-build-vision-ai/references/profiles/warehouse.md
+++ b/skills/vss-build-vision-ai/references/profiles/warehouse.md
@@ -372,7 +372,7 @@ HTTP probes, when the selected list ships them:
 ```bash
 curl -sf "http://${HOST_IP}:${HAPROXY_HOST_PORT:-7777}/vst/"
 curl -sf "http://${HOST_IP}:9200/_cluster/health"          # extended, or bp_wh
-curl -sf "http://${HOST_IP}:8081/livez"                    # extended, or bp_wh
+curl -sf "http://${HOST_IP}:8081/livez"                    # liveness only; extended, or bp_wh
 curl -sf "http://${HOST_IP}:5601/kibana/api/status"        # extended, or bp_wh
 curl -sf "http://${HOST_IP}:8000/health"                   # bp_wh only
 ```

--- a/skills/vss-build-vision-ai/references/services/video-analytics-api.md
+++ b/skills/vss-build-vision-ai/references/services/video-analytics-api.md
@@ -67,7 +67,7 @@ Foundation-specific alias or a second API instance.
 | `VSS_DATA_DIR` | Resolve the optional persistent files mount. |
 
 The API loads JSON through `--config`; the stock Compose command mounts
-`$VSS_APPS_DIR/services/analytics/video-analytics-api/configs/vss-video-analytics-api-config.json`.
+`services/analytics/video-analytics-api/configs/vss-video-analytics-api-config.json`.
 That file controls `server.port`, Elasticsearch (`node`, index prefix/pattern,
 retries), Kafka brokers/retries, and application settings such as body-size and
 config-ack timeouts. Keep `server.configs[].value` values as strings. The

--- a/skills/vss-build-vision-ai/references/services/video-analytics-api.md
+++ b/skills/vss-build-vision-ai/references/services/video-analytics-api.md
@@ -14,10 +14,10 @@ Foundation-specific alias or a second API instance.
 
 ## Required peers
 
-- Elasticsearch is mandatory. The API does not listen or make `/livez` available
-  until Elasticsearch is reachable **and** its `insertion-timestamp-pipeline`
-  exists. Select `elasticsearch` and `elasticsearch-init-container`; a reachable
-  Elasticsearch port by itself is not readiness.
+- Elasticsearch is required for the API's Elasticsearch-backed operations.
+  Select `elasticsearch` and `elasticsearch-init-container`, including the
+  `insertion-timestamp-pipeline`; a reachable Elasticsearch port alone does not
+  establish that those operations are ready.
 - With `STREAM_TYPE=kafka` and non-empty `kafka.brokers`, it also waits for
   `mdx-notification`, `mdx-amr`, and at least one `mdx-rtls*` topic. Include
   `kafka`, `kafka-topic-init-container`, and `broker-health-check` when the
@@ -26,8 +26,9 @@ Foundation-specific alias or a second API instance.
   `kafka.brokers` to `[]` or `null`; `redis` here skips Kafka work and does not
   configure a Redis client.
 - The data-query routes need matching Elasticsearch indices and upstream
-  producers. A healthy `/livez` with empty query results means the API is ready
-  but no matching analytics data has been indexed; it is not a deployment error.
+  producers. `/livez` returning `{ "isAlive": true }` is only liveness; empty
+  query results mean no matching analytics data has been indexed, not a deployment
+  failure.
 - Dynamic configuration publishes on `mdx-notification` under the
   `behavior-analytics-config` key and needs Behavior Analytics to consume and
   acknowledge it. Dynamic calibration publishes on the same topic with the
@@ -43,9 +44,11 @@ Foundation-specific alias or a second API instance.
 
 ## API and ingress surface
 
-- The service publishes `${VIDEO_ANALYTICS_API_HOST_PORT:-8081}:8081` and its
-  health probe is `GET /livez`, which returns `{ "isAlive": true }` only after
-  all selected readiness gates pass.
+- The service publishes `${VIDEO_ANALYTICS_API_HOST_PORT:-8081}:8081`.
+  `GET /livez` is a liveness endpoint and returns `{ "isAlive": true }` when
+  its route is served; it does **not** attest that Elasticsearch, the ingest
+  pipeline, Kafka, or upstream analytics data are ready. Check those dependencies
+  independently for an end-to-end readiness decision.
 - When HAProxy ingress is selected, expose the same service at
   `/video-analytics-api/...`; ingress strips that prefix before forwarding. Do
   not construct a distinct API URL for a profile.

--- a/skills/vss-build-vision-ai/references/services/video-analytics-api.md
+++ b/skills/vss-build-vision-ai/references/services/video-analytics-api.md
@@ -45,10 +45,10 @@ Foundation-specific alias or a second API instance.
 ## API and ingress surface
 
 - The service publishes `${VIDEO_ANALYTICS_API_HOST_PORT:-8081}:8081`.
-  `GET /livez` is a liveness endpoint and returns `{ "isAlive": true }` when
-  its route is served; it does **not** attest that Elasticsearch, the ingest
-  pipeline, Kafka, or upstream analytics data are ready. Check those dependencies
-  independently for an end-to-end readiness decision.
+  `GET /livez` returns `{ "isAlive": true }` once the API registers its route.
+  Registration follows the Elasticsearch ingest-pipeline check and, with configured
+  Kafka, its topic check; it does not attest that upstream analytics data or the
+  Elasticsearch indices queried by routes are populated.
 - When HAProxy ingress is selected, expose the same service at
   `/video-analytics-api/...`; ingress strips that prefix before forwarding. Do
   not construct a distinct API URL for a profile.

--- a/skills/vss-build-vision-ai/references/services/video-analytics-api.md
+++ b/skills/vss-build-vision-ai/references/services/video-analytics-api.md
@@ -1,0 +1,84 @@
+# Video Analytics API Capability Owner
+
+## Capabilities and service keys
+
+| Capability | Canonical service profile keys |
+|---|---|
+| REST query and configuration API | `vss-video-analytics-api` |
+| Warehouse calibration import | `import-calibration-output-container-<mode>` |
+
+`vss-video-analytics-api` is a shared Compose service: every Foundation uses the
+same profile key and the same `vss-video-analytics-api` container. Include it
+once when the requested capability needs its REST surface; never create a
+Foundation-specific alias or a second API instance.
+
+## Required peers
+
+- Elasticsearch is mandatory. The API does not listen or make `/livez` available
+  until Elasticsearch is reachable **and** its `insertion-timestamp-pipeline`
+  exists. Select `elasticsearch` and `elasticsearch-init-container`; a reachable
+  Elasticsearch port by itself is not readiness.
+- With `STREAM_TYPE=kafka` and non-empty `kafka.brokers`, it also waits for
+  `mdx-notification`, `mdx-amr`, and at least one `mdx-rtls*` topic. Include
+  `kafka`, `kafka-topic-init-container`, and `broker-health-check` when the
+  requested API features need dynamic configuration/calibration or RTLS/AMR.
+  To intentionally omit Kafka startup work, use `STREAM_TYPE=redis`, or set
+  `kafka.brokers` to `[]` or `null`; `redis` here skips Kafka work and does not
+  configure a Redis client.
+- The data-query routes need matching Elasticsearch indices and upstream
+  producers. A healthy `/livez` with empty query results means the API is ready
+  but no matching analytics data has been indexed; it is not a deployment error.
+- Dynamic configuration publishes on `mdx-notification` under the
+  `behavior-analytics-config` key and needs Behavior Analytics to consume and
+  acknowledge it. Dynamic calibration publishes on the same topic with the
+  `calibration` key. These are API features, not a reason to add a second
+  Behavior Analytics service.
+- The default bind mount for `/web-api-app/files` needs
+  `VSS_DATA_DIR/data_log/vss_video_analytics_api`. Retain it for calibration-image
+  or other file upload endpoints; it may be removed when those files can be
+  ephemeral.
+- Warehouse extended variants pair the shared API key with
+  `import-calibration-output-container-<mode>`; minimal variants do not. The
+  import container posts to the API and is not a general dependency of the API.
+
+## API and ingress surface
+
+- The service publishes `${VIDEO_ANALYTICS_API_HOST_PORT:-8081}:8081` and its
+  health probe is `GET /livez`, which returns `{ "isAlive": true }` only after
+  all selected readiness gates pass.
+- When HAProxy ingress is selected, expose the same service at
+  `/video-analytics-api/...`; ingress strips that prefix before forwarding. Do
+  not construct a distinct API URL for a profile.
+- Its REST routes cover calibration/configuration, sensors, behavior, alerts,
+  incidents, events, frames, metrics, tracking, and clustering. Route presence
+  does not imply data availability: most query routes are Elasticsearch-backed.
+
+## Configuration knobs
+
+| Environment variable | Use |
+|---|---|
+| `VSS_VIDEO_ANALYTICS_API_IMAGE`, `VSS_VIDEO_ANALYTICS_API_TAG` | Select the API image. |
+| `VIDEO_ANALYTICS_API_HOST_PORT` | Publish the API's host port (default `8081`). |
+| `STREAM_TYPE` | Select `kafka` (default) or `redis`; any other value makes startup fail. |
+| `VSS_APPS_DIR` | Resolve the service-shipped bootstrap JSON mount. |
+| `VSS_DATA_DIR` | Resolve the optional persistent files mount. |
+
+The API loads JSON through `--config`; the stock Compose command mounts
+`services/analytics/video-analytics-api/configs/vss-video-analytics-api-config.json`.
+That file controls `server.port`, Elasticsearch (`node`, index prefix/pattern,
+retries), Kafka brokers/retries, and application settings such as body-size and
+config-ack timeouts. Keep `server.configs[].value` values as strings. The
+image-baked config disables Kafka with an empty broker list; the service-shipped
+config enables localhost Kafka. Replace the mounted JSON when the requested
+deployment needs a different endpoint or startup behavior rather than trying to
+express those settings as Compose environment deltas.
+
+## Sources
+
+- `deploy/docker/services/analytics/video-analytics-api/compose.yml`
+- `deploy/docker/services/analytics/video-analytics-api/configs/vss-video-analytics-api-config.json`
+- `services/analytics/video-analytics-api/configs/default-configs/config.json`
+- `deploy/docker/services/infra/compose.yml`
+- `deploy/docker/services/ingress/haproxy.cfg`
+- `skills/deployment/vss-setup-video-analytics-api/references/configuration.md`
+- `skills/deployment/vss-setup-video-analytics-api/references/deploy-video-analytics-api-service.md`

--- a/skills/vss-build-vision-ai/references/services/video-analytics-api.md
+++ b/skills/vss-build-vision-ai/references/services/video-analytics-api.md
@@ -67,7 +67,7 @@ Foundation-specific alias or a second API instance.
 | `VSS_DATA_DIR` | Resolve the optional persistent files mount. |
 
 The API loads JSON through `--config`; the stock Compose command mounts
-`services/analytics/video-analytics-api/configs/vss-video-analytics-api-config.json`.
+`$VSS_APPS_DIR/services/analytics/video-analytics-api/configs/vss-video-analytics-api-config.json`.
 That file controls `server.port`, Elasticsearch (`node`, index prefix/pattern,
 retries), Kafka brokers/retries, and application settings such as body-size and
 config-ack timeouts. Keep `server.configs[].value` values as strings. The
@@ -82,6 +82,6 @@ express those settings as Compose environment deltas.
 - `deploy/docker/services/analytics/video-analytics-api/configs/vss-video-analytics-api-config.json`
 - `services/analytics/video-analytics-api/configs/default-configs/config.json`
 - `deploy/docker/services/infra/compose.yml`
-- `deploy/docker/services/ingress/haproxy.cfg`
+- `deploy/docker/services/infra/haproxy/haproxy.cfg.template`
 - `skills/deployment/vss-setup-video-analytics-api/references/configuration.md`
 - `skills/deployment/vss-setup-video-analytics-api/references/deploy-video-analytics-api-service.md`


### PR DESCRIPTION
…capabilities and configuration

This commit introduces a new markdown file detailing the capabilities, required peers, API surface, and configuration options for the Video Analytics API. It outlines the service's dependencies, operational requirements, and environment variables necessary for deployment, ensuring clarity for developers integrating this service.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
