### PR TITLE
fix: fail fast on an unusable LLM endpoint, order the vios ingress behind its upstreams, and link reports by URL value

### DIFF
--- a/deploy/docker/services/vios/foundational/docker-compose.yaml
+++ b/deploy/docker/services/vios/foundational/docker-compose.yaml
@@ -61,6 +61,13 @@ services:
       timeout: 3s
       retries: 30
       start_period: 2s
+    # Nginx resolves every proxy_pass host at config-parse time and exits with
+    # [emerg] "host not found in upstream" if one is missing, so every host named
+    # by nginx-${VST_NGINX_MODE}.conf must exist first: vss-vios-sensor and
+    # vss-vios-streamprocessing (vst), sdr-controller (vst-sdrc, mms).
+    # service_started suffices -- nginx needs the DNS alias, not a serving
+    # upstream -- and streamprocessing's healthcheck is widened to ~25min to
+    # outlast slow apt mirrors, which service_healthy would hold this edge down for.
     depends_on:
       sensor-ms:
         condition: service_healthy
@@ -70,6 +77,24 @@ services:
         required: false
       sensor-ms-3d:
         condition: service_healthy
+        required: false
+      sensor-ms-mv3dt:
+        condition: service_healthy
+        required: false
+      streamprocessing-ms:
+        condition: service_started
+        required: false
+      streamprocessing-ms-2d:
+        condition: service_started
+        required: false
+      streamprocessing-ms-3d:
+        condition: service_started
+        required: false
+      streamprocessing-ms-mv3dt:
+        condition: service_started
+        required: false
+      sdr-controller:
+        condition: service_started
         required: false
 
 volumes:

--- a/services/agent/packages/vss_agents/src/vss_agents/agents/report_agent.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/agents/report_agent.py
@@ -61,6 +61,59 @@ def _append_artifact_display_note(side_effects: dict[str, Any]) -> None:
         side_effects["artifact_note"] = _ARTIFACT_DISPLAY_NOTE
 
 
+def _build_report_side_effects(report_result: Any, incident_id: str) -> dict[str, Any]:
+    """Build the download and media side effects for a generated incident report.
+
+    ``TemplateReportGenOutput`` declares ``http_url`` and ``pdf_url`` as required
+    fields, so ``hasattr`` is always true for them: only the values say whether the
+    object store produced anything linkable. Gating the section on the attribute
+    instead emitted a bare ``**Report Downloads:**`` heading with no anchors
+    whenever both URLs came back empty, which is indistinguishable -- to a reader
+    and to any link assertion -- from report generation having silently failed.
+
+    Media is treated differently on purpose: an incident need not have a snapshot
+    or a clip, so an absent media block is normal and is omitted rather than
+    announced. A report with nothing at all to download is not normal, so it says
+    so explicitly and logs a warning.
+    """
+
+    side_effects: dict[str, Any] = {}
+
+    downloads = [
+        f"- [{label}]({url})"
+        for label, url in (
+            ("Markdown Report", getattr(report_result, "http_url", "")),
+            ("PDF Report", getattr(report_result, "pdf_url", "")),
+        )
+        if url
+    ]
+    if downloads:
+        side_effects["report_downloads"] = "\n".join(["**Report Downloads:**", *downloads]) + "\n"
+    else:
+        logger.warning(
+            "Report for incident %s produced no downloadable artifact: the object store returned "
+            "neither a markdown nor a PDF URL",
+            incident_id,
+        )
+        side_effects["report_downloads"] = (
+            "**Report Downloads:** none - the report was generated, but the object store returned "
+            "no markdown or PDF URL, so there is nothing to download.\n"
+        )
+
+    media = [
+        f"- {prefix}[{label}]({url})"
+        for prefix, label, url in (
+            ("!", "Incident Snapshot", getattr(report_result, "image_url", "")),
+            ("", "Incident Video", getattr(report_result, "video_url", "")),
+        )
+        if url
+    ]
+    if media:
+        side_effects["media"] = "\n".join(["**Media:**", *media]) + "\n"
+
+    return side_effects
+
+
 # ========== REPORT AGENT MODELS ==========
 
 
@@ -553,21 +606,7 @@ async def report_agent(config: ReportAgentConfig, builder: Builder) -> AsyncGene
         report_result = await template_report_tool.ainvoke(report_tool_args)
         logger.info("Single incident report generated successfully")
 
