### PR TITLE
fix(top-agent): fix hallucinations after video tool failures

### DIFF
--- a/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
@@ -475,7 +475,6 @@ class TopAgent(AsyncMixin):
         scratchpad_lines: list[str] = []
         tool_results_lines: list[str] = []
         has_tool_failure = False
-        has_tool_success = False
         pending_calls: dict[str, dict[str, Any]] = {}  # tool_call_id -> {name, args}
         for msg in state.agent_scratchpad:
             if isinstance(msg, AIMessage) and msg.tool_calls:
@@ -486,12 +485,11 @@ class TopAgent(AsyncMixin):
                 call_info = pending_calls.pop(msg.tool_call_id, None)
                 tool_name = (call_info["name"] if call_info else None) or getattr(msg, "name", None) or "tool"
                 result_text = _get_content_text(msg)
-                tool_failed = msg.status == "error" or result_text.lstrip().startswith(_TOOL_FAILURE_PREFIX)
+                tool_failed = _tool_response_failed(msg) or result_text.lstrip().startswith(_TOOL_FAILURE_PREFIX)
                 has_tool_failure = has_tool_failure or tool_failed
                 # Full result for programmatic appendix
                 tool_results_lines.append(f"`{tool_name}` result:\n{result_text}")
                 if not tool_failed:
-                    has_tool_success = True
                     if call_info:
                         scratchpad_lines.append(f"Called tool `{tool_name}` with args: {call_info['args']}")
                     # Failed results are deliberately excluded from the plan-tracking
@@ -542,11 +540,13 @@ class TopAgent(AsyncMixin):
         llm_kwargs = get_llm_reasoning_bind_kwargs(self.llm, state.options.llm_reasoning)
         llm_to_use = self.llm.bind(**llm_kwargs) if llm_kwargs else self.llm
 
-        if has_tool_failure and not has_tool_success:
+        if has_tool_failure:
             # A plan-updating LLM can mistake an exception message for evidence
-            # that the requested work completed. When every tool failed, keep
-            # the existing plan pending deterministically and expose the exact
-            # failures to the next agent turn for correction or reporting.
+            # that the requested work completed. Keep the existing plan pending
+            # whenever any call in a batch fails, including mixed batches, and
+            # expose every exact result to the next turn. Successful results are
+            # therefore preserved without letting failed work be completed or
+            # discarded by an LLM rewrite.
             updated_plan = clean_plan
             logger.warning("Tool failure detected; preserving the current plan without marking steps complete")
         else:

--- a/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
@@ -93,6 +93,7 @@ NO_INPUT_ERROR_MESSAGE = "No human input received to the agent, Please ask a val
 EMPTY_MESSAGES_ERROR = 'No input received in state: "current_message"'
 EMPTY_SCRATCHPAD_ERROR = 'No tool input received in state: "agent_scratchpad"'
 _TOOL_RESULTS_DELIMITER = "\n\n---\n### Latest Tool Results\n"
+_TOOL_FAILURE_PREFIX = "Tool call failed:"
 _REQUEST_OPTIONS_CONTEXT_MARKERS = ("current_request_options", "previous_request_options")
 _CONTEXT_BLOCK_PREFIX = "[Context:"
 
@@ -456,6 +457,7 @@ class TopAgent(AsyncMixin):
         # tool_results_lines → exact results appended programmatically
         scratchpad_lines: list[str] = []
         tool_results_lines: list[str] = []
+        has_tool_failure = False
         pending_calls: dict[str, dict[str, Any]] = {}  # tool_call_id -> {name, args}
         for msg in state.agent_scratchpad:
             if isinstance(msg, AIMessage) and msg.tool_calls:
@@ -467,6 +469,7 @@ class TopAgent(AsyncMixin):
                 call_info = pending_calls.pop(msg.tool_call_id, None)
                 tool_name = (call_info["name"] if call_info else None) or getattr(msg, "name", None) or "tool"
                 result_text = _get_content_text(msg)
