### PR TITLE
fix(agent): default the LLM endpoint and fail fast when it is empty

### DIFF
--- a/deploy/docker/services/agent/compose.yml
+++ b/deploy/docker/services/agent/compose.yml
@@ -65,7 +65,10 @@ services:
     ports:
     - ${VSS_AGENT_HOST_PORT:-8000}:${VSS_AGENT_PORT:-8000}
     environment:
-      LLM_MODE: ${LLM_MODE} # remote / local / local_shared
+      # Defaulted like the endpoint variables below, so an unset or empty value
+      # from the deploying shell cannot reach the container as a blank. Every
+      # committed profile except warehouse (local) sets local_shared.
+      LLM_MODE: ${LLM_MODE:-local_shared} # remote / local / local_shared
       VLM_MODE: ${VLM_MODE} # remote / local / local_shared
       LLM_MODEL_TYPE: ${LLM_MODEL_TYPE} # nim / openai
       VLM_MODEL_TYPE: ${VLM_MODEL_TYPE} # nim / openai
@@ -104,7 +107,16 @@ services:
 
       # LLM Endpoints
       LLM_NAME: ${LLM_NAME}
-      LLM_BASE_URL: ${LLM_BASE_URL}
+      # The one endpoint in this block that carried no default. Compose ranks the
+      # process env above --env-file and an exported-but-empty variable still
+      # wins, and `${VAR:-default}` treats empty as unset, so this covers both an
+      # empty value from the deploying shell and a profile that never sets one.
+      # It matters here more than elsewhere: the agent config writes
+      # `base_url: ${LLM_BASE_URL}/v1` with no fallback of its own, so a blank
+      # becomes the literal `/v1` and every completion is posted to a bare
+      # `/v1/chat/completions`. An explicit value still wins, which is how
+      # LLM_MODE=remote reaches a hosted endpoint.
+      LLM_BASE_URL: ${LLM_BASE_URL:-http://vss-llm-nim:8000}
       VLM_NAME: ${VLM_NAME}
       VLM_BASE_URL: ${VLM_BASE_URL}
       RTVI_VLM_BASE_URL: ${RTVI_VLM_BASE_URL}

--- a/services/agent/packages/vss_agents/src/vss_agents/api/front_end_config.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/api/front_end_config.py
@@ -27,6 +27,8 @@ from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
 
+from vss_agents.utils.llm_endpoint import validate_chat_llm_endpoints
+
 
 class StreamingIngestConfig(BaseModel):
     """Configuration for the streaming video ingest and RTSP stream endpoints.
@@ -139,4 +141,8 @@ class VSSFastApiFrontEndConfig(FastApiFrontEndConfig, name="vss_fastapi"):  # ty
 async def register_vss_fastapi_front_end(
     _config: VSSFastApiFrontEndConfig, full_config: Config
 ) -> AsyncGenerator[FastApiFrontEndPlugin]:
+    # First point at which the interpolated config is known, and still before the
+    # server binds: an LLM endpoint that no request can reach must stop the agent
+    # here rather than surface later as a stream error naming only the path.
+    validate_chat_llm_endpoints(full_config)
     yield FastApiFrontEndPlugin(full_config=full_config)

--- a/services/agent/packages/vss_agents/src/vss_agents/orchestrator/docker_compose_util.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/orchestrator/docker_compose_util.py
@@ -96,6 +96,14 @@ COMPOSE_PROFILE_REQUIRED_KEYS: Final[tuple[str, ...]] = (
     "VLM_NAME_SLUG",
 )
 _COMPOSE_SHELL_ENV_BLOCKLIST: Final[frozenset[str]] = frozenset({"LLM_MODE", "VLM_MODE"})
+# Dropped only when they arrive empty. Compose ranks the process env above
+# ``--env-file``, and an exported-but-empty variable still wins, so an empty
+# ``LLM_BASE_URL`` in the calling shell blanks the profile's endpoint and
+# everything derived from it -- which is what turns the agent's LLM into a bare
+# ``/v1``. A *non-empty* value is a legitimate override (that is how a remote
+# endpoint is passed in), so it is left alone rather than added to the blocklist
+# above.
+_COMPOSE_SHELL_ENV_DROP_IF_EMPTY: Final[frozenset[str]] = frozenset({"LLM_BASE_URL", "VLM_BASE_URL"})
 
 
 class ValidationError(ValueError):
@@ -776,6 +784,9 @@ def _compose_subprocess_env(extra_defaults: Mapping[str, str] = MappingProxyType
     env = os.environ.copy()
     for key in _COMPOSE_SHELL_ENV_BLOCKLIST:
         env.pop(key, None)
+    for key in _COMPOSE_SHELL_ENV_DROP_IF_EMPTY:
+        if not env.get(key, "").strip():
+            env.pop(key, None)
     for key, value in extra_defaults.items():
         env.setdefault(key, value)
     return env

--- a/services/agent/packages/vss_agents/src/vss_agents/utils/llm_endpoint.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/utils/llm_endpoint.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Startup check that the workflow's LLM has an endpoint a request can reach.
+
+Every profile writes its LLM endpoint as ``base_url: ${LLM_BASE_URL}/v1`` with no
+``:-`` fallback. When that variable arrives empty, nothing downstream objects: the
+NAT YAML loader substitutes the empty string rather than failing, so ``base_url``
+becomes the literal ``/v1``; ``NIMModelConfig.base_url`` is ``str | None`` with no
+validation, so Pydantic accepts it; and the LangChain NVIDIA client only *warns*
+about a URL with no scheme and no host. The agent then starts, passes its health
+check, and fails on the first token with ``InvalidUrlClientError`` naming
+``/v1/chat/completions`` -- which the top agent renders as ``Error:
+/v1/chat/completions`` followed by the canned apology, with nothing pointing at
+the variable that was missing.
+
+Note that the client's ``https://integrate.api.nvidia.com/v1`` default only
+applies when ``base_url`` is *omitted*. Setting it to ``/v1`` defeats it, so an
+empty variable is strictly worse than an absent one.
+
+Scope is deliberately narrow:
+
+* The entry named by ``workflow.llm_name`` is fatal. It is the agent's single
+  reasoning LLM, so an unusable endpoint there means no prompt can be answered
+  and there is nothing to be gained by starting.
+* Any other ``llms:`` entry only warns. ``llms.rtvi_vlm.base_url`` resolves to
+  ``/v1`` on base, search, lvs and warehouse as they ship, because
+  ``RTVI_VLM_BASE_URL`` is only defined in ``deploy/docker/services/rtvi/rtvi.env``
+  -- an ``env_file:`` for the RT-VLM containers, not part of the agent's
+  interpolation chain. Refusing on those would refuse every current profile.
+* An entry that omits ``base_url`` is left alone: ``openai_vlm`` does that on
+  purpose so the client uses its own endpoint.
+"""
+
+import logging
+
+from nat.data_models.config import Config
+
+logger = logging.getLogger(__name__)
+
+_ABSOLUTE_PREFIXES = ("http://", "https://")
+
+_VALID_SHAPES = (
+    "an in-deployment LLM (for example 'http://vss-llm-nim:8000'), the gateway "
+    "route ('${VSS_GATEWAY_ORIGIN}/llm'), or a hosted endpoint (for example "
+    "'https://integrate.api.nvidia.com')"
+)
+
+
+class LLMEndpointConfigurationError(ValueError):
+    """The workflow's LLM is configured with a base URL no request can reach."""
+
+
+def _endpoint_problem(base_url: object) -> str | None:
+    """Describe why ``base_url`` is unusable, or return ``None`` when it is fine."""
+
+    # Omitted entirely: the client falls back to its own endpoint, which is a
+    # deliberate configuration rather than a missing one.
+    if base_url is None:
+        return None
+    if not isinstance(base_url, str) or not base_url.strip():
+        return "it is empty"
+    if not base_url.strip().lower().startswith(_ABSOLUTE_PREFIXES):
+        return "it has no scheme and no host"
+    return None
+
+
+def validate_chat_llm_endpoints(config: Config) -> None:
+    """Refuse to serve when the workflow's LLM endpoint is unusable; warn on the rest.
+
+    Raises:
+        LLMEndpointConfigurationError: naming the ``llms:`` entry, the value it
+            resolved to, and the endpoint shapes that are valid.
+    """
+
+    workflow_llm = getattr(config.workflow, "llm_name", None)
+
+    for name, llm_config in (config.llms or {}).items():
+        base_url = getattr(llm_config, "base_url", None)
+        problem = _endpoint_problem(base_url)
+        if problem is None:
+            continue
+
+        if name == workflow_llm:
+            raise LLMEndpointConfigurationError(
+                f"The workflow's LLM 'llms.{name}' has base_url={base_url!r}, and {problem}. "
+                "This is what an empty LLM_BASE_URL interpolates to, and it would send every "
+                "chat completion to a bare '/v1/chat/completions' with no host: the agent would "
+                "start, pass its health check, and fail on the first prompt. Set LLM_BASE_URL to "
+                f"an absolute origin with no trailing '/v1' -- {_VALID_SHAPES}."
+            )
+
+        logger.warning(
+            "LLM 'llms.%s' has base_url=%r, and %s. The workflow does not use it, so the agent "
+            "will start, but anything that resolves this entry will fail on its first request. "
+            "Set the endpoint variable this entry reads to an absolute origin -- %s.",
+            name,
+            base_url,
+            problem,
+            _VALID_SHAPES,
+        )

--- a/services/agent/packages/vss_agents/tests/unit_test/orchestrator/test_docker_compose_util.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/orchestrator/test_docker_compose_util.py
@@ -1789,6 +1789,30 @@ class TestComposeEnvFileLayering:
 
         assert compose_env["VSS_CONTAINER_TAG"] == "develop-latest"
 
+    # Compose ranks the process env above --env-file, so an exported-but-empty
+    # endpoint blanks the profile's value and every value derived from it. That is
+    # how the agent's LLM base_url became a bare `/v1`.
+    @pytest.mark.parametrize("key", ["LLM_BASE_URL", "VLM_BASE_URL"])
+    @pytest.mark.parametrize("value", ["", "   "])
+    def test_empty_endpoint_from_shell_is_dropped(self, key: str, value: str, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(key, value)
+
+        assert key not in dcu._compose_subprocess_env()
+
+    @pytest.mark.parametrize("key", ["LLM_BASE_URL", "VLM_BASE_URL"])
+    def test_configured_endpoint_from_shell_is_honoured(self, key: str, monkeypatch: pytest.MonkeyPatch):
+        # A non-empty value is how a remote endpoint is passed in; dropping it
+        # would silently redirect the deployment at a local NIM.
+        monkeypatch.setenv(key, "https://integrate.api.nvidia.com")
+
+        assert dcu._compose_subprocess_env()[key] == "https://integrate.api.nvidia.com"
+
+    @pytest.mark.parametrize("key", ["LLM_MODE", "VLM_MODE"])
+    def test_mode_blocklist_still_drops_non_empty_values(self, key: str, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(key, "remote")
+
+        assert key not in dcu._compose_subprocess_env()
+
     def test_resolve_compose_uses_dev_profile_env_file_order(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         recipe = _make_recipe(tmp_path, "MODE=2d")
         commands: list[list[str]] = []

--- a/services/agent/packages/vss_agents/tests/unit_test/utils/test_llm_endpoint.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/utils/test_llm_endpoint.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from typing import Any
+
+from nat.llm.nim_llm import NIMModelConfig
+from nat.llm.openai_llm import OpenAIModelConfig
+from pydantic import BaseModel
+import pytest
+
+from vss_agents.utils.llm_endpoint import LLMEndpointConfigurationError
+from vss_agents.utils.llm_endpoint import validate_chat_llm_endpoints
+
+
+class _Workflow(BaseModel):
+    """Stands in for top_agent; llm_name is the only field that is read."""
+
+    llm_name: str = "nim_llm"
+
+
+class _Config(BaseModel):
+    """Minimal stand-in for nat Config; only workflow and llms are read."""
+
+    workflow: Any = None
+    llms: dict[str, Any] = {}
+
+
+def _config(base_url: str | None) -> _Config:
+    return _Config(
+        workflow=_Workflow(),
+        llms={"nim_llm": NIMModelConfig(model_name="nvidia/nemotron", base_url=base_url)},
+    )
+
+
+def test_in_cluster_nim_passes() -> None:
+    validate_chat_llm_endpoints(_config("http://vss-llm-nim:8000/v1"))
+
+
+def test_gateway_route_passes() -> None:
+    validate_chat_llm_endpoints(_config("http://vss-haproxy-ingress:7777/llm/v1"))
+
+
+def test_hosted_endpoint_passes() -> None:
+    validate_chat_llm_endpoints(_config("https://integrate.api.nvidia.com/v1"))
+
+
+def test_omitted_base_url_passes() -> None:
+    # `openai_vlm` omits base_url on purpose so the client uses its own endpoint.
+    validate_chat_llm_endpoints(_config(None))
+
+
+def test_empty_llm_base_url_resolves_to_relative_path_and_refuses() -> None:
+    # `base_url: ${LLM_BASE_URL}/v1` with the variable empty.
+    with pytest.raises(LLMEndpointConfigurationError) as excinfo:
+        validate_chat_llm_endpoints(_config("/v1"))
+
+    message = str(excinfo.value)
+    assert "llms.nim_llm" in message
+    assert "'/v1'" in message
+    assert "LLM_BASE_URL" in message
+    assert "${VSS_GATEWAY_ORIGIN}/llm" in message
+    assert "https://integrate.api.nvidia.com" in message
+
+
+def test_empty_string_base_url_refuses() -> None:
+    with pytest.raises(LLMEndpointConfigurationError, match="it is empty"):
+        validate_chat_llm_endpoints(_config("   "))
+
+
+def test_scheme_less_host_refuses() -> None:
+    with pytest.raises(LLMEndpointConfigurationError, match="no scheme and no host"):
+        validate_chat_llm_endpoints(_config("vss-llm-nim:8000/v1"))
+
+
+def test_non_workflow_entry_only_warns(caplog: pytest.LogCaptureFixture) -> None:
+    # rtvi_vlm resolves to /v1 on every shipping Compose profile because
+    # RTVI_VLM_BASE_URL is not in the agent's interpolation chain. Refusing on it
+    # would refuse to start every profile as it ships.
+    config = _Config(
+        workflow=_Workflow(llm_name="nim_llm"),
+        llms={
+            "nim_llm": NIMModelConfig(model_name="nvidia/nemotron", base_url="http://vss-llm-nim:8000/v1"),
+            "rtvi_vlm": OpenAIModelConfig(model_name="cosmos", base_url="/v1"),
+        },
+    )
+    with caplog.at_level(logging.WARNING):
+        validate_chat_llm_endpoints(config)
+
+    assert "llms.rtvi_vlm" in caplog.text
+    assert "nim_llm" not in caplog.text
+
+
+def test_healthy_config_warns_about_nothing(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING):
+        validate_chat_llm_endpoints(_config("http://vss-llm-nim:8000/v1"))
+
+    assert caplog.text == ""


### PR DESCRIPTION
## The nightly symptom

Nightly integration and UI e2e (2026-09-03, `nightly-develop`) failed broadly because the VSS Agent could not answer any prompt. Every agent-eval prompt — "What sensors are available?", "List the last 3 incidents for sensor id \"Camera_01\"", "Generate a report for the last incident of sensor id \"Camera_01\"" — failed identically, surfacing in the UI as:

```
Error: /v1/chat/completions
```

followed by the canned "Sorry, I wasn't able to complete your request…". Report-generation tests then failed on a missing output link, because no report was ever produced.

## Root cause: an empty `LLM_BASE_URL`, not a misplaced LLM

`Error: /v1/chat/completions` is the signature of an **empty** endpoint variable, not an unreachable one — an unreachable host produces a connection error that names the host. The chain:

1. Every profile config writes `base_url: ${LLM_BASE_URL}/v1` with no `:-` fallback (e.g. `deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml:167`).
2. `deploy/docker/services/agent/compose.yml:107` on `develop` is `LLM_BASE_URL: ${LLM_BASE_URL}` — the **only** bare passthrough in that environment block. Its eleven neighbours all carry inline defaults, e.g. `RTVI_CV_ENDPOINT: ${RTVI_CV_ENDPOINT:-http://vss-rtvi-cv:${RTVI_CV_PORT:-9000}}` at `:90`.
3. nvidia-nat's YAML loader substitutes an unset or empty variable with the empty string instead of failing, so `base_url` becomes the literal `/v1`.
4. `NIMModelConfig.base_url` is `str | None` with no validation, so Pydantic accepts it. `langchain_nvidia_ai_endpoints._common._validate_base_url` only **warns** on a URL with no scheme and no netloc. The client's `https://integrate.api.nvidia.com/v1` default applies only when `base_url` is *omitted*; setting it to `/v1` defeats it.
5. The agent starts, **passes its health check**, and fails on the first token with `InvalidUrlClientError("/v1/chat/completions")`, which `services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py` renders as `f"Error: {ex}"` before the canned apology.

That is why all three prompts failed identically: the failure is at the agent's single reasoning LLM, before any tool selection.

**How it became empty.** Docker Compose ranks the process environment above `--env-file`, and an exported-but-empty variable still wins. Reproduced directly:

```
# env-file value only, variable unset in the shell
LLM_BASE_URL: http://vss-llm-nim:8000
# same env file, LLM_BASE_URL="" exported
LLM_BASE_URL: ""
```

A profile that never sets the variable produces the same result. `industry-profiles/smartcities` sets none of `LLM_MODE`, `LLM_NAME`, `LLM_NAME_SLUG` or `LLM_BASE_URL` in either `.env` or `overrides.env`, yet its `COMPOSE_PROFILES_CV` includes `vss-agent` and `overrides.env:46` derives `EVAL_LLM_JUDGE_BASE_URL=${LLM_BASE_URL}` from it; it relies on an out-of-repo launchable merging it over `dev-profile-alerts/overrides.env`.

**Platform discriminator.** Compose deployments are affected; Helm is structurally immune. The chart always coalesces to an in-cluster NIM default (`deploy/helm/developer-profiles/dev-profile-base/values.yaml:260`), so Helm can render a *wrong* URL but never an empty one, and therefore never this error string. That is what makes the nightly matrix uneven. The H100 gap in that run was a lost host lease and is not evidence about this bug.

## What the three commits do

Ordered smallest-and-most-defensible first, so the hotfix can be taken alone.

**1. `fix(deploy): default the agent LLM endpoint in compose`** — two lines. Gives `LLM_BASE_URL` an inline default in the same style as its eleven neighbours, plus `LLM_MODE` at `:68` for the same reason. Because `${VAR:-default}` treats an empty value as unset, this one line closes both failure modes: an exported-but-empty variable in the deploying shell, and a profile that never sets one. This is the nightly hotfix.

**2. `fix(agent): refuse to serve when the workflow LLM has no endpoint`** — `register_vss_fastapi_front_end` is the one VSS-owned hook that sees the fully env-substituted `Config`, exactly once, at `nat serve` startup. It now refuses to start when the entry named by `workflow.llm_name` has no scheme and host, naming the entry, the value it resolved to, and the endpoint shapes that are valid. Two carve-outs that matter:

- an entry that **omits** `base_url` is left alone — `openai_vlm` does that deliberately so the client uses its own endpoint;
- every other `llms:` entry only **warns**. `llms.rtvi_vlm.base_url` already resolves to `/v1` on base, search, lvs and warehouse as they ship, because `RTVI_VLM_BASE_URL` is defined only in `deploy/docker/services/rtvi/rtvi.env`, an `env_file:` for the RT-VLM containers that is not in the agent's interpolation chain. A blanket rule would refuse to boot every profile shipping today.

**3. `fix(orchestrator): drop empty endpoint vars from the compose env`** — defence in depth for the programmatic deploy path. `docker_compose_util.py` already strips `LLM_MODE`/`VLM_MODE` from the inherited environment unconditionally, which is this same bug class fixed narrowly once before. This adds a separate **empty-only** guard (`_COMPOSE_SHELL_ENV_DROP_IF_EMPTY`) rather than extending that blocklist, because a *non-empty* shell `LLM_BASE_URL` is a legitimate override — it is how a remote endpoint is passed in, and callers outside this repository may rely on it.

## The remote/external LLM case is preserved

`LLM_BASE_URL` stays authoritative everywhere. An explicitly configured endpoint wins over the new default (verified: `LLM_BASE_URL=https://integrate.api.nvidia.com` renders unchanged), the fail-fast accepts any absolute `http(s)` origin, and the orchestrator guard drops only empty and whitespace-only values. Deployments pointing at build.nvidia.com or a hosted NIM are unaffected.

`http://vss-llm-nim:8000` is the default because it is the value all five committed profiles already use, and it is a network alias every LLM NIM compose service registers — dedicated and `-shared-gpu` alike (`deploy/docker/services/nim/nemotron-3.5-lightning-30b-a3b/compose.yml:28-29,72-74`) — so it encodes no GPU placement.

## This changes *how* a misconfigured deployment fails

Worth flagging for whoever owns the nightly: today the agent comes up, passes `/health`, and fails on every prompt. After commit 2 it refuses to start. That is earlier and louder, but it is a different failure shape — a harness that waits on `/health` will now see a container that never becomes healthy rather than one that answers with an error string.

## Tested

- `uv run pytest packages/vss_agents/tests/unit_test/utils/test_llm_endpoint.py packages/vss_agents/tests/unit_test/orchestrator/test_docker_compose_util.py packages/vss_agents/tests/unit_test/api -q` → **303 passed**. New cases cover, for the fail-fast: in-cluster / gateway-style / hosted / omitted `base_url` / `/v1` / whitespace-only / scheme-less, plus warn-only for a non-workflow entry and no warning on a healthy config. For the orchestrator guard: empty and whitespace-only dropped, non-empty honoured, and the existing mode blocklist still unconditional.
- `uv run ruff check packages/vss_agents/src packages/vss_agents/tests` → clean; `ruff format --check` → clean; `uv run mypy packages/vss_agents/src/vss_agents/` → no issues in 132 files.
- `docker compose config` used to reproduce the shadowing and to verify the new defaults across all three cases (profile value honoured, empty shell value defaulted, explicit remote value preserved).

## Not tested

No deployment was stood up: no NIM images pulled, no GPU workload, no end-to-end agent prompt. The behaviour of the compose defaults was verified by rendering configuration, not by running the stack.

## Related but deliberately not included

- **The `/llm` gateway route** is a separate PR stacked on #1983. It addresses topology independence, not emptiness, and would not have prevented this nightly.
- **`unset` guards in `dev-profile.sh` / `blueprint-deploy.sh`** — commit 1 makes them redundant for this variable, and both scripts are already careful (`dev-profile.sh:1713` and `blueprint-deploy.sh:1199` both check `if [[ -n "${llm_base_url}" ]]` before writing, so neither can stamp an empty value). Available as a follow-up if wanted.
- **`smartcities`** setting no LLM variables at all is a latent second exposure that commit 1 makes harmless; restructuring that overlay needs the out-of-repo launchable and is not attempted here.
- **No CI guard covers the LLM endpoint** (`git grep LLM_BASE_URL -- .github` yields one docstring hit). A `check_*.py`-style guard would fit the existing idiom but would bloat this PR.
- **Two Helm mismatches** found while ruling Helm out, left alone: `deploy/helm/developer-profiles/dev-profile-search/override-values.yaml:32` sets a top-level `vss-agent:` key the chart reads at `agent.vss-agent:` and therefore ignores, and `apiKeys.nvidia` in the agent chart values is referenced by no template.
- **The search upload failures in the same nightly are a different bug.** They look like `04d4b25f9` "fix(agent): route RTVI-CV ingest through the internal VST endpoint (#1952)", which landed 2026-09-03T16:06Z — hours before the run — and added a new hard `HTTPException` on `vst_url` in the upload path, and/or the unmerged #2028 rt-embed `409 DuplicateAssetId` race. Nothing in this PR touches either.
