### PR TITLE
fix(deploy): clamp GPU device placement to the GPUs a host has

### DIFF
--- a/.github/scripts/check_gpu_device_clamp.py
+++ b/.github/scripts/check_gpu_device_clamp.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Keep every committed GPU device index reachable through the single-GPU clamp.
+
+The profile env files under ``deploy/docker`` place each service on a specific
+GPU, and those indices describe the host the profile was validated on rather
+than the host it will run on:
+
+  dev-profile-alerts    LLM, VLM and RT-VLM on device 1, RT-CV on 0   -> 2 GPUs
+  dev-profile-search    RT-CV + RT-VLM on 0, RT-Embed + LLM on 1      -> 2 GPUs
+  warehouse-operations  RT-CV on 0, RT-VLM on 1, LLM on 2             -> 3 GPUs
+
+Compose passes those values straight into ``device_ids``, and a request for an
+index the host does not have is a hard container-start failure, not a fallback.
+So on a single-GPU machine the stack never comes up, and the reason is invisible
+in the configuration: every value in the files is individually correct.
+
+What this lint asserts is therefore not a value but a route. The deploy scripts
+resolve committed placement against the GPU count the host reports
+(``clamp_device_ids_to_gpu_count``), folding any index at or above that count
+onto the last real device and logging every remap. This checks that:
+
+  1. every device index committed in a profile parses as a device index at all;
+  2. every key a profile uses to place a service is one the clamp knows about;
+  3. the clamp is actually invoked, and is not gated behind one profile or one
+     environment marker.
+
+(3) is the shape the defect originally had. ``get_nvidia_smi_gpu_count`` already
+existed in ``dev-profile.sh`` and was called from exactly one place: a
+search-only, ``BREV_ENV_ID``-gated pre-flight. The helper was there, the general
+case was not covered, and nothing in the tree said so.
+
+Deliberately NOT asserted: that no profile commits an index above 0. A two-GPU
+default is the validated configuration for alerts and search, and forbidding it
+would push those profiles onto a layout nothing has been tested on. Nor is a
+declared "this profile needs N GPUs" value required: the highest committed index
+already is that number, so a second copy of it would only be something to keep
+in sync. The requirement is reported below instead, derived from the files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ENV_SUFFIX = ".env"
+
+# Bash arrays in the deploy scripts that enumerate the keys the clamp handles.
+# Placement keys are remapped; reservation keys name GPUs the LLM and VLM must
+# stay off and are filtered instead, so they are declared separately.
+CLAMP_KEY_ARRAYS = ("DEVICE_ID_KEYS", "DEVICE_RESERVATION_KEYS")
+CLAMP_FUNCTION = "clamp_device_ids_to_gpu_count"
+GPU_COUNT_FUNCTIONS = ("get_deployment_gpu_count", "get_nvidia_smi_gpu_count")
+
+# Any env key naming a GPU by index. Matched by suffix rather than listed, so a
+# newly invented placement key is in scope the moment it is committed.
+DEVICE_KEY_RE = re.compile(r"^[A-Z0-9_]*DEVICE_IDS?$")
+ASSIGNMENT = re.compile(r"^\s*(?P<name>[A-Z0-9_]+)\s*=\s*(?P<value>.*)$")
+
+# An enclosing condition mentioning any of these means the clamp only runs for
+# one profile or one kind of host, which is the failure this lint exists for.
+# ``profile ==``/``deployment ==`` pin the run to a single profile;
+# BREV_ENV_ID and SKIP_HARDWARE_CHECK pin it to one environment.
+SCOPING_CONDITIONS = (
+    re.compile(r"\$\{profile\}\"?\s*=="),
+    re.compile(r"\$\{deployment\}\"?\s*=="),
+    re.compile(r"\$\{mode\}\"?\s*=="),
+    re.compile(r"BREV_ENV_ID"),
+    re.compile(r"SKIP_HARDWARE_CHECK"),
+)
+
+BASH_OPENERS = ("if ", "elif ", "case ", "for ", "while ", "until ")
+BASH_CLOSERS = ("fi", "esac", "done")
+FUNCTION_START = re.compile(r"^(function\s+[A-Za-z0-9_]+|[A-Za-z0-9_]+\s*\(\))")
+
+
+@dataclass(frozen=True)
+class ProfileFamily:
+    """A directory of profiles and the deploy script that reads them."""
+
+    env_root: str
+    script: str
+
+
+PROFILE_FAMILIES = (
+    ProfileFamily(
+        env_root="deploy/docker/developer-profiles",
+        script="deploy/docker/scripts/dev-profile.sh",
+    ),
+    ProfileFamily(
+        env_root="deploy/docker/industry-profiles",
+        script="deploy/docker/scripts/blueprint-deploy.sh",
+    ),
+)
+
+
+def is_env_file(path: Path) -> bool:
+    """Match env files including a bare ``.env``, whose ``Path.suffix`` is empty."""
+    return path.suffix == ENV_SUFFIX or path.name == ENV_SUFFIX
+
+
+def profile_env_files(root: Path) -> list[Path]:
+    """A profile's own top-level env files. ``generated.env`` is a runtime
+    artefact written by the deploy script and is not checked in."""
+    if not root.is_dir():
+        return []
+    return sorted(
+        path
+        for path in root.rglob("*")
+        if is_env_file(path)
+        and len(path.relative_to(root).parts) == 2
+        and path.name != "generated.env"
+    )
+
+
+def strip_quotes(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        return value[1:-1]
+    return value
+
+
+def device_assignments(path: Path) -> list[tuple[int, str, str]]:
+    """``(line number, key, unquoted value)`` for every device-index key."""
+    found: list[tuple[int, str, str]] = []
+    for line_number, line in enumerate(path.read_text().splitlines(), start=1):
+        stripped = line.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        match = ASSIGNMENT.match(line)
+        if not match:
+            continue
+        name = match.group("name")
+        if DEVICE_KEY_RE.match(name):
+            found.append((line_number, name, strip_quotes(match.group("value"))))
+    return found
+
+
+def parse_device_list(value: str) -> tuple[list[int], list[str]]:
+    """Split a committed value into ``(indices, unparsable entries)``.
+
+    An entry containing ``$`` is neither: its index is only known at deploy
+    time, so it is reported as unknown by returning it in neither list while
+    still requiring its key to be clamped (see ``scan_family``)."""
+    indices: list[int] = []
+    invalid: list[str] = []
+    for raw in value.replace(" ", "").split(","):
+        if not raw or "$" in raw:
+            continue
+        if raw.isdigit():
+            indices.append(int(raw))
+        else:
+            invalid.append(raw)
+    return indices, invalid
+
+
+def declared_clamp_keys(script_text: str) -> set[str]:
+    """Keys enumerated in the deploy script's clamp arrays."""
+    keys: set[str] = set()
+    for array in CLAMP_KEY_ARRAYS:
+        match = re.search(rf"^{array}=\((.*?)^\)", script_text, re.M | re.S)
+        if not match:
+            continue
+        keys.update(re.findall(r"['\"]([A-Z0-9_]+)['\"]", match.group(1)))
+    return keys
+
+
+def is_single_line_block(stripped: str) -> bool:
+    """``case x in y) z ;; esac`` on one line opens and closes in place, so it
+    must not move the depth counter in ``enclosing_conditions``."""
+    for opener, closer in (("if ", "fi"), ("case ", "esac"), ("for ", "done"), ("while ", "done")):
+        if stripped.startswith(opener) and re.search(rf"(^|[;\s]){closer}\s*$", stripped):
+            return True
+    return False
+
+
+def enclosing_conditions(lines: list[str], index: int) -> list[str]:
+    """Conditions of the blocks that enclose ``lines[index]``, innermost first.
+
+    Walks upward to the start of the enclosing function, counting closers so
+    that sibling blocks already closed above the call are not mistaken for
+    enclosing ones."""
+    conditions: list[str] = []
+    pending = 0
+    # Set after recording an ``elif``: the earlier branches of that same chain,
+    # and the ``if`` that heads it, are not conditions on this call. Reporting
+    # them would put a branch the call cannot be in into the diagnostic.
+    in_chain = False
+    for cursor in range(index - 1, -1, -1):
+        stripped = lines[cursor].strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if FUNCTION_START.match(lines[cursor]):
+            break
+        if is_single_line_block(stripped):
+            continue
+        if stripped in BASH_CLOSERS or stripped.rstrip(";") in BASH_CLOSERS:
+            pending += 1
+            continue
+        if stripped.startswith(BASH_OPENERS):
+            if pending:
+                pending -= 1
+            elif in_chain:
+                in_chain = stripped.startswith("elif ")
+            else:
+                conditions.append(stripped)
+                in_chain = stripped.startswith("elif ")
+    return conditions
+
+
+def clamp_call_lines(lines: list[str]) -> list[int]:
+    """Indices of lines that call the clamp, excluding its own definition."""
+    calls: list[int] = []
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if CLAMP_FUNCTION not in stripped or stripped.startswith("#"):
+            continue
+        if re.match(rf"^(function\s+)?{CLAMP_FUNCTION}\s*\(\)", stripped):
+            continue
+        calls.append(index)
+    return calls
+
+
+def scan_family(family: ProfileFamily, report: list[str]) -> list[str]:
+    """Diagnostics for one profile directory and its deploy script."""
+    failures: list[str] = []
+    script_path = ROOT / family.script
+    if not script_path.is_file():
+        return [f"{family.script}: deploy script is missing; nothing clamps {family.env_root}"]
+
+    script_text = script_path.read_text()
+    script_lines = script_text.splitlines()
+    declared = declared_clamp_keys(script_text)
+    if not declared:
+        failures.append(
+            f"{family.script}: no {' or '.join(CLAMP_KEY_ARRAYS)} array found; "
+            "the clamp cannot enumerate the keys it is supposed to handle"
+        )
+
+    # (3) The clamp must run, and must run for every profile on every host.
+    calls = clamp_call_lines(script_lines)
+    if CLAMP_FUNCTION not in script_text:
+        failures.append(
+            f"{family.script}: {CLAMP_FUNCTION} is not defined; committed device "
+            "indices reach Compose unresolved and a host with fewer GPUs than the "
+            "profile assumes fails to start"
+        )
+    elif not calls:
+        failures.append(
+            f"{family.script}: {CLAMP_FUNCTION} is defined but never called; a "
+            "helper nothing invokes is why this defect shipped in the first place"
+        )
+    else:
+        unscoped = []
+        for call in calls:
+            conditions = enclosing_conditions(script_lines, call)
+            scoping = [
+                condition
+                for condition in conditions
+                if any(pattern.search(condition) for pattern in SCOPING_CONDITIONS)
+            ]
+            if not scoping:
+                unscoped.append(call)
+        if not unscoped:
+            call = calls[0]
+            conditions = enclosing_conditions(script_lines, call)
+            failures.append(
+                f"{family.script}:{call + 1}: every {CLAMP_FUNCTION} call is gated on "
+                f"a single profile or environment ({conditions!r}); the general case "
+                "goes unclamped, which is exactly how get_nvidia_smi_gpu_count came "
+                "to be called only from the BREV_ENV_ID search pre-flight"
+            )
+
+    # The clamp has to compare against the host, not a constant.
+    if not any(name in script_text for name in GPU_COUNT_FUNCTIONS):
+        failures.append(
+            f"{family.script}: none of {GPU_COUNT_FUNCTIONS} is used; the clamp has "
+            "no GPU count to clamp against"
+        )
+
+    # (1) and (2). A profile's placement is spread across .env and
+    # overrides.env, so the GPU requirement is only meaningful per profile.
+    env_root = ROOT / family.env_root
+    for profile_dir in sorted({path.parent for path in profile_env_files(env_root)}):
+        placement: dict[str, int] = {}
+        for env_file in sorted(profile_env_files(env_root)):
+            if env_file.parent != profile_dir:
+                continue
+            display = env_file.relative_to(ROOT)
+            for line_number, key, value in device_assignments(env_file):
+                indices, invalid = parse_device_list(value)
+                for entry in invalid:
+                    failures.append(
+                        f"{display}:{line_number}: {key} entry {entry!r} is not a "
+                        "device index; Compose forwards it to device_ids verbatim "
+                        "and the container fails to start with an opaque driver "
+                        "error"
+                    )
+                if indices:
+                    placement[key] = max(indices)
+                needs_clamp = any(index > 0 for index in indices) or "$" in value
+                if needs_clamp and key not in declared:
+                    failures.append(
+                        f"{display}:{line_number}: {key}={value!r} places a service "
+                        f"above device 0, but {key} is not listed in "
+                        f"{' / '.join(CLAMP_KEY_ARRAYS)} in {family.script}, so the "
+                        "single-GPU clamp leaves it alone and a one-GPU host cannot "
+                        "start this profile"
+                    )
+        name = profile_dir.relative_to(env_root)
+        if not placement:
+            report.append(f"  {name}: no device placement committed")
+            continue
+        highest = max(placement.values())
+        detail = ", ".join(f"{key}={index}" for key, index in sorted(placement.items()))
+        report.append(f"  {name}: needs {highest + 1} GPU(s)  [{detail}]")
+
+    return failures
+
+
+def scan(report: list[str] | None = None) -> list[str]:
+    failures: list[str] = []
+    for family in PROFILE_FAMILIES:
+        failures.extend(scan_family(family, report if report is not None else []))
+    return failures
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="suppress the per-profile GPU requirement summary",
+    )
+    args = parser.parse_args(argv)
+
+    report: list[str] = []
+    failures = scan(report)
+    if failures:
+        print("\n".join(failures), file=sys.stderr)
+        return 1
+
+    if not args.quiet:
+        print("Committed GPU device placement:")
+        print("\n".join(report))
+    print(f"GPU device clamp lint passed ({len(report)} profiles).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_check_gpu_device_clamp.py
+++ b/.github/scripts/test_check_gpu_device_clamp.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("check_gpu_device_clamp.py")
+SPEC = importlib.util.spec_from_file_location("check_gpu_device_clamp", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+LINT = importlib.util.module_from_spec(SPEC)
+# Registered before exec: @dataclass resolves its annotations through
+# sys.modules, and an unregistered module makes that lookup fail.
+sys.modules[SPEC.name] = LINT
+SPEC.loader.exec_module(LINT)
+
+# A deploy script shaped like dev-profile.sh: the clamp arrays, the clamp
+# itself, and a call from the middle of process_args.
+GOOD_SCRIPT = """#!/bin/bash
+DEVICE_ID_KEYS=(
+  'LLM_DEVICE_ID'
+  'RT_CV_DEVICE_ID'
+)
+
+DEVICE_RESERVATION_KEYS=(
+  'RESERVED_DEVICE_IDS'
+)
+
+function get_deployment_gpu_count() {
+  echo 1
+}
+
+function clamp_device_ids_to_gpu_count() {
+  gpu_count="$(get_deployment_gpu_count)"
+  case ",${_out}," in *",0,"*) return ;; esac
+}
+
+function process_args() {
+  if [[ -n "${profile}" ]]; then
+    if [[ "${profile}" == "search" ]]; then
+      echo "search only"
+    fi
+    clamp_device_ids_to_gpu_count "${_profile_env}"
+  fi
+}
+"""
+
+
+def _write(directory: str, name: str, body: str) -> Path:
+    path = Path(directory) / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    return path
+
+
+class TreeTest(unittest.TestCase):
+    """The committed tree must satisfy the lint."""
+
+    def test_tree_routes_every_device_index_through_the_clamp(self) -> None:
+        self.assertEqual([], LINT.scan([]))
+
+    def test_profiles_are_actually_covered(self) -> None:
+        # A lint that silently matches nothing passes forever. The two-GPU
+        # developer profiles and the three-GPU warehouse profile are the whole
+        # reason this exists, so assert they are in scope.
+        report: list[str] = []
+        LINT.scan(report)
+        text = "\n".join(report)
+        for profile in ("dev-profile-alerts", "dev-profile-search", "warehouse-operations"):
+            self.assertIn(profile, text, f"{profile} is not in scope: {text}")
+
+    def test_report_states_the_derived_gpu_requirement(self) -> None:
+        # Nothing declares how many GPUs a profile needs; it is derived from the
+        # highest committed index. Alerts and search assume two, warehouse three.
+        report: list[str] = []
+        LINT.scan(report)
+        text = "\n".join(report)
+        self.assertIn("dev-profile-alerts: needs 2 GPU(s)", text)
+        self.assertIn("dev-profile-search: needs 2 GPU(s)", text)
+        self.assertIn("warehouse-operations: needs 3 GPU(s)", text)
+        self.assertIn("dev-profile-base: needs 1 GPU(s)", text)
+
+
+class ClampKeyCoverageTest(unittest.TestCase):
+    def test_unclamped_placement_key_above_device_zero_fails(self) -> None:
+        # The regression this guards: a new service placed on device 1 that the
+        # clamp does not know about. Every value here is individually valid.
+        with tempfile.TemporaryDirectory() as directory:
+            _write(directory, "scripts/deploy.sh", GOOD_SCRIPT)
+            _write(directory, "profiles/demo/.env", "RT_EMBED_DEVICE_ID='1'\n")
+            failures = self._scan(directory)
+        self.assertEqual(1, len(failures), failures)
+        self.assertIn("RT_EMBED_DEVICE_ID", failures[0])
+        self.assertIn("not listed in DEVICE_ID_KEYS", failures[0])
+
+    def test_unclamped_key_on_device_zero_passes(self) -> None:
+        # Device 0 exists on every GPU host, so an unclamped key pinned to 0 is
+        # not a single-GPU hazard and must not be flagged.
+        with tempfile.TemporaryDirectory() as directory:
+            _write(directory, "scripts/deploy.sh", GOOD_SCRIPT)
+            _write(directory, "profiles/demo/.env", "RT_EMBED_DEVICE_ID='0'\n")
+            failures = self._scan(directory)
+        self.assertEqual([], failures)
+
+    def test_two_gpu_default_under_a_clamped_key_passes(self) -> None:
+        # The point of clamping rather than rewriting defaults: a device-1
+        # default is the validated configuration and must stay legal.
+        with tempfile.TemporaryDirectory() as directory:
+            _write(directory, "scripts/deploy.sh", GOOD_SCRIPT)
+            _write(
+                directory,
+                "profiles/demo/.env",
+                "LLM_DEVICE_ID='1'\nRT_CV_DEVICE_ID='0'\nRESERVED_DEVICE_IDS='0'\n",
+            )
+            failures = self._scan(directory)
+        self.assertEqual([], failures)
+
+    def test_interpolated_device_value_must_be_clamped(self) -> None:
+        # The index is only known at deploy time, so the key has to be routed
+        # through the clamp regardless of what it resolves to.
+        with tempfile.TemporaryDirectory() as directory:
+            _write(directory, "scripts/deploy.sh", GOOD_SCRIPT)
+            _write(directory, "profiles/demo/.env", "RT_EMBED_DEVICE_ID=${SOME_ID:-1}\n")
+            failures = self._scan(directory)
+        self.assertEqual(1, len(failures), failures)
+        self.assertIn("RT_EMBED_DEVICE_ID", failures[0])
+
+    def test_non_numeric_device_index_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            _write(directory, "scripts/deploy.sh", GOOD_SCRIPT)
+            _write(directory, "profiles/demo/.env", "LLM_DEVICE_ID='gpu1'\n")
+            failures = self._scan(directory)
+        self.assertEqual(1, len(failures), failures)
+        self.assertIn("is not a device index", failures[0])
+
+    def test_generated_env_is_out_of_scope(self) -> None:
+        # generated.env is written by the deploy script from already-clamped
+        # values; reading it back would flag the clamp's own output.
+        with tempfile.TemporaryDirectory() as directory:
+            _write(directory, "scripts/deploy.sh", GOOD_SCRIPT)
+            _write(directory, "profiles/demo/generated.env", "RT_EMBED_DEVICE_ID=1\n")
+            failures = self._scan(directory)
+        self.assertEqual([], failures)
+
+    def test_comments_are_not_flagged(self) -> None:
+        # The profiles document the two-GPU layout in prose beside the
+        # assignments, so a lint that read comments would fail on the
+        # explanation of the rule it enforces.
+        with tempfile.TemporaryDirectory() as directory:
+            _write(directory, "scripts/deploy.sh", GOOD_SCRIPT)
+            _write(
+                directory,
+                "profiles/demo/.env",
+                "# GPU 0: RT-CV. GPU 1: RT_EMBED_DEVICE_ID='1' on 2-GPU hosts.\n"
+                "RT_CV_DEVICE_ID='0'\n",
+            )
+            failures = self._scan(directory)
+        self.assertEqual([], failures)
+
+    def _scan(self, directory: str) -> list[str]:
+        family = LINT.ProfileFamily(env_root="profiles", script="scripts/deploy.sh")
+        original_root = LINT.ROOT
+        LINT.ROOT = Path(directory)
+        try:
+            return LINT.scan_family(family, [])
+        finally:
+            LINT.ROOT = original_root
+
+
+class ClampReachabilityTest(unittest.TestCase):
+    """The clamp has to run for every profile on every host."""
+
+    def test_missing_clamp_call_fails(self) -> None:
+        script = GOOD_SCRIPT.replace(
+            '    clamp_device_ids_to_gpu_count "${_profile_env}"\n', ""
+        )
+        failures = self._scan_script(script)
+        self.assertTrue(any("never called" in failure for failure in failures), failures)
+
+    def test_missing_clamp_definition_fails(self) -> None:
+        script = GOOD_SCRIPT.replace("clamp_device_ids_to_gpu_count", "some_other_helper")
+        failures = self._scan_script(script)
+        self.assertTrue(any("is not defined" in failure for failure in failures), failures)
+
+    def test_clamp_gated_on_brev_env_id_fails(self) -> None:
+        # The original defect exactly: get_nvidia_smi_gpu_count existed and was
+        # called from one BREV_ENV_ID-gated, search-only pre-flight, so nothing
+        # covered the general case.
+        script = GOOD_SCRIPT.replace(
+            '    clamp_device_ids_to_gpu_count "${_profile_env}"\n',
+            '    if [[ -n "${BREV_ENV_ID:-}" ]]; then\n'
+            '      clamp_device_ids_to_gpu_count "${_profile_env}"\n'
+            "    fi\n",
+        )
+        failures = self._scan_script(script)
+        self.assertTrue(
+            any("gated on a single profile or environment" in f for f in failures),
+            failures,
+        )
+        self.assertTrue(any("BREV_ENV_ID" in failure for failure in failures), failures)
+
+    def test_clamp_gated_on_one_profile_fails(self) -> None:
+        script = GOOD_SCRIPT.replace(
+            '    clamp_device_ids_to_gpu_count "${_profile_env}"\n',
+            '    if [[ "${profile}" == "search" ]]; then\n'
+            '      clamp_device_ids_to_gpu_count "${_profile_env}"\n'
+            "    fi\n",
+        )
+        failures = self._scan_script(script)
+        self.assertTrue(
+            any("gated on a single profile or environment" in f for f in failures),
+            failures,
+        )
+
+    def test_a_second_unscoped_call_rescues_a_scoped_one(self) -> None:
+        # A profile-specific extra clamp is fine as long as one call still
+        # covers everything.
+        script = GOOD_SCRIPT.replace(
+            '    clamp_device_ids_to_gpu_count "${_profile_env}"\n',
+            '    if [[ "${profile}" == "search" ]]; then\n'
+            '      clamp_device_ids_to_gpu_count "${_profile_env}"\n'
+            "    fi\n"
+            '    clamp_device_ids_to_gpu_count "${_profile_env}"\n',
+        )
+        self.assertEqual([], self._scan_script(script))
+
+    def test_clamp_without_a_gpu_count_source_fails(self) -> None:
+        script = GOOD_SCRIPT.replace("get_deployment_gpu_count", "always_two")
+        failures = self._scan_script(script)
+        self.assertTrue(any("no GPU count" in failure for failure in failures), failures)
+
+    def test_missing_key_arrays_fail(self) -> None:
+        script = GOOD_SCRIPT.replace("DEVICE_ID_KEYS=(", "UNUSED_KEYS=(").replace(
+            "DEVICE_RESERVATION_KEYS=(", "MORE_UNUSED=("
+        )
+        failures = self._scan_script(script)
+        self.assertTrue(any("no DEVICE_ID_KEYS" in failure for failure in failures), failures)
+
+    def _scan_script(self, script: str) -> list[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            _write(directory, "scripts/deploy.sh", script)
+            _write(directory, "profiles/demo/.env", "LLM_DEVICE_ID='1'\n")
+            family = LINT.ProfileFamily(env_root="profiles", script="scripts/deploy.sh")
+            original_root = LINT.ROOT
+            LINT.ROOT = Path(directory)
+            try:
+                return LINT.scan_family(family, [])
+            finally:
+                LINT.ROOT = original_root
+
+
+class EnclosingConditionsTest(unittest.TestCase):
+    """The upward walk must not mistake an already-closed sibling block for an
+    enclosing one, or the reachability check reports conditions that do not
+    apply to the call."""
+
+    def test_sibling_block_above_the_call_is_not_enclosing(self) -> None:
+        lines = [
+            "function f() {",
+            '  if [[ -n "${a}" ]]; then',
+            '    if [[ "${profile}" == "search" ]]; then',
+            "      echo sibling",
+            "    fi",
+            "    target",
+            "  fi",
+            "}",
+        ]
+        conditions = LINT.enclosing_conditions(lines, 5)
+        self.assertEqual(['if [[ -n "${a}" ]]; then'], conditions)
+
+    def test_enclosing_blocks_are_innermost_first(self) -> None:
+        lines = [
+            "function f() {",
+            '  if [[ -n "${a}" ]]; then',
+            '    if [[ -n "${BREV_ENV_ID:-}" ]]; then',
+            "      target",
+            "    fi",
+            "  fi",
+            "}",
+        ]
+        conditions = LINT.enclosing_conditions(lines, 3)
+        self.assertEqual(
+            ['if [[ -n "${BREV_ENV_ID:-}" ]]; then', 'if [[ -n "${a}" ]]; then'],
+            conditions,
+        )
+
+    def test_walk_stops_at_the_function_boundary(self) -> None:
+        lines = [
+            'if [[ -n "${BREV_ENV_ID:-}" ]]; then',
+            "  echo outside",
+            "fi",
+            "function f() {",
+            "  target",
+            "}",
+        ]
+        self.assertEqual([], LINT.enclosing_conditions(lines, 4))
+
+    def test_earlier_branches_of_the_same_chain_are_not_reported(self) -> None:
+        # dev-profile.sh calls the clamp inside `elif desired_state == "up"`.
+        # The chain's `if desired_state == "down"` heads the same construct and
+        # is a branch the call cannot be in, so it must not appear as one of the
+        # call's conditions.
+        lines = [
+            "function f() {",
+            '  if [[ "${desired_state}" == "down" ]]; then',
+            "    echo down",
+            '  elif [[ "${desired_state}" == "up" ]]; then',
+            "    target",
+            "  fi",
+            "}",
+        ]
+        self.assertEqual(
+            ['elif [[ "${desired_state}" == "up" ]]; then'],
+            LINT.enclosing_conditions(lines, 4),
+        )
+
+    def test_single_line_case_does_not_shift_the_depth(self) -> None:
+        # The clamp helpers use `case ",${x}," in *",${y},"*) continue ;; esac`
+        # on one line; counting it as an opener would misattribute conditions.
+        lines = [
+            "function f() {",
+            '  if [[ -n "${a}" ]]; then',
+            '    case ",${out}," in *",0,"*) continue ;; esac',
+            "    target",
+            "  fi",
+            "}",
+        ]
+        self.assertEqual(['if [[ -n "${a}" ]]; then'], LINT.enclosing_conditions(lines, 3))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1343,6 +1343,8 @@ jobs:
 
       - name: Unit-test static CI and deployment guards
         run: |
+          python3 .github/scripts/check_gpu_device_clamp.py
+          python3 .github/scripts/test_check_gpu_device_clamp.py
           python3 .github/scripts/test_agent_config_defaults.py
           python3 .github/scripts/test_compose_image_golden.py
           python3 .github/scripts/test_helm_release_channel_policy.py

--- a/deploy/docker/scripts/blueprint-deploy.sh
+++ b/deploy/docker/scripts/blueprint-deploy.sh
@@ -370,6 +370,202 @@ function env_var_defined_in_files() {
   return 1
 }
 
+# ===== Single-GPU device clamp =====
+#
+# Same problem and same rules as dev-profile.sh, which carries the long-form
+# explanation next to its copy of these helpers (the two scripts already keep
+# private copies of get_env_value, get_llm_slug and friends). Warehouse is the
+# most exposed profile in the tree: RT-CV on device 0, RT-VLM on 1 and the LLM
+# on 2 means it needs three GPUs before Compose will start, and asking for an
+# index the host does not have is a hard container-start failure rather than a
+# fallback.
+#
+# A host with at least as many GPUs as the highest committed index clamps
+# nothing, so the three-GPU layout the warehouse profile was validated on
+# renders unchanged. A GPU count of 0 leaves placement alone: an unknown count
+# must not silently move a model.
+DEVICE_ID_KEYS=(
+  'LLM_DEVICE_ID'
+  'VLM_DEVICE_ID'
+  'SHARED_LLM_VLM_DEVICE_ID'
+  'RT_VLM_DEVICE_ID'
+  'RT_CV_DEVICE_ID'
+  'RT_EMBED_DEVICE_ID'
+  'FIXED_SHARED_DEVICE_IDS'
+)
+
+# shellcheck disable=SC2034  # read by .github/scripts/check_gpu_device_clamp.py
+DEVICE_RESERVATION_KEYS=(
+  'RESERVED_DEVICE_IDS'
+)
+
+gpu_count=0
+device_clamp_applied="false"
+shared_llm_vlm_device_id=""
+rt_vlm_device_id=""
+rt_cv_device_id=""
+rt_embed_device_id=""
+fixed_shared_device_ids=""
+reserved_device_ids=""
+
+function get_nvidia_smi_gpu_count() {
+  local _count
+  _count="$(nvidia-smi --query-gpu=index --format=csv,noheader 2>/dev/null | sed '/^[[:space:]]*$/d' | wc -l | tr -d '[:space:]')"
+  [[ "${_count}" =~ ^[0-9]+$ ]] || _count="0"
+  echo "${_count}"
+}
+
+# VSS_GPU_COUNT is a test hook (see dev-profile.sh): it makes both the
+# single-GPU and the multi-GPU branch reachable on any host. Deploying never
+# needs it.
+function get_deployment_gpu_count() {
+  if [[ "${VSS_GPU_COUNT:-}" =~ ^[0-9]+$ ]]; then
+    echo "${VSS_GPU_COUNT}"
+    return
+  fi
+  get_nvidia_smi_gpu_count
+}
+
+function clamp_device_index() {
+  local _index="${1}" _gpu_count="${2}"
+  if [[ ! "${_index}" =~ ^[0-9]+$ ]] || [[ ! "${_gpu_count}" =~ ^[0-9]+$ ]] || (( _gpu_count <= 0 )); then
+    echo "${_index}"
+    return
+  fi
+  if (( _index >= _gpu_count )); then
+    echo "$(( _gpu_count - 1 ))"
+  else
+    echo "${_index}"
+  fi
+}
+
+function clamp_device_index_list() {
+  local _list="${1}" _gpu_count="${2}"
+  local _entry _clamped _out=""
+  local -a _entries
+  IFS=',' read -ra _entries <<< "${_list}"
+  for _entry in "${_entries[@]}"; do
+    [[ -n "${_entry}" ]] || continue
+    _clamped="$(clamp_device_index "${_entry}" "${_gpu_count}")"
+    case ",${_out}," in *",${_clamped},"*) continue ;; esac
+    _out="${_out:+${_out},}${_clamped}"
+  done
+  echo "${_out}"
+}
+
+function filter_existing_device_ids() {
+  local _list="${1}" _gpu_count="${2}"
+  local _entry _out=""
+  local -a _entries
+  IFS=',' read -ra _entries <<< "${_list}"
+  for _entry in "${_entries[@]}"; do
+    [[ -n "${_entry}" ]] || continue
+    if [[ "${_entry}" =~ ^[0-9]+$ ]] && [[ "${_gpu_count}" =~ ^[0-9]+$ ]] && (( _gpu_count > 0 )) && (( _entry >= _gpu_count )); then
+      continue
+    fi
+    case ",${_out}," in *",${_entry},"*) continue ;; esac
+    _out="${_out:+${_out},}${_entry}"
+  done
+  echo "${_out}"
+}
+
+function count_device_ids() {
+  local _list="${1}"
+  local _entry _count=0
+  local -a _entries
+  IFS=',' read -ra _entries <<< "${_list}"
+  for _entry in "${_entries[@]}"; do
+    [[ -n "${_entry}" ]] && ((_count++))
+  done
+  echo "${_count}"
+}
+
+function get_profile_max_device_index() {
+  local _max=0 _key _value _entry
+  local -a _env_files=("$@")
+  local -a _entries
+  for _key in "${DEVICE_ID_KEYS[@]}"; do
+    _value="$(get_env_value_from_files "${_key}" "${_env_files[@]}")"
+    _value="${_value// /}"
+    IFS=',' read -ra _entries <<< "${_value}"
+    for _entry in "${_entries[@]}"; do
+      [[ "${_entry}" =~ ^[0-9]+$ ]] || continue
+      (( _entry > _max )) && _max="${_entry}"
+    done
+  done
+  echo "${_max}"
+}
+
+# Clamp one index and say so on stderr; stdout carries the value for capture.
+function clamp_and_log_device_index() {
+  local _key="${1}" _value="${2}"
+  local _clamped
+  _clamped="$(clamp_device_index "${_value}" "${gpu_count}")"
+  if [[ "${_clamped}" != "${_value}" ]]; then
+    echo "[WARNING]   ${_key}: device ${_value} does not exist here, using device ${_clamped}" >&2
+  fi
+  echo "${_clamped}"
+}
+
+function clamp_device_ids_to_gpu_count() {
+  local -a _env_files=("$@")
+  local _max_index _last_device _reserved_before _reserved_kept _fixed_shared_before
+
+  gpu_count="$(get_deployment_gpu_count)"
+  device_clamp_applied="false"
+
+  shared_llm_vlm_device_id="$(get_env_value_from_files "SHARED_LLM_VLM_DEVICE_ID" "${_env_files[@]}")"
+  rt_vlm_device_id="$(get_env_value_from_files "RT_VLM_DEVICE_ID" "${_env_files[@]}")"
+  rt_cv_device_id="$(get_env_value_from_files "RT_CV_DEVICE_ID" "${_env_files[@]}")"
+  rt_embed_device_id="$(get_env_value_from_files "RT_EMBED_DEVICE_ID" "${_env_files[@]}")"
+  fixed_shared_device_ids="$(get_env_value_from_files "FIXED_SHARED_DEVICE_IDS" "${_env_files[@]}")"
+  fixed_shared_device_ids="${fixed_shared_device_ids// /}"
+  reserved_device_ids="$(get_env_value_from_files "RESERVED_DEVICE_IDS" "${_env_files[@]}")"
+  reserved_device_ids="${reserved_device_ids// /}"
+
+  _max_index="$(get_profile_max_device_index "${_env_files[@]}")"
+
+  if (( gpu_count <= 0 )); then
+    echo "[INFO] GPU count unavailable from nvidia-smi; keeping the committed device placement as-is."
+    return
+  fi
+  if (( _max_index < gpu_count )); then
+    return
+  fi
+
+  device_clamp_applied="true"
+  _last_device=$(( gpu_count - 1 ))
+  echo "[WARNING] This deployment's committed placement uses device indices up to ${_max_index}, so it assumes $(( _max_index + 1 )) GPU(s); this host has ${gpu_count}."
+  echo "[WARNING] Remapping every index >= ${gpu_count} onto device ${_last_device}. Services that were on separate GPUs will now share one:"
+
+  llm_device_id="$(clamp_and_log_device_index "LLM_DEVICE_ID" "${llm_device_id}")"
+  vlm_device_id="$(clamp_and_log_device_index "VLM_DEVICE_ID" "${vlm_device_id}")"
+  shared_llm_vlm_device_id="$(clamp_and_log_device_index "SHARED_LLM_VLM_DEVICE_ID" "${shared_llm_vlm_device_id}")"
+  rt_vlm_device_id="$(clamp_and_log_device_index "RT_VLM_DEVICE_ID" "${rt_vlm_device_id}")"
+  rt_cv_device_id="$(clamp_and_log_device_index "RT_CV_DEVICE_ID" "${rt_cv_device_id}")"
+  rt_embed_device_id="$(clamp_and_log_device_index "RT_EMBED_DEVICE_ID" "${rt_embed_device_id}")"
+
+  _fixed_shared_before="${fixed_shared_device_ids}"
+  fixed_shared_device_ids="$(clamp_device_index_list "${fixed_shared_device_ids}" "${gpu_count}")"
+  if [[ "${fixed_shared_device_ids}" != "${_fixed_shared_before}" ]]; then
+    echo "[WARNING]   FIXED_SHARED_DEVICE_IDS: '${_fixed_shared_before}' -> '${fixed_shared_device_ids}'"
+  fi
+
+  # A reservation keeps the LLM and VLM off a GPU. Clamping it would leave the
+  # models nowhere to go, so drop entries for devices that do not exist and drop
+  # it outright once it would cover every GPU the host has.
+  _reserved_before="${reserved_device_ids}"
+  _reserved_kept="$(filter_existing_device_ids "${reserved_device_ids}" "${gpu_count}")"
+  if (( $(count_device_ids "${_reserved_kept}") >= gpu_count )); then
+    reserved_device_ids=""
+  else
+    reserved_device_ids="${_reserved_kept}"
+  fi
+  if [[ "${reserved_device_ids}" != "${_reserved_before}" ]]; then
+    echo "[WARNING]   RESERVED_DEVICE_IDS: '${_reserved_before}' -> '${reserved_device_ids}' (a reservation covering every GPU cannot be honored)"
+  fi
+}
+
 function mask_secret() {
   local _secret="${1}"
   local _len="${#_secret}"
@@ -881,6 +1077,12 @@ function process_args() {
         fi
       fi
 
+      # Resolve the committed placement against the GPUs this host actually has.
+      # Runs for every warehouse mode, not just 2d/bp_wh: RT_CV_DEVICE_ID and
+      # RT_VLM_DEVICE_ID come from the deployment .env and apply to all of them,
+      # so gating this on the mode is how the general case gets missed.
+      clamp_device_ids_to_gpu_count "${_deploy_env}" "${_deploy_overrides_env}"
+
       if [[ "${deployment}" == "warehouse" ]]; then
         _valid_modes=('2d' '3d' 'mv3dt' 'auto-calibration')
         if [[ -n "${mode}" ]] && ! contains_element "${mode}" "${_valid_modes[@]}"; then
@@ -1087,6 +1289,30 @@ function state_up() {
     fi
     echo "[INFO] Set ${var_name}=${display_value}"
   }
+
+  # Push the clamped placement into generated.env, the last --env-file and so
+  # the one that wins Compose interpolation over the deployment's stable .env.
+  # Only keys whose value actually moved are written, so a host with enough GPUs
+  # emits nothing here and renders byte-identically. LLM_DEVICE_ID and
+  # VLM_DEVICE_ID are written further down from the same clamped variables.
+  if [[ "${device_clamp_applied}" == "true" ]]; then
+    local _clamp_key _clamp_committed _clamp_effective
+    for _clamp_key in SHARED_LLM_VLM_DEVICE_ID RT_VLM_DEVICE_ID RT_CV_DEVICE_ID RT_EMBED_DEVICE_ID FIXED_SHARED_DEVICE_IDS RESERVED_DEVICE_IDS; do
+      _clamp_committed="$(get_env_value_from_files "${_clamp_key}" "${_source_env}" "${_overrides_env}")"
+      _clamp_committed="${_clamp_committed// /}"
+      case "${_clamp_key}" in
+        SHARED_LLM_VLM_DEVICE_ID) _clamp_effective="${shared_llm_vlm_device_id}" ;;
+        RT_VLM_DEVICE_ID) _clamp_effective="${rt_vlm_device_id}" ;;
+        RT_CV_DEVICE_ID) _clamp_effective="${rt_cv_device_id}" ;;
+        RT_EMBED_DEVICE_ID) _clamp_effective="${rt_embed_device_id}" ;;
+        FIXED_SHARED_DEVICE_IDS) _clamp_effective="${fixed_shared_device_ids}" ;;
+        RESERVED_DEVICE_IDS) _clamp_effective="${reserved_device_ids}" ;;
+      esac
+      if [[ "${_clamp_committed}" != "${_clamp_effective}" ]]; then
+        set_env_var "${_clamp_key}" "${_clamp_effective}"
+      fi
+    done
+  fi
 
   set_env_var "VSS_APPS_DIR" "${deployment_directory}"
   set_env_var "VSS_DATA_DIR" "${data_directory}"

