### PR TITLE
fix(agent): route uploaded video questions to VQA

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
@@ -371,6 +371,7 @@ workflow:
   plan_prompt: |
     Review the available tools, the conversation history, and the user's question, then produce a concise numbered execution plan. Start each step with a tool name and a brief description of the step.
     Put relevant context (for example, sensor IDs or time ranges) from the conversation history directly in the plan steps so the execution agent does not need to re-read the history.
+    For a specific content question about named media, use one compound plan step: call `vst_video_list` to resolve `<name>`'s media type, then call `video_understanding` with `<name>` and the original question when it is `video`; use the live-stream content-question route only when it is `rtsp`. Use `lvs_video_understanding` only for whole-video summarization.
     A non-empty name supplied in the request is the sensor_id. For example, in "Generate a report for warehouse_sample", the sensor_id is "warehouse_sample"; this request is complete and MUST NOT trigger a clarifying question.
     If the user requests a report and supplies a name, the plan MUST contain exactly one action: call `report_agent` directly with that exact name as sensor_id and the original request as user_query. Do not verify the name or media type first.
     Ask which video or camera the user means only when the request contains no name and the conversation provides no usable name.
@@ -462,6 +463,7 @@ workflow:
 
   tool_call_prompt: |
     - ALWAYS include ALL required parameters when calling tools
+    - OVERRIDE THE EXECUTION PLAN if necessary: for a specific content question, once the target is known to be `media_type='video'`, call `video_understanding` next even if the plan names another tool. Use `lvs_video_understanding` only for whole-video summarization.
     - If a tool call fails with a validation error, RETRY IMMEDIATELY: Fix the error and call the tool again with correct parameters.
     - Error Handling: if a tool fails more than 3 times, just return a summarized error message. Do not endlessly try again.
 

--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
@@ -371,6 +371,7 @@ workflow:
   plan_prompt: |
     Review the available tools, the conversation history, and the user's question, then produce a concise numbered execution plan. Start each step with a tool name and a brief description of the step.
     Put relevant context (for example, sensor IDs or time ranges) from the conversation history directly in the plan steps so the execution agent does not need to re-read the history.
+    For a specific content question about named media, use one compound plan step: call `vst_video_list` to resolve `<name>`'s media type, then call `video_understanding` with `<name>` and the original question when it is `video`; use the live-stream content-question route only when it is `rtsp`. Use `lvs_video_understanding` only for whole-video summarization.
     A non-empty name supplied in the request is the sensor_id. For example, in "Generate a report for warehouse_sample", the sensor_id is "warehouse_sample"; this request is complete and MUST NOT trigger a clarifying question.
     If the user requests a report and supplies a name, the plan MUST contain exactly one action: call `report_agent` directly with that exact name as sensor_id and the original request as user_query. Do not verify the name or media type first.
     Ask which video or camera the user means only when the request contains no name and the conversation provides no usable name.
@@ -462,6 +463,7 @@ workflow:
 
   tool_call_prompt: |
     - ALWAYS include ALL required parameters when calling tools
+    - OVERRIDE THE EXECUTION PLAN if necessary: for a specific content question, once the target is known to be `media_type='video'`, call `video_understanding` next even if the plan names another tool. Use `lvs_video_understanding` only for whole-video summarization.
     - If a tool call fails with a validation error, RETRY IMMEDIATELY: Fix the error and call the tool again with correct parameters.
     - Error Handling: if a tool fails more than 3 times, just return a summarized error message. Do not endlessly try again.
 

--- a/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
@@ -491,6 +491,7 @@ class TopAgent(AsyncMixin):
             "- Mark completed steps with [x] and append a concise result summary.\n"
             "- Keep pending steps with [ ].\n"
             "- Adjust, add, or remove remaining steps based on what was learned from the results.\n"
+            "- If `vst_video_list` identifies the target as `media_type='video'`, use `video_understanding` for a specific content question; use `lvs_video_understanding` only for whole-video summarization.\n"
             "- Return ONLY the updated plan — no commentary, no preamble.\n"
         )
 


### PR DESCRIPTION
## Summary

  Fix LVS profile routing for questions about uploaded-video content.

  Previously, an uploaded-video VQA request could be routed to LVS summarization/HITL or unrelated media tools instead of `video_understanding`.

  ## Plan

  Use intent-based routing:

  - Resolve the named media type with `vst_video_list`.
  - Route specific questions about uploaded videos to `video_understanding`.
  - Reserve `lvs_video_understanding` for whole-video summarization.
  - Preserve this rule when the agent updates its execution plan.

  ## Related Issue

  [NVBug 6719345](https://nvbugspro.nvidia.com/bug/6719345)

  ## Changes

  - Added an uploaded-video VQA rule to the LVS planner prompt.
  - Added the same constraint to the tool-call prompt.
  - Updated the plan-tracking prompt so it selects `video_understanding` after media discovery.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.
