### PR TITLE
docs(lvs): refresh profile configuration guidance

### DIFF
--- a/docs/agent-workflow-lvs.mdx
+++ b/docs/agent-workflow-lvs.mdx
@@ -153,23 +153,32 @@ Stream summary and Q&A are experimental and are not available through Agent Skil
 
 ### With the VSS CLI
 
-The VSS CLI can upload media and run the Video Summarization service directly from the deployment host. Configure it once against the public VSS ingress, list the uploaded videos, and start a summary using the video's `stream_id`:
+The VSS CLI can upload media and run the Video Summarization service directly from the deployment host. Configure it once against the public VSS ingress, enable memory for persisted jobs, mint a clip URL for an uploaded video, and start a summary:
 
 ```bash
 VSS_REPO_ROOT="${VSS_REPO_ROOT:-$HOME/video-search-and-summarization}"
 vss() { uv run --project "${VSS_REPO_ROOT}/services/agent" --no-dev --extra cli vss "$@"; }
 
-vss configure --base-url http://<HOST_IP>:7777
+vss configure --base-url "http://HOST_IP:7777"
 vss configure check
+vss configure memory --enable
+
+# From this output, record the video's name and sensor_id.
 vss vios list --type video
+
+# From this output, record media_url and start_time.
+vss vios clip --sensor "VIDEO_NAME"
+
 vss summarize run \
-  --id <stream_id-from-vss-vios-list> \
+  --url "MEDIA_URL" \
+  --video-id "SENSOR_ID" \
+  --creation-time "START_TIME" \
   --scenario "warehouse monitoring" \
   --event "boxes falling" \
   --event "person entering restricted area"
 ```
 
-`vss summarize run` is synchronous and can take several minutes for a long video. It records a job before starting the model request; use `vss summarize list` to find the job ID and `vss summarize status --job-id <id>` or `vss summarize get --job-id <id>` from another shell while it runs.
+Replace `HOST_IP`, `VIDEO_NAME`, `SENSOR_ID`, `MEDIA_URL`, and `START_TIME` with values from the deployment and command outputs. `vss summarize run` is synchronous and can take several minutes for a long video. With memory enabled, it records a job before starting the model request; use `vss summarize list` to find the job ID and `vss summarize status --job-id JOB_ID` or `vss summarize get --job-id JOB_ID` from another shell while it runs. Without `vss configure memory --enable`, the retrieval commands exit with code 4.
 
 ### Manually
 

--- a/docs/agent-workflow-lvs.mdx
+++ b/docs/agent-workflow-lvs.mdx
@@ -47,7 +47,7 @@ The following diagram illustrates the video summarization architecture:
 - **VSS Agent UI:** Web UI with chat, video upload, and different views
 - **VSS Video IO & Storage (VIOS):** Video ingestion, recording, and playback services used by the agent for video access and management
 - **Nemotron LLM (NIM):** LLM inference service used for reasoning, tool selection, and response generation
-- **Cosmos3 Nano Reasoner (NIM):** Vision-language model with physical reasoning capabilities
+- **Cosmos3 Nano Reasoner:** Integrated vision-language model checkpoint with physical reasoning capabilities, loaded by RTVI-VLM
 - **RTVI-VLM:** Real-Time Video Intelligence VLM service used by the Video Summarization profile for VLM calls
 - **VSS Video Summarization:** Microservice for segmenting and summarizing video content (uploaded files of any length, plus RTSP live streams)
 - **Kafka:** Message bus used for stream caption and summary events
@@ -150,6 +150,26 @@ What the agent does:
 <Note>
 Stream summary and Q&A are experimental and are not available through Agent Skills. Use the deployed VSS Agent chat UI instead, as described in [Step 4: Summarize and query a live stream](/vss/vision-agent/agent-workflows/video-summarization#step-4-summarize-and-query-a-live-stream) in the manual flow below.
 </Note>
+
+### With the VSS CLI
+
+The VSS CLI can upload media and run the Video Summarization service directly from the deployment host. Configure it once against the public VSS ingress, list the uploaded videos, and start a summary using the video's `stream_id`:
+
+```bash
+VSS_REPO_ROOT="${VSS_REPO_ROOT:-$HOME/video-search-and-summarization}"
+vss() { uv run --project "${VSS_REPO_ROOT}/services/agent" --no-dev --extra cli vss "$@"; }
+
+vss configure --base-url http://<HOST_IP>:7777
+vss configure check
+vss vios list --type video
+vss summarize run \
+  --id <stream_id-from-vss-vios-list> \
+  --scenario "warehouse monitoring" \
+  --event "boxes falling" \
+  --event "person entering restricted area"
+```
+
+`vss summarize run` is synchronous and can take several minutes for a long video. It records a job before starting the model request; use `vss summarize list` to find the job ID and `vss summarize status --job-id <id>` or `vss summarize get --job-id <id>` from another shell while it runs.
 
 ### Manually
 
@@ -580,9 +600,8 @@ your network speed, this may take a few minutes.
 
 **This deployment uses the following defaults:**
 
-
-- LLM model: nvidia/nemotron-3.5-lightning-30b-a3b
-- VLM model: nvidia/cosmos3-nano-reasoner
+- LLM model: `nvidia/nemotron-3.5-lightning-30b-a3b`
+- VLM model: `nim_nvidia_cosmos3-nano-reasoner_bf16-final` through RTVI-VLM
 
 <Note>
 When using a remote VLM of model-type `nim` (not `openai`), see [How does a remote `nim` VLM access videos?](/vss/appendix/faq#how-does-a-remote-nim-vlm-access-videos) for access requirements.
@@ -740,11 +759,15 @@ Set `default_*` in the `Data view` dropdown. Here you can see the events detecte
 To teardown the agent, run the following command:
 
 ```bash
-cd deploy/docker
-docker compose -p vss down -v --remove-orphans
+PROFILE=lvs
+docker compose -f compose.yml \
+  --env-file containers.env \
+  --env-file "developer-profiles/dev-profile-${PROFILE}/.env" \
+  --env-file "developer-profiles/dev-profile-${PROFILE}/user-overrides.env" \
+  down -v --remove-orphans
 ```
 
-This command will stop and remove the agent containers.
+This command stops the manually deployed LVS containers and removes their Compose volumes.
 
 ## Service Endpoints
 


### PR DESCRIPTION
## Summary

  Refresh the LVS profile documentation to match the current develop configuration and user workflow compared with VSS
  3.2.1.

  ## Plan

  - Compare the LVS profile configuration with VSS 3.2.1.
  - Document relevant user-visible changes.
  - Validate the updated MDX documentation.

  ## Related Issue

  N/A. Documentation refresh.

  ## Changes

  - Updated the LVS default LLM and VLM documentation.
  - Clarified the integrated RTVI-VLM architecture.
  - Added a VSS CLI summarization example.
  - Corrected the deployment teardown command.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.
