### PR TITLE
fix(rtvi): stop vLLM MM preprocessor cache leaking host /dev/shm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
       sdr-mw-l-changed: ${{ steps.managed-image-changes.outputs.sdr-mw-l }}
       vss-configurator-changed: ${{ steps.managed-image-changes.outputs.vss-configurator }}
       vss-rt-config-adaptor-changed: ${{ steps.managed-image-changes.outputs.vss-rt-config-adaptor }}
+      vss-rt-embed-changed: ${{ steps.managed-image-changes.outputs.vss-rt-embed }}
+      vss-rt-vlm-changed: ${{ steps.managed-image-changes.outputs.vss-rt-vlm }}
       unit-test-workflow-changed: ${{ steps.changed-paths.outputs.unit-test-workflow-changed }}
       trigger-from-src-change: ${{ steps.changed-paths.outputs.trigger-from-src-change }}
     steps:
@@ -862,6 +864,85 @@ jobs:
           path: |
             services/configurators/vss-rt-config-adaptor/test/coverage/
             services/configurators/vss-rt-config-adaptor/coverage.xml
+
+  # ---------------------------------------------------------------------------
+  # Job 5g: RTVI vLLM-compatible model unit tests
+  #
+  # rt-vlm and rt-embed each carry their own copy of vllm_compatible_model.py.
+  # Its engine-args builders are env parsing that a CPU-only torch can drive,
+  # so this lane needs no GPU and no vLLM. Because vLLM is absent, rt-vlm
+  # selects the CI-safe subset of its mixed test module by the test_in_ci
+  # marker; rt-embed's file is CI-safe throughout and is selected by path.
+  # ---------------------------------------------------------------------------
+  rtvi-vllm-compatible-test:
+    name: Test (rtvi vllm-compatible)
+    needs: prepare-source
+    if: >-
+      needs.prepare-source.outputs.vss-rt-vlm-changed == 'true'
+      || needs.prepare-source.outputs.vss-rt-embed-changed == 'true'
+      || needs.prepare-source.outputs.unit-test-workflow-changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: source-${{ github.sha }}
+          path: .source-artifact
+
+      - name: Unpack source artifact
+        run: |
+          find . -mindepth 1 -maxdepth 1 ! -name .source-artifact -exec rm -rf {} +
+          tar -xzf .source-artifact/source.tar.gz --strip-components=1
+          rm -rf .source-artifact
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
+        with:
+          version: "0.11.24"
+
+      # 3.12 is the interpreter the rt-vlm image ships, so the parsing helpers
+      # are exercised on the same version that runs in production.
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: "3.12"
+
+      # The model module imports torch and torchvision at module scope. The
+      # CPU wheel index keeps this near 850 MiB instead of installing the
+      # CUDA runtime, which this lane would never use.
+      - name: Install dependencies
+        run: |
+          uv venv --python 3.12 .venv-rtvi
+          uv pip install --python .venv-rtvi/bin/python \
+            --index-url https://download.pytorch.org/whl/cpu \
+            torch \
+            torchvision
+          uv pip install --python .venv-rtvi/bin/python \
+            filelock \
+            numpy \
+            pillow \
+            pydantic \
+            pytest
+
+      # --noconftest: tests/conftest.py imports prometheus_client,
+      # sse_starlette, requests and sseclient for autouse fixtures that none
+      # of the selected tests need.
+      - name: Run rt-vlm unit tests
+        working-directory: services/rtvi/rt-vlm
+        run: |
+          PYTHONPATH=src "$GITHUB_WORKSPACE/.venv-rtvi/bin/pytest" \
+            -c tests/pytest.ini \
+            --noconftest \
+            -m test_in_ci \
+            tests/model/vllm_compatible/test_input_error_handling.py \
+            -v
+
+      - name: Run rt-embed unit tests
+        working-directory: services/rtvi/rt-embed
+        run: |
+          PYTHONPATH=src "$GITHUB_WORKSPACE/.venv-rtvi/bin/pytest" \
+            tests/model/vllm_compatible/test_mm_processor_cache_engine_args.py \
+            -v
 
   # ---------------------------------------------------------------------------
   # Job 5f: Behavior analytics Docker Compose integration test

--- a/deploy/docker/developer-profiles/dev-profile-alerts/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/overrides.env
@@ -188,6 +188,11 @@ RTVI_VLM_ENDPOINT=http://rtvi-vlm:8000/v1
 RTVI_VLM_MODEL_TO_USE=cosmos-reason3
 # Set per hardware/mode for local RT-VLM; THOR edge can pass host env override.
 RTVI_VLLM_GPU_MEMORY_UTILIZATION=''
