### PR TITLE
docs: fill empty Fern section landing pages

### DIFF
--- a/docs/api-gateway-mcp.mdx
+++ b/docs/api-gateway-mcp.mdx
@@ -3,4 +3,7 @@ title: "API Gateway / MCP"
 description: ""
 position: 2
 ---
-This section covers the Video Analytics components that provide programmatic access to video analytics data and capabilities.
+The API Gateway and Model Context Protocol (MCP) layer provide programmatic access to video analytics data and vision tools.
+
+- [Video Analytics API](/vss/system-components/middleware/api-gateway-mcp/video-analytics-api) - REST API for querying analytics, incidents, and alerts.
+- [Video Analytics MCP](/vss/system-components/middleware/api-gateway-mcp/video-analytics-mcp) - MCP server that exposes the same capabilities as tools for agents.

--- a/docs/calibration.mdx
+++ b/docs/calibration.mdx
@@ -7,5 +7,10 @@ Camera calibration is an essential step to enable using cameras as sensors for a
 It involves determining the projection matrix (combined intrinsic and extrinsic parameters) of the camera,
 which is necessary for both advanced 3D object detection as well as the spatial understanding of the detected objects.
 The camera calibration result is presented in a JSON file following a pre-defined schema which is used in multiple modules within the system.
-Below, we describe the pre-defined schema of the calibration file, the provided tools for their supported use cases
-and the fundamentals / steps to be used as reference when calibrating any of your own cameras manually for multi-camera tracking use cases.
+The following pages cover the schema, tools, and steps for calibrating cameras for multi-camera tracking.
+
+- [Auto Calibration](/vss/system-components/calibration/auto-calibration) - Automatic calibration workflow, custom datasets, and troubleshooting.
+- [SDG Calibration](/vss/system-components/calibration/sdg-calibration) - Calibration produced from synthetic data generation.
+- [Legacy Camera Calibration](/vss/system-components/calibration/legacy-camera-calibration) - Earlier manual calibration tools.
+- [Camera Positioning Guide](/vss/system-components/calibration/camera-positioning-guide) - Where to place cameras for analytics.
+- [Calibration Schema](/vss/system-components/calibration/calibration-schema) - JSON schema consumed by VSS modules.

--- a/docs/configuration-management.mdx
+++ b/docs/configuration-management.mdx
@@ -3,3 +3,9 @@ title: "Configuration"
 description: ""
 position: 6
 ---
+These services generate and apply VSS configuration for hardware profiles, sensors, DeepStream graphs, and VLM scale-out.
+
+- [VSS Configurator](/vss/system-components/configuration/vss-configurator) - Profile and sensor configuration based on GPU type and deployment mode.
+- [SDR Controller](/vss/system-components/configuration/sdr-controller) - Assign live streams to workers and keep routing stable across scale-out.
+- [Deepstream Configurator](/vss/system-components/configuration/deepstream-configurator) - Generate DeepStream pipeline configuration.
+- [VLM Autoscaling](/vss/system-components/configuration/vlm-autoscaling) - Scale Vision Language Model replicas with demand.

--- a/docs/database.mdx
+++ b/docs/database.mdx
@@ -3,3 +3,6 @@ title: "Database"
 description: ""
 position: 5
 ---
+The database layer stores analytics metadata, incidents, and verified alert results so you can search and visualize them. The blueprints use Elasticsearch for indexing, Logstash for ingest, and Kibana for dashboards.
+
+- [ELK](/vss/system-components/middleware/database/elk) - Elasticsearch, Logstash, and Kibana pipeline used by the blueprints.

--- a/docs/models/index.mdx
+++ b/docs/models/index.mdx
@@ -5,4 +5,9 @@ position: 5
 ---
 Documentation for **fine-tuning, exporting, and integrating** models used with the VSS blueprint: **embedding** models for semantic search (RT-CV and RT-Embedding), and **computer vision** models for warehouse perception (TAO Sparse4D and RT-DETR).
 
-Start with [Model customization overview](/vss/system-components/models/model-customization-overview) for a cross-service summary, then dive into the per-model pages below.
+Start with [Model customization overview](/vss/system-components/models/model-customization-overview) for a cross-service summary, then refer to the per-model pages:
+
+- [SigLIP 2 object embeddings](/vss/system-components/models/siglip-2-object-embeddings) - Object-level embeddings for RT-CV search.
+- [Cosmos-Embed1 (video embedding)](/vss/system-components/models/cosmos-embed1-video-embedding) - Video embeddings for semantic search.
+- [Sparse4D (3D multi-camera)](/vss/system-components/models/sparse4d-3d-multi-camera) - Multi-camera 3D detection and tracking.
+- [RT-DETR (2D warehouse detection)](/vss/system-components/models/rt-detr-2d-warehouse-detection) - 2D warehouse detector.

