### PR TITLE
fix(agent): optional video timestamp arguments

### DIFF
--- a/services/agent/packages/vss_agents/src/vss_agents/tools/video_understanding.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/video_understanding.py
@@ -336,11 +336,17 @@ class VideoUnderstandingOffsetInput(BaseModel):
     )
     start_timestamp: float | None = Field(
         None,
-        description="Optional start time offsets (in seconds since beginning of the stream), if None, then the entire stream is returned",
+        description=(
+            "Optional start time offset in seconds since the beginning of the stream. "
+            "For whole-video analysis, omit both timestamp fields; do not send a string placeholder."
+        ),
     )
     end_timestamp: float | None = Field(
         None,
-        description="Optional end time offsets (in seconds since beginning of the stream), if None, then the entire stream is returned",
+        description=(
+            "Optional end time offset in seconds since the beginning of the stream. "
+            "For whole-video analysis, omit both timestamp fields; do not send a string placeholder."
+        ),
     )
     user_prompt: str = Field(
         ...,
@@ -740,7 +746,7 @@ async def video_understanding(config: VideoUnderstandingConfig, builder: Builder
             end_timestamp: The end timestamp in offset seconds since beginning of the stream
             user_prompt: The prompt that is used to query the VLM to understand the video, mention all search entities in the prompt that is related to the user's query.
             vlm_reasoning: Enable VLM reasoning mode. If None, uses config.reasoning default.
-            Note: start_timestamp and end_timestamp are optional. If None, then the entire stream is returned.
+            Note: start_timestamp and end_timestamp are optional. For the entire stream, omit both fields; do not send string placeholders such as "None" or "null".
         """
 
         yield FunctionInfo.create(

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_video_understanding.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_video_understanding.py
@@ -57,6 +57,19 @@ class TestVideoUnderstandingOffsetInput:
         assert model.start_timestamp == 0.0
         assert model.end_timestamp == 12.5
 
+    def test_numeric_start_with_string_none_end_uses_open_ended_video(self):
+        model = VideoUnderstandingOffsetInput.model_validate(
+            {
+                "sensor_id": "warehouse_safety_001",
+                "start_timestamp": 0,
+                "end_timestamp": "None",
+                "user_prompt": "What happened in the video?",
+            }
+        )
+
+        assert model.start_timestamp == 0.0
+        assert model.end_timestamp is None
+
 
 class TestParseThinkingFromContent:
     """Test _parse_thinking_from_content function."""


### PR DESCRIPTION
- The Agent sent optional clip times as the string "None" (or 0 plus "None"), video_understanding crashed on float("None"), then plan-tracking treated that failure as a completed look and let invented accidents leak into the answer
- Develop already normalizes those sentinels and refuses to checkmark failed tool calls; we told the tool schema to omit unused timestamps instead of saying “If None…”, and added a test for the exact 0/"None" retry
- Stops the validation crash and stops a failed look from being written up as a verified incident.
NVBug: https://nvbugspro.nvidia.com/bug/6710157

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
