### PR TITLE
fix(lvs): route live summaries by media type

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
@@ -371,7 +371,9 @@ workflow:
   plan_prompt: |
     Review the available tools, the conversation history, and the user's question, then produce a concise numbered execution plan. Start each step with a tool name and a brief description of the step.
     Put relevant context (for example, sensor IDs or time ranges) from the conversation history directly in the plan steps so the execution agent does not need to re-read the history.
-    For a specific content question about named media, use one compound plan step: call `vst_video_list` to resolve `<name>`'s media type, then call `video_understanding` with `<name>` and the original question when it is `video`; use the live-stream content-question route only when it is `rtsp`. Use `lvs_video_understanding` only for whole-video summarization.
+    If the current request explicitly asks to start captioning or configure a stream, plan exactly one call to `lvs_config_media`; ignore any unfinished summary plan from the previous turn.
+    For summaries of named media, plan `vst_video_list` first, then exactly one summary tool based only on its result: `rtsp` → `lvs_stream_understanding`; `video` → `lvs_video_understanding`. Never choose the summary tool from duration.
+    Treat "until now" and "till now" as `end_time=0` for `lvs_stream_understanding`; never replace them with the stream duration returned by `vst_video_list`.
     A non-empty name supplied in the request is the sensor_id. For example, in "Generate a report for warehouse_sample", the sensor_id is "warehouse_sample"; this request is complete and MUST NOT trigger a clarifying question.
     If the user requests a report and supplies a name, the plan MUST contain exactly one action: call `report_agent` directly with that exact name as sensor_id and the original request as user_query. Do not verify the name or media type first.
     Ask which video or camera the user means only when the request contains no name and the conversation provides no usable name.
@@ -431,14 +433,8 @@ workflow:
       - Use when user asks to "summarize" or "describe" a stream over a time range, OR when a prior `lvs_caption_retrieval` call returned no chunks.
       - Do NOT use this tool to "check" whether a stream is configured before calling another tool — it is for showing summaries to the user.
       - Pass stream_name, numeric start_time, numeric end_time, response_type='summary'.
+      - "until now" / "till now" means `end_time=0`; do not substitute the duration reported by `vst_video_list`.
       - If the response status is "not_configured", surface the response message VERBATIM to the user and STOP. Do NOT auto-call lvs_config_media — caption generation must be confirmed by the user first.
-      - Worked example (bare prompt, no "stream" cue) — mimic this reasoning:
-        User: "Summarize warehouse_sample from 45 seconds until now"
-        1. Call `vst_video_list` → result lists only videos (e.g. clip_007, dev_base_001); `warehouse_sample` is NOT listed.
-        2. Not listed ⇒ it is NOT an uploaded video ⇒ it is a live RTSP stream.
-        3. Call `lvs_stream_understanding(stream_name='warehouse_sample', start_time=45, end_time=0, response_type='summary')`.
-        4. If it returns `not_configured`, surface that message to the user and stop. Do NOT call `lvs_config_media`.
-        (If `<name>` HAD been listed with media_type='video', step 3 would instead call `lvs_video_understanding(sensor_id='<name>', ...)`.)
       **lvs_config_media** - Start LVS caption generation for a live stream (HITL collects scenario/events/objects).
       - Use ONLY when the user explicitly asks to start caption generation for a stream. Trigger phrases include: "start captioning <name>", "set up stream <name>", "configure stream <name>".
       - "summarize <name>" or "summarize <name> from X to Y" is NOT a trigger — it must be routed by `media_type` from `vst_video_list` to `lvs_stream_understanding` (rtsp) or `lvs_video_understanding` (video).
@@ -449,7 +445,7 @@ workflow:
       - Do NOT call this tool if it has already been called for the same `<name>` earlier in the conversation. Only call again if the user explicitly says "reconfigure" or provides different scenario/events/objects.
       **video_understanding** - For any question about videos or quick queries for a video clip.
       - Use when user asks "what happens in the video" or "describe the video" or "analyze this video" or "what is happening in the video"
-      - Do NOT use when user asks to "generate a report" or "summarize" — use report_agent or lvs_video_understanding respectively.
+      - Do NOT use when user asks to "generate a report" or "summarize" — use report_agent for reports; for summaries, route by `media_type` as defined above.
       **vst_video_clip** - For queries asking for showing videos (e.g., "Let's show the videos just uploaded"), call this tool in parallel with each video name as a separate input.
       - CRITICAL: Always call vst_video_clip to get the URL even though the video clip for the same video has already been generated from previous interactions. DO NOT generate the URL yourself without calling vst_video_clip.
       **vst_snapshot** - For queries asking for a snapshot of a video at a specific timestamp.
@@ -457,13 +453,16 @@ workflow:
     ## Stream vs uploaded video: when a request mentions a `<name>` that could be either, you MUST identify its media_type before routing.
       - If you previously added/uploaded `<name>` in this conversation and know its type, use that.
       - Otherwise call `vst_video_list` and look up `<name>` in the result. Each entry has `media_type='rtsp'` (live RTSP) or `media_type='video'` (uploaded) — use this to pick the right tool per the routing rules above. Do NOT guess from the name.
