### PR TITLE
fix(agent): treat an already-registered rt-embed asset as a successful upload

### DIFF
--- a/services/agent/packages/vss_agents/src/vss_agents/api/video_ingest.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/api/video_ingest.py
@@ -188,7 +188,15 @@ class VideoIngestResponse(BaseModel):
     message: str = Field(..., description="Status message indicating completion")
     sensor_id: str = Field(..., description="VST sensor id for the uploaded video (matches the {sensor_id} path param)")
     filename: str = Field(..., description="The filename returned by VST after upload")
-    chunks_processed: int = Field(default=0, description="Number of chunks processed")
+    chunks_processed: int | None = Field(
+        default=0,
+        description=(
+            "Number of chunks embedded by this request. ``null`` means the asset was already"
+            " registered by another party — generation is running there and is still in"
+            " progress, so no count is available and the video is not yet searchable."
+            " ``0`` means no embedding work was requested at all."
+        ),
+    )
 
 
 class VideoUploadUrlInput(BaseModel):
@@ -442,17 +450,23 @@ async def _run_rtvi_embedding(
     rtvi_embed_chunk_duration: int,
     start_timestamp: str,
     timeout_seconds: float = DEFAULT_RTVI_EMBED_TIMEOUT_SECONDS,
-) -> int:
+) -> int | None:
     """POST ``/v1/generate_video_embeddings``. Returns ``total_chunks_processed``.
 
     The call is synchronous on the RTVI-Embed side — it blocks until the
-    generation completes (up to the 600s client timeout). Any non-200 raises
-    ``HTTPException(502)`` so the caller can surface the failure, except the
-    two responses that mean the asset id is already registered — see
-    :func:`_already_registered_code`. Those return 0 chunks: generation is
-    someone else's, so we cannot count it, but the upload did succeed and
-    reporting a failure would make every caller either retry work that already
-    happened or report an upload that actually worked as broken.
+    generation completes (up to the 600s client timeout), so an ``int`` return
+    means the embeddings exist and the video is searchable.
+
+    Any non-200 raises ``HTTPException(502)`` so the caller can surface the
+    failure, except the two responses that mean the asset id is already
+    registered — see :func:`_already_registered_code`. Those return ``None``,
+    which is *not* the same as zero: the upload succeeded and generation is
+    running, but it belongs to the other registrant, so there is no count to
+    report and — crucially — no completion to report either. The owning path is
+    asynchronous: rt-embed's ``stream/add`` starts generation and answers
+    ``status: "processing"`` without waiting for it, so nothing in that flow
+    blocks until the embeddings land. ``None`` is what carries that "started
+    elsewhere, not finished" state to the caller; see the response model.
     """
     rtvi_embed_url = rtvi_embed_base_url.rstrip("/")
     embedding_url = f"{rtvi_embed_url}/v1/generate_video_embeddings"