-        side_effects = {}
-        if hasattr(report_result, "http_url") or hasattr(report_result, "pdf_url"):
-            downloads = ["**Report Downloads:**"]
-            if hasattr(report_result, "http_url") and report_result.http_url:
-                downloads.append(f"- [Markdown Report]({report_result.http_url})")
-            if hasattr(report_result, "pdf_url") and report_result.pdf_url:
-                downloads.append(f"- [PDF Report]({report_result.pdf_url})")
-            side_effects["report_downloads"] = "\n".join(downloads) + "\n"
-        if hasattr(report_result, "image_url") or hasattr(report_result, "video_url"):
-            media = ["**Media:**"]
-            if hasattr(report_result, "image_url") and report_result.image_url:
-                media.append(f"- ![Incident Snapshot]({report_result.image_url})")
-            if hasattr(report_result, "video_url") and report_result.video_url:
-                media.append(f"- [Incident Video]({report_result.video_url})")
-            side_effects["media"] = "\n".join(media) + "\n"
+        side_effects = _build_report_side_effects(report_result, incident_id)
         _append_artifact_display_note(side_effects)
 
         agent_output = AgentOutput(

--- a/services/agent/packages/vss_agents/src/vss_agents/api/front_end_config.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/api/front_end_config.py
@@ -27,6 +27,8 @@ from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
 
+from vss_agents.utils.llm_endpoint import validate_chat_llm_endpoints
+
 
 class StreamingIngestConfig(BaseModel):
     """Configuration for the streaming video ingest and RTSP stream endpoints.
@@ -139,4 +141,8 @@ class VSSFastApiFrontEndConfig(FastApiFrontEndConfig, name="vss_fastapi"):  # ty
 async def register_vss_fastapi_front_end(
     _config: VSSFastApiFrontEndConfig, full_config: Config
 ) -> AsyncGenerator[FastApiFrontEndPlugin]:
+    # First point at which the interpolated config is known, and still before the
+    # server binds: an LLM endpoint that no request can reach must stop the agent
+    # here rather than surface later as a stream error naming only the path.
+    validate_chat_llm_endpoints(full_config)
     yield FastApiFrontEndPlugin(full_config=full_config)

--- a/services/agent/packages/vss_agents/src/vss_agents/utils/llm_endpoint.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/utils/llm_endpoint.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Startup check that the workflow's LLM has an endpoint a request can reach.
+
+Every profile writes its LLM endpoint as ``base_url: ${LLM_BASE_URL}/v1`` with no
+``:-`` fallback. When that variable arrives empty, nothing downstream objects: the
+NAT YAML loader substitutes the empty string rather than failing, so ``base_url``
+becomes the literal ``/v1``; ``NIMModelConfig.base_url`` is ``str | None`` with no
+validation, so Pydantic accepts it; and the LangChain NVIDIA client only *warns*
+about a URL with no scheme and no host. The agent then starts, passes its health
+check, and fails on the first token with ``InvalidUrlClientError`` naming
+``/v1/chat/completions`` -- which the top agent renders as ``Error:
+/v1/chat/completions`` followed by the canned apology, with nothing pointing at
+the variable that was missing.
+
+Note that the client's ``https://integrate.api.nvidia.com/v1`` default only
+applies when ``base_url`` is *omitted*. Setting it to ``/v1`` defeats it, so an
+empty variable is strictly worse than an absent one.
+
+Scope is deliberately narrow:
+
+* The entry named by ``workflow.llm_name`` is fatal. It is the agent's single
+  reasoning LLM, so an unusable endpoint there means no prompt can be answered
+  and there is nothing to be gained by starting.
+* Any other ``llms:`` entry only warns. The profiles declare an entry per
+  LLM/VLM flavour and select one at runtime, so an unused entry can carry an
+  unresolved endpoint without anything being wrong. ``llms.rtvi_vlm`` is the
+  live example: ``RTVI_VLM_BASE_URL`` is defined only in
+  ``deploy/docker/services/rtvi/rtvi.env``, which the agent gets through the
+  ``include:`` chain in ``deploy/docker/services/compose.yml`` -- so it resolves
+  in a Compose deployment but not for ``nat serve --config_file`` run outside
+  the container, where the entry renders as the bare ``/v1``. Refusing there
+  would break a documented dev workflow over an LLM no prompt touches.
+* An entry that omits ``base_url`` is left alone: ``openai_vlm`` does that on
+  purpose so the client uses its own endpoint.
+"""
+
+import logging
+from urllib.parse import urlsplit
+
+from nat.data_models.config import Config
+
+logger = logging.getLogger(__name__)
+
+_VALID_SCHEMES = ("http", "https")
+
+_VALID_SHAPES = (
+    "an in-deployment LLM (for example 'http://vss-llm-nim:8000') or a hosted "
+    "endpoint (for example 'https://integrate.api.nvidia.com')"
+)
+
+
+class LLMEndpointConfigurationError(ValueError):
+    """The workflow's LLM is configured with a base URL no request can reach."""
+
+
+def _endpoint_problem(base_url: object) -> str | None:
+    """Describe why ``base_url`` is unusable, or return ``None`` when it is fine."""
+
+    # Omitted entirely: the client falls back to its own endpoint, which is a
+    # deliberate configuration rather than a missing one.
+    if base_url is None:
+        return None
+    if not isinstance(base_url, str) or not base_url.strip():
+        return "it is empty"
+
+    parsed = urlsplit(base_url.strip())
+    scheme = parsed.scheme.lower()
+    if scheme not in _VALID_SCHEMES:
+        if parsed.netloc:
+            return f"its scheme {scheme!r} is not http or https"
+        return "it has no scheme and no host"
+    # `http:///v1` keeps the scheme but loses the authority, so a request built
+    # from it has nowhere to go -- the same dead end as the bare path.
+    if not parsed.netloc:
+        return "it has a scheme but no host"
+    return None
+
+
+def validate_chat_llm_endpoints(config: Config) -> None:
+    """Refuse to serve when the workflow's LLM endpoint is unusable; warn on the rest.
+
+    Raises:
+        LLMEndpointConfigurationError: naming the ``llms:`` entry, the value it
+            resolved to, and the endpoint shapes that are valid.
+    """
+
+    workflow_llm = getattr(config.workflow, "llm_name", None)
+
+    for name, llm_config in (config.llms or {}).items():
+        base_url = getattr(llm_config, "base_url", None)
+        problem = _endpoint_problem(base_url)
+        if problem is None:
+            continue
+
+        if name == workflow_llm:
+            raise LLMEndpointConfigurationError(
+                f"The workflow's LLM 'llms.{name}' has base_url={base_url!r}, and {problem}. "
+                "This is what an empty LLM_BASE_URL interpolates to, and it would send every "
+                "chat completion to a bare '/v1/chat/completions' with no host: the agent would "
+                "start, pass its health check, and fail on the first prompt. Set LLM_BASE_URL to "
+                f"an absolute origin with no trailing '/v1' -- {_VALID_SHAPES}."
+            )
+
+        logger.warning(
+            "LLM 'llms.%s' has base_url=%r, and %s. The workflow does not use it, so the agent "
+            "will start, but anything that resolves this entry will fail on its first request. "
+            "Set the endpoint variable this entry reads to an absolute origin -- %s.",
+            name,
+            base_url,
+            problem,
+            _VALID_SHAPES,
+        )

--- a/services/agent/packages/vss_agents/tests/unit_test/agents/test_report_agent.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/agents/test_report_agent.py
@@ -15,12 +15,15 @@
 """Unit tests for report_agent module."""
 
 from datetime import datetime
+from types import SimpleNamespace
 
 from pydantic import ValidationError
 import pytest
 
 from vss_agents.agents.report_agent import ReportAgentInput
 from vss_agents.agents.report_agent import VideoReportAgentInput
+from vss_agents.agents.report_agent import _build_report_side_effects
+from vss_agents.tools.template_report_gen import TemplateReportGenOutput
 
 
 class TestReportAgentInput:
@@ -84,3 +87,81 @@ class TestVideoReportAgentInput:
         input_data = VideoReportAgentInput(sensor_id="vst-sensor-001")
         assert input_data.sensor_id == "vst-sensor-001"
         assert input_data.user_query == "Generate a detailed report of the video."
+
+
+class TestBuildReportSideEffects:
+    """Test the download/media side effects attached to a generated report."""
+
+    @staticmethod
+    def _result(**overrides):
+        """A TemplateReportGenOutput-shaped result; every URL field is present."""
+        fields = {
+            "http_url": "http://vss:7777/static/agent_report_20260904_221530.md",
+            "pdf_url": "http://vss:7777/static/agent_report_20260904_221530.pdf",
+            "image_url": "",
+            "video_url": None,
+        }
+        fields.update(overrides)
+        return SimpleNamespace(**fields)
+
+    def test_both_urls_present_links_both(self):
+        side_effects = _build_report_side_effects(self._result(), "incident-1")
+        downloads = side_effects["report_downloads"]
+        assert "**Report Downloads:**" in downloads
+        assert "- [Markdown Report](http://vss:7777/static/agent_report_20260904_221530.md)" in downloads
+        assert "- [PDF Report](http://vss:7777/static/agent_report_20260904_221530.pdf)" in downloads
+
+    def test_pdf_empty_links_markdown_only(self):
+        side_effects = _build_report_side_effects(self._result(pdf_url=""), "incident-1")
+        downloads = side_effects["report_downloads"]
+        assert "[Markdown Report]" in downloads
+        assert "[PDF Report]" not in downloads
+        # No empty anchor is emitted for the missing artifact.
+        assert "()" not in downloads
+
+    def test_markdown_empty_links_pdf_only(self):
+        side_effects = _build_report_side_effects(self._result(http_url=""), "incident-1")
+        downloads = side_effects["report_downloads"]
+        assert "[PDF Report]" in downloads
+        assert "[Markdown Report]" not in downloads
+        assert "()" not in downloads
+
+    def test_both_urls_empty_says_so_instead_of_a_bare_heading(self):
+        """The regression: hasattr is always true, so only the values can gate this."""
+        side_effects = _build_report_side_effects(self._result(http_url="", pdf_url=""), "incident-1")
+        downloads = side_effects["report_downloads"]
+        # Never a heading with no anchors under it.
+        assert downloads.strip() != "**Report Downloads:**"
+        assert "[Markdown Report]" not in downloads
+        assert "[PDF Report]" not in downloads
+        assert "nothing to download" in downloads
+
+    def test_hasattr_is_vacuous_on_the_real_output_model(self):
+        """Guards the premise of the fix against a future field-optionality change."""
+        assert "http_url" in TemplateReportGenOutput.model_fields
+        assert "pdf_url" in TemplateReportGenOutput.model_fields
+        empty = TemplateReportGenOutput(
+            http_url="",
+            pdf_url="",
+            object_store_key="k",
+            summary="s",
+            file_size=0,
+            pdf_file_size=0,
+            content="c",
+            image_url="",
+        )
+        assert hasattr(empty, "http_url") and hasattr(empty, "pdf_url")
+        assert "[Markdown Report]" not in _build_report_side_effects(empty, "incident-1")["report_downloads"]
+
+    def test_media_omitted_when_absent(self):
+        side_effects = _build_report_side_effects(self._result(), "incident-1")
+        assert "media" not in side_effects
+
+    def test_media_included_when_present(self):
+        side_effects = _build_report_side_effects(
+            self._result(image_url="http://vss:7777/snap.jpg", video_url="http://vss:7777/clip.mp4"),
+            "incident-1",
+        )
+        media = side_effects["media"]
+        assert "- ![Incident Snapshot](http://vss:7777/snap.jpg)" in media
+        assert "- [Incident Video](http://vss:7777/clip.mp4)" in media

--- a/services/agent/packages/vss_agents/tests/unit_test/utils/test_llm_endpoint.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/utils/test_llm_endpoint.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from typing import Any
+
+from nat.llm.nim_llm import NIMModelConfig
+from nat.llm.openai_llm import OpenAIModelConfig
+from pydantic import BaseModel
+import pytest
+
+from vss_agents.utils.llm_endpoint import LLMEndpointConfigurationError
+from vss_agents.utils.llm_endpoint import validate_chat_llm_endpoints
+
+
+class _Workflow(BaseModel):
+    """Stands in for top_agent; llm_name is the only field that is read."""
+
+    llm_name: str = "nim_llm"
+
+
+class _Config(BaseModel):
+    """Minimal stand-in for nat Config; only workflow and llms are read."""
+
+    workflow: Any = None
+    llms: dict[str, Any] = {}
+
+
+def _config(base_url: str | None) -> _Config:
+    return _Config(
+        workflow=_Workflow(),
+        llms={"nim_llm": NIMModelConfig(model_name="nvidia/nemotron", base_url=base_url)},
+    )
+
+
+def test_in_cluster_nim_passes() -> None:
+    validate_chat_llm_endpoints(_config("http://vss-llm-nim:8000/v1"))
+
+
+def test_gateway_route_passes() -> None:
+    # An origin plus a route prefix is a valid shape: a reverse proxy in front of
+    # the LLM is addressed as host + path, not host alone.
+    validate_chat_llm_endpoints(_config("http://vss-haproxy-ingress:7777/llm/v1"))
+
+
+def test_hosted_endpoint_passes() -> None:
+    validate_chat_llm_endpoints(_config("https://integrate.api.nvidia.com/v1"))
+
+
+def test_omitted_base_url_passes() -> None:
+    # `openai_vlm` omits base_url on purpose so the client uses its own endpoint.
+    validate_chat_llm_endpoints(_config(None))
+
+
+def test_empty_llm_base_url_resolves_to_relative_path_and_refuses() -> None:
+    # `base_url: ${LLM_BASE_URL}/v1` with the variable empty.
+    with pytest.raises(LLMEndpointConfigurationError) as excinfo:
+        validate_chat_llm_endpoints(_config("/v1"))
+
+    message = str(excinfo.value)
+    assert "llms.nim_llm" in message
+    assert "'/v1'" in message
+    assert "LLM_BASE_URL" in message
+    assert "http://vss-llm-nim:8000" in message
+    assert "https://integrate.api.nvidia.com" in message
+
+
+def test_empty_string_base_url_refuses() -> None:
+    with pytest.raises(LLMEndpointConfigurationError, match="it is empty"):
+        validate_chat_llm_endpoints(_config("   "))
+
+
+def test_scheme_less_host_refuses() -> None:
+    with pytest.raises(LLMEndpointConfigurationError, match="no scheme and no host"):
+        validate_chat_llm_endpoints(_config("vss-llm-nim:8000/v1"))
+
+
+def test_scheme_without_host_refuses() -> None:
+    # A scheme alone is no better than the bare path -- there is still no host to
+    # send the completion to.
+    with pytest.raises(LLMEndpointConfigurationError, match="scheme but no host"):
+        validate_chat_llm_endpoints(_config("http:///v1"))
+
+
+def test_non_http_scheme_refuses() -> None:
+    with pytest.raises(LLMEndpointConfigurationError, match="not http or https"):
+        validate_chat_llm_endpoints(_config("ftp://vss-llm-nim:8000/v1"))
+
+
+def test_non_workflow_entry_only_warns(caplog: pytest.LogCaptureFixture) -> None:
+    # rtvi_vlm renders as /v1 whenever RTVI_VLM_BASE_URL is absent -- e.g. `nat
+    # serve` run against a profile config outside the container. The workflow
+    # does not use it, so refusing would break that over an unused entry.
+    config = _Config(
+        workflow=_Workflow(llm_name="nim_llm"),
+        llms={
+            "nim_llm": NIMModelConfig(model_name="nvidia/nemotron", base_url="http://vss-llm-nim:8000/v1"),
+            "rtvi_vlm": OpenAIModelConfig(model_name="cosmos", base_url="/v1"),
+        },
+    )
+    with caplog.at_level(logging.WARNING):
+        validate_chat_llm_endpoints(config)
+
+    assert "llms.rtvi_vlm" in caplog.text
+    assert "nim_llm" not in caplog.text
+
+
+def test_healthy_config_warns_about_nothing(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING):
+        validate_chat_llm_endpoints(_config("http://vss-llm-nim:8000/v1"))
+
+    assert caplog.text == ""


### PR DESCRIPTION
Three independent defects found while tracing why the nightly's report-generation
check reports "no report link". Each is a separate commit and each stands alone —
the branch is mergeable at every commit.

None of the three is *the* cause of that nightly failure. That cause is
environmental and is written up at the bottom, because the investigation is the
only reason these were found and it should not be lost.

## 1. `da027bd` — refuse to serve when the workflow LLM endpoint is unusable

`LLM_BASE_URL` is interpolated into the workflow config as `${LLM_BASE_URL}/v1`.
When the variable is empty or unset that resolves to the string `/v1` — no
scheme, no host. The agent started anyway, passed its health check, reported
ready, and then failed on the first prompt with a connection error naming a bare
`/v1/chat/completions`. The deployment looks healthy and the failure surfaces one
layer away from its cause.

This validates the workflow's LLM endpoints at startup and refuses to serve if one
cannot be used, with a diagnostic that names the variable, what it resolved to,
why that cannot work, and what a correct value looks like.

**Proven on a live GPU host** against the real deployed profile config, varying
only `LLM_BASE_URL` across four otherwise-identical containers:

| Case | Container | Bound and serving |
|---|---|---|
| `develop` as shipped, `LLM_BASE_URL=''` | running | **yes** — the bug |
| this branch, `LLM_BASE_URL=''` | exit 1 | no |
| this branch, `LLM_BASE_URL` unset | exit 1 | no |
| this branch, `LLM_BASE_URL='http://vss-llm-nim:8000'` | running | yes |

The pre-fix baseline starting and serving with no usable LLM is the defect; cases
2 and 3 are the fix; case 4 shows nothing else regressed.

## 2. `9dad18e` — wait for nginx ingress upstreams before starting

nginx resolves every `proxy_pass` host at config-parse time and exits
`[emerg] host not found in upstream` if one is missing. `vst-ingress` declared
`depends_on` for the sensor services but not for `streamprocessing-ms*` or
`sdr-controller`, which `nginx-${VST_NGINX_MODE}.conf` also names. On a cold start
where those lose the race, the ingress dies instead of waiting.

Adds the missing `depends_on` edges with `condition: service_started` and
`required: false`, matching the pattern already used for the sensor services.
`service_started` is deliberate: nginx needs the DNS name to exist, not the
upstream to be serving, and `service_healthy` would hold the ingress down behind
`streamprocessing`'s deliberately wide (~25 min) healthcheck window.

Chosen over adding an nginx `resolver` with variable `proxy_pass`, which would
have touched 19 `proxy_pass` sites and moved hostname resolution into the request
path for all of them. Ordering is the smaller change and the one with no
data-path consequence.

**Verified live**: without the fix, nginx exits `host not found in upstream`;
with it, the ingress comes up and stays up. `docker compose config` accepts it,
and a negative control with a deliberately misspelled service name is rejected,
confirming the edges are really being resolved.

## 3. `b53f257` — link reports by URL value, not by attribute presence

`TemplateReportGenOutput` declares `http_url` and `pdf_url` as **required**
fields, so `hasattr(report_result, "http_url")` is always true. The download
section was gated on exactly that check, so when the object store returned empty
strings for both URLs the agent emitted

```
**Report Downloads:**
```

— a heading with no anchors under it. To a reader, and to any assertion looking
for a report link, that is indistinguishable from report generation having
silently failed. **It is the same observable as the nightly failure, from an
unrelated cause**, which is worth fixing on its own so the two can never be
confused again.

Truth-tests the values instead. A report with at least one artifact links exactly
those that exist and never emits an empty `()` anchor; a report with nothing to
download says so and logs a warning naming the incident.

Media is deliberately treated differently: an incident need not have a snapshot or
a clip, so an absent media block stays omitted rather than announced. Only a
report with no downloadable copy at all is anomalous.

The block moves to a module-level `_build_report_side_effects` helper so it can be
tested — it previously sat inside a closure nested in the NAT registration
function and was unreachable from a unit test. Tests cover both-present,
markdown-only, pdf-only, both-empty, and media present/absent, plus a guard
asserting the required-field premise against the real output model so a future
optionality change fails loudly here.

## What this PR does *not* fix

**The nightly's report-generation failure itself.** That is environmental, not a
code defect in this repo. The shared LLM endpoint the nightly points at rejects
tool-bound requests, so the report agent is never reached at all.

Measured on a live host, same model, identical tool-bound payload:

- a locally started NIM with `--enable-auto-tool-choice` and a `--tool-call-parser`
  returns **HTTP 200** with a populated `tool_calls`
- the shared endpoint the nightly uses returns **HTTP 400**

The fix belongs to whoever owns that endpoint: it needs to be started with tool
calling enabled, or the nightly needs to point at one that is. Commit `da027bd`
makes a *missing* endpoint fail loudly at startup; it deliberately does not try
to detect a *tool-incapable* one, which would mean issuing a probe tool call on
every boot.

Two further findings from the same investigation — how a sensor can be served by
VIOS but never subscribed by rt-cv, and an ungrounded answer path in the top
agent's planner — are written up in a comment on this PR rather than changed
here, because neither has a fix that is safe to improvise.
