### PR TITLE
fix(osrb): stop asking OSRB to review NVIDIA's own components

### DIFF
--- a/.github/osrb/osrb_agent.py
+++ b/.github/osrb/osrb_agent.py
@@ -263,8 +263,43 @@ _FIRST_PARTY_RE = re.compile(
     r"pynvvideocodec)",
     re.IGNORECASE,
 )
+# NVIDIA-published packages. OSRB reviews third-party open source; what
+# NVIDIA ships is governed by NVIDIA's own agreements, so a proprietary
+# licence on an NVIDIA artifact is the expected answer rather than a finding.
+# The agent researched nvcr.io/nvidia/distroless/python, read "NVIDIA
+# proprietary" from its NGC licenseTerms, and asked for OSRB review of an
+# NVIDIA base image (#2006).
+#
+# Anchored on the namespace, never a substring: `langchain-nvidia-ai-endpoints`
+# and `llama-index-embeddings-nvidia` are LangChain and LlamaIndex packages
+# that merely carry the word, and suppressing those would hide real
+# third-party dependencies.
+_NVIDIA_OWNED_RE = re.compile(
+    r"^(?:"
+    r"nvcr\.io/"                                       # NGC, NVIDIA's registry
+    r"|(?:docker\.io/|ghcr\.io/)?nvidia(?:[-_][a-z0-9]+)*/"  # NVIDIA orgs
+    r"|@nvidia/"                                       # npm scope
+    r"|nvidia[-_]"                                     # PyPI namespace
+    r"|cuda[-_]"                                       # CUDA components
+    r")",
+    re.IGNORECASE,
+)
 _ARTIFACT_RE = re.compile(r"^\$\{|\.deb$|\.tar\.|^install\.|\.org$|^https?://")
 _IMAGE_LANGS = {"container", "deb", "apk"}
+
+
+def is_nvidia_owned(package: str) -> bool:
+    """True when the package is NVIDIA's own, so OSRB has nothing to review.
+
+    A condition or refusal on file still outranks this: if OSRB has looked at
+    an NVIDIA component and said something about it, that stands.
+    """
+    name = (package or "").strip()
+    if not name:
+        return False
+    return bool(_NVIDIA_OWNED_RE.match(name)) or bool(
+        _FIRST_PARTY_RE.match(canonical_package(name))
+    )
 
 
 def _not_approved_class(row: dict[str, str]) -> str:
@@ -1117,6 +1152,17 @@ def build_comment(
         for entry in triage["refused_or_conditional"]
     }
 
