### PR TITLE
feat(deploy): mount the LLM NIM at the gateway's /llm

### DIFF
--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -468,6 +468,7 @@ serve that prefix natively.
 | `/rtvi-cv` | strip | `${VSS_GATEWAY_ORIGIN}/rtvi-cv` | `/rtvi-cv/api/v1/stream/add` | `/api/v1/stream/add` |
 | `/rtvi-embed` | strip | `${VSS_GATEWAY_ORIGIN}/rtvi-embed` | `/rtvi-embed/v1/models` | `/v1/models` |
 | `/lvs` | strip | `${VSS_GATEWAY_ORIGIN}/lvs` | `/lvs/v1/live` | `/v1/live` |
+| `/llm` | strip | opt-in; nothing is pointed here | `/llm/v1/chat/completions` | `/v1/chat/completions` |
 | `/phoenix` | strip | `${VSS_GATEWAY_ORIGIN}/phoenix` | `/phoenix` | `/` (keep `PHOENIX_HOST_ROOT_PATH=/phoenix`) |
 | `/vst` | preserve | `${VSS_GATEWAY_ORIGIN}` (not `/vst`) | `/vst/api/...` | `/vst/api/...` |
 | `/vios` | **rewrite to `/vst`** | `${VSS_GATEWAY_ORIGIN}/vios` | `/vios/api/...` | `/vst/api/...` |
@@ -477,6 +478,24 @@ serve that prefix natively.
 | `/kibana` | preserve | origin + `/kibana` | `/kibana/...` | `/kibana/...` |
 | `/api`, `/chat`, `/websocket`, `/static` | preserve | origin | `/api/v1/...` | `/api/v1/...` |
 | `/behavior-analytics`, `/perception-sdr` | preserve | origin + prefix | prefix paths | same (often 503 if backend has no HTTP) |
+
+#### `/llm` is available, not adopted
+
+The gateway mounts the in-deployment LLM NIM at `/llm`, and **nothing points at
+it**. Every profile keeps `LLM_BASE_URL=http://vss-llm-nim:8000`, the agent
+keeps addressing the model over Docker DNS, and the rule stated in
+`remote-agent.env.example` — model APIs are configured directly, not as gateway
+mounts — is still the default. The mount only makes the other arrangement
+possible: a caller that has been given one origin and nothing else can reach
+the model at `${VSS_GATEWAY_ORIGIN}/llm/v1` instead of needing a second
+endpoint, which is the same problem `/va-mcp` and `/elasticsearch` solve for
+their services.
+
+Adopting it is a per-deployment decision, made by setting `LLM_BASE_URL`, and
+it costs a hop and this listener's 600s server timeout. A deployment that runs
+no in-stack model leaves the backend with no server, so `/llm` answers 503 with
+`x-vss-gateway-unavailable: llm` — absent from this deployment, not broken —
+exactly like the other optional mounts.
 
 #### `/vios`, `/alerts`, `/video-summarization` are aliases, not renames
 
@@ -609,7 +628,7 @@ header is the contract** — the value names the route for logs, and a caller th
 switched on it would need editing every time a mount is added.
 
 Marked routes: `/video-analytics-api`, `/alert-bridge`, `/alerts`, `/kibana`,
-`/elasticsearch`, `/rtvi-embed`, `/rtvi-cv`, `/rtvi-vlm`, `/lvs`,
+`/elasticsearch`, `/rtvi-embed`, `/rtvi-cv`, `/rtvi-vlm`, `/llm`, `/lvs`,
 `/video-summarization`, `/phoenix`, `/behavior-analytics`, `/perception-sdr`,
 `/va-mcp`. The UI, agent and VST/VIOS routes are not marked: nothing treats the
 deployment's own front door or its media plane as optional, and their path

--- a/deploy/docker/services/infra/haproxy/compose.yml
+++ b/deploy/docker/services/infra/haproxy/compose.yml
@@ -41,6 +41,15 @@ services:
       # the compose network, where the published port does not apply.
       RTVI_VLM_SERVICE_HOST: ${RTVI_VLM_SERVICE_HOST:-rtvi-vlm}
       RTVI_VLM_SERVICE_PORT: ${RTVI_VLM_SERVICE_PORT:-8000}
