### PR TITLE
fix(ci): disable npm audit during video-analytics-api builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -662,6 +662,9 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.prepare-source.outputs.build-video-analytics-api == 'true' || needs.prepare-source.outputs.unit-test-workflow-changed == 'true'
     timeout-minutes: 30
+    env:
+      NPM_CONFIG_AUDIT: "false"
+      NPM_CONFIG_FUND: "false"
     defaults:
       run:
         working-directory: services/analytics/video-analytics-api
@@ -927,6 +930,8 @@ jobs:
     env:
       COMPOSE_TIMEOUT: "300"
       BUILD_TIMEOUT: "600"
+      NPM_CONFIG_AUDIT: "false"
+      NPM_CONFIG_FUND: "false"
       BUILD_SERVICE_IMAGE: ${{ needs.prepare-source.outputs.build-video-analytics-api }}
       CURRENT_VIDEO_ANALYTICS_API_IMAGE: ${{ needs.prepare-source.outputs.current-video-analytics-api-image }}
     defaults:

--- a/services/analytics/video-analytics-api/docker/Dockerfile
+++ b/services/analytics/video-analytics-api/docker/Dockerfile
@@ -14,6 +14,12 @@
 # limitations under the License.
 FROM node:22.23.2-trixie AS builder
 
+# Container builds use pinned lockfiles; npm's audit API is unrelated and can
+# hang for minutes when registry.npmjs.org/-/npm/v1/security/audits/quick
+# returns 503, which blows the CI BUILD_TIMEOUT of 600s.
+ENV NPM_CONFIG_AUDIT=false \
+    NPM_CONFIG_FUND=false
+
 # Build web-api-core from source
 COPY ./src/web-api-core /web-api-core
 


### PR DESCRIPTION
## Summary
- Disable npm audit/fund during video-analytics-api Docker builds and CI npm install steps.
- Fixes `Integration (video analytics API)` timing out at 600s when `registry.npmjs.org/-/npm/v1/security/audits/quick` returns 503 even though dependencies are already resolved.

## Root cause
`npm install` was spending ~7 minutes per step waiting on npm's security audit API (503 after 120s retries). The Dockerfile runs three `npm install` steps; with audit enabled the builder stage took ~8 minutes locally and exceeded CI's `BUILD_TIMEOUT=600`.

## Fix
Set `NPM_CONFIG_AUDIT=false` and `NPM_CONFIG_FUND=false` in:
- `services/analytics/video-analytics-api/docker/Dockerfile`
- `Test (video analytics API)` and `Integration (video analytics API)` jobs in `.github/workflows/ci.yml`

## Local verification
`timeout 600 docker build --no-cache --target builder` on develop source:
- before: ~8m00s (final `npm install` alone ~421s)
- after: ~11s (final `npm install` ~0.9s)

## Test plan
- [ ] CI `Integration (video analytics API)` completes within `BUILD_TIMEOUT`
- [ ] CI `Test (video analytics API)` npm install steps finish in seconds, not minutes