-      - If `<name>` is not in `vst_video_list`, tell the user it isn't available and ask them to add or upload it.
+      - If `<name>` is not in `vst_video_list`, follow STEP 1's live-stream fallback: call `lvs_stream_understanding` and surface `not_configured` verbatim if returned.
     ## Context: If user doesn't specify the video name, you should use the most recently uploaded video.
 
 
   tool_call_prompt: |
+    - CURRENT REQUEST TAKES PRIORITY: if it explicitly asks to start captioning or configure a stream, call `lvs_config_media` once and wait for its HITL response. Do not call another tool and do not continue an earlier summary plan.
+    - HARD ROUTING RULE FOR SUMMARIES: read the target's `media_type` from the latest `vst_video_list` result. If it is `rtsp`, the only permitted summary tool is `lvs_stream_understanding`; never call `lvs_video_understanding`. If it is `video`, the only permitted summary tool is `lvs_video_understanding`. Ignore duration when making this choice, even if the execution plan chose differently.
+    - For `rtsp`, pass `stream_name`, `response_type='summary'`, and the requested numeric time range. "Until now" or "till now" always means `end_time=0`.
     - ALWAYS include ALL required parameters when calling tools
-    - OVERRIDE THE EXECUTION PLAN if necessary: for a specific content question, once the target is known to be `media_type='video'`, call `video_understanding` next even if the plan names another tool. Use `lvs_video_understanding` only for whole-video summarization.
+    - OVERRIDE THE EXECUTION PLAN if necessary: for a specific content question, once the target is known to be `media_type='video'`, call `video_understanding` next even if the plan names another tool.
     - If a tool call fails with a validation error, RETRY IMMEDIATELY: Fix the error and call the tool again with correct parameters.
     - Error Handling: if a tool fails more than 3 times, just return a summarized error message. Do not endlessly try again.
 

--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
@@ -435,6 +435,13 @@ workflow:
       - Pass stream_name, numeric start_time, numeric end_time, response_type='summary'.
       - "until now" / "till now" means `end_time=0`; do not substitute the duration reported by `vst_video_list`.
       - If the response status is "not_configured", surface the response message VERBATIM to the user and STOP. Do NOT auto-call lvs_config_media — caption generation must be confirmed by the user first.
+      - Worked example (bare prompt, no "stream" cue) — mimic this reasoning:
+        User: "Summarize warehouse_sample from 45 seconds until now"
+        1. Call `vst_video_list` → result lists only videos (e.g. clip_007, dev_base_001); `warehouse_sample` is NOT listed.
+        2. Not listed ⇒ it is NOT an uploaded video ⇒ it is a live RTSP stream.
+        3. Call `lvs_stream_understanding(stream_name='warehouse_sample', start_time=45, end_time=0, response_type='summary')`.
+        4. If it returns `not_configured`, surface that message to the user and stop. Do NOT call `lvs_config_media`.
+        (If `<name>` HAD been listed with media_type='video', step 3 would instead call `lvs_video_understanding(sensor_id='<name>', ...)`.)
       **lvs_config_media** - Start LVS caption generation for a live stream (HITL collects scenario/events/objects).
       - Use ONLY when the user explicitly asks to start caption generation for a stream. Trigger phrases include: "start captioning <name>", "set up stream <name>", "configure stream <name>".
       - "summarize <name>" or "summarize <name> from X to Y" is NOT a trigger — it must be routed by `media_type` from `vst_video_list` to `lvs_stream_understanding` (rtsp) or `lvs_video_understanding` (video).

--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
@@ -371,7 +371,7 @@ workflow:
   plan_prompt: |
     Review the available tools, the conversation history, and the user's question, then produce a concise numbered execution plan. Start each step with a tool name and a brief description of the step.
     Put relevant context (for example, sensor IDs or time ranges) from the conversation history directly in the plan steps so the execution agent does not need to re-read the history.
-    If the current request explicitly asks to start captioning or configure a stream, plan exactly one call to `lvs_config_media`; ignore any unfinished summary plan from the previous turn.
+    If the current request explicitly asks to start captioning or configure a stream, ignore any unfinished summary plan and plan exactly one call to `lvs_config_media`, unless the same stream was already configured successfully. For an explicit reconfiguration request, call it with `reconfigure=true`.
     For summaries of named media, plan `vst_video_list` first, then exactly one summary tool based only on its result: `rtsp` → `lvs_stream_understanding`; `video` → `lvs_video_understanding`. Never choose the summary tool from duration.
     Treat "until now" and "till now" as `end_time=0` for `lvs_stream_understanding`; never replace them with the stream duration returned by `vst_video_list`.
     A non-empty name supplied in the request is the sensor_id. For example, in "Generate a report for warehouse_sample", the sensor_id is "warehouse_sample"; this request is complete and MUST NOT trigger a clarifying question.
