### PR TITLE
fix(rtvi-vlm): Release callbacks before pipeline replacement

### DIFF
--- a/services/rtvi/rt-vlm/src/vlm_pipeline/video_file_frame_getter.py
+++ b/services/rtvi/rt-vlm/src/vlm_pipeline/video_file_frame_getter.py
@@ -977,6 +977,25 @@ class VideoFileFrameGetter:
     def _cache_decodebin(self, key, decodebin) -> None:
         self._vdecodebin_cache[key] = decodebin
 
+    def _detach_pipeline_for_replacement(self):
+        """Detach a pipeline while retaining any reusable decoder."""
+        old_pipeline = self._pipeline
+        if old_pipeline is None:
+            return None
+
+        if self._vdecodebin:
+            old_pipeline.remove(self._vdecodebin)
+            if not self._is_cached_decodebin(self._vdecodebin):
+                self._vdecodebin.set_state(Gst.State.NULL)
+
+        self._vdecodebin = None
+        # The bus must still be referenced when callbacks are disconnected so
+        # remove_signal_watch() can release its GLib source and file descriptors.
+        self._disconnect_gst_callbacks()
+        self._bus = None
+        self._pipeline = None
+        return old_pipeline
+
     def _disconnect_cached_decodebin_from_pipeline(self) -> None:
         if (
             not self._pipeline
@@ -2820,22 +2839,8 @@ class VideoFileFrameGetter:
             # filesrc/parsebin for the same file under file-burst load.
             is_file_changed = self._last_stream_id != file
 
-            def backup_decodebin():
-                # If codec or resolution has changed, remove the decodebin from the pipeline
-                # and keep reusable decoders backed up under their codec/resolution key.
-                if self._pipeline:
-
-                    if self._vdecodebin:
-                        self._pipeline.remove(self._vdecodebin)
-                        if not self._is_cached_decodebin(self._vdecodebin):
-                            self._vdecodebin.set_state(Gst.State.NULL)
-                self._vdecodebin = None
-
             if (is_codec_changed or is_resolution_changed) and self._pipeline:
-                backup_decodebin()
-                old_pipeline = self._pipeline
-                self._pipeline = None
-                self._vdecodebin = None
+                old_pipeline = self._detach_pipeline_for_replacement()
                 if not (self._frame_width and self._frame_height):
                     # Next pipeline should use same resolution as first
                     # to allow all frames in the chunk have same resolution

--- a/services/rtvi/rt-vlm/src/vlm_pipeline/video_file_frame_getter.py
+++ b/services/rtvi/rt-vlm/src/vlm_pipeline/video_file_frame_getter.py
@@ -895,6 +895,48 @@ class VideoFileFrameGetter:
         self._gst_pad_probe_ids.append((pad, probe_id))
         return probe_id
 
+    def _attach_parser_gop_probe(self, parser) -> None:
+        factory = parser.get_factory()
+        if factory is None:
+            return
+        parser_name = factory.get_name()
+        if parser_name not in ("h264parse", "h265parse", "mpeg4videoparse"):
+            return
+        if not self._gop_decode_opt_enabled:
+            logger.debug(
+                "GOP decode-opt disabled via RTVI_ENABLE_GOP_DECODE_OPT; "
+                "probe not attached to %s",
+                parser_name,
+            )
+            return
+
+        src_pad = parser.get_static_pad("src")
+        if src_pad is None or any(pad == src_pad for pad, _ in self._gst_pad_probe_ids):
+            return
+        self._add_gst_pad_probe(
+            src_pad,
+            Gst.PadProbeType.BUFFER,
+            lambda pad, info: self._on_parser_src_buffer(pad, info),
+        )
+        logger.debug("GOP decode-opt probe attached to %s", parser_name)
+
+    def _restore_cached_decoder_parser_probes(self, decodebin) -> None:
+        """Restore probes on parser children retained by a cached decodebin."""
+        try:
+            iterator = decodebin.iterate_recurse()
+            while True:
+                result, elem = iterator.next()
+                if result == Gst.IteratorResult.OK:
+                    self._attach_parser_gop_probe(elem)
+                elif result == Gst.IteratorResult.RESYNC:
+                    iterator.resync()
+                else:
+                    if result == Gst.IteratorResult.ERROR:
+                        logger.warning("Failed to iterate cached decoder children")
+                    break
+        except Exception as ex:
+            logger.warning("Failed to restore cached decoder parser probes: %s", ex)
+
     def _disconnect_gst_callbacks(self):
         for pad, probe_id in reversed(self._gst_pad_probe_ids):
             try:
@@ -1496,30 +1538,14 @@ class VideoFileFrameGetter:
         self._frame_duration_ns = 0
 
         def cb_elem_added(elem, username, password, selff):
-            if "nvv4l2decoder" in elem.get_factory().get_name():
+            parser_name = elem.get_factory().get_name()
+            if "nvv4l2decoder" in parser_name:
                 _set_gst_property_if_supported(elem, "gpu-id", self._gpu_id)
                 _set_gst_property_if_supported(elem, "extract-sei-type5-data", True)
                 _set_gst_property_if_supported(elem, "sei-uuid", "NVDS_CUSTOMMETA")
-            if "mpeg4videoparse" in elem.get_factory().get_name():
+            if "mpeg4videoparse" in parser_name:
                 elem.set_property("config-interval", -1)
-            parser_name = elem.get_factory().get_name()
-            if parser_name in ("h264parse", "h265parse", "mpeg4videoparse"):
-                if self._gop_decode_opt_enabled:
-                    src_pad = elem.get_static_pad("src")
-                    if src_pad is not None:
-                        self._add_gst_pad_probe(
-                            src_pad,
-                            Gst.PadProbeType.BUFFER,
-                            lambda pad, info: self._on_parser_src_buffer(pad, info),
-                        )
-                        logger.debug("GOP decode-opt probe attached to %s", parser_name)
-                else:
-                    logger.debug(
-                        "GOP decode-opt disabled via RTVI_ENABLE_GOP_DECODE_OPT; "
-                        "probe not attached to %s",
-                        parser_name,
-                    )
-                    logger.debug("GOP decode-opt probe attached to %s", parser_name)
+            self._attach_parser_gop_probe(elem)
             if parser_name == "rtpjitterbuffer":
                 drop_on_latency = _env_bool("RTVI_RTPJITTERBUFFER_DROP_ON_LATENCY", False)
                 if elem.find_property("drop-on-latency"):
@@ -1696,6 +1722,7 @@ class VideoFileFrameGetter:
                         else:
                             pipeline.add(self._vdecodebin)
                             self._vdecodebin.link(self._q1)
+                            self._restore_cached_decoder_parser_probes(self._vdecodebin)
                             logger.debug(
                                 "Reusing cached %s decoder for %sx%s",
                                 reusable_codec,

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_decode_retry.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_decode_retry.py
@@ -423,6 +423,61 @@ def test_late_file_frame_after_cache_handoff_is_dropped(monkeypatch):
 
 
 @pytest.mark.no_gpu
+def test_pipeline_replacement_removes_bus_watch_and_callbacks(monkeypatch):
+    monkeypatch.setitem(sys.modules, "pyds", types.SimpleNamespace())
+
+    from vlm_pipeline.video_file_frame_getter import VideoFileFrameGetter
+
+    events = []
+
+    class FakePad:
+        def remove_probe(self, probe_id):
+            events.append(("probe", probe_id))
+
+    class FakeSignalObject:
+        def disconnect(self, handler_id):
+            events.append(("handler", handler_id))
+
+    class FakeBus:
+        def remove_signal_watch(self):
+            events.append(("bus-watch", None))
+
+    class FakePipeline:
+        def remove(self, element):
+            events.append(("decoder", element))
+
+    fgetter = VideoFileFrameGetter.__new__(VideoFileFrameGetter)
+    old_pipeline = FakePipeline()
+    cached_decoder = object()
+    old_bus = FakeBus()
+    fgetter._pipeline = old_pipeline
+    fgetter._vdecodebin = cached_decoder
+    fgetter._vdecodebin_cache = {("h264", 320, 320): cached_decoder}
+    fgetter._gst_pad_probe_ids = [(FakePad(), 11)]
+    fgetter._gst_signal_handler_ids = [(FakeSignalObject(), 22)]
+    fgetter._vdecodebin_cache_signal_keys = {("h264", 320, 320)}
+    fgetter._bus = old_bus
+    fgetter._bus_signal_watch_added = True
+
+    detached = fgetter._detach_pipeline_for_replacement()
+
+    assert detached is old_pipeline
+    assert events == [
+        ("decoder", cached_decoder),
+        ("probe", 11),
+        ("handler", 22),
+        ("bus-watch", None),
+    ]
+    assert fgetter._pipeline is None
+    assert fgetter._vdecodebin is None
+    assert fgetter._bus is None
+    assert fgetter._gst_pad_probe_ids == []
+    assert fgetter._gst_signal_handler_ids == []
+    assert fgetter._vdecodebin_cache_signal_keys == set()
+    assert not fgetter._bus_signal_watch_added
+
+
+@pytest.mark.no_gpu
 def test_handle_cuda_oom_records_err_msg_and_drops_cached_frames(monkeypatch):
     monkeypatch.setitem(sys.modules, "pyds", types.SimpleNamespace())
     monkeypatch.delenv("RTVI_ENABLE_CUDA_OOM_RECOVERY", raising=False)

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_decode_retry.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_decode_retry.py
@@ -453,7 +453,8 @@ def test_pipeline_replacement_removes_bus_watch_and_callbacks(monkeypatch):
     fgetter._pipeline = old_pipeline
     fgetter._vdecodebin = cached_decoder
     fgetter._vdecodebin_cache = {("h264", 320, 320): cached_decoder}
-    fgetter._gst_pad_probe_ids = [(FakePad(), 11)]
+    old_parser_pad = FakePad()
+    fgetter._gst_pad_probe_ids = [(old_parser_pad, 11)]
     fgetter._gst_signal_handler_ids = [(FakeSignalObject(), 22)]
     fgetter._vdecodebin_cache_signal_keys = {("h264", 320, 320)}
     fgetter._bus = old_bus
@@ -475,6 +476,62 @@ def test_pipeline_replacement_removes_bus_watch_and_callbacks(monkeypatch):
     assert fgetter._gst_signal_handler_ids == []
     assert fgetter._vdecodebin_cache_signal_keys == set()
     assert not fgetter._bus_signal_watch_added
+
+
+@pytest.mark.no_gpu
+def test_cached_decoder_restores_existing_parser_probe(monkeypatch):
+    monkeypatch.setitem(sys.modules, "pyds", types.SimpleNamespace())
+
+    from vlm_pipeline import video_file_frame_getter as frame_getter_module
+    from vlm_pipeline.video_file_frame_getter import VideoFileFrameGetter
+
+    class FakeFactory:
+        def get_name(self):
+            return "h264parse"
+
+    class FakePad:
+        def __init__(self):
+            self.probes = []
+
+        def add_probe(self, probe_type, callback, *args):
+            self.probes.append((probe_type, callback, args))
+            return len(self.probes)
+
+    class FakeParser:
+        def __init__(self):
+            self.src_pad = FakePad()
+
+        def get_factory(self):
+            return FakeFactory()
+
+        def get_static_pad(self, name):
+            assert name == "src"
+            return self.src_pad
+
+    class FakeIterator:
+        def __init__(self, elem):
+            self.elem = elem
+
+        def next(self):
+            if self.elem is not None:
+                elem, self.elem = self.elem, None
+                return frame_getter_module.Gst.IteratorResult.OK, elem
+            return frame_getter_module.Gst.IteratorResult.DONE, None
+
+        def resync(self):
+            raise AssertionError("unexpected iterator resync")
+
+    parser = FakeParser()
+    cached_decoder = SimpleNamespace(iterate_recurse=lambda: FakeIterator(parser))
+    fgetter = VideoFileFrameGetter.__new__(VideoFileFrameGetter)
+    fgetter._gop_decode_opt_enabled = True
+    fgetter._gst_pad_probe_ids = []
+
+    fgetter._restore_cached_decoder_parser_probes(cached_decoder)
+    fgetter._restore_cached_decoder_parser_probes(cached_decoder)
+
+    assert len(parser.src_pad.probes) == 1
+    assert fgetter._gst_pad_probe_ids == [(parser.src_pad, 1)]
 
 
 @pytest.mark.no_gpu


### PR DESCRIPTION
## Summary

Release GStreamer callback registrations and the bus signal watch before
replacing an RT-VLM file-decoder pipeline.

## Plan

- Reproduce resource growth across repeated codec transitions.
- Clean up callbacks while the old pipeline and bus are still referenced.
- Validate the fix with the RTVI unit suite and the recorded reproduction.

## Related Issue

NVBug 6697886

## Changes

- Disconnect tracked pad probes and signal handlers during pipeline
  replacement.
- Remove the old bus signal watch before clearing the bus reference.
- Preserve reusable decoders and allow callbacks to be registered again.
- Add focused coverage for callback and bus-watch cleanup ordering.

## Validation

- Independent Compose validation passed eight alternating H.264/H.265
  transitions with stable FD, socket, and handler counts.
- The configured RTVI unit suite introduced no new failures against the exact
  baseline SHA.
- The focused pipeline-replacement cleanup test passed.
- The authoritative fixed-phase Compose reproduction passed.