+# Keep the MM processor cache off: vLLM unlinks its shm cache only from
+# __del__, so a SIGKILL leaks a 1 GiB object into the host tmpfs because
+# rtvi-vlm runs ipc: host. Opting in also needs
+# RTVI_VLLM_DISABLE_MM_PREPROCESSOR_CACHE=false.
+RTVI_VLLM_MM_PROCESSOR_CACHE_GB=0
 # Set to 18000 for RTXPRO4500BW local RT-VLM.
 RTVI_VLM_MAX_MODEL_LEN=''
 # Remote VLM uses none; RTXPRO4500BW local alerts/LVS uses the Cosmos3 Nano BF16 path.

--- a/deploy/docker/developer-profiles/dev-profile-base/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-base/overrides.env
@@ -157,6 +157,11 @@ RTVI_VLM_ENDPOINT=''
 RTVI_VLM_MODEL_TO_USE=cosmos-reason3
 # Set per hardware/mode for local RT-VLM; THOR edge can pass host env override.
 RTVI_VLLM_GPU_MEMORY_UTILIZATION=''
+# Keep the MM processor cache off: vLLM unlinks its shm cache only from
+# __del__, so a SIGKILL leaks a 1 GiB object into the host tmpfs because
+# rtvi-vlm runs ipc: host. Opting in also needs
+# RTVI_VLLM_DISABLE_MM_PREPROCESSOR_CACHE=false.
+RTVI_VLLM_MM_PROCESSOR_CACHE_GB=0
 # Set to 18000 for RTXPRO4500BW local RT-VLM.
 RTVI_VLM_MAX_MODEL_LEN=''
 # Remote VLM sets none; local RT-VLM uses Cosmos3 Nano BF16 path.

--- a/deploy/docker/developer-profiles/dev-profile-lvs/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/overrides.env
@@ -168,6 +168,11 @@ RTVI_VLM_ENDPOINT=''
 RTVI_VLM_MODEL_TO_USE=cosmos-reason3
 # Set per hardware/mode for local RT-VLM; THOR edge can pass host env override.
 RTVI_VLLM_GPU_MEMORY_UTILIZATION=''
+# Keep the MM processor cache off: vLLM unlinks its shm cache only from
+# __del__, so a SIGKILL leaks a 1 GiB object into the host tmpfs because
+# rtvi-vlm runs ipc: host. Opting in also needs
+# RTVI_VLLM_DISABLE_MM_PREPROCESSOR_CACHE=false.
+RTVI_VLLM_MM_PROCESSOR_CACHE_GB=0
 # Set to 18000 for RTXPRO4500BW local RT-VLM.
 RTVI_VLM_MAX_MODEL_LEN=''
 # Remote VLM uses none; RTXPRO4500BW local alerts/LVS uses the Cosmos3 Nano BF16 path.

--- a/deploy/docker/developer-profiles/dev-profile-search/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-search/overrides.env
@@ -193,6 +193,11 @@ RTVI_VLM_MODEL_TO_USE=cosmos-reason3
 # Set per hardware/mode for local RT-VLM. Fraction leaves room for RT-CV on the
 # shared GPU 0 (H100 local_shared default).
 RTVI_VLLM_GPU_MEMORY_UTILIZATION='0.4'
+# Keep the MM processor cache off: vLLM unlinks its shm cache only from
+# __del__, so a SIGKILL leaks a 1 GiB object into the host tmpfs because
+# rtvi-vlm runs ipc: host. Opting in also needs
+# RTVI_VLLM_DISABLE_MM_PREPROCESSOR_CACHE=false.
+RTVI_VLLM_MM_PROCESSOR_CACHE_GB=0
 # Required for RT-VLM concurrency on GB300. Leave unset for other platforms.
 # RTVI_VLLM_ATTENTION_BACKEND=TRITON_ATTN
 # Set to 18000 for RTXPRO4500BW local RT-VLM.

--- a/deploy/docker/services/rtvi/rtvi-vlm/rtvi-vlm-docker-compose.yml
+++ b/deploy/docker/services/rtvi/rtvi-vlm/rtvi-vlm-docker-compose.yml
@@ -64,8 +64,11 @@ services:
       VLM_PROMPT_MAX_LENGTH: "${VLM_PROMPT_MAX_LENGTH:-10240}"
       # MoE backend override (empty by default; code auto-picks triton on B200 for Qwen3.5).
       VLLM_MOE_BACKEND: "${RTVI_VLLM_MOE_BACKEND:-}"