--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -98,6 +98,239 @@ function get_nvidia_smi_gpu_count() {
   echo "${_count}"
 }
 
+# ===== Single-GPU device clamp =====
+#
+# The device indices committed in the profile env files describe the GPU layout
+# each profile was validated on: alerts puts the LLM, the VLM and RT-VLM on
+# device 1 and keeps device 0 for RT-CV, search splits RT-CV + RT-VLM on 0 from
+# RT-Embed + the LLM on 1, warehouse goes as far as device 2. Compose passes
+# those straight into `device_ids`, and asking for an index the host does not
+# have is a hard container-start failure, not a fallback -- the stack never comes
+# up on a single-GPU host.
+#
+# Capacity is not the problem being solved here: the LLM and the VLM co-resident
+# on one card measured 71 GiB of 96 GiB in use, so collapsing placement onto a
+# device that exists genuinely runs. What breaks is the *selection* of an index
+# that is not there.
+#
+# Two properties this deliberately keeps:
+#
+#   * A host with at least as many GPUs as the profile's highest index needs
+#     clamps nothing, so every already-validated multi-GPU layout renders
+#     byte-identically. The clamp is dormant there by construction, not by a
+#     hardware-profile special case.
+#   * A GPU count of 0 -- no nvidia-smi, a CI or dry-run host with no GPU --
+#     leaves placement alone. An unknown count must never silently rewrite it.
+#
+# Every remap is logged. A quiet remap that moves a model to a different GPU is
+# barely better than the crash, because the next person to read a bug report
+# cannot tell where the model actually ran.
+
+# GPU count the placement decisions are made against. VSS_GPU_COUNT overrides
+# the nvidia-smi probe so both the single-GPU and the multi-GPU branch are
+# reachable on any host, including a CI runner with no GPU at all -- the same
+# role SKIP_HARDWARE_CHECK plays for the hardware-profile match. It is a test
+# hook: deploying never needs it, and setting it does not change placement on a
+# host that already has enough GPUs.
+function get_deployment_gpu_count() {
+  if [[ "${VSS_GPU_COUNT:-}" =~ ^[0-9]+$ ]]; then
+    echo "${VSS_GPU_COUNT}"
+    return
+  fi
+  get_nvidia_smi_gpu_count
+}
+
+# Every key a profile may use to place a service on a GPU. The clamp walks this
+# list, and .github/scripts/check_gpu_device_clamp.py fails the build when a
+# profile commits an index above 0 under a key that is missing from it -- a new
+# placement key that nothing clamps is how this defect reaches a single-GPU host
+# in the first place.
+DEVICE_ID_KEYS=(
+  'LLM_DEVICE_ID'
+  'VLM_DEVICE_ID'
+  'SHARED_LLM_VLM_DEVICE_ID'
+  'RT_VLM_DEVICE_ID'
+  'RT_CV_DEVICE_ID'
+  'RT_EMBED_DEVICE_ID'
+  'FIXED_SHARED_DEVICE_IDS'
+)
+
+# Keys that name GPUs the LLM and VLM must stay OFF, rather than GPUs they run
+# on. Clamping these would be wrong (see clamp_device_ids_to_gpu_count), so they
+# are listed separately and filtered instead.
+# shellcheck disable=SC2034  # read by .github/scripts/check_gpu_device_clamp.py
+DEVICE_RESERVATION_KEYS=(
+  'RESERVED_DEVICE_IDS'
+)
+
+# Effective placement after the clamp. Everything downstream -- LLM/VLM mode
+# derivation, the reserved-device validation, the generated.env writes -- reads
+# these rather than the profile files, so there is one answer per run.
+gpu_count=0
+device_clamp_applied="false"
+shared_llm_vlm_device_id=""
+rt_vlm_device_id=""
+rt_cv_device_id=""
+rt_embed_device_id=""
+fixed_shared_device_ids=""
+reserved_device_ids=""
+
+# Fold one index onto the last device the host has. Non-numeric values and an
+# unknown GPU count pass through untouched.
+function clamp_device_index() {
+  local _index="${1}" _gpu_count="${2}"
+  if [[ ! "${_index}" =~ ^[0-9]+$ ]] || [[ ! "${_gpu_count}" =~ ^[0-9]+$ ]] || (( _gpu_count <= 0 )); then
+    echo "${_index}"
+    return
+  fi
+  if (( _index >= _gpu_count )); then
+    echo "$(( _gpu_count - 1 ))"
+  else
+    echo "${_index}"
+  fi
+}
+
+# Clamp every entry of a comma-separated device list, dropping the duplicates
+# the clamp creates. FIXED_SHARED_DEVICE_IDS='0,1' becomes '0' on one GPU rather
+# than '0,0', which is what keeps the LLM/VLM mode derivation reading it as a
+# single shared device.
+function clamp_device_index_list() {
+  local _list="${1}" _gpu_count="${2}"
+  local _entry _clamped _out=""
+  local -a _entries
+  IFS=',' read -ra _entries <<< "${_list}"
+  for _entry in "${_entries[@]}"; do
+    [[ -n "${_entry}" ]] || continue
+    _clamped="$(clamp_device_index "${_entry}" "${_gpu_count}")"
+    case ",${_out}," in *",${_clamped},"*) continue ;; esac
+    _out="${_out:+${_out},}${_clamped}"
+  done
+  echo "${_out}"
+}
+
+# Drop entries naming a device the host does not have, and de-duplicate.
+function filter_existing_device_ids() {
+  local _list="${1}" _gpu_count="${2}"
+  local _entry _out=""
+  local -a _entries
+  IFS=',' read -ra _entries <<< "${_list}"
+  for _entry in "${_entries[@]}"; do
+    [[ -n "${_entry}" ]] || continue
+    if [[ "${_entry}" =~ ^[0-9]+$ ]] && [[ "${_gpu_count}" =~ ^[0-9]+$ ]] && (( _gpu_count > 0 )) && (( _entry >= _gpu_count )); then
+      continue
+    fi
+    case ",${_out}," in *",${_entry},"*) continue ;; esac
+    _out="${_out:+${_out},}${_entry}"
+  done
+  echo "${_out}"
+}
+
+function count_device_ids() {
+  local _list="${1}"
+  local _entry _count=0
+  local -a _entries
+  IFS=',' read -ra _entries <<< "${_list}"
+  for _entry in "${_entries[@]}"; do
+    [[ -n "${_entry}" ]] && ((_count++))
+  done
+  echo "${_count}"
+}
+
+# Highest device index the profile commits anywhere. The profile implicitly
+# requires that many GPUs plus one; nothing declares it, so it is derived.
+function get_profile_max_device_index() {
+  local _max=0 _key _value _entry
+  local -a _env_files=("$@")
+  local -a _entries
+  for _key in "${DEVICE_ID_KEYS[@]}"; do
+    _value="$(get_env_value_from_files "${_key}" "${_env_files[@]}")"
+    _value="${_value// /}"
+    IFS=',' read -ra _entries <<< "${_value}"
+    for _entry in "${_entries[@]}"; do
+      [[ "${_entry}" =~ ^[0-9]+$ ]] || continue
+      (( _entry > _max )) && _max="${_entry}"
+    done
+  done
+  echo "${_max}"
+}
+
+# Clamp one index and say so on stderr; stdout carries the value for capture.
+function clamp_and_log_device_index() {
+  local _key="${1}" _value="${2}"
+  local _clamped
+  _clamped="$(clamp_device_index "${_value}" "${gpu_count}")"
+  if [[ "${_clamped}" != "${_value}" ]]; then
+    echo "[WARNING]   ${_key}: device ${_value} does not exist here, using device ${_clamped}" >&2
+  fi
+  echo "${_clamped}"
+}
+
+# Resolve the profile's committed placement against the GPUs this host has, and
+# publish the result in the globals above. Must run before anything derives
+# LLM/VLM mode or validates a reservation, since both read device indices.
+function clamp_device_ids_to_gpu_count() {
+  local -a _env_files=("$@")
+  local _max_index _last_device _reserved_before _reserved_kept
+
+  gpu_count="$(get_deployment_gpu_count)"
+  device_clamp_applied="false"
+
+  shared_llm_vlm_device_id="$(get_env_value_from_files "SHARED_LLM_VLM_DEVICE_ID" "${_env_files[@]}")"
+  rt_vlm_device_id="$(get_env_value_from_files "RT_VLM_DEVICE_ID" "${_env_files[@]}")"
+  rt_cv_device_id="$(get_env_value_from_files "RT_CV_DEVICE_ID" "${_env_files[@]}")"
+  rt_embed_device_id="$(get_env_value_from_files "RT_EMBED_DEVICE_ID" "${_env_files[@]}")"
+  fixed_shared_device_ids="$(get_env_value_from_files "FIXED_SHARED_DEVICE_IDS" "${_env_files[@]}")"
+  fixed_shared_device_ids="${fixed_shared_device_ids// /}"
+  reserved_device_ids="$(get_env_value_from_files "RESERVED_DEVICE_IDS" "${_env_files[@]}")"
+  reserved_device_ids="${reserved_device_ids// /}"
+
+  _max_index="$(get_profile_max_device_index "${_env_files[@]}")"
+
+  if (( gpu_count <= 0 )); then
+    echo "[INFO] GPU count unavailable from nvidia-smi; keeping the committed device placement as-is."
+    return
+  fi
+  if (( _max_index < gpu_count )); then
+    return
+  fi
+
+  device_clamp_applied="true"
+  _last_device=$(( gpu_count - 1 ))
+  echo "[WARNING] This profile's committed placement uses device indices up to ${_max_index}, so it assumes $(( _max_index + 1 )) GPU(s); this host has ${gpu_count}."
+  echo "[WARNING] Remapping every index >= ${gpu_count} onto device ${_last_device}. Services that were on separate GPUs will now share one:"
+
+  llm_device_id="$(clamp_and_log_device_index "LLM_DEVICE_ID" "${llm_device_id}")"
+  vlm_device_id="$(clamp_and_log_device_index "VLM_DEVICE_ID" "${vlm_device_id}")"
+  shared_llm_vlm_device_id="$(clamp_and_log_device_index "SHARED_LLM_VLM_DEVICE_ID" "${shared_llm_vlm_device_id}")"
+  rt_vlm_device_id="$(clamp_and_log_device_index "RT_VLM_DEVICE_ID" "${rt_vlm_device_id}")"
+  rt_cv_device_id="$(clamp_and_log_device_index "RT_CV_DEVICE_ID" "${rt_cv_device_id}")"
+  rt_embed_device_id="$(clamp_and_log_device_index "RT_EMBED_DEVICE_ID" "${rt_embed_device_id}")"
+
+  local _fixed_shared_before="${fixed_shared_device_ids}"
+  fixed_shared_device_ids="$(clamp_device_index_list "${fixed_shared_device_ids}" "${gpu_count}")"
+  if [[ "${fixed_shared_device_ids}" != "${_fixed_shared_before}" ]]; then
+    echo "[WARNING]   FIXED_SHARED_DEVICE_IDS: '${_fixed_shared_before}' -> '${fixed_shared_device_ids}'"
+  fi
+
+  # RESERVED_DEVICE_IDS means "keep the LLM and VLM off these GPUs, the
+  # perception services need them". Clamping it would be backwards -- folding
+  # alerts' reservation of device 0 onto device 0 leaves the models nowhere to
+  # go, and the run dies on "Device ID 0 is reserved" instead of the crash it
+  # replaced. So drop entries for devices that do not exist, and drop the
+  # reservation outright once it would cover every GPU the host has: on one GPU
+  # there is no other device to reserve one *from*.
+  _reserved_before="${reserved_device_ids}"
+  _reserved_kept="$(filter_existing_device_ids "${reserved_device_ids}" "${gpu_count}")"
+  if (( $(count_device_ids "${_reserved_kept}") >= gpu_count )); then
+    reserved_device_ids=""
+  else
+    reserved_device_ids="${_reserved_kept}"
+  fi
+  if [[ "${reserved_device_ids}" != "${_reserved_before}" ]]; then
+    echo "[WARNING]   RESERVED_DEVICE_IDS: '${_reserved_before}' -> '${reserved_device_ids}' (a reservation covering every GPU cannot be honored)"
+  fi
+}
+
 # Returns the indices of GPUs whose product name matches the requested hardware
 # profile, one per line. This is used when a service-specific device ID cannot
 # identify the deployment GPU (for example, when both LLM and VLM are remote).