@@ -388,11 +388,11 @@ workflow:
     ## STEP 1 — Resolve media_type BEFORE routing (always, for any request that names a <name>):
       - If you already know `<name>`'s type from this conversation (you uploaded it as a video, or added it as an RTSP stream), use that.
       - Otherwise your FIRST tool call MUST be `vst_video_list`. Look up `<name>` in the result. Each entry has `media_type='rtsp'` (live stream) or `media_type='video'` (uploaded file).
-      - `vst_video_list` is AUTHORITATIVE for uploaded videos: every uploaded video appears there. It is NOT authoritative for live streams — a live RTSP stream may be absent from the list.
+      - `vst_video_list` is AUTHORITATIVE for available media: both uploaded videos and live RTSP streams appear there.
       - POSITIVE ROUTING RULE (no dead-ends):
         * If `<name>` is listed with `media_type='video'` → it is an uploaded video.
         * If `<name>` is listed with `media_type='rtsp'` → it is a live stream.
-        * If `<name>` is NOT listed → it is NOT an uploaded video, so it MUST be a live RTSP stream. Call `lvs_stream_understanding(stream_name='<name>', ...)`. If that returns `not_configured`, surface the message to the user and stop.
+        * If `<name>` is NOT listed → tell the user it is unavailable and ask them to check the name or add the media. Do not call a summary or captioning tool for it.
       - Route on the `media_type` field or on absence from the list — NEVER on the words "stream"/"video" in the user's message, and NEVER on the name itself.
       - This applies to "summarize", "describe", "give a summary of", "generate a report for", and any content question about a named `<name>`.
 
@@ -437,8 +437,8 @@ workflow:
       - If the response status is "not_configured", surface the response message VERBATIM to the user and STOP. Do NOT auto-call lvs_config_media — caption generation must be confirmed by the user first.
       - Worked example (bare prompt, no "stream" cue) — mimic this reasoning:
         User: "Summarize warehouse_sample from 45 seconds until now"
-        1. Call `vst_video_list` → result lists only videos (e.g. clip_007, dev_base_001); `warehouse_sample` is NOT listed.
-        2. Not listed ⇒ it is NOT an uploaded video ⇒ it is a live RTSP stream.
+        1. Call `vst_video_list` → `warehouse_sample` is listed with `media_type='rtsp'`.
+        2. Route by that media type ⇒ it is a live RTSP stream.
         3. Call `lvs_stream_understanding(stream_name='warehouse_sample', start_time=45, end_time=0, response_type='summary')`.
         4. If it returns `not_configured`, surface that message to the user and stop. Do NOT call `lvs_config_media`.
         (If `<name>` HAD been listed with media_type='video', step 3 would instead call `lvs_video_understanding(sensor_id='<name>', ...)`.)
@@ -449,7 +449,7 @@ workflow:
       - Do NOT call this tool just because a previous tool's response said the stream is "not configured" — surface that response to the user and wait for an explicit start request.
       - Do NOT call speculatively or as a pre-check.
       - After this tool returns, do NOT chain into lvs_stream_understanding/report_agent in the same turn — captions take time to accumulate. Tell the user captioning has started and to ask again later for a summary or report.
-      - Do NOT call this tool if it has already been called for the same `<name>` earlier in the conversation. Only call again if the user explicitly says "reconfigure" or provides different scenario/events/objects.
+      - Do NOT call this tool if it successfully configured the same `<name>` earlier in the conversation. Only call again with `reconfigure=true` if the user explicitly says "reconfigure" or provides different scenario/events/objects.
       **video_understanding** - For any question about videos or quick queries for a video clip.
       - Use when user asks "what happens in the video" or "describe the video" or "analyze this video" or "what is happening in the video"
       - Do NOT use when user asks to "generate a report" or "summarize" — use report_agent for reports; for summaries, route by `media_type` as defined above.
@@ -460,12 +460,12 @@ workflow:
     ## Stream vs uploaded video: when a request mentions a `<name>` that could be either, you MUST identify its media_type before routing.
       - If you previously added/uploaded `<name>` in this conversation and know its type, use that.
       - Otherwise call `vst_video_list` and look up `<name>` in the result. Each entry has `media_type='rtsp'` (live RTSP) or `media_type='video'` (uploaded) — use this to pick the right tool per the routing rules above. Do NOT guess from the name.
-      - If `<name>` is not in `vst_video_list`, follow STEP 1's live-stream fallback: call `lvs_stream_understanding` and surface `not_configured` verbatim if returned.
+      - If `<name>` is not in `vst_video_list`, tell the user it is unavailable and ask them to check the name or add the media. Do not offer to start captioning it.
     ## Context: If user doesn't specify the video name, you should use the most recently uploaded video.
 
 
   tool_call_prompt: |