+      # vss-llm-nim is a network alias every LLM NIM compose service registers,
+      # dedicated and -shared-gpu alike, so this one name follows the model
+      # wherever it is placed. 8000 is its container port; LLM_PORT is the
+      # host-published one (30081) and must not be used here, same as
+      # RTVI_VLM_PORT above. Nothing resolves this name when the deployment runs
+      # no in-stack model, which is what leaves the backend DOWN and makes /llm
+      # report itself absent rather than broken.
+      LLM_SERVICE_HOST: ${LLM_SERVICE_HOST:-vss-llm-nim}
+      LLM_SERVICE_PORT: ${LLM_SERVICE_PORT:-8000}
       # BACKEND_PORT is lvs-server's container port, not BACKEND_HOST_PORT.
       LVS_SERVICE_HOST: ${LVS_SERVICE_HOST:-lvs-server}
       LVS_SERVICE_PORT: ${BACKEND_PORT:-38111}

--- a/deploy/docker/services/infra/haproxy/haproxy.cfg.template
+++ b/deploy/docker/services/infra/haproxy/haproxy.cfg.template
@@ -113,6 +113,33 @@ backend bk_rtvi_vlm_strip
     http-request replace-path ^/rtvi-vlm$ /
     server s1 "${RTVI_VLM_SERVICE_HOST}:${RTVI_VLM_SERVICE_PORT}" check resolvers docker init-addr none
 
+# The in-deployment LLM NIM, mounted like its RTVI siblings: the NIM serves its
+# OpenAI-compatible surface at the root, so /llm/v1/chat/completions has to
+# arrive as /v1/chat/completions.
+#
+# Additive and unused by default. No profile's LLM_BASE_URL points here, and
+# none is changed to; a colocated agent keeps addressing vss-llm-nim directly.
+# This exists so a caller that has only the gateway origin -- a remote agent, a
+# host-side tool behind a secure link -- can reach the model without being told
+# a second endpoint.
+#
+# TCP `check`, not `option httpchk GET /v1/health/ready`, and the difference is
+# load-bearing for the absent-backend marker in the frontend. A NIM holds its
+# port open while it loads weights, which takes minutes; a readiness check would
+# leave this backend DOWN for that whole window and the marker would report the
+# model "not part of this deployment" when it is merely warming up. Port-open
+# means deployed, which is the fact the marker needs. Plain `check` is also what
+# every other backend in this file uses.
+backend bk_llm_strip
+    http-request replace-path ^/llm/(.*) /\1
+    http-request replace-path ^/llm$ /
+    # A non-streaming completion sends nothing until generation finishes, and a
+    # reasoning model can outlast the 120s default; a 504 mid-generation would
+    # read as a backend failure. Streaming is unaffected either way, since
+    # `timeout server` measures inactivity and a token stream is never idle.
+    timeout server 600s
+    server s1 "${LLM_SERVICE_HOST}:${LLM_SERVICE_PORT}" check resolvers docker init-addr none
+
 backend bk_lvs_strip
     http-request replace-path ^/lvs/(.*) /\1
     http-request replace-path ^/lvs$ /
@@ -407,6 +434,13 @@ frontend fe_http
     acl p_rtvi_vlm path_beg /rtvi-vlm/
     use_backend bk_rtvi_vlm_strip if h_main p_rtvi_vlm
 
+    # The LLM NIM. Profiles that run no in-stack model -- every LLM_MODE=remote
+    # deployment -- leave the backend DOWN, so this answers 503 with the
+    # absent-backend marker rather than pretending a model is mounted here.
+    acl p_llm path /llm
+    acl p_llm path_beg /llm/
+    use_backend bk_llm_strip if h_main p_llm
+
     # Profiles without lvs-server leave the backend DOWN, so this answers 503
     # and `vss configure` records the service absent, not present-but-broken.
     acl p_lvs path /lvs
@@ -556,6 +590,7 @@ frontend fe_http
     http-request set-var(txn.gw_absent) str(rtvi-embed) if h_main p_rtvi_embed { nbsrv(bk_rtvi_embed_strip) eq 0 }
     http-request set-var(txn.gw_absent) str(rtvi-cv) if h_main p_rtvi_cv { nbsrv(bk_rtvi_cv_strip) eq 0 }
     http-request set-var(txn.gw_absent) str(rtvi-vlm) if h_main p_rtvi_vlm { nbsrv(bk_rtvi_vlm_strip) eq 0 }
+    http-request set-var(txn.gw_absent) str(llm) if h_main p_llm { nbsrv(bk_llm_strip) eq 0 }
     http-request set-var(txn.gw_absent) str(lvs) if h_main p_lvs { nbsrv(bk_lvs_strip) eq 0 }
     http-request set-var(txn.gw_absent) str(video-summarization) if h_main p_video_summarization { nbsrv(bk_video_summarization_strip) eq 0 }
     http-request set-var(txn.gw_absent) str(phoenix) if h_main p_phoenix { nbsrv(bk_phoenix_strip) eq 0 }