--- a/docs/smartcity-docs/Operations.mdx
+++ b/docs/smartcity-docs/Operations.mdx
@@ -3,4 +3,9 @@ title: "Operations (Monitoring, Troubleshooting, FAQ, Known Limitations)"
 description: ""
 position: 5
 ---
-This section provides additional resources, including optimization tools, known limitations, troubleshooting guide, FAQ, and license information.
+Operational references for running the Smart City Blueprint after you deploy it.
+
+- [Known Limitations](/vss/vision-agent/agent-workflows/industry-specific-examples/smart-city-blueprint/operations-monitoring-troubleshooting-faq-known-limitations/known-limitations) - Current constraints of the blueprint.
+- [Troubleshooting Guide](/vss/vision-agent/agent-workflows/industry-specific-examples/smart-city-blueprint/operations-monitoring-troubleshooting-faq-known-limitations/troubleshooting-guide) - Diagnose common deployment and runtime issues.
+- [FAQ](/vss/vision-agent/agent-workflows/industry-specific-examples/smart-city-blueprint/operations-monitoring-troubleshooting-faq-known-limitations/faq) - Frequently asked questions.
+- [License Information](/vss/vision-agent/agent-workflows/industry-specific-examples/smart-city-blueprint/operations-monitoring-troubleshooting-faq-known-limitations/license-information) - Licensing for blueprint components.

--- a/docs/smartcity-docs/Smartcity-Development-Workflow.mdx
+++ b/docs/smartcity-docs/Smartcity-Development-Workflow.mdx
@@ -3,3 +3,10 @@ title: "Development Workflow"
 description: ""
 position: 4
 ---
+Use this workflow to understand the Smart City Blueprint architecture, then customize calibration, deployment, simulation, and model training.
+
+- [Blueprint Deep Dive](/vss/vision-agent/agent-workflows/industry-specific-examples/smart-city-blueprint/development-workflow/blueprint-deep-dive) - Architecture and component layout.
+- [Calibration](/vss/vision-agent/agent-workflows/industry-specific-examples/smart-city-blueprint/development-workflow/calibration) - Camera calibration for the smart city deployment.
+- [Deployment](/vss/vision-agent/agent-workflows/industry-specific-examples/smart-city-blueprint/development-workflow/deployment) - Deploy and customize the blueprint.
+- [Simulation and Synthetic Data Generation](/vss/vision-agent/agent-workflows/industry-specific-examples/smart-city-blueprint/development-workflow/simulation-and-synthetic-data-generation) - Generate synthetic video and scenarios.
+- [Model Fine Tuning](/vss/vision-agent/agent-workflows/industry-specific-examples/smart-city-blueprint/development-workflow/model-fine-tuning) - Fine-tune perception models for your site.

--- a/docs/vss-vios.mdx
+++ b/docs/vss-vios.mdx
@@ -3,3 +3,13 @@ title: "Video IO & Storage (VIOS)"
 description: ""
 position: 1
 ---
+Video IO and Storage (VIOS) manages cameras, video ingest, storage, and playback for VSS. NVStreamer serves file-based RTSP sources for testing. The VST APIs control sensors, live streams, replay, recording, proxying, and storage.
+
+- [VIOS Microservices](/vss/system-components/middleware/video-io-storage-vios/vios-microservices) - Camera discovery, recording, RTSP proxy, WebRTC playback, and the VIOS REST API.
+- [NVStreamer](/vss/system-components/middleware/video-io-storage-vios/nvstreamer) - Serve video files over RTSP as VIOS inputs when you do not have live cameras.
+- [VST Sensor Management API](/vss/system-components/middleware/video-io-storage-vios/vst-api-reference/vst-sensor-management-api) - Add, list, and configure sensors.
+- [VST Live Stream Management API](/vss/system-components/middleware/video-io-storage-vios/vst-api-reference/vst-live-stream-management-api) - Manage live streams.
+- [VST Replay Stream Management API](/vss/system-components/middleware/video-io-storage-vios/vst-api-reference/vst-replay-stream-management-api) - Control replay of recorded video.
+- [VST Record Stream Management API](/vss/system-components/middleware/video-io-storage-vios/vst-api-reference/vst-record-stream-management-api) - Configure recording.
+- [VST Proxy Stream Management API](/vss/system-components/middleware/video-io-storage-vios/vst-api-reference/vst-proxy-stream-management-api) - Manage RTSP proxy streams.
+- [VST Storage Management API](/vss/system-components/middleware/video-io-storage-vios/vst-api-reference/vst-storage-management-api) - Manage video storage.

