### PR TITLE
Fix/mv3dt standalone bugs

### DIFF
--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/README.md
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/README.md
@@ -46,7 +46,8 @@ includes a 4-camera warehouse **sample dataset** you can run end-to-end.
 - [3. Launch](#3-launch)
   - [3.1 Option A — bundled brokers](#31-option-a--bundled-brokers)
   - [3.2 Option B — your own brokers](#32-option-b--your-own-brokers)
-  - [3.3 Verify startup](#33-verify-startup)
+  - [3.3 On screen, display, and GPU selection](#33-on-screen-display-and-gpu-selection)
+  - [3.4 Verify startup](#34-verify-startup)
 - [4. Add streams dynamically (RTSP)](#4-add-streams-dynamically-rtsp)
 - [5. Check logs and receive metadata from Kafka](#5-check-logs-and-receive-metadata-from-kafka)
 - [6. Visualization](#6-visualization)
@@ -221,7 +222,21 @@ docker compose up -d
 #   docker compose --profile "*" down
 ```
 
-### 3.3 Verify startup
+### 3.3 On screen, display, and GPU selection
+
+`GPU_DEVICE` in [docker/.env](docker/.env) picks the GPU the pipeline computes on. With `OSD=1` the container also has to reach the GPU that drives the X display, which is often a different one on a multi-GPU host.
+
+`stage-configs.sh` resolves this: it adds the display GPU to `GPU_DEVICE` when it is missing, and writes `gpu-id` into the staged config as the compute GPU's ordinal within that set. The two are not the same number, because the container runtime orders the visible devices by PCI address rather than by the order you list them.
+
+```
+GPU_DEVICE=7   OSD=1   ->   GPU_DEVICE=3,7   gpu-id=1     # compute on 7, display via 3
+```
+
+When the display GPU cannot be determined, staging says so and changes nothing. The on-screen display may then fail with `Failed to set pipeline to PAUSED`; add the GPU driving the display to `GPU_DEVICE` and restage.
+
+On a laptop or any host whose display is rendered by Mesa rather than by an NVIDIA GPU, this is a different problem with a different fix: uncomment the `devices` block in [docker/compose.yml](docker/compose.yml). The preflight names whichever of the two it sees.
+
+### 3.4 Verify startup
 
 Either option — follow the perception logs until the pipeline reports ready:
 
@@ -283,6 +298,8 @@ testing on recorded files — see [§2.3](#23-stage-the-deepstream-configs).*
 > not: VST unifies their SEI). A source that does not go through VST must supply
 > `NVDS_CUSTOMMETA` SEI itself.
 >
+> **Restage after any `docker/.env` change.** Several values are resolved at staging and written into `generated/`: the camera count, the broker endpoints, and the GPU selection. Editing `docker/.env` and bringing the stack up without re-running `./scripts/stage-configs.sh` leaves the staged configuration describing the previous settings. The container checks the ones it can and refuses rather than starting wrong.
+
 > `scripts/add-streams.sh` checks this before registering anything and refuses
 > with the remedy. To fix it, set `"enable_proxy_server_sei_metadata": true` in
 > both the VST and NVStreamer `vst_config.json` your deployment uses, redeploy,

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/README.md
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/README.md
@@ -433,14 +433,14 @@ ffmpeg -i video-output/grid-view.mkv -c copy video-output/grid-view.mp4
 
 > **NVENC-less GPUs (e.g. A100, H100, H200, GB200, GB300).** The video output from the perception container is encoded with the GPU's NVENC hardware
 > encoder by default (`enc-type=0` for `[sink2]` in `configs/ds-main-config-mv3dt.txt`). When `SAVE_VIDEO=1`,
-> `stage-configs.sh` detects these GPUs with `nvidia-smi` and stages the software (CPU) encoder
-> (`enc-type=1`) instead. First prepare the image once:
+> `stage-configs.sh` detects these GPUs with `nvidia-smi` and stages the software (CPU) encoder (`enc-type=1`) instead.
+> The stock image does not carry that encoder, so staging also prepares it: it runs DeepStream's `user_additional_install.sh` in a throwaway container, commits the result as `<tag>-swenc`, and points `PERCEPTION_TAG` at it. That takes a few minutes on first use and needs network access to the Ubuntu archives; afterwards it is a no-op. Staging refuses rather than writing a config that would fail at runtime for lack of an encoder.
+> The prepared image is local to that host, so a later `PERCEPTION_TAG` bump needs it again — staging notices and redoes it.
+> To prepare it on its own, or just to check:
 > ```bash
-> docker exec -it vss-rtvi-cv-mv3dt \
->   bash -c 'cd /opt/nvidia/deepstream/deepstream/ && bash user_additional_install.sh'   # install the software encoder
-> docker commit vss-rtvi-cv-mv3dt <your-image>:<tag>    # then set this image in docker/.env
+> ./scripts/prepare-sw-encoder.sh           # prepare and update docker/.env
+> ./scripts/prepare-sw-encoder.sh --check   # report only; exit 1 if the encoder is missing
 > ```
-> Then stage and launch normally.
 
 ### 6.3 BEV visualizer — live window
 

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/README.md
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/README.md
@@ -290,6 +290,8 @@ testing on recorded files — see [§2.3](#23-stage-the-deepstream-configs).*
 > docker exec streamprocessing-ms-1 sh -lc \
 >   'grep -n enable_proxy_server_sei_metadata /home/vst/vst_release/configs/vst_config.json'
 > ```
+>
+> The check finds the proxy by probing ports 30000-30005 and 31000-31005: a VIOS deployment runs several VST services and only the proxy answers `/api/v1/proxy/configuration`, so a 404 does not mean VST is absent. Set `VST_HTTP_PORT` to pin the port. If nothing answers, the run stops rather than registering streams that could never activate; a source that carries the SEI without going through VST needs `--no-sei-check`.
 
 Register your RTSP streams via the perception REST API — one
 `<sensor_id>=<rtsp_url>` pair per camera, for all `NUM_CAMS` cameras.

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/README.md
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/README.md
@@ -206,10 +206,14 @@ COMPOSE_PROFILES=mosquitto,kafka docker compose up -d
 
 ### 3.2 Option B — your own brokers
 
-If you want to use your own mosquitto and kafka brokers, set `MQTT_HOST`/`MQTT_PORT` and `KAFKA_BOOTSTRAP` in [docker/.env](docker/.env)
-and launch without `COMPOSE_PROFILES`:
+> **The two brokers propagate differently.** `MQTT_HOST`/`MQTT_PORT` are read by the container at every start, so editing `docker/.env` is enough for MQTT. The Kafka endpoint is written into `generated/configs/ds-main-config-mv3dt.txt` by `stage-configs.sh` and the configs are mounted read-only, so changing `KAFKA_BOOTSTRAP` without restaging leaves the old endpoint in place. Perception then retries a broker that is not there and aborts. The container checks the two against each other at startup and refuses with this remedy rather than failing that way, but restaging is what fixes it.
+
+If you want to use your own mosquitto and kafka brokers, set `MQTT_HOST`/`MQTT_PORT` and `KAFKA_BOOTSTRAP` in [docker/.env](docker/.env),
+**restage**, then launch without `COMPOSE_PROFILES`:
 
 ```bash
+./scripts/stage-configs.sh     # required: the Kafka endpoint is written into the staged config
+
 cd docker
 docker compose up -d
 

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/docker/compose.yml
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/docker/compose.yml
@@ -50,6 +50,7 @@ services:
       GST_ENABLE_CUSTOM_PARSER_MODIFICATIONS: 1
       OTEL_SDK_DISABLED: "true"
       DISPLAY: ${DISPLAY:-:0}
+      CUDA_DEVICE_ORDER: PCI_BUS_ID
       NVIDIA_VISIBLE_DEVICES: ${GPU_DEVICE:-0}
     volumes:
       - ${MODELS_DIR:?set MODELS_DIR in docker/.env}/mtmc:/opt/storage

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/docker/compose.yml
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/docker/compose.yml
@@ -42,6 +42,10 @@ services:
       DS_HTTP_PORT: "${DS_HTTP_PORT:-9000}"
       MQTT_HOST: ${MQTT_HOST:-localhost}
       MQTT_PORT: ${MQTT_PORT:-1883}
+      # Not used to configure Kafka, which is staged into the main config. Passed
+      # so the container can tell a stale staged endpoint from a current one.
+      KAFKA_BOOTSTRAP: ${KAFKA_BOOTSTRAP:-localhost:9092}
+      RAW_TOPIC: ${RAW_TOPIC:-mdx-raw}
       DEEPSTREAM_ENABLE_SENSOR_ID_EXTRACTION: "0"
       GST_ENABLE_CUSTOM_PARSER_MODIFICATIONS: 1
       OTEL_SDK_DISABLED: "true"

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/docker/init-scripts/ds-start-mv3dt.sh
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/docker/init-scripts/ds-start-mv3dt.sh
@@ -198,6 +198,34 @@ if ! kafka_endpoint_matches_env "${CONFIG_DIR}/ds-main-config-mv3dt.txt"; then
   exit 1
 fi
 
+# A refused restage leaves the previous staged config in place, so the stack can
+# still come up against it. Compare what was staged with what is mounted.
+batch_matches_caminfo() {  # $1=staged main config
+  local cfg="$1" staged mounted
+  [ -f "$cfg" ] || return 0
+  [ -d /tmp/camInfo ] || return 0
+  mounted="$(find /tmp/camInfo -maxdepth 1 -name '*.yml' 2>/dev/null | wc -l)"
+  [ "$mounted" -gt 0 ] || return 0
+  staged="$(awk '/^[[:space:]]*\[/ { s = ($0 ~ /^[[:space:]]*\[streammux\]/) }
+                 s && /^[[:space:]]*batch-size[[:space:]]*=/ {
+                   sub(/.*=[[:space:]]*/, ""); print $1; exit }' "$cfg")"
+  [ -n "$staged" ] || return 0
+  [ "$staged" = "$mounted" ] && return 0
+
+  { echo "** ERROR: the staged config and the mounted camera set disagree."
+    echo "          staged  [streammux] batch-size = ${staged}"
+    echo "          mounted generated/camInfo      = ${mounted} camera(s)"
+    echo "          This is a stale staging: scripts/stage-configs.sh refused the last"
+    echo "          run and left the previous config in place. Restage for this camera"
+    echo "          set, with NUM_CAMS matching it:"
+    echo "            ./scripts/stage-configs.sh"; } >&2
+  return 1
+}
+
+if ! batch_matches_caminfo "${CONFIG_DIR}/ds-main-config-mv3dt.txt"; then
+  exit 1
+fi
+
 if ! osd_preflight "${CONFIG_DIR}/ds-main-config-mv3dt.txt"; then
   { echo
     echo "** ERROR: not starting the pipeline: it would fail at 'Failed to set pipeline"

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/docker/init-scripts/ds-start-mv3dt.sh
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/docker/init-scripts/ds-start-mv3dt.sh
@@ -165,9 +165,38 @@ PY
 MQTT_HOST=${MQTT_HOST:-localhost}
 MQTT_PORT=${MQTT_PORT:-1883}
 MQTT_ENDPOINT="${MQTT_HOST}:${MQTT_PORT}"
+
+# MQTT is rewritten at every start, so docker/.env alone is enough. Kafka is
+# baked into the staged config, so an edit without a restage leaves the old
+# endpoint and the app retries a broker that is not there. Compare and report.
+kafka_endpoint_matches_env() {  # $1=staged main config
+  local cfg="$1" staged want_host want_port
+  [ -n "${KAFKA_BOOTSTRAP:-}" ] || return 0          # nothing to compare against
+  [ -f "$cfg" ] || return 0
+  staged="$(awk '/^[[:space:]]*\[/ { s = ($0 ~ /^[[:space:]]*\[sink1\]/) }
+                 s && /^[[:space:]]*msg-broker-conn-str[[:space:]]*=/ {
+                   sub(/.*=[[:space:]]*/, ""); print $1; exit }' "$cfg")"
+  [ -n "$staged" ] || return 0
+  want_host="${KAFKA_BOOTSTRAP%%:*}"
+  want_port="${KAFKA_BOOTSTRAP##*:}"
+  [ "$staged" = "${want_host};${want_port};${RAW_TOPIC:-mdx-raw}" ] && return 0
+
+  { echo "** ERROR: the staged Kafka endpoint does not match docker/.env."
+    echo "          staged  [sink1] msg-broker-conn-str = ${staged}"
+    echo "          .env    KAFKA_BOOTSTRAP=${KAFKA_BOOTSTRAP} RAW_TOPIC=${RAW_TOPIC:-mdx-raw}"
+    echo "          Unlike MQTT, the Kafka endpoint is written into the staged config, so"
+    echo "          editing docker/.env is not enough. Restage, then bring the stack up:"
+    echo "            ./scripts/stage-configs.sh"
+    echo "          Starting now would retry a broker that is not there and then abort."; } >&2
+  return 1
+}
 cd /opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/metropolis_perception_app
 APP_DIR="$(pwd)"
 CONFIG_DIR="${APP_DIR}/configs"
+
+if ! kafka_endpoint_matches_env "${CONFIG_DIR}/ds-main-config-mv3dt.txt"; then
+  exit 1
+fi
 
 if ! osd_preflight "${CONFIG_DIR}/ds-main-config-mv3dt.txt"; then
   { echo

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/docker/init-scripts/ds-start-mv3dt.sh
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/docker/init-scripts/ds-start-mv3dt.sh
@@ -153,10 +153,19 @@ PY
     # pipeline's failure: stop rather than stall at PAUSED.
     { echo "** ERROR: the EGL sink could not render a test frame, so OSD will not work."
       grep -iE 'drm|dri2|EGL' /tmp/egl-probe.log 2>/dev/null | tail -3 | sed 's/^/          /'
-      # The NVIDIA runtime always exposes a couple of DRI nodes, so their
-      # presence says nothing about whether the full set is mapped.
-      grep -qiE 'drm|dri2' /tmp/egl-probe.log 2>/dev/null &&
-        echo "          Mesa cannot reach the DRM device: uncomment the devices block in docker/compose.yml"; } >&2
+      # Same failure, opposite remedies, so pick by what the probe logged:
+      # hybrid graphics render through a DRM device, multi-GPU hosts through an
+      # NVIDIA GPU the container was not given.
+      if grep -qiE 'mesa|dri2|drm' /tmp/egl-probe.log 2>/dev/null; then
+        echo "          The display is rendered through Mesa, so it needs the DRM device."
+        echo "          Uncomment the devices block in docker/compose.yml."
+      else
+        echo "          The GPUs given to this container do not include the one driving"
+        echo "          ${DISPLAY}. Restage if docker/.env changed since, and if staging"
+        echo "          reported it could not tell, add that GPU to GPU_DEVICE by hand."
+        echo "          This is GPU selection, not permissions: privileged and group_add"
+        echo "          do not help."
+      fi; } >&2
     return 1
   fi
   return 0

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/add-streams.sh
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/add-streams.sh
@@ -33,7 +33,7 @@
 #   ./scripts/add-streams.sh --remove-all --yes                   # same, no confirmation prompt
 #   ./scripts/add-streams.sh --list                      # show current stream-info
 #
-# Options / env:
+# Options:
 #   --ds-port P        perception REST port      (default: $DS_HTTP_PORT or 9000)
 #   --delay S          seconds between adds      (default: 1)
 #   --no-url-check     skip the pre-add RTSP reachability check
@@ -44,6 +44,12 @@
 #                      is reported as inactive.
 #   --ready-timeout S  wait for ds-ready: YES    (default: 600 — a cold TensorRT
 #                      engine build for a new batch size takes minutes)
+#
+# Env:
+#   DS_HTTP_PORT     perception REST port      (default: 9000)
+#   VST_HTTP_PORT    pin the VST proxy API port. Unset probes 30000-30005
+#                    and 31000-31005, and reuses whichever answered. 0 skips
+#                    the check, same as --no-sei-check.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -59,8 +65,10 @@ ACTIVATION_TIMEOUT="${ACTIVATION_TIMEOUT:-60}"
 RTSP_PROBE_TIMEOUT="${RTSP_PROBE_TIMEOUT:-2}"
 # VST management API, used to confirm the proxy emits SEI frame IDs before
 # streams are registered. Port is VST's http_port; host is taken from the RTSP
-# URLs. Set VST_HTTP_PORT=0 or pass --no-sei-check to skip.
-VST_HTTP_PORT="${VST_HTTP_PORT:-30000}"
+# URLs. Set VST_HTTP_PORT to pin the port, or pass --no-sei-check to skip.
+# Unset means "discover it": see check_sei_frame_ids.
+VST_HTTP_PORT="${VST_HTTP_PORT:-}"
+SEI_CHECK=1
 
 STREAMS=()
 MODE=add
@@ -85,7 +93,7 @@ while (($#)); do
     --ready-timeout)  READY_TIMEOUT="$2"; shift 2 ;;
     --activation-timeout) ACTIVATION_TIMEOUT="$2"; shift 2 ;;
     --no-url-check)   RTSP_PROBE_TIMEOUT=0; shift ;;
-    --no-sei-check)   VST_HTTP_PORT=0; shift ;;
+    --no-sei-check)   SEI_CHECK=0; shift ;;
     -h|--help)        usage 0 ;;
     *=*)              STREAMS+=("$1"); shift ;;
     *) if [[ "$MODE" == remove ]]; then STREAMS+=("$1"); shift; else echo "Unknown arg: $1" >&2; usage 2; fi ;;
@@ -626,32 +634,63 @@ except Exception as exc:
 '
 }
 
-# With INPUT_MODE=stream every RTSP source must carry NVDS_CUSTOMMETA SEI: the
-# staged DeepStream config sets extract-sei-sim-time=1 with
-# attach-sys-ts-as-ntp=0, so frame timestamps come from the SEI. File input is
-# staged the other way round (SEI extraction off, attach-sys-ts-as-ntp=1) and
-# takes them from the host clock, so this prerequisite is specific to the live
-# stream path, not to MV3DT as such.
-# In this deployment the VST proxy is what injects that SEI. With
-# "enable_proxy_server_sei_metadata": false the proxy serves video without it,
-# and the perception service accepts every stream but never activates any
-# source -- no bbox, no mdx-raw. That misconfiguration is invisible from the
-# perception side, so ask VST directly before registering anything.
-#
-# VST exposes it at GET /api/v1/proxy/configuration on its http_port as
-# "enableProxyServerFrameIdSupport". Fails open: deployments that feed RTSP
-# from cameras rather than a VST proxy have no such endpoint, and must not be
-# blocked by a check that cannot apply to them.
-check_sei_frame_ids() {  # $1=an rtsp:// url the streams will come from
-  [[ "$VST_HTTP_PORT" =~ ^[0-9]+$ ]] || return 0
-  (( VST_HTTP_PORT > 0 )) || return 0
+# An explicit VST_HTTP_PORT is used alone; otherwise probe both ranges. The
+# caller stores whatever answered, so later hosts skip the search.
+vst_candidate_ports() {
+  if [[ -n "$VST_HTTP_PORT" ]]; then printf '%s\n' "$VST_HTTP_PORT"; return; fi
+  seq 30000 30005
+  seq 31000 31005
+}
 
-  local host payload enabled
+# True when the staged config takes frame timestamps from the SEI. Absent
+# config means we cannot tell, so do not block.
+sei_required() {
+  local cfg="${ROOT}/generated/configs/ds-main-config-mv3dt.txt" v
+  [[ -f "$cfg" ]] || return 1
+  v="$(awk '/^[[:space:]]*\[/ { s = ($0 ~ /^[[:space:]]*\[streammux\]/) }
+            s && /^[[:space:]]*extract-sei-sim-time[[:space:]]*=/ {
+              sub(/.*=[[:space:]]*/, ""); print $1; exit }' "$cfg")"
+  [[ "$v" == 1 ]]
+}
+
+# Without the SEI, streams register and no source activates, and nothing on the
+# perception side says so. Ask VST before registering anything.
+#
+# The proxy answers GET /api/v1/proxy/configuration with
+# "enableProxyServerFrameIdSupport". Its port is not fixed, and a VIOS
+# deployment runs several VST-family services of which only the proxy serves
+# that path, so a 404 means "keep looking" rather than "no VST here".
+#
+# A deployment we cannot verify is stopped: no timestamp configuration makes a
+# SEI-less live source work, so passing it through only defers the failure.
+check_sei_frame_ids() {  # $1=an rtsp:// url the streams will come from
+  (( SEI_CHECK )) || return 0
+  [[ "$VST_HTTP_PORT" == 0 ]] && return 0    # long-standing "skip" spelling
+  sei_required || return 0
+
+  local host payload enabled port
   host="${1#rtsp://}"; host="${host%%/*}"; host="${host%%:*}"
   [[ -n "$host" ]] || return 0
 
-  payload="$(curl -fsS --max-time 3 --connect-timeout 2 \
-             "http://${host}:${VST_HTTP_PORT}/api/v1/proxy/configuration" 2>/dev/null)" || return 0
+  payload=""
+  for port in $(vst_candidate_ports); do
+    payload="$(curl -fsS --max-time 2 --connect-timeout 1 \
+               "http://${host}:${port}/api/v1/proxy/configuration" 2>/dev/null)" || continue
+    [[ "$payload" == *enableProxyServerFrameIdSupport* ]] || { payload=""; continue; }
+    VST_HTTP_PORT="$port"      # remember, so later hosts skip the search
+    break
+  done
+
+  if [[ -z "$payload" ]]; then
+    echo "ERROR: could not verify the SEI frame-ID prerequisite: no VST proxy API" >&2
+    echo "       answered at ${host} (tried ports $(vst_candidate_ports | tr '\n' ' ' | sed 's/ $//'))." >&2
+    echo "       This deployment is staged for live streams (extract-sei-sim-time=1)," >&2
+    echo "       so every source must carry NVDS_CUSTOMMETA SEI. Without it the streams" >&2
+    echo "       register, ds-ready reports YES, and no source ever activates." >&2
+    echo "       If VST serves on another port, set VST_HTTP_PORT." >&2
+    echo "       If these sources carry the SEI themselves, pass --no-sei-check." >&2
+    return 1
+  fi
 
   enabled="$(printf '%s' "$payload" | python3 -c '
 import json, sys

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/add-streams.sh
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/add-streams.sh
@@ -636,8 +636,15 @@ except Exception as exc:
 
 # An explicit VST_HTTP_PORT is used alone; otherwise probe both ranges. The
 # caller stores whatever answered, so later hosts skip the search.
-vst_candidate_ports() {
+# Ports to try for one host. An explicit VST_HTTP_PORT pins every host; a port
+# we discovered is remembered per host, because a batch can span VST deployments
+# that serve the proxy API on different ports.
+declare -A VST_PORT_BY_HOST=()
+
+vst_candidate_ports() {  # $1=host
   if [[ -n "$VST_HTTP_PORT" ]]; then printf '%s\n' "$VST_HTTP_PORT"; return; fi
+  local cached="${VST_PORT_BY_HOST[${1:-}]:-}"
+  if [[ -n "$cached" ]]; then printf '%s\n' "$cached"; return; fi
   seq 30000 30005
   seq 31000 31005
 }
@@ -668,22 +675,23 @@ check_sei_frame_ids() {  # $1=an rtsp:// url the streams will come from
   [[ "$VST_HTTP_PORT" == 0 ]] && return 0    # long-standing "skip" spelling
   sei_required || return 0
 
-  local host payload enabled port
+  local host payload enabled port found_port
   host="${1#rtsp://}"; host="${host%%/*}"; host="${host%%:*}"
   [[ -n "$host" ]] || return 0
 
-  payload=""
-  for port in $(vst_candidate_ports); do
+  payload=""; found_port=""
+  for port in $(vst_candidate_ports "$host"); do
     payload="$(curl -fsS --max-time 2 --connect-timeout 1 \
                "http://${host}:${port}/api/v1/proxy/configuration" 2>/dev/null)" || continue
     [[ "$payload" == *enableProxyServerFrameIdSupport* ]] || { payload=""; continue; }
-    VST_HTTP_PORT="$port"      # remember, so later hosts skip the search
+    found_port="$port"
+    VST_PORT_BY_HOST["$host"]="$port"   # remember for this host only
     break
   done
 
   if [[ -z "$payload" ]]; then
     echo "ERROR: could not verify the SEI frame-ID prerequisite: no VST proxy API" >&2
-    echo "       answered at ${host} (tried ports $(vst_candidate_ports | tr '\n' ' ' | sed 's/ $//'))." >&2
+    echo "       answered at ${host} (tried ports $(vst_candidate_ports "$host" | tr '\n' ' ' | sed 's/ $//'))." >&2
     echo "       This deployment is staged for live streams (extract-sei-sim-time=1)," >&2
     echo "       so every source must carry NVDS_CUSTOMMETA SEI. Without it the streams" >&2
     echo "       register, ds-ready reports YES, and no source ever activates." >&2
@@ -705,7 +713,7 @@ if isinstance(v, bool):
 
   [[ "$enabled" == "false" ]] || return 0
 
-  echo "ERROR: the VST proxy at ${host}:${VST_HTTP_PORT} is not emitting SEI frame IDs" >&2
+  echo "ERROR: the VST proxy at ${host}:${found_port} is not emitting SEI frame IDs" >&2
   echo "       (enableProxyServerFrameIdSupport=false)." >&2
   echo "       MV3DT stamps frames from the host clock or from NVDS_CUSTOMMETA SEI," >&2
   echo "       depending on the input mode. This deployment is staged for live streams" >&2

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/add-streams.sh
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/add-streams.sh
@@ -48,8 +48,8 @@
 # Env:
 #   DS_HTTP_PORT     perception REST port      (default: 9000)
 #   VST_HTTP_PORT    pin the VST proxy API port. Unset probes 30000-30005
-#                    and 31000-31005, and reuses whichever answered. 0 skips
-#                    the check, same as --no-sei-check.
+#                    and 31000-31005, and reuses whichever answered.
+#                    0 skips the check, same as --no-sei-check.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -787,7 +787,7 @@ print(registered, required)
 ' 2>/dev/null || echo "0 0"
 }
 
-verify_streams_active() {  # args: camera IDs added in this run
+verify_streams_active() {  # args: camera IDs added in this run, used as a fallback
   (( $# )) || return 0
   [[ "$ACTIVATION_TIMEOUT" =~ ^[0-9]+$ ]] || return 0
   (( ACTIVATION_TIMEOUT > 0 )) || return 0
@@ -802,6 +802,19 @@ verify_streams_active() {  # args: camera IDs added in this run
     return 0
   fi
 
+  # The batch is complete, so judge every registered source rather than only the
+  # ones this run added. One source that cannot decode stalls the whole batch, so
+  # the camera that completes the batch is reported as not producing even when the
+  # broken one was registered earlier. Fall back to this run's list when the
+  # registry cannot be read, which is worse but still better than nothing.
+  local judged=() all_ids
+  if all_ids="$(registered_camera_ids)" && [[ -n "$all_ids" ]]; then
+    mapfile -t judged <<<"$all_ids"
+  else
+    judged=("$@")
+  fi
+  (( ${#judged[@]} )) || return 0
+
   # Liveness is frame_number advancing, not membership of stream-stats. That list
   # is a rolling buffer of recent per-source samples, not one row per stream: a
   # single payload can carry the same sensor_id twice with consecutive frame
@@ -809,13 +822,12 @@ verify_streams_active() {  # args: camera IDs added in this run
   # source that is decoding therefore shows up repeatedly across a few seconds of
   # polling with a rising frame_number, while one that is not either never
   # appears or stays frozen -- observed live at frame_number 296 while DeepStream
-  # retried its RTSP connect. Both count as not producing; only the wording of
-  # the report differs, because only cameras added by this run are judged.
+  # retried its RTSP connect. Both count as not producing.
   echo "── Waiting up to ${ACTIVATION_TIMEOUT}s for the sources to produce frames"
 
   local out rc=0
   out="$(BASE="$BASE" ACTIVATION_TIMEOUT="$ACTIVATION_TIMEOUT" \
-         python3 - "$@" <<'PY'
+         python3 - "${judged[@]}" <<'PY'
 import json
 import os
 import sys
@@ -890,8 +902,7 @@ PY
   fi
 
   echo >&2
-  echo "ERROR: the perception service accepted these streams but they are not producing frames" >&2
-  echo "       after ${ACTIVATION_TIMEOUT}s:" >&2
+  echo "ERROR: registered streams are not producing frames after ${ACTIVATION_TIMEOUT}s:" >&2
   printf '%s\n' "$out" | grep -v '^OBS ' | sed 's/^/         /' >&2
   echo "       Their frame_number never advanced in /api/v1/metrics: STATIC means the" >&2
   echo "       stream was sampled but frozen, UNSEEN that it was never sampled at all." >&2

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/generate-configs.sh
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/generate-configs.sh
@@ -101,5 +101,31 @@ echo
 echo "DONE. Generated:"
 echo "  $CAMINFO/  ($(ls -1 "$CAMINFO"/*.yml 2>/dev/null | wc -l | tr -d ' ') files)"
 echo "  $GEN/pub_sub_info_config.yml"
+# NUM_CAMS must equal the cameras just generated: stage-configs.sh checks it, and
+# compose passes it to bev-fusion as MAX_EXPECTED_SENSORS, where a stale value is
+# silent.
+CAM_COUNT="$(ls -1 "$CAMINFO"/*.yml 2>/dev/null | wc -l | tr -d ' ')"
+ENV_FILE="$ROOT/docker/.env"
 echo
-echo "Next: set NUM_CAMS=$(ls -1 "$CAMINFO"/*.yml 2>/dev/null | wc -l | tr -d ' ') in docker/.env, then ./scripts/stage-configs.sh"
+if [ ! -f "$ENV_FILE" ]; then
+  echo "NOTE: $ENV_FILE not found; set NUM_CAMS=$CAM_COUNT there before staging."
+elif grep -qE '^[[:space:]]*NUM_CAMS=' "$ENV_FILE"; then
+  PREV="$(sed -nE 's/^[[:space:]]*NUM_CAMS=([^[:space:]#]*).*/\1/p' "$ENV_FILE" | head -1)"
+  if [ "$PREV" = "$CAM_COUNT" ]; then
+    echo "NUM_CAMS=$CAM_COUNT in docker/.env (already correct)"
+  else
+    # Keep any trailing comment on the line: it is the user's, not ours.
+    TRAILER="$(sed -nE 's/^[[:space:]]*NUM_CAMS=[^#]*(#.*)?$/\1/p' "$ENV_FILE" | head -1)"
+    if [ -n "$TRAILER" ]; then
+      sed -i -E "s|^[[:space:]]*NUM_CAMS=.*|NUM_CAMS=$CAM_COUNT  $TRAILER|" "$ENV_FILE"
+    else
+      sed -i -E "s|^[[:space:]]*NUM_CAMS=.*|NUM_CAMS=$CAM_COUNT|" "$ENV_FILE"
+    fi
+    echo "NUM_CAMS: $PREV -> $CAM_COUNT in docker/.env"
+  fi
+else
+  printf 'NUM_CAMS=%s\n' "$CAM_COUNT" >> "$ENV_FILE"
+  echo "NUM_CAMS=$CAM_COUNT appended to docker/.env"
+fi
+echo
+echo "Next: ./scripts/stage-configs.sh"

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/prepare-sw-encoder.sh
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/prepare-sw-encoder.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# prepare-sw-encoder.sh — put the software (CPU) encoder into the perception
+# image, for GPUs with no hardware encoder.
+#
+# Usage:
+#   ./scripts/prepare-sw-encoder.sh             # prepare, point docker/.env at the result
+#   ./scripts/prepare-sw-encoder.sh --check     # report only (exit 1 if missing)
+#   ./scripts/prepare-sw-encoder.sh --probe-hw  # 0 hardware ok, 10 needs software, 2 unknown
+#
+# The image is slimmed: gstreamer1.0-plugins-ugly and libx264-164 are marked
+# installed with their files deleted, so only --reinstall brings them back.
+# DeepStream's user_additional_install.sh also reinstalls plugins-good and
+# plugins-bad, which clobbers its own patched plugins; restoring just these two
+# does not. It stays as a fallback.
+#
+# Needs network (apt) and root in the container (the image runs as uid 1000).
+# Idempotent: exits early when the image already has a working encoder.
+#
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="$ROOT/docker/.env"
+
+CHECK_ONLY=0
+PROBE_HW=0
+case "${1:-}" in
+  --check)    CHECK_ONLY=1 ;;
+  --probe-hw) PROBE_HW=1 ;;
+esac
+
+env_value() {
+  local key="$1" v=""
+  [ -f "$ENV_FILE" ] || return 1
+  v="$(grep -E "^[[:space:]]*${key}=" "$ENV_FILE" | tail -1 | cut -d= -f2-)" || return 1
+  v="${v%\"}"; v="${v#\"}"; v="${v%\'}"; v="${v#\'}"
+  printf '%s' "$v"
+}
+
+IMAGE="$(env_value PERCEPTION_IMAGE)"; IMAGE="${IMAGE:-ghcr.io/nvidia-ai-blueprints/vss/vss-rt-cv}"
+TAG="$(env_value PERCEPTION_TAG)";     TAG="${TAG:-develop-latest}"
+TARGET_TAG="${TAG}-swenc"
+GPU_DEVICE="${GPU_DEVICE:-$(env_value GPU_DEVICE)}"; GPU_DEVICE="${GPU_DEVICE:-0}"
+
+# The .so can be present and still not load, so ask GStreamer for the element.
+has_encoder() {
+  docker run --rm --entrypoint sh "$1" \
+    -c 'gst-inspect-1.0 x264enc' >/dev/null 2>&1
+}
+
+# docker commit captures the prep container's overridden entrypoint, so a
+# prepared image can carry the encoder and still not start.
+entrypoint_matches() {
+  local want got
+  want="$(docker inspect -f '{{json .Config.Entrypoint}}' "${IMAGE}:${TAG}" 2>/dev/null)"
+  got="$(docker inspect -f '{{json .Config.Entrypoint}}' "$1" 2>/dev/null)"
+  [ -n "$want" ] && [ "$want" = "$got" ]
+}
+
+manual_steps() {
+  echo "       Prepare the image by hand instead (note -u 0: the image runs as uid 1000," >&2
+  echo "       so without it apt cannot write):" >&2
+  echo "         docker run -d --name swenc -u 0 --entrypoint sleep ${IMAGE}:${TAG} 3600" >&2
+  echo "         docker exec -u 0 swenc sh -c 'apt-get update && apt-get install -y --reinstall gstreamer1.0-plugins-ugly libx264-164'" >&2
+  echo "         docker commit --change \"ENTRYPOINT \$(docker inspect -f '{{json .Config.Entrypoint}}' ${IMAGE}:${TAG})\" \\" >&2
+  echo "                       swenc ${IMAGE}:${TARGET_TAG} && docker rm -f swenc" >&2
+  echo "       (the --change is required: the prep container overrides the entrypoint)" >&2
+  echo "       Then set PERCEPTION_TAG=${TARGET_TAG} in docker/.env and restage." >&2
+}
+
+# The image is needed to deploy either way, so pulling here just moves it earlier.
+ensure_image() {
+  docker image inspect "${IMAGE}:${TAG}" >/dev/null 2>&1 && return 0
+  echo "   pulling ${IMAGE}:${TAG} (needed to run at all; this takes a while)"
+  docker pull "${IMAGE}:${TAG}" >/dev/null 2>&1
+}
+
+# 0 hardware encodes, 10 it cannot, 2 no answer. The element exists even where
+# it cannot encode, so it is run, not inspected.
+probe_hw_encoder() {
+  command -v docker >/dev/null 2>&1 || return 2
+  # No GPU visible means the probe cannot run, so do not pull an image for it.
+  nvidia-smi -L >/dev/null 2>&1 || return 2
+  ensure_image || return 2
+  docker image inspect "${IMAGE}:${TAG}" >/dev/null 2>&1 || return 2
+  # Jetson has no --gpus; failing to start says nothing about the encoder.
+  docker run --rm --gpus "device=${GPU_DEVICE%%,*}" --entrypoint sh \
+    "${IMAGE}:${TAG}" -c true >/dev/null 2>&1 || return 2
+  if docker run --rm --gpus "device=${GPU_DEVICE%%,*}" --entrypoint sh "${IMAGE}:${TAG}" -c \
+       'gst-launch-1.0 -q videotestsrc num-buffers=2 ! video/x-raw,width=256,height=256 ! nvvideoconvert ! nvv4l2h264enc ! fakesink' \
+       >/dev/null 2>&1; then
+    return 0
+  fi
+  return 10
+}
+
+command -v docker >/dev/null 2>&1 || {
+  echo "ERROR: docker not found; cannot prepare the software encoder." >&2
+  exit 1
+}
+
+if [ "$PROBE_HW" = 1 ]; then
+  probe_hw_encoder
+  exit $?
+fi
+
+ensure_image
+
+if has_encoder "${IMAGE}:${TAG}"; then
+  echo "   software encoder: already present in ${IMAGE}:${TAG}"
+  exit 0
+fi
+
+if has_encoder "${IMAGE}:${TARGET_TAG}"; then
+  if entrypoint_matches "${IMAGE}:${TARGET_TAG}"; then
+    echo "   software encoder: found in ${IMAGE}:${TARGET_TAG} (prepared earlier)"
+    if [ "$CHECK_ONLY" = 0 ] && [ -f "$ENV_FILE" ]; then
+      sed -i -E "s|^[[:space:]]*PERCEPTION_TAG=.*|PERCEPTION_TAG=\"${TARGET_TAG}\"|" "$ENV_FILE"
+      echo "   PERCEPTION_TAG -> ${TARGET_TAG}"
+    fi
+    exit 0
+  fi
+  # Has the encoder but would not start: rebuild rather than deploy it.
+  echo "   ${IMAGE}:${TARGET_TAG} has the encoder but does not start like the base"
+  echo "   image; rebuilding it."
+fi
+
+if [ "$CHECK_ONLY" = 1 ]; then
+  echo "   software encoder: MISSING from ${IMAGE}:${TAG}"
+  exit 1
+fi
+
+mkdir -p "$ROOT/generated"
+C="mv3dt-swenc-prep-$$"
+cleanup() { docker rm -f "$C" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "── Preparing the software encoder in ${IMAGE}:${TAG} (apt install, a few minutes)"
+if ! docker run -d --name "$C" -u 0 --entrypoint sleep "${IMAGE}:${TAG}" 3600 >/dev/null 2>&1; then
+  echo "ERROR: could not start a container from ${IMAGE}:${TAG}." >&2
+  manual_steps
+  exit 1
+fi
+
+LOG="$ROOT/generated/sw-encoder-install.log"
+
+# --reinstall: they are marked installed but their files were slimmed out.
+docker exec -u 0 "$C" sh -c \
+  'apt-get update && apt-get install -y --reinstall gstreamer1.0-plugins-ugly libx264-164 && rm -rf /root/.cache/gstreamer-1.0' \
+  > "$LOG" 2>&1
+
+if ! docker exec "$C" sh -c 'gst-inspect-1.0 x264enc' >/dev/null 2>&1; then
+  echo "   minimal install did not yield x264enc; falling back to user_additional_install.sh" >&2
+  docker exec -u 0 "$C" bash -c \
+    'cd /opt/nvidia/deepstream/deepstream && bash user_additional_install.sh' \
+    >> "$LOG" 2>&1
+fi
+
+if ! docker exec "$C" sh -c 'gst-inspect-1.0 x264enc' >/dev/null 2>&1; then
+  echo "ERROR: could not make x264enc available; not committing." >&2
+  echo "       Full log: generated/sw-encoder-install.log" >&2
+  tail -5 "$LOG" | sed 's/^/         /' >&2
+  echo "       This step needs network access to the Ubuntu archives." >&2
+  manual_steps
+  exit 1
+fi
+
+# This container has no GPU, so probing here blacklists every DeepStream plugin
+# in the registry cache. Drop it so the deployment rebuilds it with the GPU.
+docker exec -u 0 "$C" sh -c \
+  'rm -rf /root/.cache/gstreamer-1.0 /home/*/.cache/gstreamer-1.0 /tmp/.cache/gstreamer-1.0 2>/dev/null; true' \
+  >/dev/null 2>&1
+
+# Restore the image's own entrypoint/cmd: commit would otherwise capture the
+# prep container's sleep override.
+commit_args=()
+orig_ep="$(docker inspect -f '{{json .Config.Entrypoint}}' "${IMAGE}:${TAG}" 2>/dev/null)"
+orig_cmd="$(docker inspect -f '{{json .Config.Cmd}}' "${IMAGE}:${TAG}" 2>/dev/null)"
+[ -n "$orig_ep" ]  && [ "$orig_ep" != null ]  && commit_args+=(--change "ENTRYPOINT $orig_ep")
+[ -n "$orig_cmd" ] && [ "$orig_cmd" != null ] && commit_args+=(--change "CMD $orig_cmd")
+
+if ! docker commit "${commit_args[@]}" "$C" "${IMAGE}:${TARGET_TAG}" >/dev/null 2>&1; then
+  echo "ERROR: docker commit to ${IMAGE}:${TARGET_TAG} failed." >&2
+  manual_steps
+  exit 1
+fi
+
+# The committed image must still start the way the original does.
+new_ep="$(docker inspect -f '{{json .Config.Entrypoint}}' "${IMAGE}:${TARGET_TAG}" 2>/dev/null)"
+if [ "$new_ep" != "$orig_ep" ]; then
+  echo "ERROR: ${IMAGE}:${TARGET_TAG} did not keep the original entrypoint." >&2
+  echo "         original: $orig_ep" >&2
+  echo "         committed: $new_ep" >&2
+  docker rmi "${IMAGE}:${TARGET_TAG}" >/dev/null 2>&1
+  exit 1
+fi
+
+# Adding the encoder must not cost the pipeline its source bin. Needs the GPU:
+# nv* plugins do not load without one.
+if ! docker run --rm --gpus "device=${GPU_DEVICE%%,*}" --entrypoint sh \
+       "${IMAGE}:${TARGET_TAG}" -c 'gst-inspect-1.0 nvmultiurisrcbin' >/dev/null 2>&1; then
+  echo "ERROR: ${IMAGE}:${TARGET_TAG} has the encoder but lost nvmultiurisrcbin;" >&2
+  echo "       the pipeline would fail to build. Not keeping this image." >&2
+  docker rmi "${IMAGE}:${TARGET_TAG}" >/dev/null 2>&1
+  exit 1
+fi
+echo "   committed ${IMAGE}:${TARGET_TAG}"
+
+if [ -f "$ENV_FILE" ] && grep -qE '^[[:space:]]*PERCEPTION_TAG=' "$ENV_FILE"; then
+  sed -i -E "s|^[[:space:]]*PERCEPTION_TAG=.*|PERCEPTION_TAG=\"${TARGET_TAG}\"|" "$ENV_FILE"
+  echo "   PERCEPTION_TAG -> ${TARGET_TAG}"
+else
+  echo "   ⚠ docker/.env has no PERCEPTION_TAG line; set PERCEPTION_TAG=${TARGET_TAG} by hand" >&2
+fi
+
+echo "── Software encoder ready. This image is local to this host: a later image"
+echo "   bump means re-running this script."

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/stage-configs.sh
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/stage-configs.sh
@@ -91,27 +91,48 @@ KAFKA_HOST="${KAFKA_BOOTSTRAP%%:*}"
 KAFKA_PORT_ONLY="${KAFKA_BOOTSTRAP##*:}"
 NVENC_LESS_GPU_NAME=""
 
-# /dev/v4l2-nvenc is a Tegra signal, not a dGPU signal. For dGPU hosts, only
-# switch when the selected GPU is a known encoder-less compute SKU.
-is_nvenc_less_gpu_name() {
-  local name="$1"
-  [[ "$name" =~ (^|[^[:alnum:]])(A100|H100|H200|GB200|GB300)([^[:alnum:]]|$) ]]
+# Which encoder [sink2] can use, asked of the hardware rather than a GPU name:
+# nvidia-smi reports encoder usage but never capability, and a name list misses
+# whatever ships next (a GB200 node reports its GPUs as B200). In order:
+# run DeepStream's encoder element in the image, then the Tegra encoder node,
+# then ffmpeg. If none can answer, staging refuses rather than guess.
+gpu_name() {
+  command -v nvidia-smi >/dev/null 2>&1 || return 1
+  nvidia-smi --id="$GPU_DEVICE" --query-gpu=name --format=csv,noheader 2>/dev/null | head -1
 }
 
-detect_nvenc_less_gpu() {
-  local name
+# Positive-only: present means an encoder exists, absent means nothing.
+TEGRA_ENCODER_NODE="${TEGRA_ENCODER_NODE:-/dev/v4l2-nvenc}"
+has_tegra_encoder_node() { [ -e "$TEGRA_ENCODER_NODE" ]; }
 
-  command -v nvidia-smi >/dev/null 2>&1 || return 1
+# Encoding proves the encoder exists; only "unsupported device" proves it does
+# not. Any other failure is inconclusive.
+ffmpeg_encoder_kind() {
+  command -v ffmpeg >/dev/null 2>&1 || { echo unknown; return; }
+  ffmpeg -hide_banner -encoders 2>/dev/null | grep -q h264_nvenc || { echo unknown; return; }
+  local out
+  if out="$(ffmpeg -hide_banner -loglevel error -f lavfi -i nullsrc=s=256x256:d=0.1 \
+            -pix_fmt yuv420p -c:v h264_nvenc -f null - 2>&1)"; then
+    echo hardware; return
+  fi
+  if printf '%s' "$out" | grep -qi "unsupported device"; then echo software; return; fi
+  echo unknown
+}
 
-  while IFS= read -r name; do
-    [ -n "$name" ] || continue
-    if is_nvenc_less_gpu_name "$name"; then
-      NVENC_LESS_GPU_NAME="$name"
-      return 0
-    fi
-  done < <(nvidia-smi --id="$GPU_DEVICE" --query-gpu=name --format=csv,noheader 2>/dev/null || true)
-
-  return 1
+# echoes: hardware | software | unknown
+encoder_kind() {
+  local rc=0
+  # Cheap and local first: on Jetson this answers outright, so we never reach the
+  # probe, which would otherwise pull a multi-GB image onto a small disk.
+  has_tegra_encoder_node && { echo hardware; return; }
+  if [ -x "$ROOT/scripts/prepare-sw-encoder.sh" ]; then
+    "$ROOT/scripts/prepare-sw-encoder.sh" --probe-hw >/dev/null 2>&1 || rc=$?
+    case "$rc" in
+      0)  echo hardware; return ;;
+      10) echo software; return ;;
+    esac
+  fi
+  ffmpeg_encoder_kind
 }
 
 STAGE="$ROOT/generated/configs"
@@ -169,6 +190,27 @@ print(" ".join(sorted(str(i) for i in ids if i)))
   exit 1
 }
 check_camera_consistency
+
+# enc-type=1 needs an encoder the stock image lacks. Settle it before staging so
+# a config known to fail at runtime is never written.
+ensure_sw_encoder() {
+  [ "$SAVE_VIDEO" = "1" ] || return 0
+  case "$(encoder_kind)" in
+    hardware) return 0 ;;
+    unknown)
+      { echo "ERROR: cannot tell whether this GPU has a hardware video encoder, and"
+        echo "       SAVE_VIDEO=1 needs that answer. Nothing was staged."
+        echo "       The check runs DeepStream's encoder in ${PERCEPTION_IMAGE:-the perception image};"
+        echo "       it needs docker, GPU access and that image on this host."; } >&2
+      exit 1 ;;
+  esac
+  NVENC_LESS_GPU_NAME="$(gpu_name || echo "this GPU")"
+  "$ROOT/scripts/prepare-sw-encoder.sh" && return 0
+  { echo "ERROR: SAVE_VIDEO=1 on ${NVENC_LESS_GPU_NAME} needs the software encoder and it"
+    echo "       could not be prepared. Nothing was staged."; } >&2
+  exit 1
+}
+ensure_sw_encoder
 
 # file-mode source URIs / sensor ids (file:///videos/<cam>.mp4), built from CAMS.
 URIS=""; IDS=""
@@ -330,9 +372,9 @@ set_ini sink1        msg-broker-conn-str "$KAFKA_HOST;$KAFKA_PORT_ONLY;$RAW_TOPI
 set_ini sink0 enable "$([ "$OSD" = 1 ] && echo 1 || echo 0)"          # on-screen OSD (needs a display)
 set_ini sink1 enable 1                                                # Kafka metadata sink
 set_ini sink2 enable "$([ "$SAVE_VIDEO" = 1 ] && echo 1 || echo 0)"   # grid file sink (SAVE_VIDEO)
-if [ "$SAVE_VIDEO" = "1" ] && detect_nvenc_less_gpu; then
+if [ "$SAVE_VIDEO" = "1" ] && [ -n "$NVENC_LESS_GPU_NAME" ]; then
   set_ini sink2 enc-type 1
-  echo "   SAVE_VIDEO=1 on ${NVENC_LESS_GPU_NAME} -> using software encoder for sink2 (enc-type=1; no NVENC hardware encoder available)"
+  echo "   SAVE_VIDEO=1 on ${NVENC_LESS_GPU_NAME} -> using software encoder for sink2 (enc-type=1; this GPU cannot encode in hardware)"
 fi
 
 # File input: static file:// [source-list], SEI extraction off, clips play once,

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/stage-configs.sh
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/stage-configs.sh
@@ -241,6 +241,87 @@ set_ini tiled-display columns "$COLS"
 set_ini tiled-display width "$TILE_WIDTH"
 set_ini tiled-display height "$TILE_HEIGHT"
 set_ini tiled-display enable 1                  # tiler on: on-screen grid + SAVE_VIDEO grid sink
+# OSD needs the GPU driving the display to be visible to the container. gpu-id is
+# a CUDA ordinal within that visible set, and the runtime orders it by PCI
+# address, so it is not the nvidia-smi index. Resolve both here, where every GPU
+# is visible. Nothing is changed when the display GPU cannot be determined, to
+# avoid moving the workload to a GPU nobody chose.
+resolve_gpu_selection() {   # echoes "<visible_csv> <gpu_id>", or nothing
+  GPU_DEVICE="$GPU_DEVICE" OSD="$OSD" python3 - <<'PY'
+import os, re, subprocess, sys
+
+def smi(q):
+    try:
+        out = subprocess.run(["nvidia-smi", "--query-gpu=" + q, "--format=csv,noheader"],
+                             capture_output=True, text=True, timeout=10)
+        return [l.strip() for l in out.stdout.splitlines() if l.strip()]
+    except Exception:
+        return []
+
+rows = [l.split(", ") for l in smi("index,pci.bus_id")]
+if not rows:
+    sys.exit(0)
+bus = {r[0]: r[1].upper() for r in rows if len(r) == 2}
+
+want = (os.environ.get("GPU_DEVICE") or "0").strip()
+compute = [d.strip() for d in want.split(",") if d.strip()]
+if want == "all":
+    compute = sorted(bus, key=lambda i: bus[i])
+# UUIDs cannot be ordered here.
+if any(not d.isdigit() for d in compute):
+    sys.exit(0)
+
+visible = list(compute)
+
+# xorg.conf states the bus in decimal, nvidia-smi in hex.
+if os.environ.get("OSD") == "1":
+    disp = None
+    try:
+        conf = open("/etc/X11/xorg.conf").read()
+        m = re.search(r'BusID\s+"PCI:(\d+)', conf)
+        if m:
+            tag = ":%02X:00" % int(m.group(1))
+            disp = next((i for i, b in bus.items() if tag in b), None)
+    except Exception:
+        disp = None
+    if disp is None:
+        # Only worth reporting when there is a choice to get wrong.
+        if len(bus) > 1:
+            print("UNKNOWN")
+        sys.exit(0)
+    if disp not in visible:
+        visible.append(disp)
+
+visible = sorted(set(visible), key=lambda i: bus.get(i, ""))
+try:
+    gpu_id = visible.index(compute[0])    # CUDA ordinal, not nvidia-smi index
+except ValueError:
+    sys.exit(0)
+print("%s %s" % (",".join(visible), gpu_id))
+PY
+}
+
+read -r RESOLVED_VISIBLE RESOLVED_GPU_ID <<<"$(resolve_gpu_selection)"
+if [ "${RESOLVED_VISIBLE:-}" = UNKNOWN ]; then
+  echo "   ⚠ cannot tell which GPU drives the display (no BusID in /etc/X11/xorg.conf)." >&2
+  echo "     GPU_DEVICE=$GPU_DEVICE is unchanged. If the OSD fails to start, add the GPU" >&2
+  echo "     that drives the display to GPU_DEVICE and restage." >&2
+elif [ -n "${RESOLVED_GPU_ID:-}" ]; then
+  if [ "$RESOLVED_VISIBLE" != "$GPU_DEVICE" ]; then
+    ENV_FILE="$ROOT/docker/.env"
+    if [ -f "$ENV_FILE" ] && grep -qE '^[[:space:]]*GPU_DEVICE=' "$ENV_FILE"; then
+      sed -i -E "s|^[[:space:]]*GPU_DEVICE=.*|GPU_DEVICE=$RESOLVED_VISIBLE|" "$ENV_FILE"
+      echo "   GPU_DEVICE: $GPU_DEVICE -> $RESOLVED_VISIBLE (added the GPU driving the display)"
+    else
+      echo "   ⚠ OSD needs GPU_DEVICE=$RESOLVED_VISIBLE; docker/.env has no GPU_DEVICE line" >&2
+    fi
+    GPU_DEVICE="$RESOLVED_VISIBLE"
+  fi
+  sed -i -E "s|^gpu-id=.*|gpu-id=$RESOLVED_GPU_ID|" "$STAGE/ds-main-config-mv3dt.txt"
+  sed -i -E "s|^([[:space:]]*)gpu-id:.*|\1gpu-id: $RESOLVED_GPU_ID|" "$STAGE/ds-pgie-config.yml" 2>/dev/null || true
+  echo "   gpu-id=$RESOLVED_GPU_ID within GPU_DEVICE=$GPU_DEVICE"
+fi
+
 set_ini source-list  max-batch-size "$NUM_CAMS"
 set_ini source-list  http-port "$DS_HTTP_PORT"
 set_ini streammux    batch-size "$NUM_CAMS"

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/stage-configs.sh
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/scripts/stage-configs.sh
@@ -56,6 +56,11 @@ if [ -f "$ROOT/docker/.env" ]; then
     [[ "$k" =~ ^[A-Z_][A-Z0-9_]*$ ]] || continue
     [ -n "${!k:-}" ] && continue          # already-exported value wins
     v="${v%$'\r'}"                         # tolerate CRLF line endings
+    # Strip an unquoted trailing comment: "NUM_CAMS=4  # four cams" is a normal
+    # .env line, and without this the value carries the comment into the staged
+    # config. Quoted values keep their # (paths and connection strings use it).
+    if [[ $v != \"* && $v != \'* ]]; then v="${v%%[[:space:]]#*}"; fi
+    v="${v%"${v##*[![:space:]]}"}"           # drop trailing whitespace
     if [[ $v == \"*\" ]]; then v="${v#\"}"; v="${v%\"}"; fi   # strip paired "…"
     if [[ $v == \'*\' ]]; then v="${v#\'}"; v="${v%\'}"; fi   # strip paired '…'
     printf -v "$k" '%s' "$v" && export "$k"
@@ -118,6 +123,52 @@ CAMS=()
 if ls "$GEN/camInfo"/*.yml >/dev/null 2>&1; then
   mapfile -t CAMS < <(cd "$GEN/camInfo" && LC_ALL=C ls -1 *.yml | sed 's/\.yml$//')
 fi
+
+# NUM_CAMS drives batch-size, the grid and the engine suffix; camInfo drives the
+# tracker map and the file-mode source list. When they disagree nothing notices
+# until sources fail to activate, so compare every source we have.
+check_camera_consistency() {
+  local problems=() calib_ids pubsub_ids
+  (( ${#CAMS[@]} )) || return 0          # no camInfo: handled separately per mode
+
+  [ "${#CAMS[@]}" = "$NUM_CAMS" ] || problems+=(
+    "NUM_CAMS=$NUM_CAMS but generated/camInfo has ${#CAMS[@]} camera(s): $(printf '%s ' "${CAMS[@]}")")
+
+  if [ -f "$GEN/calibration.json" ]; then
+    calib_ids="$(python3 -c '
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(0)
+s = d.get("sensors", d)
+ids = [x.get("id") or x.get("sensorId") for x in s] if isinstance(s, list) else list(s)
+print(" ".join(sorted(str(i) for i in ids if i)))
+' "$GEN/calibration.json" 2>/dev/null)"
+    if [ -n "$calib_ids" ] && [ "$calib_ids" != "$(printf '%s\n' "${CAMS[@]}" | sort | tr '\n' ' ' | sed 's/ $//')" ]; then
+      problems+=("calibration.json sensors [$calib_ids] do not match camInfo [$(printf '%s ' "${CAMS[@]}" | sed 's/ $//')]")
+    fi
+  fi
+
+  if [ -f "$GEN/pub_sub_info_config.yml" ]; then
+    pubsub_ids="$(awk '/^pubBrokerTopicStr:/ { p = 1; next }
+                       /^[^[:space:]]/       { p = 0 }
+                       p && /^[[:space:]]+[A-Za-z0-9_.-]+:/ {
+                         sub(/^[[:space:]]+/, ""); sub(/:.*$/, ""); print }' \
+                  "$GEN/pub_sub_info_config.yml" | sort | tr '\n' ' ' | sed 's/ $//')"
+    if [ -n "$pubsub_ids" ] && [ "$pubsub_ids" != "$(printf '%s\n' "${CAMS[@]}" | sort | tr '\n' ' ' | sed 's/ $//')" ]; then
+      problems+=("pub_sub_info_config.yml sensors [$pubsub_ids] do not match camInfo")
+    fi
+  fi
+
+  (( ${#problems[@]} )) || return 0
+  { echo "ERROR: camera configuration is inconsistent, nothing was staged."
+    printf '       %s\n' "${problems[@]}"
+    echo "       Re-run scripts/generate-configs.sh <calibration.json> for this camera set,"
+    echo "       and set NUM_CAMS in docker/.env to match it."; } >&2
+  exit 1
+}
+check_camera_consistency
 
 # file-mode source URIs / sensor ids (file:///videos/<cam>.mp4), built from CAMS.
 URIS=""; IDS=""


### PR DESCRIPTION
## Summary

Six P0s from SQA against the RT-CV-3D (MV3DT) standalone deployment, one commit per bug.
Scripts and documentation only — no image changes.

Four of them share a shape: the deployment accepted a configuration it could not run, and only
failed later where the cause was no longer visible. Staging now refuses instead, at the point
the problem can still be fixed.

## Related Issue

- Bug 6553034 — SEI check silently bypassed on a non-default VST port
- Bug 6636526 — the wrong stream is blamed for a stalled batch
- Bug 6551512 — OSD fails unless the container is run `privileged: true`
- Bug 6564660 — staging accepts an inconsistent camera set
- Bug 6565438 — Option B omits the restage the Kafka endpoint needs
- Bug 6646812 — software encoder install not automated for GPUs without NVENC

Tracker: Bug 6124541 (build drops). Related but **not** fixed here: Bug 6636594 (perception
segfaults during dynamic stream removal — reproduced during this work, but the fault is in
DeepStream's `nvstreammux` and not addressable from the deployment scripts).

## Changes

**`scripts/add-streams.sh`**
- **6553034** — the SEI prerequisite check assumed the VST proxy on port 30000 and ended in
  `|| return 0`, so a 404 was indistinguishable from "no VST here". The port is now discovered
  (30000-30005, 31000-31005), the check applies only when the staged config requires the SEI,
  and it stops rather than passing silently. A config-level fallback was tested and ruled out:
  a SEI-less live source does not activate under host-clock timestamps either.
- **6636526** — only the cameras passed to that invocation were judged, so a stalled source
  caused the last camera *added* to be reported. Every registered stream is judged once the
  batch completes.

**`scripts/stage-configs.sh`**
- **6551512** — `NVIDIA_VISIBLE_DEVICES` is gated by `GPU_DEVICE`, so on a multi-GPU host the
  GPU driving `DISPLAY` was usually not exposed and the OSD died at PAUSED; `privileged: true`
  "worked" only by bypassing the device cgroup. Staging resolves the display GPU, adds it to
  `GPU_DEVICE`, and derives `gpu-id` from the resulting visible set (a CUDA ordinal, not the
  `nvidia-smi` index). Inference stays on the requested GPU.
- **6564660** — `NUM_CAMS`, `calibration.json`, `camInfo` and `pub_sub_info_config.yml` were
  never compared. Staging now refuses a mismatch, writing nothing.
- **6565438** — the Kafka endpoint is baked into the staged config and configs are mounted
  read-only, so editing `docker/.env` without restaging left the old broker in place.
- **6646812** — `SAVE_VIDEO=1` on a GPU with no hardware encoder staged `enc-type=1`, which no
  shipping image can satisfy. Staging prepares the encoder into the image and points
  `PERCEPTION_TAG` at the result, or refuses.

**`scripts/prepare-sw-encoder.sh`** (new) — prepares and commits the software encoder.

**`docker/init-scripts/ds-start-mv3dt.sh`** — startup refuses a stale staged Kafka endpoint
(6565438) or camera set (6564660), so a refused staging cannot be launched anyway.

**`README.md`** — restage requirements, OSD/GPU selection, and the NVENC-less path. The previous
NVENC-less instructions could not work: the image runs as uid 1000, so the documented
`docker exec` needed `-u 0` for `apt` to write.

### Two notes for review

**Encoder detection asks the hardware, not a GPU name.** `nvidia-smi` reports encoder *usage*
but never *capability* — an NVENC-less H100 is indistinguishable from an NVENC-capable
RTX PRO 6000 in every field it exposes, and NVML's `nvmlDeviceGetEncoderCapacity` returns 100%
on the H100. Detection runs DeepStream's own encoder element in the image on the selected GPU,
falls back to `/dev/v4l2-nvenc` (Tegra, positive-only), then to an `ffmpeg` probe, and refuses
if none can answer. A name list would already miss this generation: a GB200 node reports its
GPUs as B200.

**Committing a prepared image needs three guards**, each of which otherwise produced an image
that passed every static check and still broke the deployment: restore the base entrypoint
(`docker commit` captures the prep container's `sleep` override); drop the GStreamer registry
cache before committing (the prep container has no GPU, so probing there blacklists every
DeepStream plugin); and re-validate an image left by an earlier run. Both properties are
verified after commit, with the GPU attached, and the image is discarded if either fails.

### Verification

Syntax and behaviour checks pass at **every commit checked out standalone**, on six machines:
H100 NVL (no hardware encoder), RTX PRO 6000 Blackwell, Orin (aarch64/Tegra), a GPU-less host,
a hybrid-graphics laptop, and RTX 4090.

Full pipeline on four cameras for both encoder paths — software (`enc-type=1`) and hardware
(`enc-type=0`), each producing `h264 1920x1080 30/1` output.

Not covered: end-to-end runs for 6553034 and 6636526, which need live RTSP through the SQA VST;
and the 6646812 prepare-and-commit path on aarch64 (GB200/GB300 are aarch64; the mechanism is
architecture-neutral and the package names match, but it has only been exercised on x86_64).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.

> On tests: `rt-cv-mv3dt` carries no test suite in this repo, and these changes are shell
> scripts. They are covered by an external harness (11 script-level tests plus a 20-case
> regression suite for the encoder path) run at every commit on the six machines above, but
> nothing lands in-tree here, so the box stays unticked. Happy to add an in-repo suite if that
> is wanted for merge.