### PR DESCRIPTION
> **Stacked on #1983** (`feat/via-2713-gateway-consolidated`). Review that first; this branch is one commit on top of it. Base retargets to `develop` when #1983 merges.

## What this is not

**This is not the fix for the 2026-09-03 nightly.** That failure was an *empty* `LLM_BASE_URL` interpolating to a bare `/v1`, and it is fixed in #2049 against `develop` with an inline Compose default. `/llm` addresses topology independence — a caller that has one origin and no second endpoint — and it would not have prevented that nightly. Please do not let the two be conflated.

For the same reason #1983 is not implicated in the nightly either: it is unmerged, is not an ancestor of `develop` (58 commits ahead), `git grep -c VSS_GATEWAY_ORIGIN origin/develop` returns zero matches on the whole branch, and it leaves `LLM_BASE_URL` byte-identical (`develop:107`, PR head `:146`) while moving eleven sibling endpoints onto the gateway. None of its rework was running.

## What it does

Mounts the in-deployment LLM NIM at `/llm`, so `${VSS_GATEWAY_ORIGIN}/llm/v1/chat/completions` reaches the model. Every other service a caller must reach is already on the gateway; the model is the one that still requires a separately communicated endpoint.

**Nothing is pointed at it.** Every profile keeps `LLM_BASE_URL=http://vss-llm-nim:8000`, a colocated agent addresses the model exactly as it does today, and the rule `remote-agent.env.example:64` states — model APIs are configured directly, not mounted — remains the default. This PR makes the other arrangement *possible*; adopting it stays a per-deployment decision made by setting `LLM_BASE_URL`.

That is also the honest test for whether this should merge: if keeping model APIs off the gateway is a deliberate policy rather than an artefact of ordering, close this. Nothing depends on it.

## Conforming to #1983

- Shaped like `bk_rtvi_vlm_strip` and its siblings — the NIM serves its OpenAI-compatible surface at the root, so `/llm/v1/...` must arrive as `/v1/...`. As you note, the Docker edge is a hand-written template with shell-style expansion; a strip backend plus an ACL pair is the idiomatic shape here.
- Uses your `nbsrv() eq 0` optional-mount convention rather than letting HAProxy answer a bare 503, so an `LLM_MODE=remote` deployment reports `x-vss-gateway-unavailable: llm` and stays distinguishable from a model that is deployed and failing.
- Host allowlist, `h_main` gating and `X-Forwarded-Proto` normalisation are inherited unchanged; this adds no Host exceptions.

Two deliberate departures, both stated in the config:

- **`timeout server 600s`**, following the raised timeout on `bk_lvs_strip`. A non-streaming completion sends nothing until generation finishes and a reasoning model can outlast the 120s default; a 504 mid-generation reads as a backend failure. Streaming needs nothing extra — `timeout server` measures inactivity and a token stream is never idle.
- **TCP `check`, not `option httpchk GET /v1/health/ready`**, and this one interacts with your marker. A NIM holds its port open while it loads weights, which takes minutes; a readiness check would leave the backend DOWN for that whole window and the marker would report the model *absent from the deployment* when it is merely warming up. Port-open means deployed, which is precisely the fact `nbsrv` needs. It is also what every other backend in the file uses.

## Verified against a live HAProxy 3.4.2

Stub backend on a Compose network, aliased `vss-llm-nim`, with the real template:

| Request | Result |
|---|---|
| `POST /llm/v1/chat/completions` | backend received `/v1/chat/completions` |
| `GET /llm/v1/models` | backend received `/v1/models` |
| same, backend removed | `503` + `x-vss-gateway-unavailable: llm` and the synthesised body |
| `/rtvi-vlm/v1/models` (control) | `503` + `x-vss-gateway-unavailable: rtvi-vlm`, unchanged |

`haproxy -c` on the expanded template reports no new warnings — only the pre-existing "http-request rule placed after a use_backend rule" notices this file already relies on.

Not verified: no real NIM was loaded, so the 600s timeout and the warm-up behaviour of the TCP check are reasoned from the NIM's documented readiness sequence, not measured.

## Kubernetes deliberately not included

`_ingress-routes.tpl` is declarative and `verify-ingress-routes.py` asserts, among other things, that disabling a component removes its route rather than leaving an Ingress pointed at a Service that was never created. A `/llm` row therefore needs the NIM Service name and its per-profile enable condition threaded through each profile — more than a row, and with no caller yet. Better as a follow-up once something actually uses the Docker mount.

Also not added: `/llm` is not in the CLI's `INGRESS_SERVICES` probe list, since no `vss` command group needs the model endpoint.