-      # vLLM multimodal preprocessor cache size in GiB.
-      VLLM_MM_PROCESSOR_CACHE_GB: "${RTVI_VLLM_MM_PROCESSOR_CACHE_GB:-1}"
+      # vLLM multimodal preprocessor cache size in GiB, off by default: vLLM
+      # unlinks the shm cache only from __del__, so a SIGKILL leaks a 1 GiB
+      # object into the host tmpfs because this service runs ipc: host.
+      # Opting in also needs RTVI_VLLM_DISABLE_MM_PREPROCESSOR_CACHE=false.
+      VLLM_MM_PROCESSOR_CACHE_GB: "${RTVI_VLLM_MM_PROCESSOR_CACHE_GB:-0}"
       VLLM_MM_PROCESSOR_CACHE_TYPE: "${RTVI_VLLM_MM_PROCESSOR_CACHE_TYPE:-shm}"
       GST_ENABLE_CUSTOM_PARSER_MODIFICATIONS: "${RTVI_VLM_GST_ENABLE_CUSTOM_PARSER_MODIFICATIONS:-1}"
       VLM_MODEL_TO_USE: "${RTVI_VLM_MODEL_TO_USE:-openai-compat}"

--- a/deploy/helm/services/rtvi/charts/rtvi-vlm/overrides_rtvi_vlm.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-vlm/overrides_rtvi_vlm.yaml
@@ -186,9 +186,12 @@ env:
   # Bounded queue size for the async Kafka sender.
   - name: KAFKA_ASYNC_SEND_QUEUE_MAXSIZE
     value: "1024"
-  # vLLM multimodal preprocessor cache size in GiB.
+  # vLLM multimodal preprocessor cache size in GiB, off by default: vLLM
+  # unlinks the shm cache only from __del__, so every SIGKILL'd container
+  # strands a 1 GiB object in the pod's /dev/shm budget until the pod is
+  # deleted. Opting in also needs VLLM_DISABLE_MM_PREPROCESSOR_CACHE=false.
   - name: VLLM_MM_PROCESSOR_CACHE_GB
-    value: "1"
+    value: "0"
   - name: VLLM_MM_PROCESSOR_CACHE_TYPE
     value: "shm"
   - name: VLLM_ENABLE_PREFIX_CACHING

--- a/deploy/helm/services/rtvi/charts/rtvi-vlm/values.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-vlm/values.yaml
@@ -251,9 +251,12 @@ env:
   # Bounded queue size for the async Kafka sender.
   - name: KAFKA_ASYNC_SEND_QUEUE_MAXSIZE
     value: "1024"
-  # vLLM multimodal preprocessor cache size in GiB.
+  # vLLM multimodal preprocessor cache size in GiB, off by default: vLLM
+  # unlinks the shm cache only from __del__, so every SIGKILL'd container
+  # strands a 1 GiB object in the pod's /dev/shm budget until the pod is
+  # deleted. Opting in also needs VLLM_DISABLE_MM_PREPROCESSOR_CACHE=false.
   - name: VLLM_MM_PROCESSOR_CACHE_GB
-    value: "1"
+    value: "0"
   - name: VLLM_MM_PROCESSOR_CACHE_TYPE
     value: "shm"
   - name: VLLM_ENABLE_PREFIX_CACHING

--- a/docs/real-time-vlm.mdx
+++ b/docs/real-time-vlm.mdx
@@ -1428,14 +1428,14 @@ standalone Helm override.
 | `VLLM_NUM_SCHEDULER_STEPS` | Number of scheduler steps for vLLM | `8` |
 | `VLLM_WORKER_MULTIPROC_METHOD` | Multiprocessing method for vLLM workers | `spawn` |
 | `VLLM_ENABLE_PREFIX_CACHING` | Enable vLLM prefix caching | `true` |
-| `VLLM_DISABLE_MM_PREPROCESSOR_CACHE` | Disable vLLM multimodal preprocessor cache | `false` |
+| `VLLM_DISABLE_MM_PREPROCESSOR_CACHE` | Disable vLLM multimodal preprocessor cache | `true` |
 | `VLM_VIDEO_PRUNING_RATE` | Fixed-rate EVS pruning rate; also required to activate EVS++ pruning when `VIA_EVS_SESSION=true` | Compose: Empty; Helm: `0.0` |
 | `VIA_EVS_SESSION` | Enable the optional EVS++ video-session path when set to `true` or `1` | Empty (disabled) |
 | `VLLM_EVS_SIMILARITY_THRESHOLD` | EVS++ frame/clip similarity threshold | `0.2` when EVS++ session mode is enabled |
 | `VIA_EVS_TOKEN_BUDGET` | EVS++ visual-token budget accumulated across clips before generation is forced | `20000` |
 | `VIA_EVS_MAX_SESSIONS` | Maximum concurrent EVS++ video sessions | `100` |
 | `RTVI_VLLM_MOE_BACKEND` (Helm env: `VLLM_MOE_BACKEND`) | vLLM MoE backend override | Empty |