--- a/docs/warehouse-docs/Appendix-toc.mdx
+++ b/docs/warehouse-docs/Appendix-toc.mdx
@@ -3,4 +3,11 @@ title: "Operations (Monitoring, Troubleshooting, FAQ, Known Limitations)"
 description: ""
 position: 7
 ---
-This section provides additional resources, including accuracy and performance benchmarks, system sizing guide, profiling and optimization tools, known limitations, troubleshooting guide, FAQ, and license information.
+Operational references for running the Warehouse Operations Blueprint after you deploy it.
+
+- [Accuracy and Performance Benchmarks](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/operations-monitoring-troubleshooting-faq-known-limitations/accuracy-performance-benchmarks) - Measured accuracy and throughput.
+- [System Sizing Guide](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/operations-monitoring-troubleshooting-faq-known-limitations/system-sizing-guide) - GPU and stream-count guidance.
+- [Known Limitations](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/operations-monitoring-troubleshooting-faq-known-limitations/known-limitations) - Current constraints of the blueprint.
+- [Troubleshooting Guide](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/operations-monitoring-troubleshooting-faq-known-limitations/troubleshooting-guide) - Diagnose common deployment and runtime issues.
+- [FAQ](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/operations-monitoring-troubleshooting-faq-known-limitations/faq) - Frequently asked questions.
+- [License Information](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/operations-monitoring-troubleshooting-faq-known-limitations/license-information) - Licensing for blueprint components.

--- a/docs/warehouse-docs/Core-Development-Workflow.mdx
+++ b/docs/warehouse-docs/Core-Development-Workflow.mdx
@@ -3,3 +3,8 @@ title: "Development Workflow"
 description: ""
 position: 5
 ---
+Customize the Warehouse Operations Blueprint after the quickstart: pick a perception profile, generate synthetic data, and fine-tune models.
+
+- [Deployment and Customization](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/development-workflow/deployment-customization) - 2D, 3D, MV3DT, and agent-enabled warehouse profiles.
+- [Simulation and Synthetic Data Generation](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/development-workflow/simulation-and-synthetic-data-generation) - Isaac Sim workflows, scene setup, and dataset transfer.
+- [Model Finetuning](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/development-workflow/model-finetuning) - Fine-tune RT-DETR, Sparse4D, and Cosmos Reasoner.

--- a/docs/warehouse-docs/Models.mdx
+++ b/docs/warehouse-docs/Models.mdx
@@ -3,3 +3,8 @@ title: "Model Finetuning"
 description: ""
 position: 1
 ---
+Fine-tune warehouse perception and reasoning models on your data, then export them for the blueprint pipelines.
+
+- [RT-DETR](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/development-workflow/model-finetuning/rt-detr) - 2D detector used by the warehouse 2D and MV3DT profiles.
+- [Sparse4D](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/development-workflow/model-finetuning/sparse4d) - Multi-camera 3D detector and tracker.
+- [Cosmos Reasoner](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/development-workflow/model-finetuning/cosmos-reasoner) - Vision language model used for warehouse reasoning.

--- a/docs/warehouse-docs/Perception.mdx
+++ b/docs/warehouse-docs/Perception.mdx
@@ -3,3 +3,8 @@ title: "Perception"
 description: ""
 position: 1
 ---
+Warehouse perception pipelines run on DeepStream. Choose the detector and tracker that match your camera layout.
+
+- [2D Single Camera Detection and Tracking (RT-DETR)](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/microservice-configuration/perception/2d-single-camera-detection-and-tracking-rt-detr) - Per-camera 2D detection and tracking.
+- [3D Multi Camera Detection and Tracking (Sparse4D)](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/microservice-configuration/perception/3d-multi-camera-detection-and-tracking-sparse4d) - Synchronized multi-camera 3D perception with Sparse4D.
+- [3D Multi Camera Detection and Tracking (MV3DT)](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/microservice-configuration/perception/3d-multi-camera-detection-and-tracking-mv3dt) - Multi-view 3D tracking on top of 2D RT-DETR.