@@ -486,12 +500,14 @@ async def _run_rtvi_embedding(
                 logger.warning(
                     "RTVI-Embed already holds asset %s (%d %s) — another registrant, normally"
                     " VIOS streamprocessing's stream/add webhook, owns it and drives generation."
-                    " Treating the upload as successful; the chunk count is not ours to report.",
+                    " The upload succeeded, but that generation is asynchronous and still in"
+                    " flight: the embeddings are not queryable yet and this request cannot tell"
+                    " when they will be. Callers that search straight after uploading must poll.",
                     sensor_id,
                     response.status_code,
                     already_registered,
                 )
-                return 0
+                return None
             error_msg = f"Embedding generation failed with status {response.status_code}: {response.text}"
             logger.error(error_msg)
             raise HTTPException(status_code=502, detail=f"Embedding generation failed: {error_msg}")
@@ -622,7 +638,7 @@ async def _run_post_upload_processing(
     else:
         logger.info("RTVI-CV not configured, skipping")
 
-    chunks_processed = 0
+    chunks_processed: int | None = 0
     if parsed_embed is not None:
         rtvi_tasks.append(
             (
@@ -656,13 +672,26 @@ async def _run_post_upload_processing(
                 logger.error("%s task failed: %s", label, result)
                 raise result
             if label == "rtvi-embed":
-                chunks_processed = result or 0
+                # ``None`` is meaningful here (generation deferred to whoever
+                # already owns the asset) so it must survive to the response —
+                # ``or 0`` would collapse it into "no work requested".
+                chunks_processed = result
 
-    message = (
-        f"Video {filename} successfully uploaded to VST and embeddings generated"
-        if parsed_embed is not None
-        else f"Video {filename} successfully uploaded to VST"
-    )
+    # Three distinct outcomes, and the message says which. The deferred one is
+    # the only case where the upload succeeded but the video is *not* yet
+    # searchable, so it must not read like the completed one — a caller that
+    # uploads and immediately searches was correct against the old synchronous
+    # behaviour and now races, and this is what tells it so.
+    if parsed_embed is None:
+        message = f"Video {filename} successfully uploaded to VST"
+    elif chunks_processed is None:
+        message = (
+            f"Video {filename} successfully uploaded to VST; embedding generation is owned by"
+            " another registrant and is still in progress. The video is not searchable yet —"
+            " poll for its embeddings before querying."
+        )
+    else:
+        message = f"Video {filename} successfully uploaded to VST and embeddings generated"
     return VideoIngestResponse(
         message=message,
         sensor_id=sensor_id,

--- a/services/agent/packages/vss_agents/src/vss_agents/api/video_ingest.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/api/video_ingest.py
@@ -384,6 +384,55 @@ async def _register_with_rtvi_cv(
         logger.warning("RTVI-CV timed out at %s, skipping", rtvi_cv_add_url)
 
 
+# rt-embed refuses a ``generate_video_embeddings`` call whose asset id is
+# already taken, and the status it uses depends on how far the other
+# registration has got: ``check_asset_exists`` rejects a published asset with
+# ``400 AssetAlreadyExists``, while ``_reserve_asset_slot`` rejects one that is
+# still reserved (mid-download) with ``409 DuplicateAssetId``. Both mean
+# something else owns this asset id, which on a deployment where VIOS
+# streamprocessing fans ``camera_streaming`` out to rt-embed's ``/v1/stream/add``
+# is the normal outcome: that webhook registers the asset *and* starts
+# generation, so the agent's call for the same id is redundant rather than
+# unlucky.
+#
+# It is only redundant where that webhook exists, which is why the call is not
+# simply dropped. The Docker ``dev-profile-search`` ships it; the Helm
+# ``dev-profile-search`` sets ``RTVI_EMBED_BASE_URL`` for the agent but renders
+# streamprocessing's ``notification_config.json`` with ``webhooks.enabled:
+# false``, so there the agent's call is the *only* thing that generates
+# embeddings for an uploaded file. Deleting it would turn this 502 into a 200
+# with an empty index — the same bug, now silent.
+_ALREADY_REGISTERED_CODE_BY_STATUS = {
+    400: "AssetAlreadyExists",
+    409: "DuplicateAssetId",
+}
+
+
+def _already_registered_code(response: httpx.Response) -> str | None:
+    """Return rt-embed's error code when it says the asset id is already owned.
+
+    ``None`` for anything else, so every other non-200 stays fatal. The pairing
+    is checked both ways round: a 400 must carry ``AssetAlreadyExists`` and a
+    409 must carry ``DuplicateAssetId``, because the whole point is to
+    distinguish "already done" from a request rt-embed rejected on its merits.
+    ``400 BadParameters`` (bad model, bad url) and ``409 DuplicateCameraId``
+    (a *different* asset already holds this camera id) are real failures that
+    share a status code with the tolerated pair, so the code is what decides.
+    An unparseable body is not tolerated either — same discipline as the
+    gateway's marked-vs-unmarked 503.
+    """
+    expected_code = _ALREADY_REGISTERED_CODE_BY_STATUS.get(response.status_code)
+    if expected_code is None:
+        return None
+    try:
+        body = response.json()
+    except ValueError:
+        return None
+    if not isinstance(body, dict) or body.get("code") != expected_code:
+        return None
+    return expected_code
+
+
 async def _run_rtvi_embedding(
     *,
     rtvi_embed_base_url: str,
@@ -398,7 +447,12 @@ async def _run_rtvi_embedding(
 
     The call is synchronous on the RTVI-Embed side — it blocks until the
     generation completes (up to the 600s client timeout). Any non-200 raises
-    ``HTTPException(502)`` so the caller can surface the failure.
+    ``HTTPException(502)`` so the caller can surface the failure, except the
+    two responses that mean the asset id is already registered — see
+    :func:`_already_registered_code`. Those return 0 chunks: generation is
+    someone else's, so we cannot count it, but the upload did succeed and
+    reporting a failure would make every caller either retry work that already
+    happened or report an upload that actually worked as broken.
     """
     rtvi_embed_url = rtvi_embed_base_url.rstrip("/")
     embedding_url = f"{rtvi_embed_url}/v1/generate_video_embeddings"
@@ -427,6 +481,17 @@ async def _run_rtvi_embedding(
             )
 
         if response.status_code != 200:
+            already_registered = _already_registered_code(response)
+            if already_registered is not None:
+                logger.warning(
+                    "RTVI-Embed already holds asset %s (%d %s) — another registrant, normally"
+                    " VIOS streamprocessing's stream/add webhook, owns it and drives generation."
+                    " Treating the upload as successful; the chunk count is not ours to report.",
+                    sensor_id,
+                    response.status_code,
+                    already_registered,
+                )
+                return 0
             error_msg = f"Embedding generation failed with status {response.status_code}: {response.text}"
             logger.error(error_msg)
             raise HTTPException(status_code=502, detail=f"Embedding generation failed: {error_msg}")

--- a/services/agent/packages/vss_agents/src/vss_agents/api/video_search_ingest.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/api/video_search_ingest.py
@@ -88,7 +88,15 @@ def create_video_search_ingest_router(
             "Deprecated: streamed PUT upload to VST in a single request. "
             "Prefer the universal three-step flow: "
             "POST /api/v1/videos → chunked POST to VST → "
-            "POST /api/v1/videos/{sensor_id}/complete."
+            "POST /api/v1/videos/{sensor_id}/complete.\n\n"
+            "A 200 does not always mean the video is searchable. Where another "
+            "party already registered the asset with RTVI-Embed — VIOS "
+            "streamprocessing's stream/add webhook does this on the search "
+            "profiles — generation runs there asynchronously and this response "
+            "returns as soon as the upload lands, with "
+            "``chunks_processed: null``. Clients that search straight after "
+            "uploading must poll until the embeddings appear; only a numeric "
+            "``chunks_processed`` means generation finished within this request."
         ),
         tags=["Video Ingest (deprecated)"],
         deprecated=True,

--- a/services/agent/packages/vss_agents/tests/unit_test/api/test_video_ingest.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/api/test_video_ingest.py
@@ -599,9 +599,18 @@ class TestRtEmbedAssetAlreadyRegistered:
         )
 
         assert result.sensor_id == "sensor-abc"
-        # Zero, not a guess: the generation belongs to the other registrant, so
-        # there is no chunk count of ours to report.
-        assert result.chunks_processed == 0
+        # ``None``, not ``0``: the deferral has to be distinguishable from "no
+        # embedding work was requested", which is what 0 means. This is the
+        # assertion that keeps the response honest — reporting 0 here would
+        # read as "ran, embedded nothing", and reporting a positive count would
+        # be inventing one for work another service is still doing.
+        assert result.chunks_processed is None
+        # And the message must not claim completion. A caller that uploads and
+        # immediately searches was correct against the old synchronous
+        # behaviour and now races; this text is the only thing that tells it so.
+        assert "not searchable yet" in result.message
+        assert "poll" in result.message.lower()
+        assert "embeddings generated" not in result.message
         # The call was really made and the rest of the pipeline still ran.
         assert "POST /v1/generate_video_embeddings" in seen
         assert "POST /api/v1/stream/add" in seen
@@ -661,6 +670,48 @@ class TestRtEmbedAssetAlreadyRegistered:
 
         assert result.chunks_processed == 9
         assert "embeddings generated" in result.message
+        # A number means the synchronous call ran to completion, so this is the
+        # one case where the video really is searchable when we answer.
+        assert "not searchable yet" not in result.message
+
+    @pytest.mark.asyncio
+    async def test_the_three_outcomes_are_distinguishable(self):
+        """``chunks_processed`` has to separate "done", "deferred" and "none".
+
+        Before this, deferred and "no embedding configured" were both ``0``, so
+        a client could not tell "the corpus is ready and empty of new chunks"
+        from "generation is running somewhere else and the corpus is not ready".
+        That ambiguity is the whole reason a caller would search too early, so
+        the three states are pinned together here rather than apart — the bug
+        is a collision between them, and only a shared test can catch it.
+        """
+        done, _ = await self._upload(httpx.Response(200, json={"usage": {"total_chunks_processed": 9}}))
+        deferred, _ = await self._upload(
+            httpx.Response(400, json={"code": "AssetAlreadyExists", "message": "already exists"})
+        )
+
+        factory, _seen = self._stub(embed_response=httpx.Response(200, json={}))
+        with (
+            patch(
+                "vss_agents.api.video_ingest.get_timeline",
+                new=AsyncMock(return_value=("2025-01-01T00:00:00.000Z", "2025-01-01T00:00:10.000Z")),
+            ),
+            patch("vss_agents.api.video_ingest.httpx.AsyncClient", new=factory),
+        ):
+            not_configured = await _run_post_upload_processing(
+                camera_name="clip",
+                sensor_id="sensor-abc",
+                filename="clip.mp4",
+                vst_url="http://vst:30888",
+                rtvi_embed_base_url="",
+                rtvi_cv_base_url="http://vss-rtvi-cv:9000",
+            )
+
+        assert done.chunks_processed == 9
+        assert deferred.chunks_processed is None
+        assert not_configured.chunks_processed == 0
+        # Three outcomes, three distinct values — no two collapse together.
+        assert len({repr(r.chunks_processed) for r in (done, deferred, not_configured)}) == 3
 
 
 class TestVideoUploadUrlRoute:

--- a/services/agent/packages/vss_agents/tests/unit_test/api/test_video_ingest.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/api/test_video_ingest.py
@@ -21,6 +21,7 @@ from unittest.mock import patch
 
 from fastapi import FastAPI
 from fastapi import HTTPException
+import httpx
 from pydantic import ValidationError
 import pytest
 
@@ -510,6 +511,156 @@ class TestRunPostUploadProcessing:
                     rtvi_embed_base_url="http://rtvi-embed:8017",
                 )
         assert exc_info.value.status_code == 500
+
+
+class TestRtEmbedAssetAlreadyRegistered:
+    """An asset id rt-embed already owns is a successful upload, not a 502.
+
+    The defect this pins: where VIOS streamprocessing fans ``camera_streaming``
+    out to rt-embed's ``/v1/stream/add``, that webhook registers the asset
+    *and* starts generation. The agent's ``generate_video_embeddings`` for the
+    same id then loses the race and rt-embed rejects it — ``400
+    AssetAlreadyExists`` once the asset is published, ``409 DuplicateAssetId``
+    while it is still reserved mid-download. ``_run_rtvi_embedding`` raised on
+    any non-200, so ``PUT /api/v1/videos-for-search/<file>`` returned 502 while
+    the embeddings were generated and indexed correctly. Every automated caller
+    then either retried work that had already happened or reported a false
+    failure.
+
+    Deliberately still fatal below: any other 4xx. ``400 BadParameters`` and
+    ``409 DuplicateCameraId`` share a status code with the tolerated pair but
+    mean rt-embed rejected the request on its merits, so tolerating the status
+    alone would re-create the class of bug the gateway branch had just fixed by
+    distinguishing a marked 503 from an unmarked one. The error *code* is what
+    decides, and it has to arrive in a body we can actually parse.
+
+    Driven through a real ``httpx`` client over ``httpx.MockTransport`` so real
+    ``Response`` objects and real ``response.json()`` parsing are in the path.
+    That matters here: the fix reads a JSON body, and a ``MagicMock`` would
+    return whatever we told it to regardless of what rt-embed really sends.
+    """
+
+    MEDIA_URL = "http://vst:30888/vst/storage/temp_files/clip.mp4"
+
+    def _stub(self, *, embed_response: httpx.Response):
+        """VST and rt-cv succeed; rt-embed answers as given."""
+        # Bound before the patch replaces the module attribute, or the factory
+        # would recurse into itself.
+        real_client = httpx.AsyncClient
+        seen: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            seen.append(f"{request.method} {path}")
+            if path.endswith("/url"):
+                return httpx.Response(200, json={"videoUrl": self.MEDIA_URL})
+            if path == "/api/v1/stream/add":
+                return httpx.Response(200, json={"ok": True})
+            if path == "/v1/generate_video_embeddings":
+                return embed_response
+            raise AssertionError(f"unexpected request: {request.method} {request.url}")
+
+        def factory(*_args, **kwargs):
+            return real_client(transport=httpx.MockTransport(handler), timeout=kwargs.get("timeout"))
+
+        return factory, seen
+
+    async def _upload(self, embed_response: httpx.Response) -> tuple[VideoIngestResponse, list[str]]:
+        factory, seen = self._stub(embed_response=embed_response)
+        with (
+            patch(
+                "vss_agents.api.video_ingest.get_timeline",
+                new=AsyncMock(return_value=("2025-01-01T00:00:00.000Z", "2025-01-01T00:00:10.000Z")),
+            ),
+            patch("vss_agents.api.video_ingest.httpx.AsyncClient", new=factory),
+        ):
+            result = await _run_post_upload_processing(
+                camera_name="clip",
+                sensor_id="sensor-abc",
+                filename="clip.mp4",
+                vst_url="http://vst:30888",
+                rtvi_embed_base_url="http://rtvi-embed:8000",
+                rtvi_cv_base_url="http://vss-rtvi-cv:9000",
+            )
+        return result, seen
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("status", "code"),
+        [
+            (400, "AssetAlreadyExists"),
+            (409, "DuplicateAssetId"),
+        ],
+    )
+    async def test_already_registered_asset_completes_the_upload(self, status: int, code: str):
+        """streamprocessing got there first — the work is done, so report success."""
+        result, seen = await self._upload(
+            httpx.Response(status, json={"code": code, "message": "Asset with id sensor-abc already exists."})
+        )
+
+        assert result.sensor_id == "sensor-abc"
+        # Zero, not a guess: the generation belongs to the other registrant, so
+        # there is no chunk count of ours to report.
+        assert result.chunks_processed == 0
+        # The call was really made and the rest of the pipeline still ran.
+        assert "POST /v1/generate_video_embeddings" in seen
+        assert "POST /api/v1/stream/add" in seen
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("status", "code"),
+        [
+            # Real rejections that share a status code with the tolerated pair.
+            (400, "BadParameters"),
+            (400, "InvalidParameters"),
+            (409, "DuplicateCameraId"),
+            (409, "ResourceInUse"),
+            # Right code, wrong status — rt-embed pairs these exactly, so a
+            # mismatch is not a response it produces.
+            (400, "DuplicateAssetId"),
+            (409, "AssetAlreadyExists"),
+        ],
+    )
+    async def test_other_errors_at_the_same_statuses_stay_fatal(self, status: int, code: str):
+        """Tolerating the status rather than the code is the fix's failure mode."""
+        with pytest.raises(HTTPException) as exc_info:
+            await self._upload(httpx.Response(status, json={"code": code, "message": "nope"}))
+
+        assert exc_info.value.status_code == 502
+        assert str(status) in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "Asset with id sensor-abc already exists.",  # right words, not JSON
+            '["AssetAlreadyExists"]',  # JSON, but not the error object
+            "",
+        ],
+    )
+    async def test_unparseable_bodies_stay_fatal(self, body: str):
+        """A 400 we cannot attribute to the duplicate case is still a failure."""
+        with pytest.raises(HTTPException) as exc_info:
+            await self._upload(httpx.Response(400, text=body))
+
+        assert exc_info.value.status_code == 502
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [500, 502, 503])
+    async def test_server_side_failures_stay_fatal(self, status: int):
+        """rt-embed being unwell is not an already-registered asset."""
+        with pytest.raises(HTTPException) as exc_info:
+            await self._upload(httpx.Response(status, json={"code": "AssetAlreadyExists", "message": "x"}))
+
+        assert exc_info.value.status_code == 502
+
+    @pytest.mark.asyncio
+    async def test_healthy_generation_still_reports_its_chunk_count(self):
+        """The path that already worked has to keep working."""
+        result, _ = await self._upload(httpx.Response(200, json={"usage": {"total_chunks_processed": 9}}))
+
+        assert result.chunks_processed == 9
+        assert "embeddings generated" in result.message
 
 
 class TestVideoUploadUrlRoute:


### PR DESCRIPTION
> **Caller-visible behaviour change — please read before reviewing the diff.**
> On a deployment where VIOS streamprocessing owns embedding generation, this upload now returns **200 in ~0.13s with the video not yet searchable**, reporting `chunks_processed: null`. Previously the agent's own synchronous call meant a 200 implied "indexed and searchable". **Clients that upload and then search must now poll for the embeddings** rather than assume they exist. Why the barrier cannot be restored here is in [Contract change](#the-contract-change-and-why-the-barrier-cannot-be-restored-here) — that section is the substance of this PR, not an afterthought.

## The defect

`PUT /api/v1/videos-for-search/<file>` (and `POST /api/v1/videos/{sensor_id}/complete`) return **502 while the embeddings are generated and indexed correctly**.

Where VIOS streamprocessing fans `camera_streaming` out to rt-embed's `/v1/stream/add`, that webhook registers the asset **and starts generation itself**. The agent's own `generate_video_embeddings` for the same asset id then loses and rt-embed rejects it:

- `400 AssetAlreadyExists` once the asset is published — `check_asset_exists` in `generate_video_embeddings`
- `409 DuplicateAssetId` while it is still reserved mid-download — `_reserve_asset_slot`

`_run_rtvi_embedding` raised on any non-200, so the API reported failure for work that had completed. An API that reports failure while completing the work is the worst shape for anything automated: every caller either retries work that already happened or reports a false failure, and both were happening.

Pre-existing on `develop` and unrelated to the gateway work: `video_ingest.py` is byte-identical (md5 `123ffb2948ad80b837b08c437e6b25af`) on `develop`, on #1983's merge-base, on its head, and in the running container. Sibling pre-existing splits: #2015, #2023.

## Ownership: streamprocessing does *not* always register

The obvious structural fix — drop the agent's call and let streamprocessing own registration — is **wrong**, because that registration is deployment configuration, not an invariant of the code path:

| Deployment | agent `rtvi_embed_base_url` | streamprocessing → rt-embed `stream/add` |
|---|---|---|
| Docker `dev-profile-search` | set (`COSMOS_EMBED_ENDPOINT`) | **yes** — `deploy/docker/developer-profiles/dev-profile-search/vios/configs/notification_config.json`, on `camera_streaming`, with `user_defined_metadata: {model, chunk_duration: 5}` |
| Helm `dev-profile-search` | set (`RTVI_EMBED_BASE_URL`) | **no** — the chart renders `deploy/helm/services/vios/charts/vios-streamprocessing/configs/notification_config.json` verbatim (only redis/kafka/mqtt address substitution), and that file is `webhooks.enabled: false` with a single disabled dummy item |

Those are the only two deployments in the tree that configure the agent's embed call. On Helm the agent's call is the **only** thing that generates embeddings for an uploaded file, so deleting it would turn this 502 into a 200 over an empty index — the same defect, now silent.

Two further asymmetries found while checking whether the two paths are equivalent:

- rt-embed only auto-starts generation when the webhook payload carries `metadata.model` (`StreamMetadata.has_embed_inference_params`). Registration and generation are separate steps in `cv_stream_add`, so a webhook without `model` registers the asset and generates nothing — and the agent could never retry, because the id is taken.
- `cv_stream_add` swallows a generation-start failure and still answers `200 {"status": "added", "inference": false}`. Full delegation therefore discards the only failure signal on this path.

So this PR takes the narrow option.

## The change

`_run_rtvi_embedding` treats exactly two `(status, code)` pairs as success and leaves every other non-200 fatal. The error **code** decides, not the status:

- `400 BadParameters` / `400 InvalidParameters` — malformed request, still fatal
- `409 DuplicateCameraId` / `409 ResourceInUse` — a *different* asset holds that camera id, still fatal
- a body we cannot parse — not attributable to the duplicate case, still fatal

That is deliberately the same discipline #1983 used for a marked vs. an unmarked 503; tolerating the status alone would re-create the class of bug that branch had just fixed.

## The contract change, and why the barrier cannot be restored here

The first version of this fix returned `200` with `chunks_processed: 0` and *"embeddings generated"*. That was still dishonest, and the downstream run proved it: `test-search` got a clean upload and then failed its `search` and `embed_search` groups against a corpus that was **3 documents** where healthy runs have 12 and 42.

The reason is that the agent's synchronous call was doing more than generating embeddings — **it was the only thing making a 200 mean "indexed and searchable"**. The owning path is asynchronous by design: `cv_stream_add` starts generation and answers `status: "processing"` without waiting for it. Measured on hardware:

```
http_code=200 time=0.133530
{"message":"…not searchable yet — poll…","chunks_processed":null}
index at the moment of the 200:  117 (delta 0)      <- zero embeddings exist
index +15s:                      126 (delta 9)      <- generation lands later
```

So a caller that uploads and then searches was correct against the old behaviour and now races — intermittently, which is a worse debugging experience than the 502 was.

**Restoring the barrier is not feasible without a change I don't think this PR should carry.** Both candidate completion conditions fail:

- **Ask rt-embed.** There is no signal. `GET /v1/stream/get-stream-info` skips non-live assets (`if not asset.is_live: continue`) and a VIOS file sensor is not live — the live deployment answers `{"status":"ok","stream_count":0,"stream_list":[]}` while assets exist.
- **Predict the document count and wait for it.** Only a heuristic. `FileSplitter` emits `ceil(duration / (chunk_duration − overlap))` chunks, *minus* a trailing sliver shorter than two video frames (`min_video_frame_duration_ns = 2e9/fps`) — so the count depends on fps and on sub-frame duration precision. A 40.1s clip at `chunk_duration: 5` yields 9 documents, and its 0.1s tail survives only because 0.1 > 2/30. Worse, the `chunk_duration` actually in force is the one in VIOS's `notification_config.json`, which the agent never reads; the agent's own `rtvi_embed_chunk_duration` matches it only by coincidence of defaults. Waiting for a predicted count would hang forever whenever the prediction was off by one, turning a race into a guaranteed timeout.
- **"No new documents for N seconds"** is a guess, and not a conservative one: generation is chunk-by-chunk through a VLM, so any GPU stall longer than N reports false completion.

The honest structural answer is a generation-status signal on rt-embed that the agent (or the caller) can wait on. That is an API addition with its own review and is **not** in this PR.

So what this PR does instead is stop overstating what happened. `chunks_processed` distinguishes three outcomes that were previously collapsed into `0`:

| value | meaning |
|---|---|
| positive `int` | generation completed inside this request — the video **is** searchable |
| `null` | the asset was already registered elsewhere; generation is running there and is **not** finished — poll before querying |
| `0` | no embedding work was requested at all (rt-embed not configured) |

and the message says so in words: *"embedding generation is owned by another registrant and is still in progress. The video is not searchable yet — poll for its embeddings before querying."*

**The status stays 200 deliberately.** A 202 would be more expressive, but `upload_video_via_agent` in the `metromind/ci-vss-oss` fixture treats anything other than 200 as a failure and does not retry a 202 — so it would re-break `test-search` in the exact way this branch set out to fix.

I have deliberately **not** touched the fixture's `min_docs=1` readiness gate. Strengthening a test so it stops noticing a weakened contract is backwards, and that gate should only be revisited once the product behaviour is right.

## Guard

`TestRtEmbedAssetAlreadyRegistered` drives the real ingest path (`_run_post_upload_processing`) over `httpx.MockTransport`, so real `httpx.Response` objects and real `response.json()` parsing are exercised rather than mocked away — following the `TestOptionalServiceBehindTheGateway` precedent. That matters here because the fix reads a JSON body and a `MagicMock` would answer whatever we told it to.

`test_the_three_outcomes_are_distinguishable` pins the three `chunks_processed` states together rather than apart, because the bug is a *collision* between them and only a shared test catches that.

**Canaried five ways**, each reintroducing a specific wrong answer:

| Canary | Failures |
|---|---|
| the original `raise` on any non-200 | 2 — both tolerated cases |
| tolerate all 4xx | 9 — every real rejection and every unparseable body |
| drop the agent's embed call entirely (the structural option) | 19 |
| report `0` for the deferred case (the state collision) | 3 |
| keep `null` but let the message still claim "embeddings generated" | 2 |

## Proven live

`dev-profile-search` on hardware, `docker cp` into the running agent (the box's NGC credential is expired, so no image can be rebuilt). The agent carries #1983's gateway patch throughout.

| Arm | HTTP | body | index `mdx-embed-filtered-2025-01-01` |
|---|---|---|---|
| before | **502** | `Embedding generation failed with status 400: {"code":"AssetAlreadyExists"…}` | 81 → **90** (9 docs) |
| first fix | **200** | `{"message":"…embeddings generated","chunks_processed":0}` | 90 → **99** (9 docs) |
| this fix | **200** | `{"message":"…not searchable yet — poll…","chunks_processed":null}` | 117 → **126**, and **delta 0 at the moment of the 200** |

Identical work in all three; the last one is the only one whose response describes it correctly.

## Downstream evidence, including where the original claim was wrong

Pipeline [66190921](https://gitlab-master.nvidia.com/metromind/ci-vss-oss/-/pipelines/66190921) at this branch's head, on a stock image rather than a patch:

- **Upload fixed.** `✓ Video uploaded: warehouse_sample_video` first attempt. A `test-search` on an unrelated branch shows the defect and its accidental workaround — `✗ Upload attempt 1/3 failed with HTTP 502` then `✓ Video uploaded` — because the fixture retries 502 and the retry re-uploads under a fresh sensor id. That is why this looked intermittent.
- **`attribute_search` cascade cleared.** All three pass, and `RTVI CV response missing or empty 'data' field` appears nowhere in the trace.
- **The `search` timeouts were never downstream of this 502 — I claimed otherwise and was wrong.** A `test-search` on branch `ed9bb689…`, without this fix, uploaded cleanly with 12 documents indexed and `embed_search` returning 42 results, and still shows the same four `search` timeouts. That is a separate pre-existing defect. **#2021 and #1828 will not be fixed by this PR**, and the !498 / !499 workarounds should not be dropped on the strength of it.

## Checks

`196 passed` across `tests/unit_test/api/`, `ruff check` and `mypy` clean.
