### PR TITLE
fix(rtvi-vlm): Redact URL credentials from logs

### DIFF
--- a/services/rtvi/rt-vlm/src/common/logger.py
+++ b/services/rtvi/rt-vlm/src/common/logger.py
@@ -54,9 +54,7 @@ def sanitize_url_for_logging(url: str) -> str:
         netloc = parsed.netloc.rsplit("@", 1)[-1]
         return urlunsplit((parsed.scheme, netloc, parsed.path, "", ""))
     except (TypeError, ValueError):
-        # Keep malformed values out of logs past the first query/fragment
-        # delimiter even if urllib cannot parse them.
-        return str(url).split("?", 1)[0].split("#", 1)[0]
+        return "[malformed URL redacted]"
 
 
 def sanitize_urls_for_logging(message: str) -> str:

--- a/services/rtvi/rt-vlm/src/common/logger.py
+++ b/services/rtvi/rt-vlm/src/common/logger.py
@@ -17,7 +17,11 @@
 import logging
 import logging.handlers
 import os
+import re
 import time
+from collections.abc import Mapping
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 LOG_COLORS = {
     "RESET": "\033[0m",
@@ -33,11 +37,93 @@ LOG_COLORS = {
 LOG_PERF_LEVEL = 15
 LOG_STATUS_LEVEL = 16
 
+_LOGGED_URL_PATTERN = re.compile(
+    r"(?:https?|s3|rtsp|file)://[^\s\"'<>]+", re.IGNORECASE
+)
+
+
+def sanitize_url_for_logging(url: str) -> str:
+    """Return a URL safe to include in logs.
+
+    URL user-info, query parameters, and fragments can all carry credentials.
+    Logging only the origin and path keeps the source identifiable without
+    requiring an ever-growing list of sensitive parameter names.
+    """
+    try:
+        parsed = urlsplit(url)
+        netloc = parsed.netloc.rsplit("@", 1)[-1]
+        return urlunsplit((parsed.scheme, netloc, parsed.path, "", ""))
+    except (TypeError, ValueError):
+        # Keep malformed values out of logs past the first query/fragment
+        # delimiter even if urllib cannot parse them.
+        return str(url).split("?", 1)[0].split("#", 1)[0]
+
+
+def sanitize_urls_for_logging(message: str) -> str:
+    """Remove credential-bearing portions from URLs embedded in log text.
+
+    This is a defense-in-depth fallback for call sites that have not sanitized
+    their structured values.  Once a query or fragment starts, its contents
+    are attacker-controlled and may contain any apparent log delimiter.  The
+    only safe generic boundary is therefore the end of the message.
+    """
+    message = str(message)
+    match = _LOGGED_URL_PATTERN.search(message)
+    while match:
+        url = match.group(0)
+        delimiter_offsets = [
+            offset for offset in (url.find("?"), url.find("#")) if offset >= 0
+        ]
+        if delimiter_offsets:
+            delimiter = min(delimiter_offsets)
+            safe_url = sanitize_url_for_logging(url[:delimiter])
+            return f"{message[:match.start()]}{safe_url} [URL query redacted]"
+
+        safe_url = sanitize_url_for_logging(url)
+        message = f"{message[:match.start()]}{safe_url}{message[match.end():]}"
+        next_start = match.start() + len(safe_url)
+        match = _LOGGED_URL_PATTERN.search(message, next_start)
+    return message
+
+
+def sanitize_data_for_logging(value: Any) -> Any:
+    """Return structured request data with URL credentials removed."""
+    if isinstance(value, Mapping):
+        sanitized = {}
+        for key, item in value.items():
+            normalized_key = str(key).lower()
+            if normalized_key == "url_headers":
+                sanitized[key] = "[redacted]"
+            elif normalized_key.endswith("url") and isinstance(item, str):
+                sanitized[key] = sanitize_url_for_logging(item)
+            else:
+                sanitized[key] = sanitize_data_for_logging(item)
+        return sanitized
+    if isinstance(value, list):
+        return [sanitize_data_for_logging(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(sanitize_data_for_logging(item) for item in value)
+    return value
+
+
+class _SensitiveURLFilter(logging.Filter):
+    """Sanitize the LogRecord itself before any handler or propagation."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.msg = sanitize_urls_for_logging(record.getMessage())
+        record.args = ()
+        return True
+
+
 # Configure the logger
 logger = logging.getLogger(__name__)
 
 for handler in logger.handlers[:]:
     logger.removeHandler(handler)
+
+for log_filter in logger.filters[:]:
+    logger.removeFilter(log_filter)
+logger.addFilter(_SensitiveURLFilter())
 
 logging.addLevelName(LOG_PERF_LEVEL, "PERF")
 logging.addLevelName(LOG_STATUS_LEVEL, "STATUS")

--- a/services/rtvi/rt-vlm/src/common/logger.py
+++ b/services/rtvi/rt-vlm/src/common/logger.py
@@ -40,6 +40,10 @@ LOG_STATUS_LEVEL = 16
 _LOGGED_URL_PATTERN = re.compile(
     r"(?:https?|s3|rtsp|file)://[^\s\"'<>]+", re.IGNORECASE
 )
+_LOGGED_DATA_URL_PATTERN = re.compile(r"(?<![A-Za-z0-9+.-])data:", re.IGNORECASE)
+_NETWORK_URL_SCHEMES = frozenset({"http", "https", "rtsp", "s3"})
+_REDACTED_DATA_URL = "[data URL redacted]"
+_REDACTED_MALFORMED_URL = "[malformed URL redacted]"
 
 
 def sanitize_url_for_logging(url: str) -> str:
@@ -51,10 +55,14 @@ def sanitize_url_for_logging(url: str) -> str:
     """
     try:
         parsed = urlsplit(url)
+        if parsed.scheme.lower() == "data":
+            return _REDACTED_DATA_URL
+        if parsed.scheme.lower() in _NETWORK_URL_SCHEMES and not parsed.netloc:
+            return _REDACTED_MALFORMED_URL
         netloc = parsed.netloc.rsplit("@", 1)[-1]
         return urlunsplit((parsed.scheme, netloc, parsed.path, "", ""))
     except (TypeError, ValueError):
-        return "[malformed URL redacted]"
+        return _REDACTED_MALFORMED_URL
 
 
 def sanitize_urls_for_logging(message: str) -> str:
@@ -66,8 +74,17 @@ def sanitize_urls_for_logging(message: str) -> str:
     only safe generic boundary is therefore the end of the message.
     """
     message = str(message)
-    match = _LOGGED_URL_PATTERN.search(message)
-    while match:
+    search_start = 0
+    while True:
+        match = _LOGGED_URL_PATTERN.search(message, search_start)
+        data_match = _LOGGED_DATA_URL_PATTERN.search(message, search_start)
+        if data_match is not None and (
+            match is None or data_match.start() < match.start()
+        ):
+            return f"{message[:data_match.start()]}{_REDACTED_DATA_URL}"
+        if match is None:
+            return message
+
         url = match.group(0)
         delimiter_offsets = [
             offset for offset in (url.find("?"), url.find("#")) if offset >= 0
@@ -79,9 +96,7 @@ def sanitize_urls_for_logging(message: str) -> str:
 
         safe_url = sanitize_url_for_logging(url)
         message = f"{message[:match.start()]}{safe_url}{message[match.end():]}"
-        next_start = match.start() + len(safe_url)
-        match = _LOGGED_URL_PATTERN.search(message, next_start)
-    return message
+        search_start = match.start() + len(safe_url)
 
 
 def sanitize_data_for_logging(value: Any) -> Any:
@@ -108,8 +123,20 @@ class _SensitiveURLFilter(logging.Filter):
     """Sanitize the LogRecord itself before any handler or propagation."""
 
     def filter(self, record: logging.LogRecord) -> bool:
-        record.msg = sanitize_urls_for_logging(record.getMessage())
+        message = sanitize_urls_for_logging(record.getMessage())
+        if record.exc_info:
+            exception_text = logging.Formatter().formatException(record.exc_info)
+            message = f"{message}\n{sanitize_urls_for_logging(exception_text)}"
+        elif record.exc_text:
+            message = f"{message}\n{sanitize_urls_for_logging(record.exc_text)}"
+
+        record.msg = message
         record.args = ()
+        # The exception has been rendered and sanitized above. Leaving either
+        # field intact would let a propagating handler format the original
+        # exception message and reintroduce credentials.
+        record.exc_info = None
+        record.exc_text = None
         return True
 
 

--- a/services/rtvi/rt-vlm/src/server/alert_verification_server.py
+++ b/services/rtvi/rt-vlm/src/server/alert_verification_server.py
@@ -60,7 +60,12 @@ from api_models.file import (
 )
 from api_models.live_stream import AddLiveStream, AddLiveStreamResponse, LiveStreamInfo
 from api_models.models import ListModelsResponse
-from common.logger import LOG_PERF_LEVEL, TimeMeasure, logger
+from common.logger import (
+    LOG_PERF_LEVEL,
+    TimeMeasure,
+    logger,
+    sanitize_data_for_logging,
+)
 from common.service_exception import ServiceException
 from common.version import VERSION
 from utils.asset_manager import Asset, AssetManager
@@ -801,7 +806,12 @@ class RTVIServer:
                 "Received generate_captions query: id=%s, is_live=%s, query=%s",
                 ", ".join(videoIdList),
                 asset.is_live,
-                query.model_dump_json(exclude_none=True),
+                json.dumps(
+                    sanitize_data_for_logging(
+                        query.model_dump(mode="json", exclude_none=True)
+                    ),
+                    separators=(",", ":"),
+                ),
             )
 
             # Check if user has specified the model that is initialized

--- a/services/rtvi/rt-vlm/src/server/rtvi_vlm_server.py
+++ b/services/rtvi/rt-vlm/src/server/rtvi_vlm_server.py
@@ -108,7 +108,13 @@ from api_models.nim_compat import (
     ManifestResponse,
     VersionResponse,
 )
-from common.logger import LOG_PERF_LEVEL, TimeMeasure, logger
+from common.logger import (
+    LOG_PERF_LEVEL,
+    TimeMeasure,
+    logger,
+    sanitize_data_for_logging,
+    sanitize_url_for_logging,
+)
 from common.service_exception import ServiceException
 from common.version import VERSION
 from utils.asset_manager import Asset, AssetManager
@@ -1298,13 +1304,18 @@ class RTVIServer:
                 logger.info(
                     "URL asset created: id=%s, url=%s",
                     video_id_from_url,
-                    url[:100],
+                    sanitize_url_for_logging(url),
                 )
                 video_id_list = [video_id_from_url]
             except ServiceException:
                 raise
             except Exception as e:
-                logger.error("Failed to process URL %s: %s", url[:100], str(e), exc_info=True)
+                logger.error(
+                    "Failed to process URL %s: %s",
+                    sanitize_url_for_logging(url),
+                    str(e),
+                    exc_info=True,
+                )
                 raise ServiceException(
                     f"Failed to download/register URL: {str(e)}",
                     "DownloadFailed",
@@ -2414,7 +2425,7 @@ class RTVIServer:
             logger.info(
                 "Received CV stream/add: camera_id=%s, url=%s",
                 value.camera_id,
-                value.camera_url,
+                sanitize_url_for_logging(value.camera_url),
             )
 
             is_vios_file_sensor = self._is_vios_file_sensor(
@@ -2691,7 +2702,12 @@ class RTVIServer:
             logger.info(
                 "Received generate_captions query: id=%s, query=%s",
                 ", ".join(videoIdList),
-                query.model_dump_json(exclude_none=True),
+                json.dumps(
+                    sanitize_data_for_logging(
+                        query.model_dump(mode="json", exclude_none=True)
+                    ),
+                    separators=(",", ":"),
+                ),
             )
 
             # Validate api_type if specified
@@ -3197,7 +3213,7 @@ class RTVIServer:
                         logger.info(
                             "Created temporary asset from URL: id=%s, url=%s",
                             asset_id_from_url,
-                            media_url[:100],
+                            sanitize_url_for_logging(media_url),
                         )
 
                     temp_asset_ids.append(asset_id_from_url)

--- a/services/rtvi/rt-vlm/src/server/rtvi_vlm_server.py
+++ b/services/rtvi/rt-vlm/src/server/rtvi_vlm_server.py
@@ -3147,7 +3147,7 @@ class RTVIServer:
 
                 logger.info(
                     "Processing media for chat completion: %s (type: %s)",
-                    media_url[:100] if len(media_url) > 100 else media_url,
+                    sanitize_url_for_logging(media_url),
                     media_type.value,
                 )
 

--- a/services/rtvi/rt-vlm/src/utils/asset_manager.py
+++ b/services/rtvi/rt-vlm/src/utils/asset_manager.py
@@ -39,7 +39,7 @@ from api_models.common import (
     AWS_S3_URL_PATTERN,
     BLOCKED_IP_RANGES,
 )
-from common.logger import TimeMeasure, logger
+from common.logger import TimeMeasure, logger, sanitize_url_for_logging
 from common.service_exception import ServiceException
 
 AGE_OUT_THRESHOLD = 0.9  # Start aging out when usage is within this threshold of the max
@@ -731,7 +731,10 @@ class AssetManager:
                 aws_access_key_id=aws_access_key_id,
                 aws_secret_access_key=aws_secret_access_key,
             )
-            logger.info(f"Using custom S3 endpoint: {endpoint_url}")
+            logger.info(
+                "Using custom S3 endpoint: %s",
+                sanitize_url_for_logging(endpoint_url),
+            )
         else:
             s3_client = boto3.client(
                 "s3",
@@ -741,7 +744,10 @@ class AssetManager:
             logger.debug("Using default S3 endpoint")
 
         logger.info(
-            f"Downloading file from S3 - url: {url} bucket_name: {bucket_name} object_key: {object_key}"
+            "Downloading file from S3 - url: %s bucket_name: %s object_key: %s",
+            sanitize_url_for_logging(url),
+            bucket_name,
+            object_key,
         )
 
         async with tempfile.NamedTemporaryFile(mode="wb+", delete=True) as temp_file:
@@ -807,7 +813,11 @@ class AssetManager:
                 bytes_written += len(chunk)
                 download_tracker.add_bytes(len(chunk))
                 chunk_count += 1
-            logger.info(f"Downloaded file from S3 - url: {url} bytes: {bytes_written}")
+            logger.info(
+                "Downloaded file from S3 - url: %s bytes: %d",
+                sanitize_url_for_logging(url),
+                bytes_written,
+            )
 
             # Flush and seek to beginning so save_file can read it
             await temp_file.flush()
@@ -908,11 +918,16 @@ class AssetManager:
             # VST download URL may not have an extension, so use the file_name extension
             extension = os.path.splitext(file_name)[-1].lower()
             logger.warning(
-                f"Could not determine extension from URL - url: {url}, trying with default name: {file_name}"
+                "Could not determine extension from URL - url: %s, trying with default name: %s",
+                sanitize_url_for_logging(url),
+                file_name,
             )
 
         logger.info(
-            f"Downloading file from URL - url: {url} file_name: {file_name} extension: {extension}"
+            "Downloading file from URL - url: %s file_name: %s extension: %s",
+            sanitize_url_for_logging(url),
+            file_name,
+            extension,
         )
 
         async with tempfile.NamedTemporaryFile(mode="wb+", delete=True) as temp_file:
@@ -1052,7 +1067,7 @@ class AssetManager:
                     response = await session.get(current_url, allow_redirects=False)
                     logger.info(
                         "Downloading file from URL - url: %s response: %d (hop %d)",
-                        current_url,
+                        sanitize_url_for_logging(current_url),
                         response.status,
                         hop,
                     )
@@ -1079,7 +1094,11 @@ class AssetManager:
 
                         # Resolve relative redirect URLs
                         current_url = urljoin(current_url, location)
-                        logger.info("Redirect hop %d -> %s", hop + 1, current_url)
+                        logger.info(
+                            "Redirect hop %d -> %s",
+                            hop + 1,
+                            sanitize_url_for_logging(current_url),
+                        )
 
                         # SSRF-validate each intermediate redirect target
                         await validate_url_ssrf_runtime_async(current_url)
@@ -1124,7 +1143,7 @@ class AssetManager:
 
                 logger.info(
                     "Downloaded file from URL - url: %s bytes: %d",
-                    current_url,
+                    sanitize_url_for_logging(current_url),
                     total_size,
                 )
             finally:
@@ -1530,7 +1549,11 @@ class AssetManager:
             self._release_asset_slot(asset_id, camera_id)
             raise
 
-        logger.info(f"[AssetManager] Added live stream - asset-id: {asset_id} URL: {url}")
+        logger.info(
+            "[AssetManager] Added live stream - asset-id: %s URL: %s",
+            asset_id,
+            sanitize_url_for_logging(url),
+        )
         return asset_id
 
     def cleanup_asset(self, asset_id: str, executor: Optional[ThreadPoolExecutor] = None):

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_logger_redaction.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_logger_redaction.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for sensitive URL data redaction at the logging boundary."""
+
+import logging
+
+import pytest
+
+from common.logger import (
+    _SensitiveURLFilter,
+    sanitize_data_for_logging,
+    sanitize_url_for_logging,
+)
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        (
+            "http://example.com/video.mp4?access_token=CANARY_SECRET",
+            "http://example.com/video.mp4",
+        ),
+        (
+            "https://bucket.s3.amazonaws.com/video.mp4?X-Amz-Credential=SECRET&X-Amz-Signature=SIG",
+            "https://bucket.s3.amazonaws.com/video.mp4",
+        ),
+        (
+            "https://user:password@example.com:8443/path/video.mp4#token=SECRET",
+            "https://example.com:8443/path/video.mp4",
+        ),
+        ("file:///data/video.mp4", "file:///data/video.mp4"),
+    ],
+)
+def test_sanitize_url_for_logging(url, expected):
+    assert sanitize_url_for_logging(url) == expected
+
+
+def test_sensitive_url_filter_sanitizes_formatted_log_record():
+    record = logging.LogRecord(
+        name="common.logger",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="Received query=%s",
+        args=(
+            '{"url":"http://example.com/video.mp4?access_token=CANARY_SECRET",'
+            '"prompt":"describe"}',
+        ),
+        exc_info=None,
+    )
+
+    assert _SensitiveURLFilter().filter(record)
+    assert record.getMessage() == (
+        'Received query={"url":"http://example.com/video.mp4 [URL query redacted]'
+    )
+    assert "CANARY_SECRET" not in record.getMessage()
+
+
+@pytest.mark.parametrize(
+    "query_suffix",
+    [
+        "prefix'CANARY_SECRET",
+        'prefix\\\"CANARY_SECRET',
+        "prefix%22CANARY_SECRET",
+        "prefix\tCANARY_SECRET",
+        "prefix\nCANARY_SECRET",
+    ],
+)
+def test_sensitive_url_filter_drops_untrusted_query_remainder(query_suffix):
+    record = logging.LogRecord(
+        name="common.logger",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg='Received query={"url":"http://example.com/video.mp4?access_token=%s"}',
+        args=(query_suffix,),
+        exc_info=None,
+    )
+
+    assert _SensitiveURLFilter().filter(record)
+    assert record.getMessage() == (
+        'Received query={"url":"http://example.com/video.mp4 [URL query redacted]'
+    )
+    assert "CANARY_SECRET" not in record.getMessage()
+
+
+@pytest.mark.parametrize(
+    "query_suffix",
+    [
+        "prefix'CANARY_SECRET",
+        'prefix\\\"CANARY_SECRET',
+        "prefix\tCANARY_SECRET",
+        "prefix\nCANARY_SECRET",
+    ],
+)
+def test_sanitize_data_for_logging_preserves_structure_and_removes_secrets(
+    query_suffix,
+):
+    value = {
+        "url": f"http://example.com/video.mp4?access_token={query_suffix}",
+        "url_headers": {"Authorization": "Bearer CANARY_HEADER_SECRET"},
+        "prompt": "describe",
+    }
+
+    assert sanitize_data_for_logging(value) == {
+        "url": "http://example.com/video.mp4",
+        "url_headers": "[redacted]",
+        "prompt": "describe",
+    }

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_logger_redaction.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_logger_redaction.py
@@ -40,6 +40,10 @@ from common.logger import (
             "https://user:password@example.com:8443/path/video.mp4#token=SECRET",
             "https://example.com:8443/path/video.mp4",
         ),
+        (
+            "rtsp://user:CANARY_SECRET@[camera/path",
+            "[malformed URL redacted]",
+        ),
         ("file:///data/video.mp4", "file:///data/video.mp4"),
     ],
 )