+                has_tool_failure = has_tool_failure or result_text.lstrip().startswith(_TOOL_FAILURE_PREFIX)
                 # Full result for programmatic appendix
                 tool_results_lines.append(f"`{tool_name}` result:\n{result_text}")
                 # Truncated for the LLM prompt
@@ -516,11 +519,18 @@ class TopAgent(AsyncMixin):
         llm_kwargs = get_llm_reasoning_bind_kwargs(self.llm, state.options.llm_reasoning)
         llm_to_use = self.llm.bind(**llm_kwargs) if llm_kwargs else self.llm
 
-        result = await llm_to_use.ainvoke(messages, config=RunnableConfig(callbacks=self.callbacks))
+        if has_tool_failure:
+            # A plan-updating LLM can mistake an exception message for evidence
+            # that the requested work completed. Keep the existing plan pending
+            # deterministically and expose the exact failure to the next agent
+            # turn so it can correct the arguments or report the failure.
+            updated_plan = clean_plan
+            logger.warning("Tool failure detected; preserving the current plan without marking steps complete")
+        else:
+            result = await llm_to_use.ainvoke(messages, config=RunnableConfig(callbacks=self.callbacks))
 
-        _, updated_plan = parse_reasoning_content(result)
-        if not updated_plan:
-            updated_plan = str(result.content) if hasattr(result, "content") else clean_plan
+            _, parsed_plan = parse_reasoning_content(result)
+            updated_plan = parsed_plan or (str(result.content) if hasattr(result, "content") else clean_plan)
 
         # Programmatically append exact tool results so the agent has them,
         # combining previous results with new ones from this cycle.

--- a/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
@@ -475,25 +475,29 @@ class TopAgent(AsyncMixin):
         scratchpad_lines: list[str] = []
         tool_results_lines: list[str] = []
         has_tool_failure = False
+        has_tool_success = False
         pending_calls: dict[str, dict[str, Any]] = {}  # tool_call_id -> {name, args}
         for msg in state.agent_scratchpad:
             if isinstance(msg, AIMessage) and msg.tool_calls:
                 for tc in msg.tool_calls:
                     tc_id = tc["id"] or ""
                     pending_calls[tc_id] = {"name": tc["name"], "args": tc["args"]}
-                    scratchpad_lines.append(f"Called tool `{tc['name']}` with args: {tc['args']}")
             elif isinstance(msg, ToolMessage):
                 call_info = pending_calls.pop(msg.tool_call_id, None)
                 tool_name = (call_info["name"] if call_info else None) or getattr(msg, "name", None) or "tool"
                 result_text = _get_content_text(msg)
-                has_tool_failure = (
-                    has_tool_failure or msg.status == "error" or result_text.lstrip().startswith(_TOOL_FAILURE_PREFIX)
-                )
+                tool_failed = msg.status == "error" or result_text.lstrip().startswith(_TOOL_FAILURE_PREFIX)
+                has_tool_failure = has_tool_failure or tool_failed
                 # Full result for programmatic appendix
                 tool_results_lines.append(f"`{tool_name}` result:\n{result_text}")
-                # Truncated for the LLM prompt
-                truncated = result_text[:500] + "…" if len(result_text) > 500 else result_text
-                scratchpad_lines.append(f"Result from `{tool_name}`: {truncated}")
+                if not tool_failed:
+                    has_tool_success = True
+                    if call_info:
+                        scratchpad_lines.append(f"Called tool `{tool_name}` with args: {call_info['args']}")
+                    # Failed results are deliberately excluded from the plan-tracking
+                    # prompt so they cannot be mistaken for successful evidence.
+                    truncated = result_text[:500] + "…" if len(result_text) > 500 else result_text
+                    scratchpad_lines.append(f"Result from `{tool_name}`: {truncated}")
             else:
                 text = _get_content_text(msg)
                 if text.strip():