-    - CURRENT REQUEST TAKES PRIORITY: if it explicitly asks to start captioning or configure a stream, call `lvs_config_media` once and wait for its HITL response. Do not call another tool and do not continue an earlier summary plan.
+    - CURRENT REQUEST TAKES PRIORITY: if it explicitly asks to start captioning or configure a stream, call `lvs_config_media` once and wait for its HITL response. Do not continue an earlier summary plan. If that stream was already configured successfully, do not call it again unless the user explicitly requests reconfiguration; then pass `reconfigure=true`.
     - HARD ROUTING RULE FOR SUMMARIES: read the target's `media_type` from the latest `vst_video_list` result. If it is `rtsp`, the only permitted summary tool is `lvs_stream_understanding`; never call `lvs_video_understanding`. If it is `video`, the only permitted summary tool is `lvs_video_understanding`. Ignore duration when making this choice, even if the execution plan chose differently.
     - For `rtsp`, pass `stream_name`, `response_type='summary'`, and the requested numeric time range. "Until now" or "till now" always means `end_time=0`.
     - ALWAYS include ALL required parameters when calling tools

--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
@@ -371,7 +371,9 @@ workflow:
   plan_prompt: |
     Review the available tools, the conversation history, and the user's question, then produce a concise numbered execution plan. Start each step with a tool name and a brief description of the step.
     Put relevant context (for example, sensor IDs or time ranges) from the conversation history directly in the plan steps so the execution agent does not need to re-read the history.
-    For a specific content question about named media, use one compound plan step: call `vst_video_list` to resolve `<name>`'s media type, then call `video_understanding` with `<name>` and the original question when it is `video`; use the live-stream content-question route only when it is `rtsp`. Use `lvs_video_understanding` only for whole-video summarization.
+    If the current request explicitly asks to start captioning or configure a stream, plan exactly one call to `lvs_config_media`; ignore any unfinished summary plan from the previous turn.
+    For summaries of named media, plan `vst_video_list` first, then exactly one summary tool based only on its result: `rtsp` → `lvs_stream_understanding`; `video` → `lvs_video_understanding`. Never choose the summary tool from duration.
+    Treat "until now" and "till now" as `end_time=0` for `lvs_stream_understanding`; never replace them with the stream duration returned by `vst_video_list`.
     A non-empty name supplied in the request is the sensor_id. For example, in "Generate a report for warehouse_sample", the sensor_id is "warehouse_sample"; this request is complete and MUST NOT trigger a clarifying question.
     If the user requests a report and supplies a name, the plan MUST contain exactly one action: call `report_agent` directly with that exact name as sensor_id and the original request as user_query. Do not verify the name or media type first.
     Ask which video or camera the user means only when the request contains no name and the conversation provides no usable name.
@@ -431,6 +433,7 @@ workflow:
       - Use when user asks to "summarize" or "describe" a stream over a time range, OR when a prior `lvs_caption_retrieval` call returned no chunks.
       - Do NOT use this tool to "check" whether a stream is configured before calling another tool — it is for showing summaries to the user.
       - Pass stream_name, numeric start_time, numeric end_time, response_type='summary'.
+      - "until now" / "till now" means `end_time=0`; do not substitute the duration reported by `vst_video_list`.
       - If the response status is "not_configured", surface the response message VERBATIM to the user and STOP. Do NOT auto-call lvs_config_media — caption generation must be confirmed by the user first.
       - Worked example (bare prompt, no "stream" cue) — mimic this reasoning:
         User: "Summarize warehouse_sample from 45 seconds until now"
@@ -449,7 +452,7 @@ workflow:
       - Do NOT call this tool if it has already been called for the same `<name>` earlier in the conversation. Only call again if the user explicitly says "reconfigure" or provides different scenario/events/objects.
       **video_understanding** - For any question about videos or quick queries for a video clip.
       - Use when user asks "what happens in the video" or "describe the video" or "analyze this video" or "what is happening in the video"
-      - Do NOT use when user asks to "generate a report" or "summarize" — use report_agent or lvs_video_understanding respectively.
+      - Do NOT use when user asks to "generate a report" or "summarize" — use report_agent for reports; for summaries, route by `media_type` as defined above.
       **vst_video_clip** - For queries asking for showing videos (e.g., "Let's show the videos just uploaded"), call this tool in parallel with each video name as a separate input.
       - CRITICAL: Always call vst_video_clip to get the URL even though the video clip for the same video has already been generated from previous interactions. DO NOT generate the URL yourself without calling vst_video_clip.
       **vst_snapshot** - For queries asking for a snapshot of a video at a specific timestamp.
@@ -457,13 +460,16 @@ workflow:
     ## Stream vs uploaded video: when a request mentions a `<name>` that could be either, you MUST identify its media_type before routing.
       - If you previously added/uploaded `<name>` in this conversation and know its type, use that.
       - Otherwise call `vst_video_list` and look up `<name>` in the result. Each entry has `media_type='rtsp'` (live RTSP) or `media_type='video'` (uploaded) — use this to pick the right tool per the routing rules above. Do NOT guess from the name.