@@ -899,13 +1132,13 @@ function process_args() {
       if ! contains_element "vlm-device-id" "${options_provided[@]}"; then
         vlm_device_id="$(get_env_value_from_files "VLM_DEVICE_ID" "${_profile_env}" "${_profile_overrides_env}")"
       fi
-      local _fixed_shared_raw _fixed_shared_norm _reserved_raw _reserved_norm
-      _fixed_shared_raw="$(get_env_value_from_files "FIXED_SHARED_DEVICE_IDS" "${_profile_env}" "${_profile_overrides_env}")"
-      _fixed_shared_raw="${_fixed_shared_raw// /}"
-      _fixed_shared_norm=",${_fixed_shared_raw},"
-      _reserved_raw="$(get_env_value_from_files "RESERVED_DEVICE_IDS" "${_profile_env}" "${_profile_overrides_env}")"
-      _reserved_raw="${_reserved_raw// /}"
-      _reserved_norm=",${_reserved_raw},"
+      # Resolve the committed placement against the GPUs this host actually has
+      # before anything reads a device index. Mode derivation, the reserved-device
+      # validation and every generated.env write below depend on it, so a clamp
+      # applied later would leave them disagreeing about where a model runs.
+      clamp_device_ids_to_gpu_count "${_profile_env}" "${_profile_overrides_env}"
+      local _fixed_shared_norm=",${fixed_shared_device_ids},"
+      local _reserved_norm=",${reserved_device_ids},"
       if ! contains_element "llm-model-type" "${options_provided[@]}"; then
         llm_model_type="$(get_env_value_from_files "LLM_MODEL_TYPE" "${_profile_env}" "${_profile_overrides_env}")"
       fi
@@ -1239,12 +1472,11 @@ function process_args() {
       # Exception: DGX-SPARK, IGX-THOR, AGX-THOR are exempt (device ID options not accepted).
       if ! contains_element "${hardware_profile}" "${edge_hardware_profiles[@]}"; then
         if [[ -n "${profile}" ]] && [[ -f "${deployment_directory}/developer-profiles/dev-profile-${profile}/.env" ]]; then
-          local _profile_env_reserved="${deployment_directory}/developer-profiles/dev-profile-${profile}/.env"
-          local _profile_overrides_env_reserved="${deployment_directory}/developer-profiles/dev-profile-${profile}/overrides.env"
-          local _reserved_raw
-          _reserved_raw="$(get_env_value_from_files "RESERVED_DEVICE_IDS" "${_profile_env_reserved}" "${_profile_overrides_env_reserved}")"
-          _reserved_raw="${_reserved_raw// /}"  # normalize: remove spaces so "0, 1" matches id "0" and "1"
-          local _reserved_norm=",${_reserved_raw},"
+          # The effective reservation, not the committed one: on a host with
+          # fewer GPUs than the profile assumes the reservation has already been
+          # relaxed, and re-reading the file here would reject the placement the
+          # clamp just chose.
+          local _reserved_norm=",${reserved_device_ids},"
           if [[ "${llm_mode}" != "remote" ]] && [[ -n "${llm_device_id}" ]]; then
             if [[ "${_reserved_norm}" == *",${llm_device_id},"* ]]; then
               echo "[ERROR] Device ID ${llm_device_id} is reserved and cannot be assigned to LLM or VLM for this profile"
@@ -1374,7 +1606,7 @@ function process_args() {
       # that layout, so fail fast instead of a broken deployment.
       if [[ "${profile}" == "search" ]] && [[ "${hardware_profile}" != "GB300" ]] && [[ -n "${BREV_ENV_ID:-}" ]] && [[ "${vlm_mode}" != "remote" ]]; then
         local _brev_gpu_count
-        _brev_gpu_count="$(get_nvidia_smi_gpu_count)"
+        _brev_gpu_count="$(get_deployment_gpu_count)"
         if [[ "${_brev_gpu_count}" =~ ^[0-9]+$ ]] && [[ "${_brev_gpu_count}" -gt 0 ]] && [[ "${_brev_gpu_count}" -lt 2 ]]; then
           echo "[ERROR] Search deploys a local RT-VLM and needs at least 2 GPUs, but this Brev environment has ${_brev_gpu_count} GPU(s). Pass --use-remote-vlm with VLM_ENDPOINT_URL to run search here."
           ((_all_good++))
@@ -1592,6 +1824,32 @@ function state_up() {
     fi
     echo "[INFO] Set ${var_name}=${display_value}"
   }
+
+  # Push the clamped placement into generated.env. Compose reads the profile's
+  # stable .env too, and generated.env is the last --env-file, so this is where
+  # a corrected index has to land to win interpolation. Only keys whose value
+  # actually moved are written, which is what keeps a host with enough GPUs
+  # producing a byte-identical generated.env: nothing is emitted at all.
+  # LLM_DEVICE_ID / VLM_DEVICE_ID are not listed -- they are written further down
+  # from the same clamped shell variables.
+  if [[ "${device_clamp_applied}" == "true" ]]; then
+    local _clamp_key _clamp_committed _clamp_effective
+    for _clamp_key in SHARED_LLM_VLM_DEVICE_ID RT_VLM_DEVICE_ID RT_CV_DEVICE_ID RT_EMBED_DEVICE_ID FIXED_SHARED_DEVICE_IDS RESERVED_DEVICE_IDS; do
+      _clamp_committed="$(get_env_value_from_files "${_clamp_key}" "${_source_env}" "${_overrides_env}")"
+      _clamp_committed="${_clamp_committed// /}"
+      case "${_clamp_key}" in
+        SHARED_LLM_VLM_DEVICE_ID) _clamp_effective="${shared_llm_vlm_device_id}" ;;
+        RT_VLM_DEVICE_ID) _clamp_effective="${rt_vlm_device_id}" ;;
+        RT_CV_DEVICE_ID) _clamp_effective="${rt_cv_device_id}" ;;
+        RT_EMBED_DEVICE_ID) _clamp_effective="${rt_embed_device_id}" ;;
+        FIXED_SHARED_DEVICE_IDS) _clamp_effective="${fixed_shared_device_ids}" ;;
+        RESERVED_DEVICE_IDS) _clamp_effective="${reserved_device_ids}" ;;
+      esac
+      if [[ "${_clamp_committed}" != "${_clamp_effective}" ]]; then
+        set_env_var "${_clamp_key}" "${_clamp_effective}"
+      fi
+    done
+  fi
 
   # Set the required environment variables
   set_env_var "VSS_APPS_DIR" "${deployment_directory}"