@@ -538,11 +542,11 @@ class TopAgent(AsyncMixin):
         llm_kwargs = get_llm_reasoning_bind_kwargs(self.llm, state.options.llm_reasoning)
         llm_to_use = self.llm.bind(**llm_kwargs) if llm_kwargs else self.llm
 
-        if has_tool_failure:
+        if has_tool_failure and not has_tool_success:
             # A plan-updating LLM can mistake an exception message for evidence
-            # that the requested work completed. Keep the existing plan pending
-            # deterministically and expose the exact failure to the next agent
-            # turn so it can correct the arguments or report the failure.
+            # that the requested work completed. When every tool failed, keep
+            # the existing plan pending deterministically and expose the exact
+            # failures to the next agent turn for correction or reporting.
             updated_plan = clean_plan
             logger.warning("Tool failure detected; preserving the current plan without marking steps complete")
         else:

--- a/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
@@ -94,7 +94,7 @@ EMPTY_MESSAGES_ERROR = 'No input received in state: "current_message"'
 EMPTY_SCRATCHPAD_ERROR = 'No tool input received in state: "agent_scratchpad"'
 _TOOL_RESULTS_DELIMITER = "\n\n---\n### Latest Tool Results\n"
 _TOOL_FAILURE_PREFIX = "Tool call failed:"
-_TOOL_FAILURE_STATUSES = {"error", "failed", "failure"}
+_TOOL_FAILURE_STATUSES = {"aborted", "error", "failed", "failure"}
 _REQUEST_OPTIONS_CONTEXT_MARKERS = ("current_request_options", "previous_request_options")
 _CONTEXT_BLOCK_PREFIX = "[Context:"
 

--- a/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
@@ -94,6 +94,7 @@ EMPTY_MESSAGES_ERROR = 'No input received in state: "current_message"'
 EMPTY_SCRATCHPAD_ERROR = 'No tool input received in state: "agent_scratchpad"'
 _TOOL_RESULTS_DELIMITER = "\n\n---\n### Latest Tool Results\n"
 _TOOL_FAILURE_PREFIX = "Tool call failed:"
+_TOOL_FAILURE_STATUSES = {"error", "failed", "failure"}
 _REQUEST_OPTIONS_CONTEXT_MARKERS = ("current_request_options", "previous_request_options")
 _CONTEXT_BLOCK_PREFIX = "[Context:"
 
@@ -154,6 +155,22 @@ def _get_content_text(msg: BaseMessage) -> str:
         elif isinstance(item, str):
             texts.append(item)
     return " ".join(texts)
+
+
+def _tool_response_failed(response: Any) -> bool:
+    """Return whether a tool response explicitly reports failure."""
+    if isinstance(response, dict):
+        success = response.get("success")
+        status = response.get("status")
+    else:
+        success = getattr(response, "success", None)
+        status = getattr(response, "status", None)
+
+    if success is False:
+        return True
+
+    status_value = getattr(status, "value", status)
+    return isinstance(status_value, str) and status_value.lower() in _TOOL_FAILURE_STATUSES
 
 
 def strip_frontend_tags(content: str) -> str:
@@ -469,7 +486,9 @@ class TopAgent(AsyncMixin):
                 call_info = pending_calls.pop(msg.tool_call_id, None)
                 tool_name = (call_info["name"] if call_info else None) or getattr(msg, "name", None) or "tool"
                 result_text = _get_content_text(msg)
-                has_tool_failure = has_tool_failure or result_text.lstrip().startswith(_TOOL_FAILURE_PREFIX)
+                has_tool_failure = (
+                    has_tool_failure or msg.status == "error" or result_text.lstrip().startswith(_TOOL_FAILURE_PREFIX)
+                )
                 # Full result for programmatic appendix
                 tool_results_lines.append(f"`{tool_name}` result:\n{result_text}")
                 # Truncated for the LLM prompt
@@ -1220,6 +1239,7 @@ class TopAgent(AsyncMixin):
                         name=tool_call["name"],
                         tool_call_id=tool_call["id"],
                         content=tool_content,