-      - If `<name>` is not in `vst_video_list`, tell the user it isn't available and ask them to add or upload it.
+      - If `<name>` is not in `vst_video_list`, follow STEP 1's live-stream fallback: call `lvs_stream_understanding` and surface `not_configured` verbatim if returned.
     ## Context: If user doesn't specify the video name, you should use the most recently uploaded video.
 
 
   tool_call_prompt: |
+    - CURRENT REQUEST TAKES PRIORITY: if it explicitly asks to start captioning or configure a stream, call `lvs_config_media` once and wait for its HITL response. Do not call another tool and do not continue an earlier summary plan.
+    - HARD ROUTING RULE FOR SUMMARIES: read the target's `media_type` from the latest `vst_video_list` result. If it is `rtsp`, the only permitted summary tool is `lvs_stream_understanding`; never call `lvs_video_understanding`. If it is `video`, the only permitted summary tool is `lvs_video_understanding`. Ignore duration when making this choice, even if the execution plan chose differently.
+    - For `rtsp`, pass `stream_name`, `response_type='summary'`, and the requested numeric time range. "Until now" or "till now" always means `end_time=0`.
     - ALWAYS include ALL required parameters when calling tools
-    - OVERRIDE THE EXECUTION PLAN if necessary: for a specific content question, once the target is known to be `media_type='video'`, call `video_understanding` next even if the plan names another tool. Use `lvs_video_understanding` only for whole-video summarization.
+    - OVERRIDE THE EXECUTION PLAN if necessary: for a specific content question, once the target is known to be `media_type='video'`, call `video_understanding` next even if the plan names another tool.
     - If a tool call fails with a validation error, RETRY IMMEDIATELY: Fix the error and call the tool again with correct parameters.
     - Error Handling: if a tool fails more than 3 times, just return a summarized error message. Do not endlessly try again.
 

--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
@@ -371,7 +371,7 @@ workflow:
   plan_prompt: |
     Review the available tools, the conversation history, and the user's question, then produce a concise numbered execution plan. Start each step with a tool name and a brief description of the step.
     Put relevant context (for example, sensor IDs or time ranges) from the conversation history directly in the plan steps so the execution agent does not need to re-read the history.
-    If the current request explicitly asks to start captioning or configure a stream, plan exactly one call to `lvs_config_media`; ignore any unfinished summary plan from the previous turn.
+    If the current request explicitly asks to start captioning or configure a stream, ignore any unfinished summary plan and plan exactly one call to `lvs_config_media`, unless the same stream was already configured successfully. For an explicit reconfiguration request, call it with `reconfigure=true`.
     For summaries of named media, plan `vst_video_list` first, then exactly one summary tool based only on its result: `rtsp` → `lvs_stream_understanding`; `video` → `lvs_video_understanding`. Never choose the summary tool from duration.
     Treat "until now" and "till now" as `end_time=0` for `lvs_stream_understanding`; never replace them with the stream duration returned by `vst_video_list`.
     A non-empty name supplied in the request is the sensor_id. For example, in "Generate a report for warehouse_sample", the sensor_id is "warehouse_sample"; this request is complete and MUST NOT trigger a clarifying question.
@@ -388,11 +388,11 @@ workflow:
     ## STEP 1 — Resolve media_type BEFORE routing (always, for any request that names a <name>):
       - If you already know `<name>`'s type from this conversation (you uploaded it as a video, or added it as an RTSP stream), use that.
       - Otherwise your FIRST tool call MUST be `vst_video_list`. Look up `<name>` in the result. Each entry has `media_type='rtsp'` (live stream) or `media_type='video'` (uploaded file).
-      - `vst_video_list` is AUTHORITATIVE for uploaded videos: every uploaded video appears there. It is NOT authoritative for live streams — a live RTSP stream may be absent from the list.
+      - `vst_video_list` is AUTHORITATIVE for available media: both uploaded videos and live RTSP streams appear there.
       - POSITIVE ROUTING RULE (no dead-ends):
         * If `<name>` is listed with `media_type='video'` → it is an uploaded video.
         * If `<name>` is listed with `media_type='rtsp'` → it is a live stream.
-        * If `<name>` is NOT listed → it is NOT an uploaded video, so it MUST be a live RTSP stream. Call `lvs_stream_understanding(stream_name='<name>', ...)`. If that returns `not_configured`, surface the message to the user and stop.
+        * If `<name>` is NOT listed → tell the user it is unavailable and ask them to check the name or add the media. Do not call a summary or captioning tool for it.
       - Route on the `media_type` field or on absence from the list — NEVER on the words "stream"/"video" in the user's message, and NEVER on the name itself.
       - This applies to "summarize", "describe", "give a summary of", "generate a report for", and any content question about a named `<name>`.
 