+    nvidia_owned_skipped: set[str] = set()
+
+    def _osrb_skip_nvidia(package: str) -> bool:
+        """Skip NVIDIA's own components, unless OSRB has ruled on them."""
+        if canonical_package(package) in conditioned:
+            return False
+        if not is_nvidia_owned(package):
+            return False
+        nvidia_owned_skipped.add(package)
+        return True
+
     lines: list[str] = [MARKER, "# OSRB triage", ""]
     if skip_agent:
         lines += ["_Agent triage skipped this run"
@@ -1146,6 +1192,8 @@ def build_comment(
             continue  # unknowns are triage rows; permissive is section 2's verdict
         if dep_key(row) in cleared_keys:
             continue
+        if _osrb_skip_nvidia(row.get("package", "")):
+            continue
         osrb_rows.append([
             row.get("package", ""),
             row.get("new_version", ""),
@@ -1156,6 +1204,8 @@ def build_comment(
         ])
     for row in triage["license_changes"]:
         if not _risk_band_moved(row):
+            continue
+        if _osrb_skip_nvidia(row.get("package", "")):
             continue
         osrb_rows.append([
             row.get("package", ""),
@@ -1168,6 +1218,8 @@ def build_comment(
             row.get("repository_url", ""),
         ])
     for row in triage["usage_drift"]:
+        if _osrb_skip_nvidia(row.get("package", "")):
+            continue
         osrb_rows.append([
             row.get("package", ""),
             row.get("version", ""),
@@ -1176,6 +1228,8 @@ def build_comment(
             row.get("source_file", ""),
         ])
     for verdict in rejected:
+        if _osrb_skip_nvidia(verdict.get("package", "")):
+            continue
         osrb_rows.append([
             verdict.get("package", ""),
             verdict.get("version", ""),
@@ -1184,6 +1238,8 @@ def build_comment(
             verdict.get("evidence_url", ""),
         ])
     for row in unverifiable:
+        if _osrb_skip_nvidia(row.get("package", "")):
+            continue
         osrb_rows.append([
             row.get("package", ""),
             row.get("new_version", "") or row.get("version", ""),
@@ -1192,6 +1248,8 @@ def build_comment(
             "",
         ])
     for verdict in flagged:
+        if _osrb_skip_nvidia(verdict.get("package", "")):
+            continue
         osrb_rows.append([
             verdict.get("package", ""),
             verdict.get("version", ""),
@@ -1201,6 +1259,8 @@ def build_comment(
         ])
     for entry in not_triaged:
         row, why = entry["row"], entry["reason"]
+        if _osrb_skip_nvidia(row.get("package", "")):
+            continue
         osrb_rows.append([
             row.get("package", ""),
             row.get("new_version", "") or row.get("version", ""),
@@ -1220,6 +1280,19 @@ def build_comment(
             "conditional package is touched, every new dependency is "
             "permissively licensed, no licence change moves a risk band, and "
             "no usage drift was detected."
+        )
+    if nvidia_owned_skipped:
+        names = ", ".join(f"`{n}`" for n in sorted(nvidia_owned_skipped)[:6])
+        more = len(nvidia_owned_skipped) - 6
+        lines.append("")
+        lines.append(
+            f"{len(nvidia_owned_skipped)} NVIDIA-published component"
+            f"{'' if len(nvidia_owned_skipped) == 1 else 's'} "
+            f"({names}{f' and {more} more' if more > 0 else ''}) "
+            "are not listed. OSRB reviews third-party open source; what NVIDIA "
+            "ships is governed by NVIDIA's own agreements, so a proprietary "
+            "licence on one of these is the expected answer rather than a "
+            "finding. An OSRB condition on file still overrides this."
         )
     lines.append("")
 

--- a/.github/osrb/test_osrb_agent.py
+++ b/.github/osrb/test_osrb_agent.py
@@ -917,6 +917,72 @@ class RepoStateSectionTest(unittest.TestCase):
         # the escape hatch must be stated with the rule
         self.assertIn("condition on file outranks", comment)
 
+    def test_nvidia_published_components_are_not_osrb_findings(self) -> None:
+        """OSRB reviews third-party open source, not what NVIDIA ships.
+
+        The agent researched nvcr.io/nvidia/distroless/python, read "NVIDIA
+        proprietary" from its NGC licence terms and asked for OSRB review of an
+        NVIDIA base image (#2006). Proprietary is the expected answer for an
+        NVIDIA artifact, not a finding.
+        """
+        comment = agent.build_comment(
+            {"new_deps": [], "license_changes": [], "usage_drift": [],
+             "new_unknowns": [], "refused_or_conditional": [], "removed": []},
+            {"validated": [], "rejected": [], "unverifiable": [],
+             "not_triaged": [],
+             "flagged": [{"package": "nvcr.io/nvidia/distroless/python",
+                          "version": "3.13-v4.1.2", "license": "NVIDIA proprietary",
+                          "reasoning": "NGC licenseTerms declare NVIDIA proprietary",
+                          "evidence_url": "https://catalog.ngc.nvidia.com/x"}]})
+        self.assertIn("Nothing in this change requires OSRB review", comment)
+        self.assertNotIn("agent flagged for OSRB", comment)
+        # suppression is disclosed by name, never silent
+        self.assertIn("NVIDIA-published component", comment)
+        self.assertIn("nvcr.io/nvidia/distroless/python", comment)
+
+    def test_third_party_packages_named_nvidia_are_still_flagged(self) -> None:
+        """`langchain-nvidia-ai-endpoints` is LangChain's, not NVIDIA's.
+
+        Matching the word anywhere in the name would hide real third-party
+        dependencies, so the rule is anchored on the namespace.
+        """
+        comment = agent.build_comment(
+            {"new_deps": [], "license_changes": [], "usage_drift": [],
+             "new_unknowns": [], "refused_or_conditional": [], "removed": []},
+            {"validated": [], "rejected": [], "unverifiable": [],
+             "not_triaged": [],
+             "flagged": [{"package": "langchain-nvidia-ai-endpoints",
+                          "version": "1.0", "license": "UNKNOWN",
+                          "reasoning": "could not resolve", "evidence_url": ""}]})
+        self.assertIn("agent flagged for OSRB", comment)
+        self.assertIn("langchain-nvidia-ai-endpoints", comment)
+
+    def test_an_osrb_condition_outranks_nvidia_ownership(self) -> None:
+        """If OSRB ruled on an NVIDIA component, that ruling stands.
+
+        The guard has to be consulted for this to mean anything, so the
+        conditioned package is also put in front of it as an agent verdict:
+        without the override that row is silently dropped as NVIDIA-owned.
+        """
+        triage = agent.build_triage_input(
+            [delta_row(package="pyds", new_license="NVIDIA proprietary")],
+            [],
+            [{"package": "pyds", "decision": "refused", "evidence": "comment-95",
+              "condition": "must not ship", "module": "", "version": "",
+              "license": "", "quote": "", "repo_modules": ""}])
+        comment = agent.build_comment(
+            triage,
+            {"validated": [], "rejected": [], "unverifiable": [],
+             "not_triaged": [],
+             "flagged": [{"package": "pyds", "version": "1.0",
+                          "license": "NVIDIA proprietary",
+                          "reasoning": "proprietary metadata",
+                          "evidence_url": ""}]})
+        self.assertIn("OSRB refused", comment)
+        # the agent row for the SAME conditioned package must survive the guard
+        self.assertIn("agent flagged for OSRB", comment)
+        self.assertNotIn("NVIDIA-published component", comment)
+
     def test_no_repo_state_means_no_section(self) -> None:
         comment = agent.build_comment({"new_deps": [], "license_changes": [],
             "usage_drift": [], "new_unknowns": [], "refused_or_conditional": [],


### PR DESCRIPTION
## Problem

On [#2006](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/2006) the triage agent flagged an **NVIDIA base image** for OSRB review:

> | `nvcr.io/nvidia/distroless/python` | 3.13-v4.1.2 | agent flagged for OSRB: … The image's licenseTerms declare licenseId 'NVIDIA proprietary' v1.0 … Composite/proprietary licensing … requires OSRB review; permissive=false. |

The agent's research was correct — the image *is* NVIDIA-proprietary. The conclusion was wrong. OSRB reviews **third-party** open source; what NVIDIA publishes is governed by NVIDIA's own agreements, so "proprietary" on an NVIDIA artifact is the expected answer, not a finding.

## Change

NVIDIA-published components are skipped in every path that adds a row to *OSRB review required*: new deps with a non-permissive licence, licence changes that move a risk band, usage drift, and the agent's `flagged` / `rejected` / `unverifiable` / `not_triaged` verdicts.

## Two things it deliberately does not do

**It does not match the word anywhere in a name.** These are third-party packages that merely carry it, and suppressing them would hide real dependencies:

| package | owner |
|---|---|
| `langchain-nvidia-ai-endpoints` | LangChain |
| `llama-index-embeddings-nvidia` | LlamaIndex |

The rule is anchored on the namespace: `nvcr.io/`, the `nvidia` orgs on Docker Hub/GHCR, the `@nvidia/` npm scope, the `nvidia-` PyPI namespace, and `cuda-` components.

**An OSRB condition or refusal on file still outranks ownership.** If OSRB has ruled on an NVIDIA component, that ruling stands.

Skipped components are listed **by name** under the section, so the comment never implies nothing was considered.

## Verification

- 427 tests pass.
- Predicate checked against the real inventory: 11 NVIDIA-owned names match, and the two third-party lookalikes above do not.
- Mutation-tested. Replacing the anchored rule with a substring match fails the third-party test. Removing the condition override fails the override test — the first version of that test was **vacuous** (it exercised a loop the guard never reaches) and was rewritten until the mutation actually killed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)