+                        status="error" if _tool_response_failed(tool_response) else "success",
                     )
 
                 except Exception as ex:
@@ -1229,6 +1249,7 @@ class TopAgent(AsyncMixin):
                         name=tool_call["name"],
                         tool_call_id=tool_call["id"],
                         content=error_response,
+                        status="error",
                     )
 
             # Execute all tool calls

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/code_executor/python_executor.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/code_executor/python_executor.py
@@ -70,6 +70,7 @@ class CodeExecutorOutput(BaseModel):
     """Output for the Code Executor tool"""
 
     message: str = Field(..., description="The output of the code execution")
+    success: bool = Field(default=True, description="Whether the code exited successfully")
 
 
 @register_function(config_type=CodeExecutorConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
@@ -103,9 +104,9 @@ async def python_executor(config: CodeExecutorConfig, _builder: Builder) -> Asyn
         code = code_executor_input.code or ""
         output = executor.run_code(code, code_executor_input.files, image=image_name)
         if output["exit_code"] == 0:
-            return CodeExecutorOutput(message=f"{output['stdout']}")
+            return CodeExecutorOutput(message=f"{output['stdout']}", success=True)
         else:
-            return CodeExecutorOutput(message=f"Error: {output}")
+            return CodeExecutorOutput(message=f"Error: {output}", success=False)
 
     yield FunctionInfo.create(
         single_fn=_python_executor,

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/video_understanding.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/video_understanding.py
@@ -361,6 +361,17 @@ class VideoUnderstandingOffsetInput(BaseModel):
         start = info.get("start_timestamp")
         end = info.get("end_timestamp")
 
+        # Tool-calling models sometimes serialize an omitted optional value as
+        # the strings "None" or "null". Treat those JSON-like sentinels (and an
+        # empty string) as an omitted offset so whole-video requests do not fail
+        # while trying to evaluate float("None").
+        if isinstance(start, str) and start.strip().lower() in {"", "none", "null"}:
+            start = None
+            info["start_timestamp"] = None
+        if isinstance(end, str) and end.strip().lower() in {"", "none", "null"}:
+            end = None
+            info["end_timestamp"] = None
+
         if start is not None:
             start = float(start)
             if start < 0:

--- a/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
@@ -488,15 +488,22 @@ class TestRequestOptionsContext:
         assert "A worker climbed a green ladder." in result.plan
         assert "Tool call failed: invalid timestamp" in result.plan
 
+    @pytest.mark.parametrize(
+        "tool_response",
+        [
+            SimpleNamespace(message="Error: process exited with status 1", success=False),
+            SimpleNamespace(message="Video analysis was cancelled", status="aborted"),
+        ],
+    )
     @pytest.mark.asyncio
-    async def test_tool_node_marks_structured_failure_as_error(self, monkeypatch):
+    async def test_tool_node_marks_structured_failure_as_error(self, monkeypatch, tool_response):
         monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
 
         class FailedTool:
             args_schema = None
 
             async def astream(self, input, config=None):
-                yield SimpleNamespace(message="Error: process exited with status 1", success=False)
+                yield tool_response
 
         agent = TopAgent.__new__(TopAgent)
         agent.tools_dict = {"python_executor": FailedTool()}

--- a/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
@@ -357,6 +357,51 @@ class TestRequestOptionsContext:
         assert "Request options context" in captured["system"]
 
     @pytest.mark.asyncio
+    async def test_failed_tool_call_cannot_be_marked_complete(self, monkeypatch):
+        chunks = []
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: chunks.append)
+
+        agent = TopAgent.__new__(TopAgent)
+        agent.llm = MagicMock()
+        agent.llm.ainvoke = AsyncMock(return_value=AIMessage(content="1. [x] Fabricated successful result."))
+        agent.callbacks = []
+        state = TopAgentState(
+            current_message=HumanMessage(content="What happened in warehouse_safety_001?"),
+            plan="1. [ ] Call `video_understanding` to analyze the video.",
+            agent_scratchpad=[
+                AIMessage(
+                    content="calling video understanding",
+                    tool_calls=[
+                        {
+                            "name": "video_understanding",
+                            "args": {
+                                "sensor_id": "warehouse_safety_001",
+                                "start_timestamp": "None",
+                                "end_timestamp": "None",
+                            },
+                            "id": "call_1",
+                        }
+                    ],
+                ),
+                ToolMessage(
+                    name="video_understanding",
+                    tool_call_id="call_1",
+                    content="Tool call failed: invalid timestamp",
+                ),
+            ],
+            options=AgentRequestOptions(),
+        )
+
+        result = await agent._plan_update_node(state)
+
+        agent.llm.ainvoke.assert_not_awaited()
+        assert result.plan.startswith("1. [ ] Call `video_understanding`")
+        assert "1. [x]" not in result.plan
+        assert "Tool call failed: invalid timestamp" in result.plan
+        assert result.agent_scratchpad == []
+        assert any("Updated Plan" in chunk.content for chunk in chunks)
+
+    @pytest.mark.asyncio
     async def test_tool_node_forwards_request_options_to_accepting_tool(self, monkeypatch):
         chunks = []
         monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: chunks.append)