-| `RTVI_VLLM_MM_PROCESSOR_CACHE_GB` (Helm env: `VLLM_MM_PROCESSOR_CACHE_GB`) | Multimodal processor cache size | `1` |
+| `RTVI_VLLM_MM_PROCESSOR_CACHE_GB` (Helm env: `VLLM_MM_PROCESSOR_CACHE_GB`) | Multimodal processor cache size | `0` |
 | `VLLM_MM_TENSOR_IPC` | vLLM multimodal tensor IPC setting | Empty |
 | `VLLM_MULTIMODAL_TENSOR_IPC` | vLLM multimodal tensor IPC setting | Empty |
 | `VLLM_MM_ENCODER_ATTN_BACKEND` | vLLM multimodal encoder attention backend | Empty |

--- a/services/rtvi/rt-embed/src/models/vllm_compatible/vllm_compatible_model.py
+++ b/services/rtvi/rt-embed/src/models/vllm_compatible/vllm_compatible_model.py
@@ -231,6 +231,36 @@ def _get_mm_processor_cache_gb() -> float:
     return _parse_float_env("VLLM_MM_INPUT_CACHE_GIB", 1.0)
 
 
+def _apply_mm_processor_cache_engine_args(
+    engine_args_kwargs: dict[str, object],
+    supported_params: set[str],
+) -> None:
+    """Build the multimodal processor cache engine args for the installed vLLM.
+
+    vLLM 0.17.1 removed ``disable_mm_preprocessor_cache``, so on that build the
+    only way to keep the engine from creating the cache is the size:
+    ``mm_processor_cache_gb=0``. Leaving it enabled is not equivalent, because
+    the ``shm`` backend unlinks its POSIX object from ``__del__``, which a
+    SIGKILL skips.
+    """
+    disable_mm_cache = _parse_bool_env(
+        "VLLM_DISABLE_MM_PREPROCESSOR_CACHE",
+        default=True,
+    )
+    if "disable_mm_preprocessor_cache" in supported_params:
+        engine_args_kwargs["disable_mm_preprocessor_cache"] = disable_mm_cache
+    elif disable_mm_cache:
+        logger.warning(
+            "VLLM_DISABLE_MM_PREPROCESSOR_CACHE=true honored via "
+            "mm_processor_cache_gb=0; installed vLLM does not support "
+            "disable_mm_preprocessor_cache"
+        )
+    if "mm_processor_cache_gb" in supported_params:
+        engine_args_kwargs["mm_processor_cache_gb"] = (
+            0.0 if disable_mm_cache else _get_mm_processor_cache_gb()
+        )
+
+
 CPU_COPY_OTHER_THREAD = True
 
 # Fallback edges for a request that supplies only one half of `size`, per the
@@ -875,14 +905,10 @@ class VllmCompatible(BaseVlmModel):
                     enable_prefix_caching = prefix_caching_env.lower() == "true"
                     engine_args_kwargs["enable_prefix_caching"] = enable_prefix_caching
 