@@ -65,6 +69,22 @@ def test_sensitive_url_filter_sanitizes_formatted_log_record():
     assert record.getMessage() == (
         'Received query={"url":"http://example.com/video.mp4 [URL query redacted]'
     )
+    assert "CANARY_SECRET" not in record.getMessage()
+
+
+def test_sensitive_url_filter_redacts_malformed_url():
+    record = logging.LogRecord(
+        name="common.logger",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="Opening %s",
+        args=("rtsp://user:CANARY_SECRET@[camera/path",),
+        exc_info=None,
+    )
+
+    assert _SensitiveURLFilter().filter(record)
+    assert record.getMessage() == "Opening [malformed URL redacted]"
     assert "CANARY_SECRET" not in record.getMessage()
 
 

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_logger_redaction.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_logger_redaction.py
@@ -15,6 +15,7 @@
 """Tests for sensitive URL data redaction at the logging boundary."""
 
 import logging
+import sys
 
 import pytest
 
@@ -43,6 +44,14 @@ from common.logger import (
         (
             "rtsp://user:CANARY_SECRET@[camera/path",
             "[malformed URL redacted]",
+        ),
+        (
+            "http:////user:CANARY_SECRET@example.com/video.mp4",
+            "[malformed URL redacted]",
+        ),
+        (
+            "data:video/mp4,CANARY_DATA_URL_SECRET",
+            "[data URL redacted]",
         ),
         ("file:///data/video.mp4", "file:///data/video.mp4"),
     ],