--- a/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
@@ -436,6 +436,59 @@ class TestRequestOptionsContext:
         assert "Error: process exited with status 1" in result.plan
 
     @pytest.mark.asyncio
+    async def test_mixed_results_update_only_from_successes(self, monkeypatch):
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
+
+        agent = TopAgent.__new__(TopAgent)
+        agent.llm = MagicMock()
+        agent.llm.ainvoke = AsyncMock(
+            return_value=AIMessage(
+                content=(
+                    "1. [x] Inspect camera one. Result: A worker climbed a green ladder.\n2. [ ] Inspect camera two."
+                )
+            )
+        )
+        agent.callbacks = []
+        state = TopAgentState(
+            current_message=HumanMessage(content="What happened on both cameras?"),
+            plan="1. [ ] Inspect camera one.\n2. [ ] Inspect camera two.",
+            agent_scratchpad=[
+                AIMessage(
+                    content="calling video understanding",
+                    tool_calls=[
+                        {"name": "video_understanding", "args": {"sensor_id": "camera_one"}, "id": "call_1"},
+                        {"name": "video_understanding", "args": {"sensor_id": "camera_two"}, "id": "call_2"},
+                    ],
+                ),
+                ToolMessage(
+                    name="video_understanding",
+                    tool_call_id="call_1",
+                    content="A worker climbed a green ladder.",
+                ),
+                ToolMessage(
+                    name="video_understanding",
+                    tool_call_id="call_2",
+                    content="Tool call failed: invalid timestamp",
+                    status="error",
+                ),
+            ],
+            options=AgentRequestOptions(),
+        )
+
+        result = await agent._plan_update_node(state)
+
+        agent.llm.ainvoke.assert_awaited_once()
+        prompt = str(agent.llm.ainvoke.await_args.args[0][1].content)
+        assert "camera_one" in prompt
+        assert "A worker climbed a green ladder." in prompt
+        assert "camera_two" not in prompt
+        assert "invalid timestamp" not in prompt
+        assert "1. [x] Inspect camera one." in result.plan
+        assert "2. [ ] Inspect camera two." in result.plan
+        assert "A worker climbed a green ladder." in result.plan
+        assert "Tool call failed: invalid timestamp" in result.plan
+
+    @pytest.mark.asyncio
     async def test_tool_node_marks_structured_failure_as_error(self, monkeypatch):
         monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
 

--- a/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
@@ -402,6 +402,71 @@ class TestRequestOptionsContext:
         assert any("Updated Plan" in chunk.content for chunk in chunks)
 
     @pytest.mark.asyncio
