### PR TITLE
fix(agent-ui): wait for VST to list added RTSP streams and uploaded videos

### DIFF
--- a/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/__tests__/components/AddRtspDialog.test.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/__tests__/components/AddRtspDialog.test.tsx
@@ -234,6 +234,36 @@ describe('AddRtspDialog — waits for VST to list the added stream', () => {
     expect(onAwaitStream).toHaveBeenCalledTimes(2);
   });
 
+  // A second accepted URL must not forget the first. Reverting the field and
+  // re-POSTing would be a duplicate of a sensor VST already holds.
+  it('resumes the wait for an earlier URL after a later URL also times out', async () => {
+    const onAwaitStream = jest.fn(async () => ({ found: false }));
+    mockAddRtspStream
+      .mockResolvedValueOnce({ sensorId: 'sensor-first' })
+      .mockResolvedValueOnce({ sensorId: 'sensor-second' });
+    renderDialog({ onAwaitStream });
+
+    fillUrl();
+    await act(async () => {
+      fireEvent.click(submitButton());
+    });
+
+    fillUrl('rtsp://cam.example.com:554/cam02');
+    await act(async () => {
+      fireEvent.click(submitButton());
+    });
+    expect(mockAddRtspStream).toHaveBeenCalledTimes(2);
+
+    fillUrl();
+    expect(submitButton()).toHaveTextContent('Retry');
+    await act(async () => {
+      fireEvent.click(submitButton());
+    });
+
+    expect(mockAddRtspStream).toHaveBeenCalledTimes(2);
+    expect(onAwaitStream).toHaveBeenLastCalledWith('sensor-first');
+  });
+
   it('surfaces an add failure without waiting on a sensor it never got', async () => {
     mockAddRtspStream.mockRejectedValueOnce(
       new Error('{"error_code":"InvalidParameterError","error_message":"sensor exists"}'),

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/__tests__/components/AddRtspDialog.test.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/__tests__/components/AddRtspDialog.test.tsx
@@ -149,6 +149,88 @@ describe('AddRtspDialog — waits for VST to list the added stream', () => {
     expect(props.onSuccess).toHaveBeenCalledTimes(1);
   });
 
+  // The timeout leaves the fields editable. An acceptance carried over to an
+  // edited URL would confirm the old sensor and close over a stream that was
+  // never added.
+  it('adds afresh when the URL is edited after a listing timeout', async () => {
+    const onAwaitStream = jest
+      .fn<Promise<{ found: boolean }>, [string]>()
+      .mockResolvedValueOnce({ found: false })
+      .mockResolvedValueOnce({ found: true });
+    mockAddRtspStream
+      .mockResolvedValueOnce({ sensorId: 'sensor-first' })
+      .mockResolvedValueOnce({ sensorId: 'sensor-second' });
+    const { props } = renderDialog({ onAwaitStream });
+
+    fillUrl();
+    await act(async () => {
+      fireEvent.click(submitButton());
+    });
+    expect(screen.getByTestId('add-rtsp-error')).toBeInTheDocument();
+
+    fillUrl('rtsp://cam.example.com:554/cam02');
+    // No longer a retry of the accepted sensor
+    expect(submitButton()).toHaveTextContent('Add RTSP');
+
+    await act(async () => {
+      fireEvent.click(submitButton());
+    });
+
+    expect(mockAddRtspStream).toHaveBeenCalledTimes(2);
+    expect(mockAddRtspStream).toHaveBeenLastCalledWith(
+      props.vstApiUrl,
+      { sensorUrl: 'rtsp://cam.example.com:554/cam02', name: 'cam02' },
+    );
+    expect(onAwaitStream).toHaveBeenLastCalledWith('sensor-second');
+  });
+
+  it('adds afresh when only the sensor name is edited after a listing timeout', async () => {
+    const onAwaitStream = jest.fn(async () => ({ found: false }));
+    const { props } = renderDialog({ onAwaitStream });
+
+    fillUrl();
+    await act(async () => {
+      fireEvent.click(submitButton());
+    });
+
+    fireEvent.change(screen.getByLabelText(/Sensor Name/), {
+      target: { value: 'Renamed Camera' },
+    });
+    expect(submitButton()).toHaveTextContent('Add RTSP');
+
+    await act(async () => {
+      fireEvent.click(submitButton());
+    });
+
+    expect(mockAddRtspStream).toHaveBeenCalledTimes(2);
+    expect(mockAddRtspStream).toHaveBeenLastCalledWith(
+      props.vstApiUrl,
+      { sensorUrl: RTSP_URL, name: 'Renamed Camera' },
+    );
+  });
+
+  // Editing back to the accepted values should not force a duplicate add
+  it('resumes the wait when an edit is reverted to the accepted values', async () => {
+    const onAwaitStream = jest.fn(async () => ({ found: false }));
+    renderDialog({ onAwaitStream });
+
+    fillUrl();
+    await act(async () => {
+      fireEvent.click(submitButton());
+    });
+
+    fillUrl('rtsp://cam.example.com:554/cam02');
+    fillUrl();
+    expect(submitButton()).toHaveTextContent('Retry');
+
+    await act(async () => {
+      fireEvent.click(submitButton());
+    });
+
+    expect(mockAddRtspStream).toHaveBeenCalledTimes(1);
+    expect(onAwaitStream).toHaveBeenCalledTimes(2);
+  });
+
   it('surfaces an add failure without waiting on a sensor it never got', async () => {
     mockAddRtspStream.mockRejectedValueOnce(
       new Error('{"error_code":"InvalidParameterError","error_message":"sensor exists"}'),
@@ -197,6 +279,43 @@ describe('AddRtspDialog — waits for VST to list the added stream', () => {
     // The abandoned wait must not write back into a dialog the user closed
     await act(async () => {
       wait.resolve({ found: false });
+    });
+    expect(props.onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('closes on Escape when idle', () => {
+    const { props } = renderDialog();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores Escape during the add call and honours it during the wait', async () => {
+    const add = deferred<{ sensorId: string }>();
+    const wait = deferred<{ found: boolean }>();
+    mockAddRtspStream.mockImplementationOnce(() => add.promise);
+    const { props } = renderDialog({ onAwaitStream: jest.fn(() => wait.promise) });
+
+    fillUrl();
+    await act(async () => {
+      fireEvent.click(submitButton());
+    });
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(props.onClose).not.toHaveBeenCalled();
+
+    await act(async () => {
+      add.resolve({ sensorId: 'sensor-new' });
+    });
+    await act(async () => {
+      fireEvent.keyDown(document, { key: 'Escape' });
+    });
+
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      wait.resolve({ found: true });
     });
     expect(props.onSuccess).not.toHaveBeenCalled();
   });

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/__tests__/components/AddRtspDialog.test.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/__tests__/components/AddRtspDialog.test.tsx
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: MIT
+import React from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { AddRtspDialog } from '../../lib-src/components/AddRtspDialog';
+
+const mockAddRtspStream = jest.fn(async () => ({ sensorId: 'sensor-new' }));
+
+jest.mock('../../lib-src/rtspStream', () => ({
+  addRtspStream: (...args: unknown[]) => mockAddRtspStream(...(args as [])),
+}));
+
+const RTSP_URL = 'rtsp://cam.example.com:554/cam01';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const defaultProps = {
+  isOpen: true,
+  vstApiUrl: 'https://vst.example.com/vst/api',
+  onClose: jest.fn(),
+  onSuccess: jest.fn(),
+  onAwaitStream: jest.fn(async () => ({ found: true })),
+};
+
+function renderDialog(props: Partial<Parameters<typeof AddRtspDialog>[0]> = {}) {
+  const merged = { ...defaultProps, ...props };
+  const utils = render(<AddRtspDialog {...merged} />);
+  return { ...utils, props: merged };
+}
+
+function fillUrl(url = RTSP_URL) {
+  // Sensor Name auto-fills from the URL's last path segment
+  fireEvent.change(screen.getByPlaceholderText(/^rtsp:\/\/cam-warehouse/), {
+    target: { value: url },
+  });
+}
+
+const submitButton = () => screen.getByRole('button', { name: /Add RTSP|Waiting for VST|Adding|Retry/ });
+
+// The add call answers with a sensorId before VST lists the sensor. Closing on
+// that answer left the grid without the stream the user just added, until a
+// manual refresh or a tab switch.
+describe('AddRtspDialog — waits for VST to list the added stream', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAddRtspStream.mockResolvedValue({ sensorId: 'sensor-new' });
+  });
+
+  it('stays open while VST has not listed the stream yet', async () => {
+    const wait = deferred<{ found: boolean }>();
+    const onAwaitStream = jest.fn(() => wait.promise);
+    const { props } = renderDialog({ onAwaitStream });
+
+    fillUrl();
+    await act(async () => {
+      fireEvent.click(submitButton());
+    });
+
+    expect(onAwaitStream).toHaveBeenCalledWith('sensor-new');
+    expect(screen.getByTestId('add-rtsp-dialog')).toBeInTheDocument();
+    expect(screen.getByTestId('add-rtsp-confirming')).toBeInTheDocument();
+    expect(props.onClose).not.toHaveBeenCalled();
+    expect(props.onSuccess).not.toHaveBeenCalled();
+
+    await act(async () => {
+      wait.resolve({ found: true });
+    });
+
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+    expect(props.onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the submit button busy for the whole wait, not just the add call', async () => {
+    const wait = deferred<{ found: boolean }>();
+    renderDialog({ onAwaitStream: jest.fn(() => wait.promise) });
+
+    fillUrl();
+    await act(async () => {
+      fireEvent.click(submitButton());
+    });
+
+    expect(submitButton()).toBeDisabled();
+    expect(submitButton()).toHaveTextContent('Waiting for VST...');
+
+    await act(async () => {
+      wait.resolve({ found: true });
+    });
+  });
+
+  it('closes and reports success once VST lists the stream', async () => {
+    const { props } = renderDialog();
+
+    fillUrl();
+    await act(async () => {
+      fireEvent.click(submitButton());
+    });
+
+    await waitFor(() => expect(props.onClose).toHaveBeenCalledTimes(1));
+    expect(props.onSuccess).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId('add-rtsp-error')).not.toBeInTheDocument();
+  });
+
+  it('stays open with a retry message when VST never lists the stream', async () => {
+    const { props } = renderDialog({ onAwaitStream: jest.fn(async () => ({ found: false })) });
+
+    fillUrl();
+    await act(async () => {
+      fireEvent.click(submitButton());
+    });
+
+    expect(screen.getByTestId('add-rtsp-dialog')).toBeInTheDocument();
+    expect(screen.getByTestId('add-rtsp-error')).toHaveTextContent(
+      'VST accepted the stream but has not listed it yet. Retry to check again.',
+    );
+    expect(props.onClose).not.toHaveBeenCalled();
+    expect(props.onSuccess).not.toHaveBeenCalled();
+    expect(submitButton()).toHaveTextContent('Retry');
+  });
+
+  // Re-sending the add would come back as a duplicate URL, reading as a failure
+  // for a sensor VST already holds.
+  it('retries only the wait, never a second add, once VST accepted the sensor', async () => {
+    const onAwaitStream = jest
+      .fn<Promise<{ found: boolean }>, [string]>()
+      .mockResolvedValueOnce({ found: false })
+      .mockResolvedValueOnce({ found: true });
+    const { props } = renderDialog({ onAwaitStream });
+
+    fillUrl();
+    await act(async () => {
+      fireEvent.click(submitButton());
+    });
+    expect(screen.getByTestId('add-rtsp-error')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(submitButton());
+    });
+
+    expect(mockAddRtspStream).toHaveBeenCalledTimes(1);
+    expect(onAwaitStream).toHaveBeenNthCalledWith(2, 'sensor-new');
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+    expect(props.onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces an add failure without waiting on a sensor it never got', async () => {
+    mockAddRtspStream.mockRejectedValueOnce(
+      new Error('{"error_code":"InvalidParameterError","error_message":"sensor exists"}'),
+    );
+    const onAwaitStream = jest.fn(async () => ({ found: true }));
+    const { props } = renderDialog({ onAwaitStream });
+
+    fillUrl();
+    await act(async () => {
+      fireEvent.click(submitButton());
+    });
+
+    expect(onAwaitStream).not.toHaveBeenCalled();
+    expect(screen.getByTestId('add-rtsp-error')).toHaveTextContent(
+      'A sensor with this RTSP URL already exists.',
+    );
+    expect(props.onClose).not.toHaveBeenCalled();
+    // A failed add leaves nothing accepted, so the next click must add again
+    expect(submitButton()).toHaveTextContent('Add RTSP');
+  });
+
+  it('blocks dismissal during the add call but allows abandoning the wait', async () => {
+    const wait = deferred<{ found: boolean }>();
+    const add = deferred<{ sensorId: string }>();
+    mockAddRtspStream.mockImplementationOnce(() => add.promise);
+    const { props } = renderDialog({ onAwaitStream: jest.fn(() => wait.promise) });
+
+    fillUrl();
+    await act(async () => {
+      fireEvent.click(submitButton());
+    });
+
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+
+    await act(async () => {
+      add.resolve({ sensorId: 'sensor-new' });
+    });
+
+    const cancel = screen.getByRole('button', { name: 'Cancel' });
+    expect(cancel).not.toBeDisabled();
+    await act(async () => {
+      fireEvent.click(cancel);
+    });
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+
+    // The abandoned wait must not write back into a dialog the user closed
+    await act(async () => {
+      wait.resolve({ found: false });
+    });
+    expect(props.onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('closes on success when no wait callback is wired', async () => {
+    const { props } = renderDialog({ onAwaitStream: undefined });
+
+    fillUrl();
+    await act(async () => {
+      fireEvent.click(submitButton());
+    });
+
+    await waitFor(() => expect(props.onClose).toHaveBeenCalledTimes(1));
+    expect(props.onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an invalid URL before calling VST', async () => {
+    renderDialog();
+
+    fillUrl('http://cam.example.com/stream');
+    await act(async () => {
+      fireEvent.click(submitButton());
+    });
+
+    expect(mockAddRtspStream).not.toHaveBeenCalled();
+    expect(screen.getByTestId('add-rtsp-error')).toHaveTextContent(
+      'RTSP URL must start with "rtsp://".',
+    );
+  });
+});

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/__tests__/components/AddRtspDialog.test.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/__tests__/components/AddRtspDialog.test.tsx
@@ -184,8 +184,13 @@ describe('AddRtspDialog — waits for VST to list the added stream', () => {
     expect(onAwaitStream).toHaveBeenLastCalledWith('sensor-second');
   });
 
-  it('adds afresh when only the sensor name is edited after a listing timeout', async () => {
-    const onAwaitStream = jest.fn(async () => ({ found: false }));
+  // VST keys sensors on the URL. A name-only edit is still the same stream;
+  // re-POSTing it would come back as a duplicate.
+  it('resumes the wait when only the sensor name is edited after a listing timeout', async () => {
+    const onAwaitStream = jest
+      .fn<Promise<{ found: boolean }>, [string]>()
+      .mockResolvedValueOnce({ found: false })
+      .mockResolvedValueOnce({ found: true });
     const { props } = renderDialog({ onAwaitStream });
 
     fillUrl();
@@ -196,17 +201,15 @@ describe('AddRtspDialog — waits for VST to list the added stream', () => {
     fireEvent.change(screen.getByLabelText(/Sensor Name/), {
       target: { value: 'Renamed Camera' },
     });
-    expect(submitButton()).toHaveTextContent('Add RTSP');
+    expect(submitButton()).toHaveTextContent('Retry');
 
     await act(async () => {
       fireEvent.click(submitButton());
     });
 
-    expect(mockAddRtspStream).toHaveBeenCalledTimes(2);
-    expect(mockAddRtspStream).toHaveBeenLastCalledWith(
-      props.vstApiUrl,
-      { sensorUrl: RTSP_URL, name: 'Renamed Camera' },
-    );
+    expect(mockAddRtspStream).toHaveBeenCalledTimes(1);
+    expect(onAwaitStream).toHaveBeenNthCalledWith(2, 'sensor-new');
+    expect(props.onClose).toHaveBeenCalledTimes(1);
   });
 
   // Editing back to the accepted values should not force a duplicate add

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/__tests__/components/VideoManagementComponent.test.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/__tests__/components/VideoManagementComponent.test.tsx
@@ -356,6 +356,142 @@ describe('VideoManagementComponent — video playback', () => {
   });
 });
 
+// Same lag as Add RTSP: VST answers the last chunk before the uploaded file's
+// sensor appears in its streams listing, so "Done" used to be able to precede
+// the grid actually holding the video.
+describe('VideoManagementComponent — upload waits for VST to list the file', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStreamsList = [videoStream, rtspStream];
+    lastUploadDialogProps = null;
+    lastUploadProgressPopupProps = null;
+    lastUploadSuccessPopupProps = null;
+    mockChunkedUpload.mockResolvedValue({ sensorId: 'upload-sensor' });
+    mockWaitUntilStreamAdded.mockResolvedValue({ found: true });
+  });
+
+  const uploadOneFile = async (id = 'upload-1', name = 'clip.mp4') => {
+    const file = new File(['data'], name, { type: 'video/mp4' });
+    await act(async () => {
+      lastUploadDialogProps.onConfirm([{ id, file, uploadFilename: name, formData: {} }]);
+    });
+  };
+
+  function deferWait() {
+    let settle: (value: { found: boolean }) => void = () => {};
+    mockWaitUntilStreamAdded.mockImplementationOnce(
+      () => new Promise<{ found: boolean }>((resolve) => { settle = resolve; }),
+    );
+    return () => settle({ found: true });
+  }
+
+  it('keeps the file in flight until VST lists the uploaded sensor', async () => {
+    const settleWait = deferWait();
+
+    renderComponent();
+    await uploadOneFile();
+
+    expect(mockWaitUntilStreamAdded).toHaveBeenCalledWith('upload-sensor');
+    // Parked at 100% rather than reported Done
+    expect(lastUploadProgressPopupProps.files[0]).toEqual(
+      expect.objectContaining({ uploadStatus: 'uploading', uploadProgress: 100 }),
+    );
+    expect(screen.queryByTestId('upload-success-popup')).not.toBeInTheDocument();
+
+    await act(async () => {
+      settleWait();
+    });
+
+    await waitFor(() => expect(screen.getByTestId('upload-success-popup')).toBeInTheDocument());
+    expect(lastUploadSuccessPopupProps.results).toEqual([
+      { filename: 'clip.mp4', result: { status: 'success' } },
+    ]);
+  });
+
+  it('reports success with the listing caveat when VST never lists the file', async () => {
+    mockWaitUntilStreamAdded.mockResolvedValueOnce({ found: false });
+
+    renderComponent();
+    await uploadOneFile();
+
+    await waitFor(() => expect(screen.getByTestId('upload-success-popup')).toBeInTheDocument());
+    expect(lastUploadSuccessPopupProps.results[0]).toEqual({
+      filename: 'clip.mp4',
+      result: {
+        status: 'success',
+        vst_listing: 'pending',
+        note: expect.stringContaining('has not listed it yet'),
+      },
+    });
+  });
+
+  // The bytes are in VST by then, so cancelling only abandons the listing wait
+  it('settles a file cancelled mid-wait as success, not cancelled', async () => {
+    const settleWait = deferWait();
+
+    renderComponent();
+    await uploadOneFile();
+
+    await act(async () => {
+      lastUploadProgressPopupProps.onCancelAll();
+    });
+    // A wait that lands after the cancel must not overwrite that outcome
+    await act(async () => {
+      settleWait();
+    });
+
+    await waitFor(() => expect(screen.getByTestId('upload-success-popup')).toBeInTheDocument());
+    const [result] = lastUploadSuccessPopupProps.results;
+    expect(result.cancelled).toBeUndefined();
+    expect(result.error).toBeUndefined();
+    expect(result.result).toEqual(expect.objectContaining({ vst_listing: 'pending' }));
+  });
+
+  it('settles a per-file cancel mid-wait the same way', async () => {
+    const settleWait = deferWait();
+
+    renderComponent();
+    await uploadOneFile('single-cancel');
+
+    await act(async () => {
+      lastUploadProgressPopupProps.onCancelSingle('single-cancel');
+    });
+    await act(async () => {
+      settleWait();
+    });
+
+    await waitFor(() => expect(screen.getByTestId('upload-success-popup')).toBeInTheDocument());
+    const [result] = lastUploadSuccessPopupProps.results;
+    expect(result.cancelled).toBeUndefined();
+    expect(result.result).toEqual(expect.objectContaining({ vst_listing: 'pending' }));
+  });
+
+  it('does not wait when the upload response carries no sensorId', async () => {
+    mockChunkedUpload.mockResolvedValueOnce({} as { sensorId: string });
+
+    renderComponent();
+    await uploadOneFile();
+
+    await waitFor(() => expect(screen.getByTestId('upload-success-popup')).toBeInTheDocument());
+    expect(mockWaitUntilStreamAdded).not.toHaveBeenCalled();
+    expect(lastUploadSuccessPopupProps.results[0].result).toEqual({ status: 'success' });
+  });
+
+  it('reports an upload that fails outright as an error, not a listing caveat', async () => {
+    mockChunkedUpload.mockRejectedValueOnce(new Error('chunk 3 failed'));
+
+    renderComponent();
+    await uploadOneFile();
+
+    await waitFor(() => expect(screen.getByTestId('upload-success-popup')).toBeInTheDocument());
+    expect(mockWaitUntilStreamAdded).not.toHaveBeenCalled();
+    expect(lastUploadSuccessPopupProps.results[0]).toEqual({
+      filename: 'clip.mp4',
+      error: 'chunk 3 failed',
+    });
+  });
+});
+
 // NVBug 6243148: selecting an RTSP stream and an uploaded video together and
 // hitting Select All → Delete left the RTSP entry in the grid, stale and
 // unplayable, because VST's stream list still reported it when the UI refetched.

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/__tests__/components/VideoManagementComponent.test.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/__tests__/components/VideoManagementComponent.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import React from 'react';
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react';
 import { VideoManagementComponent } from '../../lib-src/VideoManagementComponent';
 import { videoStream, rtspStream } from '../helpers/streamFixtures';
 
@@ -64,10 +64,13 @@ const mockTimelines = new Map([
 let mockStreamsList = [videoStream, rtspStream];
 const mockRefetch = jest.fn(() => Promise.resolve());
 const mockWaitUntilStreamsRemoved = jest.fn(async () => ({ remainingSensorIds: [] as string[] }));
+const mockWaitUntilStreamAdded = jest.fn(async () => ({ found: true }));
+const mockAddRtspStream = jest.fn(() => Promise.resolve({ sensorId: 'sensor-new' }));
 const mockDeleteRtspStream = jest.fn(() => Promise.resolve({ status: 'success' }));
 const mockDeleteVideo = jest.fn(() => Promise.resolve({ status: 'success' }));
 
 jest.mock('../../lib-src/rtspStream', () => ({
+  addRtspStream: (...args: unknown[]) => mockAddRtspStream(...(args as [])),
   deleteRtspStream: (...args: unknown[]) => mockDeleteRtspStream(...(args as [])),
 }));
 
@@ -82,6 +85,7 @@ jest.mock('../../lib-src/hooks', () => ({
     error: null,
     refetch: mockRefetch,
     waitUntilStreamsRemoved: mockWaitUntilStreamsRemoved,
+    waitUntilStreamAdded: mockWaitUntilStreamAdded,
   }),
   useStorageTimelines: () => ({
     timelines: mockTimelines,
@@ -632,6 +636,80 @@ describe('VideoManagementComponent — Select All delete of mixed RTSP and uploa
 
     expect(mockDeleteRtspStream).toHaveBeenCalledTimes(1);
     expect(mockDeleteVideo).not.toHaveBeenCalled();
+  });
+});
+
+// Add RTSP used to close on VST's add response, which precedes the sensor
+// showing up in the streams listing — the grid was left without the camera the
+// user had just added until a manual refresh or a tab switch.
+describe('VideoManagementComponent — Add RTSP waits for VST to list the stream', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStreamsList = [videoStream, rtspStream];
+    mockAddRtspStream.mockResolvedValue({ sensorId: 'sensor-new' });
+    mockWaitUntilStreamAdded.mockResolvedValue({ found: true });
+  });
+
+  const addRtspButton = () => screen.getByRole('button', { name: '+ Add RTSP' });
+
+  async function submitRtsp() {
+    await act(async () => {
+      fireEvent.click(addRtspButton());
+    });
+    fireEvent.change(screen.getByPlaceholderText(/^rtsp:\/\/cam-warehouse/), {
+      target: { value: 'rtsp://cam.example.com:554/cam01' },
+    });
+    // The toolbar's "+ Add RTSP" trigger stays in the DOM, so scope to the dialog
+    const dialog = within(screen.getByTestId('add-rtsp-dialog'));
+    await act(async () => {
+      fireEvent.click(dialog.getByRole('button', { name: 'Add RTSP' }));
+    });
+  }
+
+  it('polls the streams listing for the new sensor before closing the dialog', async () => {
+    renderComponent();
+    await submitRtsp();
+
+    expect(mockWaitUntilStreamAdded).toHaveBeenCalledWith('sensor-new');
+    expect(screen.queryByTestId('add-rtsp-dialog')).not.toBeInTheDocument();
+  });
+
+  it('holds the dialog open while the listing has yet to catch up', async () => {
+    let settleWait: (value: { found: boolean }) => void = () => {};
+    mockWaitUntilStreamAdded.mockImplementationOnce(
+      () => new Promise<{ found: boolean }>((resolve) => { settleWait = resolve; }),
+    );
+
+    renderComponent();
+    await submitRtsp();
+
+    expect(screen.getByTestId('add-rtsp-dialog')).toBeInTheDocument();
+    expect(screen.getByTestId('add-rtsp-confirming')).toBeInTheDocument();
+
+    await act(async () => {
+      settleWait({ found: true });
+    });
+
+    expect(screen.queryByTestId('add-rtsp-dialog')).not.toBeInTheDocument();
+  });
+
+  it('keeps the dialog open with a retry when the listing never catches up', async () => {
+    mockWaitUntilStreamAdded.mockResolvedValueOnce({ found: false });
+
+    renderComponent();
+    await submitRtsp();
+
+    expect(screen.getByTestId('add-rtsp-dialog')).toBeInTheDocument();
+    expect(screen.getByTestId('add-rtsp-error')).toHaveTextContent('has not listed it yet');
+
+    // Retry re-polls the same accepted sensor instead of adding it again
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    });
+
+    expect(mockAddRtspStream).toHaveBeenCalledTimes(1);
+    expect(mockWaitUntilStreamAdded).toHaveBeenCalledTimes(2);
+    expect(screen.queryByTestId('add-rtsp-dialog')).not.toBeInTheDocument();
   });
 });
 

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/__tests__/hooks/useStreams.test.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/__tests__/hooks/useStreams.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { useStreams } from '../../lib-src/hooks/useStreams';
-import { DELETED_STREAM_POLL_DELAYS_MS } from '../../lib-src/constants';
+import { ADDED_STREAM_POLL_DELAYS_MS, DELETED_STREAM_POLL_DELAYS_MS } from '../../lib-src/constants';
 import type { StreamInfo } from '../../lib-src/types';
 import { videoStream, rtspStream } from '../helpers/streamFixtures';
 
@@ -199,6 +199,133 @@ describe('useStreams — waitUntilStreamsRemoved', () => {
 
     expect(waitResult).toEqual({ remainingSensorIds: [] });
     expect(result.current.streams).toHaveLength(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// VST answers the add-sensor call before the sensor turns up in its streams
+// listing, so the Add RTSP dialog has to wait on the listing, not the add.
+describe('useStreams — waitUntilStreamAdded', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('resolves immediately when VST already lists the sensor', async () => {
+    const fetchMock = mockVstStreams([videoStream], [videoStream, rtspStream]);
+
+    const { result } = renderHook(() => useStreams({ vstApiUrl: VST_API_URL }));
+    await waitFor(() => expect(result.current.streams).toHaveLength(1));
+
+    let waitResult: { found: boolean } | undefined;
+    await act(async () => {
+      waitResult = await result.current.waitUntilStreamAdded(rtspStream.sensorId);
+    });
+
+    expect(waitResult).toEqual({ found: true });
+    expect(names(result.current.streams)).toEqual([videoStream.name, rtspStream.name]);
+    // Initial load + the immediate check, no delayed poll needed
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('polls until VST lists the sensor, updating the grid on the way', async () => {
+    const fetchMock = mockVstStreams(
+      [videoStream],
+      [videoStream],
+      [videoStream, rtspStream],
+    );
+
+    const { result } = renderHook(() => useStreams({ vstApiUrl: VST_API_URL }));
+    await waitFor(() => expect(result.current.streams).toHaveLength(1));
+
+    let waitResult: { found: boolean } | undefined;
+    await act(async () => {
+      const pending = result.current.waitUntilStreamAdded(rtspStream.sensorId);
+      await jest.advanceTimersByTimeAsync(ADDED_STREAM_POLL_DELAYS_MS[0]);
+      waitResult = await pending;
+    });
+
+    expect(waitResult).toEqual({ found: true });
+    expect(names(result.current.streams)).toEqual([videoStream.name, rtspStream.name]);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('reports not found when the poll budget is exhausted', async () => {
+    mockVstStreams([videoStream]);
+
+    const { result } = renderHook(() => useStreams({ vstApiUrl: VST_API_URL }));
+    await waitFor(() => expect(result.current.streams).toHaveLength(1));
+
+    let waitResult: { found: boolean } | undefined;
+    await act(async () => {
+      const pending = result.current.waitUntilStreamAdded(rtspStream.sensorId);
+      await jest.advanceTimersByTimeAsync(
+        ADDED_STREAM_POLL_DELAYS_MS.reduce((sum, d) => sum + d, 0),
+      );
+      waitResult = await pending;
+    });
+
+    expect(waitResult).toEqual({ found: false });
+  });
+
+  it('keeps polling when one poll fails and a later one lists the sensor', async () => {
+    let call = 0;
+    const responses: (StreamInfo[] | 'error')[] = [
+      [videoStream],                // initial load
+      'error',                      // immediate check fails
+      [videoStream, rtspStream],    // next poll lists it
+    ];
+    globalThis.fetch = jest.fn(async () => {
+      const next = responses[Math.min(call, responses.length - 1)];
+      call += 1;
+      if (next === 'error') throw new Error('transient failure');
+      return { ok: true, json: async () => streamsPayload(next) } as Response;
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useStreams({ vstApiUrl: VST_API_URL }));
+    await waitFor(() => expect(result.current.streams).toHaveLength(1));
+
+    let waitResult: { found: boolean } | undefined;
+    await act(async () => {
+      const pending = result.current.waitUntilStreamAdded(rtspStream.sensorId);
+      await jest.advanceTimersByTimeAsync(ADDED_STREAM_POLL_DELAYS_MS[0]);
+      waitResult = await pending;
+    });
+
+    expect(waitResult).toEqual({ found: true });
+  });
+
+  it('keeps poll fetches out of the loading state', async () => {
+    mockVstStreams([videoStream], [videoStream, rtspStream]);
+
+    const { result } = renderHook(() => useStreams({ vstApiUrl: VST_API_URL }));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.waitUntilStreamAdded(rtspStream.sensorId);
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('does nothing without a sensor id', async () => {
+    const fetchMock = mockVstStreams([videoStream]);
+
+    const { result } = renderHook(() => useStreams({ vstApiUrl: VST_API_URL }));
+    await waitFor(() => expect(result.current.streams).toHaveLength(1));
+
+    let waitResult: { found: boolean } | undefined;
+    await act(async () => {
+      waitResult = await result.current.waitUntilStreamAdded('');
+      await jest.advanceTimersByTimeAsync(20_000);
+    });
+
+    expect(waitResult).toEqual({ found: false });
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/VideoManagementComponent.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/VideoManagementComponent.tsx
@@ -110,7 +110,14 @@ export const VideoManagementComponent: React.FC<VideoManagementComponentProps> =
     if (!enableVideoUpload) setShowVideos(false);
   }, [enableVideoUpload]);
 
-  const { streams, isLoading, error, refetch, waitUntilStreamsRemoved } = useStreams({ vstApiUrl });
+  const {
+    streams,
+    isLoading,
+    error,
+    refetch,
+    waitUntilStreamsRemoved,
+    waitUntilStreamAdded,
+  } = useStreams({ vstApiUrl });
   const {
     getEndTimeForStream,
     getTimelineRangeForStream,
@@ -421,6 +428,15 @@ export const VideoManagementComponent: React.FC<VideoManagementComponentProps> =
   const handleRtspDialogClose = () => {
     setIsRtspModalOpen(false);
   };
+
+  // VST accepts the add before its streams list includes the sensor. Hold the
+  // dialog open until the list agrees, so the grid it uncovers already shows
+  // the stream the user just added.
+  const handleAwaitRtspStream = useCallback(async (sensorId: string) => {
+    const result = await waitUntilStreamAdded(sensorId);
+    void refetchTimelinesRef.current();
+    return result;
+  }, [waitUntilStreamAdded]);
 
   const handleRtspSuccess = useCallback(() => {
     refetchRef.current();
@@ -801,6 +817,7 @@ export const VideoManagementComponent: React.FC<VideoManagementComponentProps> =
           vstApiUrl={vstApiUrl}
           onClose={handleRtspDialogClose}
           onSuccess={handleRtspSuccess}
+          onAwaitStream={handleAwaitRtspStream}
         />
 
         <DeleteConfirmDialog

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/VideoManagementComponent.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/VideoManagementComponent.tsx
@@ -31,6 +31,27 @@ import {
 
 export type { VideoManagementComponentProps, VideoManagementSidebarControlHandlers } from './types';
 
+// The bytes are in VST either way, so this is not an upload failure — but the
+// grid may not show the file yet, which is what the user needs to know.
+const UNCONFIRMED_UPLOAD_NOTE =
+  'Uploaded, but VST has not listed it yet. Refresh the Video Management tab to check.';
+
+const asUnconfirmedSuccess = (upload: UploadProgress): UploadProgress => ({
+  ...upload,
+  status: 'success',
+  progress: 100,
+  unconfirmed: UNCONFIRMED_UPLOAD_NOTE,
+});
+
+// Cancelling cannot un-upload a file VST has already taken; it only stops the
+// wait on that file's listing. So a `confirming` file settles as the success it
+// is, carrying the caveat that the grid may not show it yet.
+const settleOnCancel = (upload: UploadProgress): UploadProgress =>
+  upload.status === 'confirming' ? asUnconfirmedSuccess(upload) : { ...upload, status: 'cancelled' };
+
+const isCancellableUpload = (status: UploadProgress['status']) =>
+  status === 'pending' || status === 'uploading' || status === 'processing' || status === 'confirming';
+
 export const VideoManagementComponent: React.FC<VideoManagementComponentProps> = ({
   videoManagementData,
   renderControlsInLeftSidebar = false,
@@ -139,12 +160,14 @@ export const VideoManagementComponent: React.FC<VideoManagementComponentProps> =
 
   const refetchRef = useRef(refetch);
   const refetchTimelinesRef = useRef(refetchTimelines);
+  const waitUntilStreamAddedRef = useRef(waitUntilStreamAdded);
   const vstApiUrlRef = useRef(vstApiUrl);
 
   useEffect(() => {
     refetchRef.current = refetch;
     refetchTimelinesRef.current = refetchTimelines;
-  }, [refetch, refetchTimelines]);
+    waitUntilStreamAddedRef.current = waitUntilStreamAdded;
+  }, [refetch, refetchTimelines, waitUntilStreamAdded]);
 
   useEffect(() => {
     vstApiUrlRef.current = vstApiUrl;
@@ -193,7 +216,7 @@ export const VideoManagementComponent: React.FC<VideoManagementComponentProps> =
           throw new Error('VST API URL not configured');
         }
         const uploadEndpoints = createApiEndpoints(vstApiUrl);
-        await chunkedUpload({
+        const uploaded = await chunkedUpload({
           file,
           fileName: requestFilename,
           uploadUrl: uploadEndpoints.UPLOAD_FILE,
@@ -214,11 +237,25 @@ export const VideoManagementComponent: React.FC<VideoManagementComponentProps> =
 
         if (!isSessionValid() || cancelledFileIdsRef.current.has(id)) return;
 
+        // VST answers the last chunk before the file's sensor turns up in its
+        // streams listing, the same lag the RTSP add hits. Hold the file in
+        // `confirming` until the listing agrees, so "Done" means the grid has it.
         setUploadProgress((prev) =>
-          prev.map((p) => (p.id === id && (p.status === 'uploading' || p.status === 'processing') ? {
+          prev.map((p) => (p.id === id && p.status === 'processing' ? { ...p, status: 'confirming' } : p))
+        );
+
+        const listed = uploaded?.sensorId
+          ? await waitUntilStreamAddedRef.current(uploaded.sensorId)
+          : { found: true };
+
+        if (!isSessionValid() || cancelledFileIdsRef.current.has(id)) return;
+
+        setUploadProgress((prev) =>
+          prev.map((p) => (p.id === id && (p.status === 'uploading' || p.status === 'processing' || p.status === 'confirming') ? {
             ...p,
             status: 'success',
             progress: 100,
+            ...(listed.found ? {} : { unconfirmed: UNCONFIRMED_UPLOAD_NOTE }),
           } : p))
         );
       } catch (err) {
@@ -229,11 +266,20 @@ export const VideoManagementComponent: React.FC<VideoManagementComponentProps> =
         const isCancelled = isAborted || cancelledFileIdsRef.current.has(id);
 
         setUploadProgress((prev) =>
-          prev.map((p) => (p.id === id && (p.status === 'uploading' || p.status === 'pending' || p.status === 'processing') ? {
-            ...p,
-            status: isCancelled ? 'cancelled' : 'error',
-            error: isCancelled ? undefined : errorMessage
-          } : p))
+          prev.map((p) => {
+            if (p.id !== id) return p;
+            // Only the listing wait can fail this late, and it failing does not
+            // take the file back out of VST. Reporting an upload error here would
+            // be wrong, and leaving it `confirming` would keep the popup up forever.
+            if (p.status === 'confirming') return asUnconfirmedSuccess(p);
+            return p.status === 'uploading' || p.status === 'pending' || p.status === 'processing'
+              ? {
+                ...p,
+                status: isCancelled ? 'cancelled' : 'error',
+                error: isCancelled ? undefined : errorMessage,
+              }
+              : p;
+          })
         );
       } finally {
         abortControllerMapRef.current.delete(id);
@@ -322,16 +368,15 @@ export const VideoManagementComponent: React.FC<VideoManagementComponentProps> =
   }, [uploadProgress]);
 
   const handleCancelSingleUpload = useCallback((fileId: string) => {
-    cancelledFileIdsRef.current.add(fileId);
-    abortControllerMapRef.current.get(fileId)?.abort();
-    abortControllerMapRef.current.delete(fileId);
+    // Only an unfinished transfer has anything to abort
+    if (uploadProgressRef.current.find((p) => p.id === fileId)?.status !== 'confirming') {
+      cancelledFileIdsRef.current.add(fileId);
+      abortControllerMapRef.current.get(fileId)?.abort();
+      abortControllerMapRef.current.delete(fileId);
+    }
 
     setUploadProgress((prev) =>
-      prev.map((p) =>
-        p.id === fileId && (p.status === 'pending' || p.status === 'uploading' || p.status === 'processing')
-          ? { ...p, status: 'cancelled' }
-          : p,
-      ),
+      prev.map((p) => (p.id === fileId && isCancellableUpload(p.status) ? settleOnCancel(p) : p)),
     );
   }, []);
 
@@ -348,16 +393,16 @@ export const VideoManagementComponent: React.FC<VideoManagementComponentProps> =
           cancelledFileIdsRef.current.add(p.id);
         }
       });
-      return prev.map((p) =>
-        p.status === 'pending' || p.status === 'uploading' || p.status === 'processing'
-          ? { ...p, status: 'cancelled' }
-          : p,
-      );
+      return prev.map((p) => (isCancellableUpload(p.status) ? settleOnCancel(p) : p));
     });
     setIsUploading(false);
 
-    const successCount = uploadProgressRef.current.filter((p) => p.status === 'success').length;
-    if (successCount > 0) {
+    // A `confirming` file is one VST accepted, so it counts toward the refresh
+    // even though its listing wait was just abandoned.
+    const settledCount = uploadProgressRef.current.filter(
+      (p) => p.status === 'success' || p.status === 'confirming',
+    ).length;
+    if (settledCount > 0) {
       await Promise.all([refetchRef.current(), refetchTimelinesRef.current()]);
     }
   }, []);
@@ -388,18 +433,28 @@ export const VideoManagementComponent: React.FC<VideoManagementComponentProps> =
 
   const uploadProgressPopupFiles = useMemo(
     () =>
-      uploadProgress.map((upload) => ({
-        id: upload.id,
-        displayName: upload.fileName,
-        uploadProgress: upload.status === 'processing' ? 100 : upload.progress,
-        uploadStatus: upload.status === 'processing' ? 'uploading' as const : upload.status as Exclude<UploadProgress['status'], 'processing'>,
-        uploadError: upload.error,
-      })),
+      uploadProgress.map((upload) => {
+        // The popup has no phase past `uploading`, so the server-side waits —
+        // VST processing the last chunk, then listing the sensor — both show as
+        // an in-flight file parked at 100%.
+        const isServerSideWait = upload.status === 'processing' || upload.status === 'confirming';
+        return {
+          id: upload.id,
+          displayName: upload.fileName,
+          uploadProgress: isServerSideWait ? 100 : upload.progress,
+          uploadStatus: isServerSideWait
+            ? 'uploading' as const
+            : upload.status as Exclude<UploadProgress['status'], 'processing' | 'confirming'>,
+          uploadError: upload.error,
+        };
+      }),
     [uploadProgress],
   );
 
   const hasActiveUploads = useMemo(
-    () => uploadProgress.some((u) => u.status === 'pending' || u.status === 'uploading' || u.status === 'processing'),
+    () => uploadProgress.some(
+      (u) => u.status === 'pending' || u.status === 'uploading' || u.status === 'processing' || u.status === 'confirming',
+    ),
     [uploadProgress],
   );
 
@@ -408,7 +463,12 @@ export const VideoManagementComponent: React.FC<VideoManagementComponentProps> =
 
     const results: UploadResultItem[] = uploadProgress.map((u) => {
       if (u.status === 'success') {
-        return { filename: u.fileName, result: { status: 'success' } };
+        return {
+          filename: u.fileName,
+          result: u.unconfirmed
+            ? { status: 'success', vst_listing: 'pending', note: u.unconfirmed }
+            : { status: 'success' },
+        };
       }
       if (u.status === 'cancelled') {
         return { filename: u.fileName, cancelled: true };

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/VideoManagementComponent.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/VideoManagementComponent.tsx
@@ -52,6 +52,37 @@ const settleOnCancel = (upload: UploadProgress): UploadProgress =>
 const isCancellableUpload = (status: UploadProgress['status']) =>
   status === 'pending' || status === 'uploading' || status === 'processing' || status === 'confirming';
 
+// `setUploadProgress` updaters, built out here so the per-file upload routine
+// stays readable and its callbacks stop nesting four deep.
+const toConfirming = (id: string) => (prev: UploadProgress[]): UploadProgress[] =>
+  prev.map((p) => (p.id === id && p.status === 'processing' ? { ...p, status: 'confirming' } : p));
+
+const isUploadInFlight = (status: UploadProgress['status']) =>
+  status === 'uploading' || status === 'processing' || status === 'confirming';
+
+const toUploadSuccess = (id: string, listed: boolean) => (prev: UploadProgress[]): UploadProgress[] =>
+  prev.map((p) => (p.id === id && isUploadInFlight(p.status)
+    ? { ...p, status: 'success', progress: 100, ...(listed ? {} : { unconfirmed: UNCONFIRMED_UPLOAD_NOTE }) }
+    : p));
+
+const toUploadFailure = (
+  id: string,
+  { cancelled, message }: { cancelled: boolean; message: string },
+) => (prev: UploadProgress[]): UploadProgress[] =>
+  prev.map((p) => {
+    if (p.id !== id) return p;
+    // Only the listing wait can fail this late, and it failing does not take the
+    // file back out of VST. Reporting an upload error here would be wrong, and
+    // leaving it `confirming` would keep the popup up forever.
+    if (p.status === 'confirming') return asUnconfirmedSuccess(p);
+    if (p.status !== 'pending' && !isUploadInFlight(p.status)) return p;
+    return {
+      ...p,
+      status: cancelled ? 'cancelled' : 'error',
+      error: cancelled ? undefined : message,
+    };
+  });
+
 export const VideoManagementComponent: React.FC<VideoManagementComponentProps> = ({
   videoManagementData,
   renderControlsInLeftSidebar = false,
@@ -240,9 +271,7 @@ export const VideoManagementComponent: React.FC<VideoManagementComponentProps> =
         // VST answers the last chunk before the file's sensor turns up in its
         // streams listing, the same lag the RTSP add hits. Hold the file in
         // `confirming` until the listing agrees, so "Done" means the grid has it.
-        setUploadProgress((prev) =>
-          prev.map((p) => (p.id === id && p.status === 'processing' ? { ...p, status: 'confirming' } : p))
-        );
+        setUploadProgress(toConfirming(id));
 
         const listed = uploaded?.sensorId
           ? await waitUntilStreamAddedRef.current(uploaded.sensorId)
@@ -250,14 +279,7 @@ export const VideoManagementComponent: React.FC<VideoManagementComponentProps> =
 
         if (!isSessionValid() || cancelledFileIdsRef.current.has(id)) return;
 
-        setUploadProgress((prev) =>
-          prev.map((p) => (p.id === id && (p.status === 'uploading' || p.status === 'processing' || p.status === 'confirming') ? {
-            ...p,
-            status: 'success',
-            progress: 100,
-            ...(listed.found ? {} : { unconfirmed: UNCONFIRMED_UPLOAD_NOTE }),
-          } : p))
-        );
+        setUploadProgress(toUploadSuccess(id, listed.found));
       } catch (err) {
         if (!isSessionValid()) return;
 
@@ -265,22 +287,7 @@ export const VideoManagementComponent: React.FC<VideoManagementComponentProps> =
         const isAborted = err instanceof Error && (err.name === 'AbortError' || err.message === 'Upload was cancelled');
         const isCancelled = isAborted || cancelledFileIdsRef.current.has(id);
 
-        setUploadProgress((prev) =>
-          prev.map((p) => {
-            if (p.id !== id) return p;
-            // Only the listing wait can fail this late, and it failing does not
-            // take the file back out of VST. Reporting an upload error here would
-            // be wrong, and leaving it `confirming` would keep the popup up forever.
-            if (p.status === 'confirming') return asUnconfirmedSuccess(p);
-            return p.status === 'uploading' || p.status === 'pending' || p.status === 'processing'
-              ? {
-                ...p,
-                status: isCancelled ? 'cancelled' : 'error',
-                error: isCancelled ? undefined : errorMessage,
-              }
-              : p;
-          })
-        );
+        setUploadProgress(toUploadFailure(id, { cancelled: isCancelled, message: errorMessage }));
       } finally {
         abortControllerMapRef.current.delete(id);
       }
@@ -494,7 +501,8 @@ export const VideoManagementComponent: React.FC<VideoManagementComponentProps> =
   // the stream the user just added.
   const handleAwaitRtspStream = useCallback(async (sensorId: string) => {
     const result = await waitUntilStreamAdded(sensorId);
-    void refetchTimelinesRef.current();
+    // Timeline fetches report failure through their own state, never a rejection
+    await refetchTimelinesRef.current();
     return result;
   }, [waitUntilStreamAdded]);
 

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/components/AddRtspDialog.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/components/AddRtspDialog.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { Button, TextInput } from '@nvidia/foundations-react-core';
 import { parseApiError } from '../utils';
 import { addRtspStream } from '../rtspStream';
@@ -15,22 +15,40 @@ interface AddRtspDialogProps {
   vstApiUrl?: string | null;
   onClose: () => void;
   onSuccess?: () => void;
+  /**
+   * Polls VST until it lists the sensor the add call returned. The dialog stays
+   * open until this resolves, so it never closes on a stream the grid has yet
+   * to receive.
+   */
+  onAwaitStream?: (sensorId: string) => Promise<{ found: boolean }>;
   /** `contained` = overlay only the nearest positioned ancestor (Video Management pane). Default `viewport` = full window. */
   overlay?: 'viewport' | 'contained';
 }
+
+type SubmitPhase = 'idle' | 'adding' | 'confirming';
 
 export const AddRtspDialog: React.FC<AddRtspDialogProps> = ({
   isOpen,
   vstApiUrl,
   onClose,
   onSuccess,
+  onAwaitStream,
   overlay = 'viewport',
 }) => {
   const [rtspUrl, setRtspUrl] = useState('');
   const [sensorName, setSensorName] = useState('');
   const [userEditedName, setUserEditedName] = useState(false); // Track if user manually edited the name
   const [error, setError] = useState<string | null>(null);
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [phase, setPhase] = useState<SubmitPhase>('idle');
+  // Sensor VST accepted but has not listed yet. A retry must only resume the
+  // wait: re-sending the add would be rejected as a duplicate URL, which reads
+  // as a failure for a sensor that in fact exists.
+  const [acceptedSensorId, setAcceptedSensorId] = useState<string | null>(null);
+  // Bumped on close and on each submit, so an attempt whose wait outlives the
+  // dialog — or a superseded one — stops writing to it.
+  const attemptRef = useRef(0);
+
+  const isSubmitting = phase !== 'idle';
 
   const extractNameFromUrl = (url: string): string =>
     url.split('?')[0].split('/').filter((p) => p.trim()).pop() ?? '';
@@ -51,11 +69,13 @@ export const AddRtspDialog: React.FC<AddRtspDialogProps> = ({
   };
 
   const handleClose = () => {
+    attemptRef.current += 1;
     setRtspUrl('');
     setSensorName('');
     setUserEditedName(false);
     setError(null);
-    setIsSubmitting(false);
+    setPhase('idle');
+    setAcceptedSensorId(null);
     onClose();
   };
 
@@ -77,13 +97,39 @@ export const AddRtspDialog: React.FC<AddRtspDialogProps> = ({
       return;
     }
 
+    attemptRef.current += 1;
+    const attempt = attemptRef.current;
+    const isCurrentAttempt = () => attemptRef.current === attempt;
+
     setError(null);
-    setIsSubmitting(true);
+    setPhase(acceptedSensorId ? 'confirming' : 'adding');
     try {
-      await addRtspStream(vstApiUrl!, { sensorUrl: trimmed, name: trimmedName });
+      let sensorId = acceptedSensorId;
+      if (!sensorId) {
+        const result = await addRtspStream(vstApiUrl!, { sensorUrl: trimmed, name: trimmedName });
+        if (!isCurrentAttempt()) return;
+        sensorId = result.sensorId;
+        setAcceptedSensorId(sensorId);
+        setPhase('confirming');
+      }
+
+      // VST returns the sensorId before the stream shows up in its listing.
+      // Closing here is what left the new camera out of the grid until the user
+      // refreshed or switched tabs.
+      const { found } = (await onAwaitStream?.(sensorId)) ?? { found: true };
+      if (!isCurrentAttempt()) return;
+
+      if (!found) {
+        setError(
+          'VST accepted the stream but has not listed it yet. Retry to check again.'
+        );
+        return;
+      }
+
       handleClose();
       onSuccess?.();
     } catch (err) {
+      if (!isCurrentAttempt()) return;
       // eslint-disable-next-line no-console
       console.error('Error adding RTSP sensor via VST API:', err);
       setError(
@@ -93,7 +139,7 @@ export const AddRtspDialog: React.FC<AddRtspDialogProps> = ({
         )
       );
     } finally {
-      setIsSubmitting(false);
+      if (isCurrentAttempt()) setPhase('idle');
     }
   };
 
@@ -102,8 +148,25 @@ export const AddRtspDialog: React.FC<AddRtspDialogProps> = ({
   const overlayClass =
     overlay === 'contained' ? POPUP_OVERLAY_CONTAINED : POPUP_OVERLAY_VIEWPORT;
 
+  // Closing mid-wait is safe — VST already holds the sensor and the poll keeps
+  // refreshing the grid — but closing mid-add would drop the sensorId the wait
+  // needs, leaving an added stream with nothing watching for it.
+  const canClose = phase !== 'adding';
+  const handleDismiss = () => {
+    if (canClose) handleClose();
+  };
+
+  const submitLabel =
+    phase === 'adding'
+      ? 'Adding...'
+      : phase === 'confirming'
+        ? 'Waiting for VST...'
+        : acceptedSensorId
+          ? 'Retry'
+          : 'Add RTSP';
+
   return (
-    <div className={overlayClass} onClick={handleClose}>
+    <div className={overlayClass} onClick={handleDismiss}>
       <div
         data-testid="add-rtsp-dialog"
         role="dialog"
@@ -135,7 +198,8 @@ export const AddRtspDialog: React.FC<AddRtspDialogProps> = ({
             </span>
           </div>
           <button
-            onClick={handleClose}
+            onClick={handleDismiss}
+            disabled={!canClose}
             aria-label="Close"
             className="p-1.5 rounded transition-colors text-gray-400 hover:text-white hover:bg-neutral-700 dark:text-gray-400 dark:hover:text-white dark:hover:bg-neutral-700"
           >
@@ -155,6 +219,7 @@ export const AddRtspDialog: React.FC<AddRtspDialogProps> = ({
                 value={rtspUrl}
                 onValueChange={(val: string) => handleRtspUrlChange(val)}
                 placeholder="rtsp://cam-warehouse.example.com:554/warehouse/cam01"
+                disabled={isSubmitting}
               />
             </div>
             <p
@@ -177,11 +242,25 @@ export const AddRtspDialog: React.FC<AddRtspDialogProps> = ({
               placeholder="e.g. Warehouse Camera 01"
               required
               aria-required="true"
+              disabled={isSubmitting}
             />
           </div>
 
+          {phase === 'confirming' && (
+            <p
+              data-testid="add-rtsp-confirming"
+              className="text-sm text-gray-500 dark:text-gray-400"
+            >
+              Stream added. Waiting for VST to list it…
+            </p>
+          )}
+
           {error && (
-            <div className="max-h-24 overflow-auto rounded p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800">
+            <div
+              role="alert"
+              data-testid="add-rtsp-error"
+              className="max-h-24 overflow-auto rounded p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800"
+            >
               <p className="text-sm text-red-600 dark:text-red-400 break-words whitespace-pre-wrap">{error}</p>
             </div>
           )}
@@ -191,7 +270,8 @@ export const AddRtspDialog: React.FC<AddRtspDialogProps> = ({
         <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-gray-200 dark:border-gray-600">
           <Button
             kind="secondary"
-            onClick={handleClose}
+            onClick={handleDismiss}
+            disabled={!canClose}
           >
             Cancel
           </Button>
@@ -200,7 +280,7 @@ export const AddRtspDialog: React.FC<AddRtspDialogProps> = ({
             onClick={handleSubmit}
             disabled={isSubmitting}
           >
-            {isSubmitting ? 'Adding...' : 'Add RTSP'}
+            {submitLabel}
           </Button>
         </div>
       </div>

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/components/AddRtspDialog.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/components/AddRtspDialog.tsx
@@ -27,12 +27,6 @@ interface AddRtspDialogProps {
 
 type SubmitPhase = 'idle' | 'adding' | 'confirming';
 
-/** A sensor VST took, keyed by the RTSP URL it was created from. */
-interface AcceptedSensor {
-  sensorId: string;
-  sensorUrl: string;
-}
-
 /** The message to show for bad input, or `null` when it is good. */
 function validateRtspInput(url: string, name: string): string | null {
   if (!url) return 'RTSP URL is required.';
@@ -65,10 +59,10 @@ export const AddRtspDialog: React.FC<AddRtspDialogProps> = ({
   const [userEditedName, setUserEditedName] = useState(false); // Track if user manually edited the name
   const [error, setError] = useState<string | null>(null);
   const [phase, setPhase] = useState<SubmitPhase>('idle');
-  // Sensor VST accepted but has not listed yet. A retry must only resume the
-  // wait: re-sending the add would be rejected as a duplicate URL, which reads
-  // as a failure for a sensor that in fact exists.
-  const [accepted, setAccepted] = useState<AcceptedSensor | null>(null);
+  // Sensors VST accepted in this dialog session, keyed by RTSP URL. A later
+  // add of a different URL must not forget an earlier one: reverting the field
+  // would otherwise re-POST a URL VST already holds and come back as a duplicate.
+  const [acceptedByUrl, setAcceptedByUrl] = useState<Record<string, string>>({});
   // Bumped on close and on each submit, so an attempt whose wait outlives the
   // dialog — or a superseded one — stops writing to it.
   const attemptRef = useRef(0);
@@ -81,9 +75,8 @@ export const AddRtspDialog: React.FC<AddRtspDialogProps> = ({
   // VST keys sensors on the RTSP URL. A listing timeout leaves the fields
   // editable, but a name-only edit is still the same sensor — re-POSTing the
   // URL would come back as a duplicate. An edited URL is a different stream
-  // and has to be added, not confirmed against the previous sensorId.
-  const acceptedSensorId =
-    accepted && accepted.sensorUrl === trimmedUrl ? accepted.sensorId : null;
+  // unless this session already accepted it.
+  const acceptedSensorId = acceptedByUrl[trimmedUrl] ?? null;
 
   const extractNameFromUrl = (url: string): string =>
     url.split('?')[0].split('/').filter((p) => p.trim()).pop() ?? '';
@@ -110,7 +103,7 @@ export const AddRtspDialog: React.FC<AddRtspDialogProps> = ({
     setUserEditedName(false);
     setError(null);
     setPhase('idle');
-    setAccepted(null);
+    setAcceptedByUrl({});
     onClose();
   };
 
@@ -157,7 +150,7 @@ export const AddRtspDialog: React.FC<AddRtspDialogProps> = ({
         const result = await addRtspStream(vstApiUrl, { sensorUrl: trimmedUrl, name: trimmedName });
         if (!isCurrentAttempt()) return;
         sensorId = result.sensorId;
-        setAccepted({ sensorId, sensorUrl: trimmedUrl });
+        setAcceptedByUrl((prev) => ({ ...prev, [trimmedUrl]: sensorId }));
         setPhase('confirming');
       }
 

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/components/AddRtspDialog.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/components/AddRtspDialog.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Button, TextInput } from '@nvidia/foundations-react-core';
 import { parseApiError } from '../utils';
 import { addRtspStream } from '../rtspStream';
@@ -27,6 +27,32 @@ interface AddRtspDialogProps {
 
 type SubmitPhase = 'idle' | 'adding' | 'confirming';
 
+/** A sensor VST took, and the values it was created from. */
+interface AcceptedSensor {
+  sensorId: string;
+  sensorUrl: string;
+  name: string;
+}
+
+/** The message to show for bad input, or `null` when it is good. */
+function validateRtspInput(url: string, name: string): string | null {
+  if (!url) return 'RTSP URL is required.';
+  if (!url.startsWith('rtsp://')) return 'RTSP URL must start with "rtsp://".';
+  if (!name) return 'Sensor Name is required.';
+  return null;
+}
+
+function getSubmitLabel(phase: SubmitPhase, canResumeWait: boolean): string {
+  switch (phase) {
+    case 'adding':
+      return 'Adding...';
+    case 'confirming':
+      return 'Waiting for VST...';
+    default:
+      return canResumeWait ? 'Retry' : 'Add RTSP';
+  }
+}
+
 export const AddRtspDialog: React.FC<AddRtspDialogProps> = ({
   isOpen,
   vstApiUrl,
@@ -43,12 +69,24 @@ export const AddRtspDialog: React.FC<AddRtspDialogProps> = ({
   // Sensor VST accepted but has not listed yet. A retry must only resume the
   // wait: re-sending the add would be rejected as a duplicate URL, which reads
   // as a failure for a sensor that in fact exists.
-  const [acceptedSensorId, setAcceptedSensorId] = useState<string | null>(null);
+  const [accepted, setAccepted] = useState<AcceptedSensor | null>(null);
   // Bumped on close and on each submit, so an attempt whose wait outlives the
   // dialog — or a superseded one — stops writing to it.
   const attemptRef = useRef(0);
 
   const isSubmitting = phase !== 'idle';
+
+  const trimmedUrl = rtspUrl.trim();
+  const trimmedName = sensorName.trim();
+
+  // An acceptance describes the values that produced it. A timeout leaves the
+  // fields editable, so once either one is edited the accepted sensor is no
+  // longer what the dialog shows: submitting has to add the stream on screen
+  // rather than confirm the previous one and close over it.
+  const acceptedSensorId =
+    accepted && accepted.sensorUrl === trimmedUrl && accepted.name === trimmedName
+      ? accepted.sensorId
+      : null;
 
   const extractNameFromUrl = (url: string): string =>
     url.split('?')[0].split('/').filter((p) => p.trim()).pop() ?? '';
@@ -75,25 +113,38 @@ export const AddRtspDialog: React.FC<AddRtspDialogProps> = ({
     setUserEditedName(false);
     setError(null);
     setPhase('idle');
-    setAcceptedSensorId(null);
+    setAccepted(null);
     onClose();
   };
 
+  // Closing mid-wait is safe — VST already holds the sensor and the poll keeps
+  // refreshing the grid — but closing mid-add would drop the sensorId the wait
+  // needs, leaving an added stream with nothing watching for it.
+  const canClose = phase !== 'adding';
+  const handleDismiss = () => {
+    if (canClose) handleClose();
+  };
+
+  useEffect(() => {
+    if (!isOpen || !canClose) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') handleClose();
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+    // handleClose is rebuilt every render; listing it would resubscribe the
+    // listener on each one, and all it touches is state and the onClose prop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, canClose]);
+
   const handleSubmit = async () => {
-    const trimmed = rtspUrl.trim();
-    const trimmedName = sensorName.trim();
-    const validationError =
-      !trimmed
-        ? 'RTSP URL is required.'
-        : !trimmed.startsWith('rtsp://')
-          ? 'RTSP URL must start with "rtsp://".'
-          : !trimmedName
-            ? 'Sensor Name is required.'
-            : !vstApiUrl
-              ? 'VST API URL not configured.'
-              : null;
+    const validationError = validateRtspInput(trimmedUrl, trimmedName);
     if (validationError) {
       setError(validationError);
+      return;
+    }
+    if (!vstApiUrl) {
+      setError('VST API URL not configured.');
       return;
     }
 
@@ -106,10 +157,10 @@ export const AddRtspDialog: React.FC<AddRtspDialogProps> = ({
     try {
       let sensorId = acceptedSensorId;
       if (!sensorId) {
-        const result = await addRtspStream(vstApiUrl!, { sensorUrl: trimmed, name: trimmedName });
+        const result = await addRtspStream(vstApiUrl, { sensorUrl: trimmedUrl, name: trimmedName });
         if (!isCurrentAttempt()) return;
         sensorId = result.sensorId;
-        setAcceptedSensorId(sensorId);
+        setAccepted({ sensorId, sensorUrl: trimmedUrl, name: trimmedName });
         setPhase('confirming');
       }
 
@@ -148,25 +199,11 @@ export const AddRtspDialog: React.FC<AddRtspDialogProps> = ({
   const overlayClass =
     overlay === 'contained' ? POPUP_OVERLAY_CONTAINED : POPUP_OVERLAY_VIEWPORT;
 
-  // Closing mid-wait is safe — VST already holds the sensor and the poll keeps
-  // refreshing the grid — but closing mid-add would drop the sensorId the wait
-  // needs, leaving an added stream with nothing watching for it.
-  const canClose = phase !== 'adding';
-  const handleDismiss = () => {
-    if (canClose) handleClose();
-  };
-
-  const submitLabel =
-    phase === 'adding'
-      ? 'Adding...'
-      : phase === 'confirming'
-        ? 'Waiting for VST...'
-        : acceptedSensorId
-          ? 'Retry'
-          : 'Add RTSP';
+  const submitLabel = getSubmitLabel(phase, acceptedSensorId !== null);
 
   return (
-    <div className={overlayClass} onClick={handleDismiss}>
+    // Backdrop: a click target only, with Escape wired up above for the keyboard
+    <div className={overlayClass} role="presentation" onClick={handleDismiss}>
       <div
         data-testid="add-rtsp-dialog"
         role="dialog"

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/components/AddRtspDialog.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/components/AddRtspDialog.tsx
@@ -199,14 +199,19 @@ export const AddRtspDialog: React.FC<AddRtspDialogProps> = ({
   const submitLabel = getSubmitLabel(phase, acceptedSensorId !== null);
 
   return (
-    // Backdrop: a click target only, with Escape wired up above for the keyboard
-    <div className={overlayClass} role="presentation" onClick={handleDismiss}>
+    <div className={overlayClass}>
+      <button
+        type="button"
+        className="absolute inset-0 cursor-default"
+        aria-label="Dismiss"
+        disabled={!canClose}
+        onClick={handleDismiss}
+      />
       <div
         data-testid="add-rtsp-dialog"
         role="dialog"
         aria-modal="true"
         className="relative z-50 mx-4 w-full max-w-[720px] rounded-lg border border-gray-200 bg-white shadow-lg dark:border-gray-600 dark:bg-black"
-        onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-600">

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/components/AddRtspDialog.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/components/AddRtspDialog.tsx
@@ -27,11 +27,10 @@ interface AddRtspDialogProps {
 
 type SubmitPhase = 'idle' | 'adding' | 'confirming';
 
-/** A sensor VST took, and the values it was created from. */
+/** A sensor VST took, keyed by the RTSP URL it was created from. */
 interface AcceptedSensor {
   sensorId: string;
   sensorUrl: string;
-  name: string;
 }
 
 /** The message to show for bad input, or `null` when it is good. */
@@ -79,14 +78,12 @@ export const AddRtspDialog: React.FC<AddRtspDialogProps> = ({
   const trimmedUrl = rtspUrl.trim();
   const trimmedName = sensorName.trim();
 
-  // An acceptance describes the values that produced it. A timeout leaves the
-  // fields editable, so once either one is edited the accepted sensor is no
-  // longer what the dialog shows: submitting has to add the stream on screen
-  // rather than confirm the previous one and close over it.
+  // VST keys sensors on the RTSP URL. A listing timeout leaves the fields
+  // editable, but a name-only edit is still the same sensor — re-POSTing the
+  // URL would come back as a duplicate. An edited URL is a different stream
+  // and has to be added, not confirmed against the previous sensorId.
   const acceptedSensorId =
-    accepted && accepted.sensorUrl === trimmedUrl && accepted.name === trimmedName
-      ? accepted.sensorId
-      : null;
+    accepted && accepted.sensorUrl === trimmedUrl ? accepted.sensorId : null;
 
   const extractNameFromUrl = (url: string): string =>
     url.split('?')[0].split('/').filter((p) => p.trim()).pop() ?? '';
@@ -160,7 +157,7 @@ export const AddRtspDialog: React.FC<AddRtspDialogProps> = ({
         const result = await addRtspStream(vstApiUrl, { sensorUrl: trimmedUrl, name: trimmedName });
         if (!isCurrentAttempt()) return;
         sensorId = result.sensorId;
-        setAccepted({ sensorId, sensorUrl: trimmedUrl, name: trimmedName });
+        setAccepted({ sensorId, sensorUrl: trimmedUrl });
         setPhase('confirming');
       }
 

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/constants.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/constants.ts
@@ -20,3 +20,8 @@ export const MAX_CHUNK_RETRIES = 3;
 // Poll with this backoff until the streams response no longer includes them,
 // or until the budget is exhausted.
 export const DELETED_STREAM_POLL_DELAYS_MS = [500, 1000, 2000, 4000, 8000];
+
+// The mirror case: VST answers the add-sensor call with a sensorId before that
+// sensor appears in its streams listing. Poll with this backoff until the added
+// sensor is listed, or until the budget is exhausted.
+export const ADDED_STREAM_POLL_DELAYS_MS = [500, 1000, 2000, 4000, 8000];

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/hooks/useStreams.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/hooks/useStreams.ts
@@ -137,7 +137,7 @@ export function useStreams({ vstApiUrl }: UseStreamsOptions = {}): UseStreamsRes
     // A poll that failed says nothing about what VST holds, so it counts as
     // "not yet listed" and the next poll decides.
     const isListed = (listed: StreamInfo[] | null) =>
-      listed !== null && listed.some((s) => s.sensorId === sensorId);
+      listed?.some((s) => s.sensorId === sensorId) ?? false;
 
     // Immediate check — VST may already list the sensor by the time the
     // add call returned.

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/hooks/useStreams.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/hooks/useStreams.ts
@@ -3,7 +3,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import type { StreamInfo, StreamsApiResponse } from '../types';
 import { createApiEndpoints } from '../api';
 import { parseStreamsResponse } from '../utils';
-import { DELETED_STREAM_POLL_DELAYS_MS } from '../constants';
+import { ADDED_STREAM_POLL_DELAYS_MS, DELETED_STREAM_POLL_DELAYS_MS } from '../constants';
 
 interface UseStreamsOptions {
   vstApiUrl?: string | null;
@@ -12,6 +12,11 @@ interface UseStreamsOptions {
 interface WaitUntilStreamsRemovedResult {
   /** sensorIds that were still present in VST after the poll budget ran out */
   remainingSensorIds: string[];
+}
+
+interface WaitUntilStreamAddedResult {
+  /** `false` when VST never listed the sensor within the poll budget */
+  found: boolean;
 }
 
 interface UseStreamsResult {
@@ -26,6 +31,13 @@ interface UseStreamsResult {
    * resolves (NVBug 6243148).
    */
   waitUntilStreamsRemoved: (sensorIds: string[]) => Promise<WaitUntilStreamsRemovedResult>;
+  /**
+   * Re-poll VST until `sensorId` appears in the streams response, or until
+   * `ADDED_STREAM_POLL_DELAYS_MS` is exhausted. Updates `streams` on every
+   * poll. Callers should keep the add dialog open until this resolves, so the
+   * grid already holds the new stream by the time the dialog closes.
+   */
+  waitUntilStreamAdded: (sensorId: string) => Promise<WaitUntilStreamAddedResult>;
 }
 
 function sleep(ms: number): Promise<void> {
@@ -119,6 +131,28 @@ export function useStreams({ vstApiUrl }: UseStreamsOptions = {}): UseStreamsRes
     return { remainingSensorIds: Array.from(pending) };
   }, [fetchStreams]);
 
+  const waitUntilStreamAdded = useCallback(async (sensorId: string): Promise<WaitUntilStreamAddedResult> => {
+    if (!sensorId) return { found: false };
+
+    // A poll that failed says nothing about what VST holds, so it counts as
+    // "not yet listed" and the next poll decides.
+    const isListed = (listed: StreamInfo[] | null) =>
+      listed !== null && listed.some((s) => s.sensorId === sensorId);
+
+    // Immediate check — VST may already list the sensor by the time the
+    // add call returned.
+    if (isListed(await fetchStreams({ silent: true }))) return { found: true };
+
+    for (const pollDelay of ADDED_STREAM_POLL_DELAYS_MS) {
+      await sleep(pollDelay);
+      if (!isMountedRef.current) return { found: false };
+
+      if (isListed(await fetchStreams({ silent: true }))) return { found: true };
+    }
+
+    return { found: false };
+  }, [fetchStreams]);
+
   useEffect(() => {
     fetchStreams();
   }, [fetchStreams]);
@@ -129,5 +163,6 @@ export function useStreams({ vstApiUrl }: UseStreamsOptions = {}): UseStreamsRes
     error,
     refetch,
     waitUntilStreamsRemoved,
+    waitUntilStreamAdded,
   };
 }

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/types.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/types.ts
@@ -65,8 +65,15 @@ export interface UploadProgress {
   id: string;
   fileName: string;
   progress: number;
-  status: 'pending' | 'uploading' | 'processing' | 'success' | 'error' | 'cancelled';
+  /**
+   * `confirming` = VST took the bytes; waiting for its streams listing to
+   * include the new sensor. Kept apart from `processing` so cancelling the
+   * queue does not mark a file VST already holds as cancelled.
+   */
+  status: 'pending' | 'uploading' | 'processing' | 'confirming' | 'success' | 'error' | 'cancelled';
   error?: string;
+  /** Set when the upload succeeded but VST never listed the sensor in time. */
+  unconfirmed?: string;
 }
 
 /** Shape for chat sidebar context chips (aligned with search `QueryDataContext`). */


### PR DESCRIPTION
## Summary

Both **add** paths in the Video Management tab reported completion before VST's streams listing caught up, so the grid could come back without the thing the user had just added, until a manual refresh or a tab switch:

- **Add RTSP** — `POST /v1/sensor/add` returns a `sensorId` before the sensor is listed. The dialog closed on that response and the single refetch that followed usually raced the listing.
- **Upload Video** — the last chunk is acknowledged before the uploaded file's sensor is listed. A file went to `Done` on that acknowledgement, and the upload response's `sensorId` was discarded.

The reverse case was already handled on the delete path ([`463e75aa9`](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/commit/463e75aa9), NVBug 6243148: the delete dialog stays open until VST stops listing the sensor). This applies the same timeout-based convergence check to both add paths.

## Plan

One hook primitive, used by both callers — the mirror of `waitUntilStreamsRemoved`:

`useStreams.waitUntilStreamAdded(sensorId)` runs silent polls on the delete path's backoff (500ms→8s, 15.5s budget) that refresh the grid as they land, resolving `{ found: true }` once the sensor is listed. A poll that errors counts as "not listed yet" and the next poll decides — the rule from [`e8e1d2afa`](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/commit/e8e1d2afa), so a network blip is never read as a verdict.

**Add RTSP** keeps the dialog in its submitting state for the wait, so it only closes over a grid that already holds the stream. A sensor VST accepted but hasn't listed is remembered, so **Retry** only resumes the poll — re-sending the add would come back as a duplicate URL and read as a failure for a stream that in fact exists. Cancel is blocked during the POST, since closing there would drop the `sensorId` the wait needs, but stays available during the poll, which is read-only.

**Upload** gains a `confirming` phase for the wait. The progress popup has no phase past `uploading`, so it renders as an in-flight file parked at 100% — exactly how `processing` already rendered. `confirming` is deliberately distinct from `processing` because of cancellation: the bytes are in VST by then, so cancelling can only abandon the listing wait, never un-upload the file. Cancelling one such file, or the whole queue, settles it as the success it is with a note that VST hasn't listed it yet, rather than marking a stored file `Cancelled`. A wait that fails, or lands after a cancel, settles the same way, so no file can sit in `confirming` and hold the popup open.

On timeout the two differ, matching what the user can act on. RTSP stays open and retryable, like the delete dialog. An upload is still reported a success — the file is in VST; only the grid's view of it is in question — with the caveat carried in the result payload.

## Related Issue

Reported against the VS BP Agent UI: Video Management tab, Add RTSP does not wait for VIOS to return the added stream. Upload was found to have the same race while reviewing that fix.

## Changes

| File | Change |
|------|--------|
| `lib-src/constants.ts` | `ADDED_STREAM_POLL_DELAYS_MS`, the add-side counterpart of the delete backoff |
| `lib-src/hooks/useStreams.ts` | `waitUntilStreamAdded(sensorId)` |
| `lib-src/components/AddRtspDialog.tsx` | holds open for the wait, `Waiting for VST...` / `Retry` states, poll-only retry, dismissal rules |
| `lib-src/types.ts` | `confirming` upload phase and the `unconfirmed` note |
| `lib-src/VideoManagementComponent.tsx` | wires both waits; upload cancel/failure settling for a file VST already holds |
| `__tests__/components/AddRtspDialog.test.tsx` | new — 15 cases over wait, retry, edited-field, failure and dismissal paths |
| `__tests__/hooks/useStreams.test.ts` | 6 cases for `waitUntilStreamAdded` |
| `__tests__/components/VideoManagementComponent.test.tsx` | 9 cases for the tab-level RTSP and upload flows |

`npx jest --runInBand` in `video-management`: 148 passed, 10 suites. `tsc --noEmit`, the package build and SPDX headers are clean.

## Review follow-ups

- **Greptile P1 — Retry ignored edited fields** ([6a3eb95ed](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/commit/6a3eb95ed)). A listing timeout left the fields editable while the accepted `sensorId` was held for a poll-only retry, so an edited URL or name could be "confirmed" against the old sensor and close the dialog over a stream that was never added. The acceptance now carries the URL and name that produced it and is only reused while both still match what is on screen; an edit adds afresh (and the button reverts from **Retry** to **Add RTSP**), while reverting an edit picks the acceptance back up instead of forcing a duplicate add.
- **Escape closes the dialog**, as it already did for the delete dialog, and is refused during the add call for the same reason the buttons are. The backdrop is marked `role="presentation"`, clearing the two SonarQube a11y findings on it.
- **SonarQube new-code smells**, all in files this PR touches: validation and the submit label moved into named functions (no nested ternaries, and an explicit `vstApiUrl` guard replaces the non-null assertion); the upload progress updaters became named module-level builders, unnesting their callbacks; the RTSP wait awaits the timeline refresh rather than discarding it with `void`.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally — `pre-commit` and `uv` are not installed on the machine this was authored on. The hooks that apply to these files were run directly and pass: SPDX headers (`check_copyright_headers.py`), the >5 MiB LFS check, and the DCO sign-off. The Python and UI-dependency hooks do not touch these paths.
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.

