### PR TITLE
chore(behavior-analytics): bump distroless python base to 3.13-v4.1.2

### DIFF
--- a/.github/osrb/inventory.csv
+++ b/.github/osrb/inventory.csv
@@ -2574,9 +2574,9 @@ nvcr.io/nvidia/distroless/python,3.13-v4.0.5,UNKNOWN,services/rtvi/rt-cv-3d/rt-c
 nvcr.io/nvidia/distroless/python,3.13-v4.0.6,UNKNOWN,libs/analytics/spatialai-data-utils,container,container,libs/analytics/spatialai-data-utils/docker/Dockerfile,runtime,no,no,yes,container-base,Unknown
 nvcr.io/nvidia/distroless/python,3.13-v4.0.8,UNKNOWN,services/alert,container,container,services/alert/Dockerfile,runtime,no,no,yes,container-base,Unknown
 nvcr.io/nvidia/distroless/python,3.13-v4.0.8,UNKNOWN,services/video-summarization,container,container,services/video-summarization/docker/Dockerfile,runtime,no,no,yes,container-base,Unknown
-nvcr.io/nvidia/distroless/python,3.13-v4.0.9,UNKNOWN,services/analytics/behavior-analytics,container,container,services/analytics/behavior-analytics/docker/Dockerfile,runtime,no,no,yes,container-base,Unknown
 nvcr.io/nvidia/distroless/python,3.13-v4.1.1,UNKNOWN,services/configurators/vss-configurator,container,container,services/configurators/vss-configurator/docker/Dockerfile,runtime,no,no,yes,container-base,Unknown
 nvcr.io/nvidia/distroless/python,3.13-v4.1.2,UNKNOWN,services/agent,container,container,services/agent/docker/Dockerfile,runtime,no,no,yes,container-base,Unknown
+nvcr.io/nvidia/distroless/python,3.13-v4.1.2,UNKNOWN,services/analytics/behavior-analytics,container,container,services/analytics/behavior-analytics/docker/Dockerfile,runtime,no,no,yes,container-base,Unknown
 nvcr.io/nvidia/k8s/dcgm-exporter,4.2.0-4.1.0-ubuntu22.04,UNKNOWN,services/rtvi/rt-embed,container,compose,services/rtvi/rt-embed/docker/compose.yaml,runtime,no,no,yes,container-image,Unknown
 nvcr.io/nvidia/k8s/dcgm-exporter,4.2.0-4.1.0-ubuntu22.04,UNKNOWN,services/rtvi/rt-vlm,container,compose,services/rtvi/rt-vlm/docker/compose.yaml,runtime,no,no,yes,container-image,Unknown
 nvcr.io/nvidia/pytorch,26.03-py3,UNKNOWN,services/rtvi/rt-embed,container,container,services/rtvi/rt-embed/docker/Dockerfile,runtime,no,no,yes,container-base,Unknown

--- a/services/analytics/behavior-analytics/docker/Dockerfile
+++ b/services/analytics/behavior-analytics/docker/Dockerfile
@@ -17,7 +17,7 @@ ARG PYTHON_VERSION=3.13
 # manylinux CPython tag for the OpenCV build; must track PYTHON_VERSION
 # (e.g. 3.13 -> cp313-cp313, 3.14 -> cp314-cp314).
 ARG PYBIN_TAG=cp313-cp313
-ARG DISTROLESS_TAG=${PYTHON_VERSION}-v4.0.9
+ARG DISTROLESS_TAG=${PYTHON_VERSION}-v4.1.2
 ARG DISTROLESS_IMG=nvcr.io/nvidia/distroless/python
 
 ###################################################

--- a/services/analytics/behavior-analytics/tests/integration/docker_compose/infra/Dockerfiles/Dockerfile.mqttbridge
+++ b/services/analytics/behavior-analytics/tests/integration/docker_compose/infra/Dockerfiles/Dockerfile.mqttbridge
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 ARG PYTHON_VERSION=3.13
-ARG DISTROLESS_TAG=${PYTHON_VERSION}-v4.0.9
+ARG DISTROLESS_TAG=${PYTHON_VERSION}-v4.1.2
 ARG DISTROLESS_IMG=nvcr.io/nvidia/distroless/python
 
 # Build stage


### PR DESCRIPTION
Move the behavior-analytics runtime and the integration-test MQTT->Kafka bridge off 3.13-v4.0.9 (2026-08-03) onto the latest NGC distroless tag (2026-08-26) to pick up its stdlib and OpenSSL CVE fixes.

Both tags are v4 Debian 13 bases exporting the same PY_VERSION=3.13 and LD_LIBRARY_PATH=/lib/distroless/, so the trixie builder stage and the site-packages COPY paths are unchanged.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