@@ -86,6 +95,63 @@ def test_sensitive_url_filter_redacts_malformed_url():
     assert _SensitiveURLFilter().filter(record)
     assert record.getMessage() == "Opening [malformed URL redacted]"
     assert "CANARY_SECRET" not in record.getMessage()
+
+
+def test_sensitive_url_filter_redacts_empty_authority_url():
+    record = logging.LogRecord(
+        name="common.logger",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="Opening %s",
+        args=("http:////user:CANARY_SECRET@example.com/video.mp4",),
+        exc_info=None,
+    )
+
+    assert _SensitiveURLFilter().filter(record)
+    assert record.getMessage() == "Opening [malformed URL redacted]"
+    assert "CANARY_SECRET" not in record.getMessage()
+
+
+def test_sensitive_url_filter_sanitizes_propagated_exception():
+    try:
+        raise RuntimeError(
+            "download failed for "
+            "https://user:password@example.com/video.mp4?token=CANARY_SECRET"
+        )
+    except RuntimeError:
+        record = logging.LogRecord(
+            name="common.logger",
+            level=logging.ERROR,
+            pathname=__file__,
+            lineno=1,
+            msg="Download failed",
+            args=(),
+            exc_info=sys.exc_info(),
+        )
+
+    assert _SensitiveURLFilter().filter(record)
+    propagated_output = logging.Formatter().format(record)
+    assert "Traceback (most recent call last)" in propagated_output
+    assert "https://example.com/video.mp4" in propagated_output
+    assert "CANARY_SECRET" not in propagated_output
+    assert "user:password" not in propagated_output
+
+
+def test_sensitive_url_filter_redacts_data_url_payload():
+    record = logging.LogRecord(
+        name="common.logger",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="Processing media: %s (type: video)",
+        args=("data:video/mp4,CANARY_DATA_URL_SECRET",),
+        exc_info=None,
+    )
+
+    assert _SensitiveURLFilter().filter(record)
+    assert record.getMessage() == "Processing media: [data URL redacted]"
+    assert "CANARY_DATA_URL_SECRET" not in record.getMessage()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Redact credentials embedded in URLs before RTVI writes request and asset
locations to logs. Preserve the URL host and path so operators retain useful
context without exposing user information, query parameters, fragments, or
URL headers.

## Related Issue

NVBug 6715329

## Changes

- Sanitize structured request data before logging it.
- Sanitize URL-bearing asset, redirect, S3, and server log arguments.
- Apply a logger-level filter as defense in depth for embedded URLs.
- Cover access tokens, signed URLs, user information, and hostile delimiters.

## Validation

- Built `rtvi-vlm-dev:local` from the exact branch worktree.
- Started the RTVI Compose stack and reached healthy service state.
- Sent the credential-bearing `generate_captions` runtime request.
- Confirmed the credential canary was absent from service logs.
- Confirmed the request reached the download path and returned the expected
  HTTP 404 response for the intentionally missing media URL.
- Independent code review approved the change.