@@ -437,8 +437,8 @@ workflow:
       - If the response status is "not_configured", surface the response message VERBATIM to the user and STOP. Do NOT auto-call lvs_config_media — caption generation must be confirmed by the user first.
       - Worked example (bare prompt, no "stream" cue) — mimic this reasoning:
         User: "Summarize warehouse_sample from 45 seconds until now"
-        1. Call `vst_video_list` → result lists only videos (e.g. clip_007, dev_base_001); `warehouse_sample` is NOT listed.
-        2. Not listed ⇒ it is NOT an uploaded video ⇒ it is a live RTSP stream.
+        1. Call `vst_video_list` → `warehouse_sample` is listed with `media_type='rtsp'`.
+        2. Route by that media type ⇒ it is a live RTSP stream.
         3. Call `lvs_stream_understanding(stream_name='warehouse_sample', start_time=45, end_time=0, response_type='summary')`.
         4. If it returns `not_configured`, surface that message to the user and stop. Do NOT call `lvs_config_media`.
         (If `<name>` HAD been listed with media_type='video', step 3 would instead call `lvs_video_understanding(sensor_id='<name>', ...)`.)
@@ -449,7 +449,7 @@ workflow:
       - Do NOT call this tool just because a previous tool's response said the stream is "not configured" — surface that response to the user and wait for an explicit start request.
       - Do NOT call speculatively or as a pre-check.
       - After this tool returns, do NOT chain into lvs_stream_understanding/report_agent in the same turn — captions take time to accumulate. Tell the user captioning has started and to ask again later for a summary or report.
-      - Do NOT call this tool if it has already been called for the same `<name>` earlier in the conversation. Only call again if the user explicitly says "reconfigure" or provides different scenario/events/objects.
+      - Do NOT call this tool if it successfully configured the same `<name>` earlier in the conversation. Only call again with `reconfigure=true` if the user explicitly says "reconfigure" or provides different scenario/events/objects.
       **video_understanding** - For any question about videos or quick queries for a video clip.
       - Use when user asks "what happens in the video" or "describe the video" or "analyze this video" or "what is happening in the video"
       - Do NOT use when user asks to "generate a report" or "summarize" — use report_agent for reports; for summaries, route by `media_type` as defined above.
@@ -460,12 +460,12 @@ workflow:
     ## Stream vs uploaded video: when a request mentions a `<name>` that could be either, you MUST identify its media_type before routing.
       - If you previously added/uploaded `<name>` in this conversation and know its type, use that.
       - Otherwise call `vst_video_list` and look up `<name>` in the result. Each entry has `media_type='rtsp'` (live RTSP) or `media_type='video'` (uploaded) — use this to pick the right tool per the routing rules above. Do NOT guess from the name.
-      - If `<name>` is not in `vst_video_list`, follow STEP 1's live-stream fallback: call `lvs_stream_understanding` and surface `not_configured` verbatim if returned.
+      - If `<name>` is not in `vst_video_list`, tell the user it is unavailable and ask them to check the name or add the media. Do not offer to start captioning it.
     ## Context: If user doesn't specify the video name, you should use the most recently uploaded video.
 
 
   tool_call_prompt: |
-    - CURRENT REQUEST TAKES PRIORITY: if it explicitly asks to start captioning or configure a stream, call `lvs_config_media` once and wait for its HITL response. Do not call another tool and do not continue an earlier summary plan.
+    - CURRENT REQUEST TAKES PRIORITY: if it explicitly asks to start captioning or configure a stream, call `lvs_config_media` once and wait for its HITL response. Do not continue an earlier summary plan. If that stream was already configured successfully, do not call it again unless the user explicitly requests reconfiguration; then pass `reconfigure=true`.
     - HARD ROUTING RULE FOR SUMMARIES: read the target's `media_type` from the latest `vst_video_list` result. If it is `rtsp`, the only permitted summary tool is `lvs_stream_understanding`; never call `lvs_video_understanding`. If it is `video`, the only permitted summary tool is `lvs_video_understanding`. Ignore duration when making this choice, even if the execution plan chose differently.
     - For `rtsp`, pass `stream_name`, `response_type='summary'`, and the requested numeric time range. "Until now" or "till now" always means `end_time=0`.
     - ALWAYS include ALL required parameters when calling tools

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_config_media.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_config_media.py
@@ -211,6 +211,10 @@ class LVSConfigMediaInput(BaseModel):
         default="stream", description="Media type to configure. Currently stream only."
     )
     stream_name: str = Field(..., description="The VST live stream/camera name to configure for LVS.")
+    reconfigure: bool = Field(
+        default=False,
+        description="Reconfigure an already configured stream. Set only when the user explicitly requests reconfiguration.",
+    )
 
     @field_validator("stream_name")
     @classmethod
@@ -356,6 +360,19 @@ async def lvs_config_media(config: LVSConfigMediaConfig, _: Builder) -> AsyncGen
             )
 
         configured = configured_media(lvs_input.media_type, media_name)