+    async def test_error_status_cannot_be_marked_complete(self, monkeypatch):
+        chunks = []
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: chunks.append)
+
+        agent = TopAgent.__new__(TopAgent)
+        agent.llm = MagicMock()
+        agent.llm.ainvoke = AsyncMock(return_value=AIMessage(content="1. [x] Fabricated successful result."))
+        agent.callbacks = []
+        state = TopAgentState(
+            current_message=HumanMessage(content="Run the calculation."),
+            plan="1. [ ] Call `python_executor`.",
+            agent_scratchpad=[
+                AIMessage(
+                    content="calling python executor",
+                    tool_calls=[{"name": "python_executor", "args": {"code": "raise Error"}, "id": "call_1"}],
+                ),
+                ToolMessage(
+                    name="python_executor",
+                    tool_call_id="call_1",
+                    content="message='Error: process exited with status 1' success=False",
+                    status="error",
+                ),
+            ],
+            options=AgentRequestOptions(),
+        )
+
+        result = await agent._plan_update_node(state)
+
+        agent.llm.ainvoke.assert_not_awaited()
+        assert result.plan.startswith("1. [ ] Call `python_executor`")
+        assert "1. [x]" not in result.plan
+        assert "Error: process exited with status 1" in result.plan
+
+    @pytest.mark.asyncio
+    async def test_tool_node_marks_structured_failure_as_error(self, monkeypatch):
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
+
+        class FailedTool:
+            args_schema = None
+
+            async def astream(self, input, config=None):
+                yield SimpleNamespace(message="Error: process exited with status 1", success=False)
+
+        agent = TopAgent.__new__(TopAgent)
+        agent.tools_dict = {"python_executor": FailedTool()}
+        agent.subagent_names = set()
+        agent.callbacks = []
+        state = TopAgentState(
+            agent_scratchpad=[
+                AIMessage(
+                    content="calling python executor",
+                    tool_calls=[{"name": "python_executor", "args": {"code": "raise Error"}, "id": "call_1"}],
+                )
+            ],
+            options=AgentRequestOptions(),
+        )
+
+        await agent.tool_or_subagent_node(state)
+
+        result = state.agent_scratchpad[-1]
+        assert isinstance(result, ToolMessage)
+        assert result.status == "error"
+        assert not str(result.content).startswith("Tool call failed:")
+
+    @pytest.mark.asyncio
     async def test_tool_node_forwards_request_options_to_accepting_tool(self, monkeypatch):
         chunks = []
         monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: chunks.append)

--- a/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
@@ -436,7 +436,7 @@ class TestRequestOptionsContext:
         assert "Error: process exited with status 1" in result.plan
 
     @pytest.mark.asyncio
-    async def test_mixed_results_update_only_from_successes(self, monkeypatch):
+    async def test_mixed_results_preserve_plan_without_llm_rewrite(self, monkeypatch):
         monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
 
         agent = TopAgent.__new__(TopAgent)
@@ -444,7 +444,8 @@ class TestRequestOptionsContext:
         agent.llm.ainvoke = AsyncMock(
             return_value=AIMessage(
                 content=(
-                    "1. [x] Inspect camera one. Result: A worker climbed a green ladder.\n2. [ ] Inspect camera two."
+                    "1. [x] Inspect camera one. Result: A worker climbed a green ladder.\n"
+                    "2. [x] Inspect camera two. Result: An unsupported incident."
                 )
             )
         )
@@ -477,16 +478,12 @@ class TestRequestOptionsContext:
 
         result = await agent._plan_update_node(state)
 
-        agent.llm.ainvoke.assert_awaited_once()
-        prompt = str(agent.llm.ainvoke.await_args.args[0][1].content)
-        assert "camera_one" in prompt
-        assert "A worker climbed a green ladder." in prompt
-        assert "camera_two" not in prompt
-        assert "invalid timestamp" not in prompt
-        assert "1. [x] Inspect camera one." in result.plan
+        agent.llm.ainvoke.assert_not_awaited()
+        assert "1. [ ] Inspect camera one." in result.plan
         assert "2. [ ] Inspect camera two." in result.plan
         assert "A worker climbed a green ladder." in result.plan
         assert "Tool call failed: invalid timestamp" in result.plan