-                disable_mm_cache = _parse_bool_env(
-                    "VLLM_DISABLE_MM_PREPROCESSOR_CACHE",
-                    default=True,
+                _apply_mm_processor_cache_engine_args(
+                    engine_args_kwargs,
+                    _engine_supported_params,
                 )
-                if "disable_mm_preprocessor_cache" in _engine_supported_params:
-                    engine_args_kwargs["disable_mm_preprocessor_cache"] = disable_mm_cache
-                if "mm_processor_cache_gb" in _engine_supported_params:
-                    engine_args_kwargs["mm_processor_cache_gb"] = _get_mm_processor_cache_gb()
 
                 mm_tensor_ipc = (_get_rtvi_vllm_env("VLLM_MM_TENSOR_IPC", "") or "").strip()
                 if mm_tensor_ipc:

--- a/services/rtvi/rt-embed/tests/model/vllm_compatible/test_mm_processor_cache_engine_args.py
+++ b/services/rtvi/rt-embed/tests/model/vllm_compatible/test_mm_processor_cache_engine_args.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""rt-embed carries its own copy of the vLLM-compatible model module.
+
+The copies must agree on how the multimodal processor cache is disabled, so
+the size-based disable is asserted here too rather than only under rt-vlm.
+rt-embed has no mm_processor_cache_type handling, which is the one intended
+difference between the two helpers.
+
+Every test here runs without vLLM, so CI selects this file by path. rt-embed
+declares no pytest markers, unlike rt-vlm's mixed test module.
+"""
+
+import models.vllm_compatible.vllm_compatible_model as vllm_compatible_model
+
+
+def _clear_vllm_env(monkeypatch):
+    for source, target in vllm_compatible_model._RTVI_VLLM_ENV_ALIASES.items():
+        monkeypatch.delenv(source, raising=False)
+        monkeypatch.delenv(target, raising=False)
+    monkeypatch.delenv("VLLM_MM_INPUT_CACHE_GIB", raising=False)
+
+
+def test_mm_processor_cache_disable_uses_zero_gb_when_legacy_flag_missing(monkeypatch):
+    _clear_vllm_env(monkeypatch)
+    engine_args = {}
+
+    vllm_compatible_model._apply_mm_processor_cache_engine_args(
+        engine_args,
+        {"mm_processor_cache_gb"},
+    )
+
+    assert engine_args == {"mm_processor_cache_gb": 0.0}
+
+
+def test_mm_processor_cache_disable_zeros_gb_even_when_legacy_flag_exists(monkeypatch):
+    _clear_vllm_env(monkeypatch)
+    monkeypatch.setenv("VLLM_MM_PROCESSOR_CACHE_GB", "1")
+    engine_args = {}
+
+    vllm_compatible_model._apply_mm_processor_cache_engine_args(
+        engine_args,
+        {"disable_mm_preprocessor_cache", "mm_processor_cache_gb"},
+    )
+
+    assert engine_args == {
+        "disable_mm_preprocessor_cache": True,
+        "mm_processor_cache_gb": 0.0,
+    }
+
+
+def test_mm_processor_cache_opt_in_uses_configured_size(monkeypatch):
+    _clear_vllm_env(monkeypatch)
+    monkeypatch.setenv("VLLM_DISABLE_MM_PREPROCESSOR_CACHE", "false")
+    monkeypatch.setenv("VLLM_MM_PROCESSOR_CACHE_GB", "0.5")
+    engine_args = {}
+
+    vllm_compatible_model._apply_mm_processor_cache_engine_args(
+        engine_args,
+        {"mm_processor_cache_gb"},
+    )
+
+    assert engine_args == {"mm_processor_cache_gb": 0.5}
+
+
+def test_mm_processor_cache_type_is_never_applied(monkeypatch):
+    """rt-embed does not own the cache-type override; the copies differ here."""
+    _clear_vllm_env(monkeypatch)
+    engine_args = {}
+
+    vllm_compatible_model._apply_mm_processor_cache_engine_args(
+        engine_args,
+        {"mm_processor_cache_gb", "mm_processor_cache_type"},
+    )
+
+    assert engine_args == {"mm_processor_cache_gb": 0.0}

--- a/services/rtvi/rt-vlm/README.md
+++ b/services/rtvi/rt-vlm/README.md
@@ -866,11 +866,12 @@ docker logs rtvi-vlm 2>&1 | grep "VLM result:" | tail -1
 
 ### Disabling Multimodal Preprocessor Cache
 
-By default, the multimodal preprocessor cache is disabled (`VLLM_DISABLE_MM_PREPROCESSOR_CACHE=true`) to avoid a system memory leak. To re-enable caching (trades higher memory for lower latency):
+By default, the multimodal preprocessor cache is disabled (`VLLM_DISABLE_MM_PREPROCESSOR_CACHE=true`) to avoid a system memory leak. Re-enabling it takes both variables: the disable flag wins over the size, and the size defaults to `0`. To re-enable caching (trades higher memory for lower latency):
 
 ```bash
 # In .env
 VLLM_DISABLE_MM_PREPROCESSOR_CACHE=false
+RTVI_VLLM_MM_PROCESSOR_CACHE_GB=1
 ```
 
 When disabled (default), each request reprocesses video frames from scratch. This uses less memory but increases latency.
@@ -962,7 +963,7 @@ The table lists variables in the standalone Docker Compose stack and the standal
 | `VLLM_GPU_MEMORY_UTILIZATION` | vLLM GPU memory utilization fraction | Empty |
 | `VLM_VIDEO_PRUNING_RATE` | Efficient Video Sampling pruning rate | Compose: Empty; Helm: `0.0` |
 | `RTVI_VLLM_MOE_BACKEND` (Helm env: `VLLM_MOE_BACKEND`) | vLLM MoE backend override | Empty |
-| `RTVI_VLLM_MM_PROCESSOR_CACHE_GB` (Helm env: `VLLM_MM_PROCESSOR_CACHE_GB`) | Multimodal processor cache size | `1` |
+| `RTVI_VLLM_MM_PROCESSOR_CACHE_GB` (Helm env: `VLLM_MM_PROCESSOR_CACHE_GB`) | Multimodal processor cache size | `0` |
 | `VLLM_MM_TENSOR_IPC` | vLLM multimodal tensor IPC setting | Empty |
 | `VLLM_MULTIMODAL_TENSOR_IPC` | vLLM multimodal tensor IPC setting | Empty |
 | `VLLM_MM_ENCODER_ATTN_BACKEND` | vLLM multimodal encoder attention backend | Empty |

--- a/services/rtvi/rt-vlm/docker/compose.yaml
+++ b/services/rtvi/rt-vlm/docker/compose.yaml
@@ -135,8 +135,11 @@ services:
       VLM_MAX_GENERATION_TOKENS: "${RTVI_VLM_MAX_GENERATION_TOKENS:-16384}"
       # MoE backend override (empty by default; code auto-picks triton on B200 for Qwen3.5).
       VLLM_MOE_BACKEND: "${RTVI_VLLM_MOE_BACKEND:-}"
-      # vLLM multimodal preprocessor cache size in GiB.
-      VLLM_MM_PROCESSOR_CACHE_GB: "${RTVI_VLLM_MM_PROCESSOR_CACHE_GB:-1}"
+      # vLLM multimodal preprocessor cache size in GiB, off by default: vLLM
+      # unlinks the shm cache only from __del__, so a SIGKILL leaks a 1 GiB
+      # object into the host tmpfs because this service runs ipc: host.
+      # Opting in also needs VLLM_DISABLE_MM_PREPROCESSOR_CACHE=false.
+      VLLM_MM_PROCESSOR_CACHE_GB: "${RTVI_VLLM_MM_PROCESSOR_CACHE_GB:-0}"
       # Bounded queue size for the async Kafka sender.
       KAFKA_ASYNC_SEND_QUEUE_MAXSIZE: "${RTVI_VLM_KAFKA_ASYNC_SEND_QUEUE_MAXSIZE:-1024}"
       GST_ENABLE_CUSTOM_PARSER_MODIFICATIONS: "${GST_ENABLE_CUSTOM_PARSER_MODIFICATIONS:-1}"

--- a/services/rtvi/rt-vlm/src/models/vllm_compatible/vllm_compatible_model.py
+++ b/services/rtvi/rt-vlm/src/models/vllm_compatible/vllm_compatible_model.py
@@ -451,6 +451,40 @@ def _get_mm_processor_cache_type() -> str:
     return cache_type
 
 
+def _apply_mm_processor_cache_engine_args(
+    engine_args_kwargs: dict[str, object],
+    supported_params: set[str],
+) -> None:
+    """Build the multimodal processor cache engine args for the installed vLLM.
+
+    vLLM 0.17.1 removed ``disable_mm_preprocessor_cache``, so on that build the
+    only way to keep the engine from creating the cache is the size:
+    ``mm_processor_cache_gb=0``. Leaving it enabled is not equivalent, because
+    the ``shm`` backend unlinks its POSIX object from ``__del__``, which a
+    SIGKILL skips.
+    """
+    disable_mm_cache = _parse_bool_env(
+        "VLLM_DISABLE_MM_PREPROCESSOR_CACHE",
+        default=True,
+    )
+    if "disable_mm_preprocessor_cache" in supported_params:
+        engine_args_kwargs["disable_mm_preprocessor_cache"] = disable_mm_cache
+    elif disable_mm_cache:
+        logger.warning(
+            "VLLM_DISABLE_MM_PREPROCESSOR_CACHE=true honored via "
+            "mm_processor_cache_gb=0; installed vLLM does not support "
+            "disable_mm_preprocessor_cache"
+        )
+    if "mm_processor_cache_gb" in supported_params:
+        engine_args_kwargs["mm_processor_cache_gb"] = (
+            0.0 if disable_mm_cache else _get_mm_processor_cache_gb()
+        )
+    if "mm_processor_cache_type" in supported_params:
+        cache_type = _get_mm_processor_cache_type()
+        engine_args_kwargs["mm_processor_cache_type"] = cache_type
+        logger.info("VLLM MM processor cache type: %s", cache_type)
+
+
 CPU_COPY_OTHER_THREAD = True
 
 # Fallback edges for a request that supplies only one half of `size`, per the
@@ -1466,18 +1500,10 @@ class VllmCompatible(BaseVlmModel):
                     enable_prefix_caching = prefix_caching_env.lower() == "true"
                     engine_args_kwargs["enable_prefix_caching"] = enable_prefix_caching
 
-                disable_mm_cache = _parse_bool_env(
-                    "VLLM_DISABLE_MM_PREPROCESSOR_CACHE",
-                    default=True,
+                _apply_mm_processor_cache_engine_args(
+                    engine_args_kwargs,
+                    _engine_supported_params,
                 )
-                if "disable_mm_preprocessor_cache" in _engine_supported_params:
-                    engine_args_kwargs["disable_mm_preprocessor_cache"] = disable_mm_cache
-                if "mm_processor_cache_gb" in _engine_supported_params:
-                    engine_args_kwargs["mm_processor_cache_gb"] = _get_mm_processor_cache_gb()
-                if "mm_processor_cache_type" in _engine_supported_params:
-                    cache_type = _get_mm_processor_cache_type()
-                    engine_args_kwargs["mm_processor_cache_type"] = cache_type
-                    logger.info("VLLM MM processor cache type: %s", cache_type)
 
                 mm_tensor_ipc = (_get_rtvi_vllm_env("VLLM_MM_TENSOR_IPC", "") or "").strip()
                 if mm_tensor_ipc:

--- a/services/rtvi/rt-vlm/tests/model/vllm_compatible/test_input_error_handling.py
+++ b/services/rtvi/rt-vlm/tests/model/vllm_compatible/test_input_error_handling.py
@@ -1383,6 +1383,7 @@ def test_mm_processor_cache_size_rejects_negative_values(monkeypatch):
         vllm_compatible_model._get_mm_processor_cache_gb()
 
 
+@pytest.mark.test_in_ci
 def test_mm_processor_cache_disable_uses_zero_gb_when_legacy_flag_missing(monkeypatch, caplog):
     """vLLM 0.17.1 has no disable_mm_preprocessor_cache; size 0 is the only lever.
 
@@ -1406,6 +1407,7 @@ def test_mm_processor_cache_disable_uses_zero_gb_when_legacy_flag_missing(monkey
     assert "does not support disable_mm_preprocessor_cache" in caplog.text
 
 
+@pytest.mark.test_in_ci
 def test_mm_processor_cache_disable_zeros_gb_even_when_legacy_flag_exists(monkeypatch):
     for source, target in vllm_compatible_model._RTVI_VLLM_ENV_ALIASES.items():
         monkeypatch.delenv(source, raising=False)
@@ -1424,6 +1426,7 @@ def test_mm_processor_cache_disable_zeros_gb_even_when_legacy_flag_exists(monkey
     }
 
 
+@pytest.mark.test_in_ci
 def test_mm_processor_cache_opt_in_uses_configured_size(monkeypatch):
     for source, target in vllm_compatible_model._RTVI_VLLM_ENV_ALIASES.items():
         monkeypatch.delenv(source, raising=False)
@@ -1440,6 +1443,7 @@ def test_mm_processor_cache_opt_in_uses_configured_size(monkeypatch):
     assert engine_args == {"mm_processor_cache_gb": 0.5}
 
 
+@pytest.mark.test_in_ci
 def test_mm_processor_cache_opt_in_keeps_size_when_legacy_flag_exists(monkeypatch):
     for source, target in vllm_compatible_model._RTVI_VLLM_ENV_ALIASES.items():
         monkeypatch.delenv(source, raising=False)
@@ -1459,6 +1463,7 @@ def test_mm_processor_cache_opt_in_keeps_size_when_legacy_flag_exists(monkeypatc
     }
 
 
+@pytest.mark.test_in_ci
 def test_mm_processor_cache_type_is_applied_even_when_the_cache_is_disabled(monkeypatch):
     for source, target in vllm_compatible_model._RTVI_VLLM_ENV_ALIASES.items():
         monkeypatch.delenv(source, raising=False)

--- a/services/rtvi/rt-vlm/tests/model/vllm_compatible/test_input_error_handling.py
+++ b/services/rtvi/rt-vlm/tests/model/vllm_compatible/test_input_error_handling.py
@@ -16,6 +16,7 @@
 import asyncio
 import concurrent.futures
 import json
+import logging
 import sys
 import threading
 from importlib import metadata
@@ -1380,6 +1381,99 @@ def test_mm_processor_cache_size_rejects_negative_values(monkeypatch):
 
     with pytest.raises(ValueError, match="greater than or equal to 0"):
         vllm_compatible_model._get_mm_processor_cache_gb()
+
+
+def test_mm_processor_cache_disable_uses_zero_gb_when_legacy_flag_missing(monkeypatch, caplog):
+    """vLLM 0.17.1 has no disable_mm_preprocessor_cache; size 0 is the only lever.
+
+    The warning is the audit trail for that translation, so assert it as well as
+    the kwarg -- a silently dropped disable is what leaked the shm objects.
+    """
+    for source, target in vllm_compatible_model._RTVI_VLLM_ENV_ALIASES.items():
+        monkeypatch.delenv(source, raising=False)
+        monkeypatch.delenv(target, raising=False)
+    monkeypatch.delenv("VLLM_MM_INPUT_CACHE_GIB", raising=False)
+    engine_args = {}
+
+    with caplog.at_level(logging.WARNING, logger=vllm_compatible_model.logger.name):
+        vllm_compatible_model._apply_mm_processor_cache_engine_args(
+            engine_args,
+            {"mm_processor_cache_gb"},
+        )
+
+    assert engine_args == {"mm_processor_cache_gb": 0.0}
+    assert "honored via mm_processor_cache_gb=0" in caplog.text
+    assert "does not support disable_mm_preprocessor_cache" in caplog.text
+
+
+def test_mm_processor_cache_disable_zeros_gb_even_when_legacy_flag_exists(monkeypatch):
+    for source, target in vllm_compatible_model._RTVI_VLLM_ENV_ALIASES.items():
+        monkeypatch.delenv(source, raising=False)
+        monkeypatch.delenv(target, raising=False)
+    monkeypatch.setenv("VLLM_MM_PROCESSOR_CACHE_GB", "1")
+    engine_args = {}
+
+    vllm_compatible_model._apply_mm_processor_cache_engine_args(
+        engine_args,
+        {"disable_mm_preprocessor_cache", "mm_processor_cache_gb"},
+    )
+
+    assert engine_args == {
+        "disable_mm_preprocessor_cache": True,
+        "mm_processor_cache_gb": 0.0,
+    }
+
+
+def test_mm_processor_cache_opt_in_uses_configured_size(monkeypatch):
+    for source, target in vllm_compatible_model._RTVI_VLLM_ENV_ALIASES.items():
+        monkeypatch.delenv(source, raising=False)
+        monkeypatch.delenv(target, raising=False)
+    monkeypatch.setenv("VLLM_DISABLE_MM_PREPROCESSOR_CACHE", "false")
+    monkeypatch.setenv("VLLM_MM_PROCESSOR_CACHE_GB", "0.5")
+    engine_args = {}
+
+    vllm_compatible_model._apply_mm_processor_cache_engine_args(
+        engine_args,
+        {"mm_processor_cache_gb"},
+    )
+
+    assert engine_args == {"mm_processor_cache_gb": 0.5}
+
+
+def test_mm_processor_cache_opt_in_keeps_size_when_legacy_flag_exists(monkeypatch):
+    for source, target in vllm_compatible_model._RTVI_VLLM_ENV_ALIASES.items():
+        monkeypatch.delenv(source, raising=False)
+        monkeypatch.delenv(target, raising=False)
+    monkeypatch.setenv("VLLM_DISABLE_MM_PREPROCESSOR_CACHE", "false")
+    monkeypatch.setenv("VLLM_MM_PROCESSOR_CACHE_GB", "2")
+    engine_args = {}
+
+    vllm_compatible_model._apply_mm_processor_cache_engine_args(
+        engine_args,
+        {"disable_mm_preprocessor_cache", "mm_processor_cache_gb"},
+    )
+
+    assert engine_args == {
+        "disable_mm_preprocessor_cache": False,
+        "mm_processor_cache_gb": 2.0,
+    }
+
+
+def test_mm_processor_cache_type_is_applied_even_when_the_cache_is_disabled(monkeypatch):
+    for source, target in vllm_compatible_model._RTVI_VLLM_ENV_ALIASES.items():
+        monkeypatch.delenv(source, raising=False)
+        monkeypatch.delenv(target, raising=False)
+    engine_args = {}
+
+    vllm_compatible_model._apply_mm_processor_cache_engine_args(
+        engine_args,
+        {"mm_processor_cache_gb", "mm_processor_cache_type"},
+    )
+
+    assert engine_args == {
+        "mm_processor_cache_gb": 0.0,
+        "mm_processor_cache_type": "shm",
+    }
 
 
 def test_mm_processor_cache_type_defaults_to_shared_memory(monkeypatch):


### PR DESCRIPTION
## Summary
- Honor `VLLM_DISABLE_MM_PREPROCESSOR_CACHE=true` on vLLM 0.17.1 by setting `mm_processor_cache_gb=0` when the old `disable_mm_preprocessor_cache` EngineArgs field is gone, and log a warning instead of dropping the request.
- Default Compose/Helm cache size to 0 and pin `RTVI_VLLM_MM_PROCESSOR_CACHE_GB=0` on search/base/LVS/alerts (warehouse already had this). A 1 GiB POSIX `VLLM_OBJECT_STORAGE_SHM_BUFFER_*` object otherwise lands in host `/dev/shm` because RT-VLM uses `ipc: host` and teardown SIGKILLs the writer before `__del__` unlinks.
- `ipc: host` is unchanged pending RT-VLM owner confirmation that private IPC is safe for CUDA-IPC tensor passing.

## Test plan
- [ ] RT-VLM unit tests for `_apply_mm_processor_cache_engine_args` (legacy flag missing → `cache_gb=0` + warning; disable still zeros size when the old flag exists; explicit enable keeps configured size)
- [ ] Engine start with `VLLM_DISABLE_MM_PREPROCESSOR_CACHE=true` and no cache override creates zero `VLLM_OBJECT_STORAGE_SHM_BUFFER_*` objects
- [ ] `test-search` / compose teardown does not grow host `/dev/shm`
- [ ] Opt-in path still works: `VLLM_DISABLE_MM_PREPROCESSOR_CACHE=false` plus an explicit bounded `RTVI_VLLM_MM_PROCESSOR_CACHE_GB`