@@ -1850,9 +2108,9 @@ function state_up() {
     # IGX-THOR/AGX-THOR are handled in the hw sub-block below.
     if [[ "${hardware_profile}" != "IGX-THOR" ]] && [[ "${hardware_profile}" != "AGX-THOR" ]]; then
       if [[ "${vlm_mode}" == "local_shared" ]]; then
-        local _shared_rt_dev_id
-        _shared_rt_dev_id="$(get_env_value_from_files "SHARED_LLM_VLM_DEVICE_ID" "${_source_env}" "${_overrides_env}")"
-        set_env_var "RT_VLM_DEVICE_ID" "${_shared_rt_dev_id:-${vlm_device_id}}"
+        # Clamped value, not the committed one: on a host with fewer GPUs than
+        # the profile assumes, the shared device has already been moved.
+        set_env_var "RT_VLM_DEVICE_ID" "${shared_llm_vlm_device_id:-${vlm_device_id}}"
       elif [[ "${vlm_mode}" == "remote" ]]; then
         set_env_var "RT_VLM_DEVICE_ID" "0"
       else

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -18,6 +18,14 @@ export NGC_CLI_API_KEY
 # Skip hardware-profile vs nvidia-smi check so tests that pass a specific profile (e.g. DGX-SPARK) pass on CI without that GPU.
 # Unset SKIP_HARDWARE_CHECK in tests that assert the fail-fast mismatch behavior.
 export SKIP_HARDWARE_CHECK=true
+# Pin the GPU count the placement assertions are made against. Nearly every
+# generated.env expectation below encodes a committed multi-GPU layout (alerts
+# and search on two GPUs, warehouse on three), and dev-profile.sh now folds any
+# index the host cannot satisfy onto a device that exists. Without pinning, the
+# expected values would depend on how many GPUs the machine running the tests
+# happens to have -- 4 keeps every committed layout intact everywhere. The
+# single-GPU clamp itself is covered by the VSS_GPU_COUNT=1 cases further down.
+export VSS_GPU_COUNT="${VSS_GPU_COUNT:-4}"
 # Per-test timeout (seconds); dry-run can be slow on first run
 TEST_TIMEOUT="${TEST_TIMEOUT:-15}"
 TESTS_PASSED=0
@@ -692,6 +700,60 @@ run_negative_test "invalid VLM model name" 1 up -p base --vlm invalid-vlm
 # Note: shared-llm-vlm-device-id is now from profile only; reserved check for it would require profile to set SHARED_LLM_VLM_DEVICE_ID=0
 run_negative_test "llm-device-id must not be in RESERVED_DEVICE_IDS" 1 up -p alerts -i 127.0.0.1 -m verification --llm-device-id 0 --vlm-device-id 1
 run_negative_test "vlm-device-id must not be in RESERVED_DEVICE_IDS" 1 up -p alerts -i 127.0.0.1 -m verification --llm-device-id 1 --vlm-device-id 0
+
+# ===== Single-GPU device clamp (VSS_GPU_COUNT=1) =====
+# alerts and search commit a two-GPU layout, so on one GPU Compose is handed a
+# device_ids entry of "1" and no container starts. Every index at or above the
+# GPU count folds onto device 0 instead. The 2-GPU expectations above are the
+# same assertions with nothing clamped, so the pair covers both branches.
+VSS_GPU_COUNT=1 run_dry_run_up_and_check_generated_env \
+  "generated.env alerts on one GPU folds the 2-GPU layout onto device 0" "alerts" \
+  -i 127.0.0.1 -m verification -d -- \
+  "LLM_DEVICE_ID" "0" \
+  "VLM_DEVICE_ID" "0" \
+  "RT_VLM_DEVICE_ID" "0" \
+  "LLM_MODE" "local_shared" \
+  "VLM_MODE" "local_shared"
+# RESERVED_DEVICE_IDS='0' keeps alerts' models off RT-CV's GPU. With one GPU
+# there is no other device to move them to, so the reservation is dropped --
+# leaving it would turn the crash into "Device ID 0 is reserved".
+VSS_GPU_COUNT=1 run_dry_run_up_and_check_generated_env \
+  "generated.env alerts on one GPU drops the unsatisfiable reservation" "alerts" \
+  -i 127.0.0.1 -m verification -d -- \
+  "RESERVED_DEVICE_IDS" ""
+# search splits RT-CV + RT-VLM on 0 from RT-Embed + LLM on 1, and treats both as
+# shared. On one GPU FIXED_SHARED_DEVICE_IDS='0,1' has to collapse to '0' rather
+# than '0,0' or the shared-device derivation reads a device twice.
+VSS_GPU_COUNT=1 run_dry_run_up_and_check_generated_env \
+  "generated.env search on one GPU folds RT-Embed and the LLM onto device 0" "search" \
+  -i 127.0.0.1 -d -- \
+  "LLM_DEVICE_ID" "0" \
+  "RT_EMBED_DEVICE_ID" "0" \
+  "RT_CV_DEVICE_ID" "0" \
+  "FIXED_SHARED_DEVICE_IDS" "0" \
+  "LLM_MODE" "local_shared"
+# base already places everything on device 0, so a one-GPU host must clamp
+# nothing at all: no remap, and no warning claiming one happened.
+VSS_GPU_COUNT=1 run_dry_run_up_and_check_generated_env \
+  "generated.env base on one GPU is unchanged" "base" \
+  -i 127.0.0.1 -d -- \
+  "LLM_DEVICE_ID" "0" \
+  "VLM_DEVICE_ID" "0" \
+  "RT_VLM_DEVICE_ID" "0"
+VSS_GPU_COUNT=1 run_dry_run_test "alerts on one GPU reports the remap" up -p alerts -i 127.0.0.1 -m verification -d
+assert_stdout_contains "alerts on one GPU names the profile's GPU assumption" \
+  "assumes 2 GPU(s); this host has 1"
+VSS_GPU_COUNT=1 run_dry_run_test "search on one GPU reports the remap" up -p search -i 127.0.0.1 -d
+assert_stdout_contains "search on one GPU logs which key moved" \
+  "RT_EMBED_DEVICE_ID: device 1 does not exist here"
+# A count of 0 means nvidia-smi could not be reached. Placement must be left
+# exactly as committed: an unknown count must never silently move a model.
+VSS_GPU_COUNT=0 run_dry_run_up_and_check_generated_env \
+  "generated.env alerts with an unknown GPU count keeps the committed layout" "alerts" \
+  -i 127.0.0.1 -m verification -d -- \
+  "LLM_DEVICE_ID" "1" \
+  "VLM_DEVICE_ID" "1" \
+  "RT_VLM_DEVICE_ID" "1"
 
 # L40S forbids a local_shared LLM (no hw-L40S-shared.env). Search RT-VLM may share GPU 0 with RT-CV.
 run_negative_test "L40S rejects local_shared LLM" 1 up -p search -i 127.0.0.1 -H L40S -d


### PR DESCRIPTION
## The defect

Profiles commit the GPU layout they were validated on. `dev-profile-alerts`
places the LLM, the VLM and RT-VLM on **device 1** and reserves device 0 for
RT-CV; `dev-profile-search` splits RT-CV + RT-VLM on 0 from RT-Embed + the LLM
on 1; `warehouse-operations` goes as far as **device 2**.

Compose passes those indices straight into `device_ids`, so on a host with fewer
GPUs than the profile assumes the request names a device that does not exist and
containers fail to start. There is no fallback — the stack simply never comes up.

This is not hypothetical: much of the eval fleet is single-GPU
(`g7e.2xlarge` / `g7e.4xlarge`), so any one-GPU box hits it. It was found on a
Brev `g7e.4xlarge` where `dev-profile-alerts` could only be deployed after
hand-editing the device IDs on disk.

`get_nvidia_smi_gpu_count()` already existed, but was called from exactly one
place — a search-and-Brev-specific pre-flight — so nothing caught the general
case.

### Scope across the tree

The lint added here reports it directly:

| Profile | GPUs implied by committed placement |
|---|---|
| `dev-profile-alerts` | 2 |
| `dev-profile-search` | 2 |
| `warehouse-operations` | 3 |
| `dev-profile-base` | 1 |
| `dev-profile-lvs` | 1 |
| `smartcities` | no device placement committed |

**Not a capacity problem.** The LLM and the VLM co-resident on a single RTX PRO
6000 measured **71 GiB of 96 GiB** in use, so collapsing placement onto a device
that exists genuinely runs. What breaks is the *selection* of an index that is
not there.

## The fix

Consult the GPU count where device IDs are resolved and clamp any index at or
above it onto an existing device, rather than changing the committed defaults.
Two properties are deliberate:

- **A host with at least as many GPUs as the profile's highest index clamps
  nothing**, so every already-validated multi-GPU layout renders
  byte-identically. The clamp is dormant there by construction, not by a
  hardware-profile special case.
- **A GPU count of 0** — no `nvidia-smi`, a CI or dry-run host — leaves
  placement alone. An unknown count must never silently rewrite it.

`RESERVED_DEVICE_IDS` is **filtered rather than clamped**: it names GPUs a model
must stay *off*, so mapping index 1 down to 0 would reserve the only device the
profile then has to run on. That is exactly why the manual workaround had to
blank it by hand.

Every remap is logged. A quiet remap is barely better than the crash, because
the next person reading a bug report cannot tell which GPU the model actually
ran on.

`blueprint-deploy.sh` gets the same helpers — it already keeps private copies of
`get_env_value` and friends, and `warehouse-operations` is the most exposed
profile in the tree.

## Validation

- **Deployed on a real one-GPU box** (Brev `g7e.4xlarge`, one RTX PRO 6000
  Blackwell, 96 GB) with `dev-profile-alerts`: 23 containers healthy, the LLM
  NIM placed on `DeviceIDs: ["0"]`, 71358 / 97887 MiB in use with both models
  co-resident.
- **Two-GPU placement unchanged**: with a GPU count at or above each profile's
  highest committed index, the clamp is inert and the rendered configuration is
  identical.
- `deploy/docker/test-scripts/test-dev-profile.sh` extended to cover both
  branches; `VSS_GPU_COUNT` is the test hook that makes the single-GPU and
  multi-GPU paths reachable on any host, including a CI runner with no GPU
  (the same role `SKIP_HARDWARE_CHECK` plays for the hardware-profile match).

### Regression guard, and its canary

`.github/scripts/check_gpu_device_clamp.py` reports each profile's implied GPU
count and fails when a profile commits an index above 0 under a placement key
the clamp does not walk — a new placement key that nothing clamps is how this
reaches a single-GPU host in the first place.

Canaried rather than assumed: removing `RT_EMBED_DEVICE_ID` from
`DEVICE_ID_KEYS` makes it **exit 1**, naming
`dev-profile-search/.env:59`; restoring it returns **exit 0**. 22 unit tests
accompany it.

## Why this is a separate PR

The defect is pre-existing on `develop` (verified, not taken on trust) and has
nothing to do with gateway routing, so it does not belong in the large gateway
consolidation PR it was found alongside.