+        assert "unsupported incident" not in result.plan
 
     @pytest.mark.parametrize(
         "tool_response",

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_python_executor.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_python_executor.py
@@ -106,10 +106,12 @@ class TestCodeExecutorOutput:
     def test_successful_output(self):
         output = CodeExecutorOutput(message="Hello, World!")
         assert output.message == "Hello, World!"
+        assert output.success is True
 
     def test_error_output(self):
-        output = CodeExecutorOutput(message="Error: NameError: name 'undefined' is not defined")
+        output = CodeExecutorOutput(message="Error: NameError: name 'undefined' is not defined", success=False)
         assert "Error" in output.message
+        assert output.success is False
 
     def test_multiline_output(self):
         output = CodeExecutorOutput(message="Line 1\nLine 2\nLine 3")
@@ -121,3 +123,4 @@ class TestCodeExecutorOutput:
         data = output.model_dump()
         assert "message" in data
         assert data["message"] == "Test output"
+        assert data["success"] is True

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_video_understanding.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_video_understanding.py
@@ -19,6 +19,7 @@ import base64
 import pytest
 
 from vss_agents.tools.video_understanding import VideoUnderstandingConfig
+from vss_agents.tools.video_understanding import VideoUnderstandingOffsetInput
 from vss_agents.tools.video_understanding import _build_vlm_messages
 from vss_agents.tools.video_understanding import _effective_system_prompt
 from vss_agents.tools.video_understanding import _is_cosmos_model
@@ -26,6 +27,35 @@ from vss_agents.tools.video_understanding import _is_omni_audio_model
 from vss_agents.tools.video_understanding import _parse_thinking_from_content
 from vss_agents.tools.video_understanding import _should_use_video_base64
 from vss_agents.tools.video_understanding import _should_use_video_file_base64
+
+
+class TestVideoUnderstandingOffsetInput:
+    @pytest.mark.parametrize("sentinel", ["None", "none", " null ", ""])
+    def test_optional_timestamp_string_sentinels_are_normalized(self, sentinel: str):
+        model = VideoUnderstandingOffsetInput.model_validate(
+            {
+                "sensor_id": "warehouse_safety_001",
+                "start_timestamp": sentinel,
+                "end_timestamp": sentinel,
+                "user_prompt": "What happened in the video?",
+            }
+        )
+
+        assert model.start_timestamp is None
+        assert model.end_timestamp is None
+
+    def test_numeric_timestamp_strings_remain_supported(self):
+        model = VideoUnderstandingOffsetInput.model_validate(
+            {
+                "sensor_id": "warehouse_safety_001",
+                "start_timestamp": "0",
+                "end_timestamp": "12.5",
+                "user_prompt": "What happened in the video?",
+            }
+        )
+
+        assert model.start_timestamp == 0.0
+        assert model.end_timestamp == 12.5
 
 
 class TestParseThinkingFromContent:


### PR DESCRIPTION
## Summary

  Fixes hallucinated video events after video_understanding timestamp validation failures. Optional timestamps serialized as "None" are normalized, and failed tool calls can no longer be recorded as successfully completed plan results.

  ## Plan

  - Normalize string representations of omitted timestamps.
  - Prevent failed tool results from being summarized as verified evidence.
  - Preserve failed steps as pending so the agent can retry safely.
  - Add regression tests for timestamp handling and plan contamination.

  ## Related Issue
https://nvbugspro.nvidia.com/bug/6710157

  ## Changes

  - Treat "None", "null", and empty timestamp strings as omitted values.
  - Continue supporting valid numeric timestamp strings.
  - Detect failed tool results before invoking the plan-tracking LLM.
  - Preserve the existing pending plan when a tool fails.
  - Append the exact failure for retry or error reporting.
  - Add unit tests confirming:
      - Optional timestamp sentinels are normalized.
      - Numeric timestamps remain supported.
      - Failed calls cannot be marked complete with fabricated results.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.
