### PR TITLE
fix(deploy): remove duplicate GB300 help entry

### DIFF
--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -593,7 +593,6 @@ function usage() {
   echo "                                     - L40S"
   echo "                                     - RTXPRO4500BW"
   echo "                                     - RTXPRO6000BW"
-  echo "                                     - GB300"
   echo "                                     - DGX-SPARK"
   echo "                                     - IGX-THOR"
   echo "                                     - AGX-THOR"

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -373,6 +373,9 @@ elif [[ ${exit_code} -ne 0 ]]; then
 elif ! grep -q "Usage:" "${out_file}"; then
   echo "FAIL: --help (stdout missing 'Usage:')"
   ((TESTS_FAILED++)) || true
+elif [[ "$(grep -cF -- "                                     - GB300" "${out_file}")" -ne 1 ]]; then
+  echo "FAIL: --help (expected GB300 exactly once in hardware profiles)"
+  ((TESTS_FAILED++)) || true
 else
   echo "PASS: --help"
   ((TESTS_PASSED++)) || true

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -373,7 +373,7 @@ elif [[ ${exit_code} -ne 0 ]]; then
 elif ! grep -q "Usage:" "${out_file}"; then
   echo "FAIL: --help (stdout missing 'Usage:')"
   ((TESTS_FAILED++)) || true
-elif [[ "$(grep -cF -- "                                     - GB300" "${out_file}")" -ne 1 ]]; then
+elif [[ "$(grep -Ec '^[[:space:]]*-[[:space:]]+GB300[[:space:]]*$' "${out_file}")" -ne 1 ]]; then
   echo "FAIL: --help (expected GB300 exactly once in hardware profiles)"
   ((TESTS_FAILED++)) || true
 else


### PR DESCRIPTION
## Summary

- remove the duplicate `GB300` entry from `dev-profile.sh --help`
- add a focused regression assertion that requires exactly one GB300 hardware-profile entry

Fixes NvBug 6723627.

## Testing

- `bash -n deploy/docker/scripts/dev-profile.sh`
- `bash -n deploy/docker/test-scripts/test-dev-profile.sh`
- verified the hardware-profile help list contains exactly one `GB300` entry
- `git diff --check`