--- a/docs/warehouse-docs/Scene-Customization.mdx
+++ b/docs/warehouse-docs/Scene-Customization.mdx
@@ -3,4 +3,9 @@ title: "Scene Customization"
 description: ""
 position: 3
 ---
-This page links to the detailed steps for customizing the scene with UI.
+Customize the warehouse digital twin so synthetic cameras and agents match your facility layout.
+
+- [NavMesh Setup](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/development-workflow/simulation-and-synthetic-data-generation/scene-customization/navmesh-setup) - Navigation mesh for agent paths.
+- [Camera Placement](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/development-workflow/simulation-and-synthetic-data-generation/scene-customization/camera-placement) - Place and aim simulated cameras.
+- [Semantic Label Setup](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/development-workflow/simulation-and-synthetic-data-generation/scene-customization/semantic-label-setup) - Semantic labels used by perception and SDG.
+- [Customized Scene Saving](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/development-workflow/simulation-and-synthetic-data-generation/scene-customization/customized-scene-saving) - Save and reload a customized scene.

--- a/docs/warehouse-docs/blueprint-profiles.mdx
+++ b/docs/warehouse-docs/blueprint-profiles.mdx
@@ -5,4 +5,8 @@ position: 1
 ---
 VSS Warehouse Blueprint is a set of customizable reference workflows for real-time video analytics for warehouse operations use cases, designed to accelerate the development of comprehensive systems.
 There are several deployment profiles consisting of camera streaming, AI perception, analytics, and other supporting microservices.
-Refer to the sections below for more details.
+
+- [2D Vision AI Profile](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/development-workflow/deployment-customization/2d-vision-ai-profile) - Single-camera 2D detection and tracking with RT-DETR.
+- [2D Vision AI with Agents Profile](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/development-workflow/deployment-customization/2d-vision-ai-with-agents-profile) - 2D perception plus the warehouse agent.
+- [3D Vision AI Profile](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/development-workflow/deployment-customization/3d-vision-ai-profile) - Multi-camera 3D perception with Sparse4D.
+- [MV3DT Vision AI Profile](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/development-workflow/deployment-customization/mv3dt-vision-ai-profile) - Multi-view 3D tracking with RT-DETR.

--- a/docs/warehouse-docs/microservices-configs-and-outputs.mdx
+++ b/docs/warehouse-docs/microservices-configs-and-outputs.mdx
@@ -3,6 +3,10 @@ title: "Microservice Configuration"
 description: ""
 position: 6
 ---
-Below are deployment-time and runtime configuration options of VSS microservices for Warehouse Blueprint.
+These pages document deployment-time and runtime configuration for Warehouse Blueprint microservices.
 
-For detailed information on all components, APIs, and customization options of these microservices, refer to the [warehouse-toc](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint).
+- [Perception](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/microservice-configuration/perception) - DeepStream detector and tracker pipelines.
+- [Behavior Analytics](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/microservice-configuration/behavior-analytics) - Spatial events and incident rules.
+- [Alerting Service](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/microservice-configuration/alerting-service) - Alert verification for warehouse incidents.
+- [Agents](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/microservice-configuration/agents) - Warehouse agent configuration.
+- [Reference Agentic UI](/vss/vision-agent/agent-workflows/industry-specific-examples/warehouse-operations-blueprint/microservice-configuration/reference-agentic-ui) - Warehouse UI used with the agent profiles.


### PR DESCRIPTION
## Summary
- Sphinx toctree stubs were still used as Fern section `path:` overviews, so fronts such as [Video IO and Storage (VIOS)](https://nvidia-preview-pr-1819.docs.buildwithfern.com/vss/system-components/middleware/video-io-storage-vios) rendered blank.
- Add a short intro and child-page links on those landings (VIOS, API Gateway, Database, Configuration, Smart City and Warehouse workflow/ops stubs, plus a few other fronts that named children but did not list them).

## Test plan
- [x] `fern check` and `fern docs broken-links --strict` pass
- [ ] In the Fern preview, open `/vss/system-components/middleware/video-io-storage-vios` and confirm it is no longer empty
- [ ] Spot-check Database, Configuration, Smart City Development Workflow, and Warehouse Perception landings