+        if configured and not lvs_input.reconfigure:
+            return LVSConfigMediaOutput(
+                status=LVSMediaStatus.ACCEPTED,
+                media_type=lvs_input.media_type,
+                media_name=configured.media_name,
+                media_id=configured.media_id,
+                configured=True,
+                message=f"Caption generation is already configured for stream '{configured.media_name}'.",
+                scenario=configured.scenario,
+                events=list(configured.events),
+                objects_of_interest=list(configured.objects_of_interest),
+            )
+
         current_params = None
         if configured:
             current_params = (

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_stream_understanding.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_stream_understanding.py
@@ -40,6 +40,7 @@ from vss_agents.tools.lvs_config_media import _coerce_lvs_response
 from vss_agents.tools.lvs_media_state import configured_media
 from vss_agents.tools.vst.timeline import get_timeline
 from vss_agents.tools.vst.utils import VSTError
+from vss_agents.tools.vst.utils import get_stream_info_by_name
 from vss_agents.utils.time_convert import datetime_to_iso8601
 from vss_agents.utils.time_convert import iso8601_to_datetime
 
@@ -178,9 +179,30 @@ async def lvs_stream_understanding(config: LVSStreamUnderstandingConfig, _: Buil
         """
         configured = configured_media("stream", lvs_input.stream_name)
         if configured is None:
+            try:
+                stream_id, stream_url = await get_stream_info_by_name(
+                    lvs_input.stream_name,
+                    config.vst_internal_url,
+                )
+            except Exception as error:
+                logger.error("Failed to verify VST stream %r: %s", lvs_input.stream_name, error)
+                return LVSStreamUnderstandingOutput(
+                    status=LVSMediaStatus.FAILED,
+                    stream_name=lvs_input.stream_name,
+                    configured=False,
+                    message=f"Failed to verify stream '{lvs_input.stream_name}' in VST: {error}",
+                )
+            if not stream_id or not stream_url:
+                return LVSStreamUnderstandingOutput(
+                    status=LVSMediaStatus.FAILED,
+                    stream_name=lvs_input.stream_name,
+                    configured=False,
+                    message=f"Stream '{lvs_input.stream_name}' was not found in VST live streams.",
+                )
             return LVSStreamUnderstandingOutput(
                 status=LVSMediaStatus.NOT_CONFIGURED,
                 stream_name=lvs_input.stream_name,
+                stream_id=stream_id,
                 configured=False,
                 message=(
                     f"There are no captions stored for stream '{lvs_input.stream_name}'. "

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_config_media.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_config_media.py
@@ -28,8 +28,10 @@ from vss_agents.tools.lvs_config_media import LVSConfigMediaOutput
 from vss_agents.tools.lvs_config_media import LVSMediaStatus
 from vss_agents.tools.lvs_config_media import lvs_config_media
 from vss_agents.tools.lvs_config_media import user_requested_caption_generation
+from vss_agents.tools.lvs_media_state import LVSConfiguredMedia
 from vss_agents.tools.lvs_media_state import clear_configured_media_state
 from vss_agents.tools.lvs_media_state import configured_media
+from vss_agents.tools.lvs_media_state import remember_configured_media
 
 
 class TestLVSConfigMediaModels:
@@ -60,6 +62,7 @@ class TestLVSConfigMediaModels:
         input_data = LVSConfigMediaInput(stream_name=" CAM_1 ")
         assert input_data.media_type == "stream"
         assert input_data.stream_name == "CAM_1"
+        assert input_data.reconfigure is False
 
         with pytest.raises(ValidationError):
             LVSConfigMediaInput(stream_name=" ")
@@ -201,6 +204,44 @@ class TestLVSConfigMediaInner:
                 "use_fps_for_chunking": False,
             },
         )
+
+    @pytest.mark.asyncio
+    async def test_config_media_does_not_reopen_hitl_for_configured_stream(self):
+        remember_configured_media(
+            LVSConfiguredMedia(
+                media_type="stream",
+                media_name="CAM_1",
+                media_id="stream-uuid",
+                media_url="rtsp://example/stream",
+                scenario="warehouse monitoring",
+                events=("accident",),
+                objects_of_interest=("forklift",),
+            )
+        )
+        config = LVSConfigMediaConfig(
+            lvs_backend_url="http://localhost:38111",
+            vst_internal_url="http://localhost:30888",
+            hitl_scenario_template="Scenario",
+            hitl_events_template="Events",
+            hitl_objects_template="Objects",
+        )
+
+        with (
+            patch(
+                "vss_agents.tools.lvs_config_media.get_stream_info_by_name",
+                new=AsyncMock(return_value=("stream-uuid", "rtsp://example/stream")),
+            ),
+            patch("vss_agents.tools.lvs_config_media._prompt_user_input", new_callable=AsyncMock) as mock_prompt,
+            patch("vss_agents.tools.lvs_config_media.aiohttp.ClientSession") as mock_session,
+        ):
+            inner_fn = await self._get_inner_fn(config)
+            result = await inner_fn(LVSConfigMediaInput(stream_name="CAM_1"))
+
+        assert result.status == LVSMediaStatus.ACCEPTED
+        assert result.configured is True
+        assert "already configured" in result.message.lower()
+        mock_prompt.assert_not_awaited()
+        mock_session.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_config_media_payload_includes_enable_audio_when_set(self):

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_stream_understanding.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_stream_understanding.py
@@ -126,24 +126,53 @@ class TestLVSStreamUnderstandingInner:
             lvs_backend_url="http://localhost:38111",
             vst_internal_url="http://localhost:30888",
         )
-        inner_fn = await self._get_inner_fn(config)
-
-        result = await inner_fn(
-            LVSStreamUnderstandingInput(
-                stream_name="CAM_1",
-                start_time=0,
-                end_time=45,
+        with patch(
+            "vss_agents.tools.lvs_stream_understanding.get_stream_info_by_name",
+            new=AsyncMock(return_value=("stream-uuid", "rtsp://example/stream")),
+        ):
+            inner_fn = await self._get_inner_fn(config)
+            result = await inner_fn(
+                LVSStreamUnderstandingInput(
+                    stream_name="CAM_1",
+                    start_time=0,
+                    end_time=45,
+                )
             )
-        )
 
         assert result.status == LVSMediaStatus.NOT_CONFIGURED
         assert result.configured is False
+        assert result.stream_id == "stream-uuid"
         # Message must (a) tell the user there are no captions yet and
         # (b) include the explicit trigger phrase the user must reply with to
         # start caption generation. The agent prompt requires this phrasing
         # so it surfaces verbatim and does NOT auto-call lvs_config_media.
         assert "no captions stored" in result.message.lower()
         assert "start captioning CAM_1" in result.message
+
+    @pytest.mark.asyncio
+    async def test_missing_stream_does_not_offer_caption_setup(self):
+        config = LVSStreamUnderstandingConfig(
+            lvs_backend_url="http://localhost:38111",
+            vst_internal_url="http://localhost:30888",
+        )
+
+        with patch(
+            "vss_agents.tools.lvs_stream_understanding.get_stream_info_by_name",
+            new=AsyncMock(return_value=(None, None)),
+        ):
+            inner_fn = await self._get_inner_fn(config)
+            result = await inner_fn(
+                LVSStreamUnderstandingInput(
+                    stream_name="missing_camera",
+                    start_time=0,
+                    end_time=45,
+                )
+            )
+
+        assert result.status == LVSMediaStatus.FAILED
+        assert result.configured is False
+        assert "not found" in result.message.lower()
+        assert "start captioning" not in result.message.lower()
 
     @pytest.mark.asyncio
     async def test_configured_stream_calls_stream_summarize(self):
@@ -280,15 +309,18 @@ class TestLVSStreamUnderstandingInner:
                 lvs_backend_url="http://localhost:38111",
                 vst_internal_url="http://localhost:30888",
             )
-            inner_fn = await self._get_inner_fn(config)
-
-            result = await inner_fn(
-                LVSStreamUnderstandingInput(
-                    stream_name="CAM_1",
-                    start_time=0,
-                    end_time=45,
+            with patch(
+                "vss_agents.tools.lvs_stream_understanding.get_stream_info_by_name",
+                new=AsyncMock(return_value=("stream-uuid", "rtsp://example/stream")),
+            ):
+                inner_fn = await self._get_inner_fn(config)
+                result = await inner_fn(
+                    LVSStreamUnderstandingInput(
+                        stream_name="CAM_1",
+                        start_time=0,
+                        end_time=45,
+                    )
                 )
-            )
         finally:
             ContextState.get().conversation_id.reset(other_conversation_token)
 


### PR DESCRIPTION
## Summary

  Strengthen the LVS agent prompt to route live summaries by media type and correctly handle captioning follow-up requests.

  ## Plan

  - Resolve named media using `vst_video_list`.
  - Route RTSP summaries to `lvs_stream_understanding` and uploaded-video summaries to `lvs_video_understanding`.
  - Treat “until now” and “till now” as `end_time=0` for live streams.
  - Prioritize explicit captioning requests so they invoke `lvs_config_media` and wait for the HITL response.

  ## Related Issue

  Related to the nightly LVS WebSocket/UI E2E caption-setup failure.

  ## Changes

  - Prevent live RTSP streams from being routed through the recorded-video summarization path.
  - Prevent stream duration from being used to determine media type.
  - Remove the sensor-specific prompt example in favor of generic routing instructions.
  - Ensure an explicit “start captioning” follow-up invokes `lvs_config_media` instead of continuing a previous summary plan.
  - Manually verified the summary route across repeated and varied requests.
  - Verified that an explicit captioning request reaches the HITL configuration
  tool.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.
