### PR TITLE
feat(bvai): Enable BVAI to point the NemoClaw harness to the VSS deployment's own local LLM

### DIFF
--- a/deploy/docker/scripts/deploy_nemoclaw.ipynb
+++ b/deploy/docker/scripts/deploy_nemoclaw.ipynb
@@ -200,7 +200,7 @@
         "\n",
         "- `NEMOCLAW_INSTALL_REF` — pinned installer.\n",
         "- `AGENT_RUNTIME` — `openclaw` or `hermes` (env override). Add an `AGENT_HARNESS_PROFILES` entry for a new harness.\n",
-        "- `NEMOCLAW_INFERENCE_PROXY` — SSRF check and host proxy for local endpoints.\n",
+        "- `NEMOCLAW_INFERENCE_PROXY` — SSRF check and host proxy for local endpoints (env override; `0` disables it). The proxy reaches its upstream over `https` on port 443, so turn it off for a self-hosted endpoint served over plain HTTP or on another port — such as this deployment's own LLM NIM.\n",
         "- `AGENT_HOOKS_*` / `AGENT_WEBHOOK_PORT` — inbound webhooks (Hermes default `8644`).\n",
         "- `AGENT_DASHBOARD_PORT` — derived (`18789`; override via `NEMOCLAW_DASHBOARD_PORT`).\n",
         "- `NEMOCLAW_VLLM_PORT` — host port for NemoClaw-managed vLLM. Used by `install-vllm`\n",
@@ -269,6 +269,12 @@
         "VSS_REPO_DIR = Path(SHELL_ENV.get(\"VSS_REPO_DIR\", HOME_DIR / \"video-search-and-summarization\")).resolve()\n",
         "NEMOCLAW_REPO_DIR = Path(SHELL_ENV.get(\"NEMOCLAW_REPO_DIR\", HOME_DIR / \"NemoClaw\")).resolve()\n",
         "INFERENCE_API_PROXY_PORT = int(SHELL_ENV.get(\"INFERENCE_API_PROXY_PORT\", \"18080\"))\n",
+        "# Read here rather than through run_setup_notebook's parameter table: that table\n",
+        "# assigns the environment string, and 3.1 rejects anything but a real bool.\n",
+        "NEMOCLAW_INFERENCE_PROXY = (\n",
+        "    SHELL_ENV.get(\"NEMOCLAW_INFERENCE_PROXY\", \"\").strip().lower()\n",
+        "    or (\"1\" if NEMOCLAW_INFERENCE_PROXY else \"0\")\n",
+        ") not in (\"0\", \"false\", \"no\", \"off\")\n",
         "AGENT_RUNTIME = (SHELL_ENV.get(\"AGENT_RUNTIME\") or AGENT_RUNTIME).strip().lower()\n",
         "\n",
         "# Fill `{cli}` here once the harness is chosen; later cells still\n",
@@ -446,7 +452,7 @@
         "        print(\"Agent hooks path:\", AGENT_HOOKS_PATH)\n",
         "    elif AGENT_RUNTIME == \"hermes\":\n",
         "        print(\"Agent webhook port:\", AGENT_WEBHOOK_PORT)\n",
-        "print(\"NVIDIA_API_KEY set:\", bool(NVIDIA_API_KEY))\n"
+        "print(\"NVIDIA_API_KEY set:\", bool(NVIDIA_API_KEY))"
       ]
     },
     {
@@ -665,7 +671,7 @@
         "\n",
         "Exports the NemoClaw configuration (including `CHAT_UI_URL`, the dashboard origin for UI access) and installs NemoClaw at the pinned `NEMOCLAW_INSTALL_REF`. The non-interactive installer also creates and onboards the sandbox. Takes a few minutes; output streams live.\n",
         "\n",
-        "With the `custom` provider, when `NEMOCLAW_ENDPOINT_URL`'s host resolves to a non-public address, this step automatically starts the bundled host proxy and points NemoClaw at it, avoiding NemoClaw's SSRF rejection. Set the advanced setting `NEMOCLAW_INFERENCE_PROXY = False` to disable this behavior; it defaults to `True`.\n"
+        "With the `custom` provider, when `NEMOCLAW_ENDPOINT_URL`'s host resolves to a non-public address, this step automatically starts the bundled host proxy and points NemoClaw at it, avoiding NemoClaw's SSRF rejection. Set the advanced setting `NEMOCLAW_INFERENCE_PROXY = False` in 1.3, or export `NEMOCLAW_INFERENCE_PROXY=0`, to disable this behavior; it defaults to `True`. Disable it for an endpoint served over plain HTTP or on a port other than 443 — the proxy always reaches its upstream as `https://<host>` — and pass `COMPATIBLE_API_KEY=EMPTY` yourself, since the placeholder below is applied only to an endpoint this cell resolved to a private address.\n"
       ]
     },
     {

--- a/docs/nemoclaw-configuration.mdx
+++ b/docs/nemoclaw-configuration.mdx
@@ -57,7 +57,7 @@ Advanced values are set in Section 1.3 or derived from the environment.
 | Variable | Default | Description |
 | --- | --- | --- |
 | `NEMOCLAW_INSTALL_REF` | `v0.0.80` | NemoClaw installer pin. Section 3.1 reinstalls if the installed `nemoclaw` version does not match this semver tag. |
-| `NEMOCLAW_INFERENCE_PROXY` | `True` | When `NEMOCLAW_ENDPOINT_URL` resolves to a non-public address, Section 3.1 starts the bundled host proxy and points NemoClaw at it to avoid NemoClaw's SSRF rejection. Set to `False` to disable. |
+| `NEMOCLAW_INFERENCE_PROXY` | `True` | When `NEMOCLAW_ENDPOINT_URL` resolves to a non-public address, Section 3.1 starts the bundled host proxy and points NemoClaw at it to avoid NemoClaw's SSRF rejection. The proxy reaches its upstream as `https://<host>` on port 443, so disable it for an endpoint served over plain HTTP or on another port — such as this deployment's own LLM NIM — and set `COMPATIBLE_API_KEY=EMPTY` yourself. Set to `False` in Section 1.3 or export `NEMOCLAW_INFERENCE_PROXY=0`. |
 | `AGENT_RUNTIME` | `openclaw` | Sandbox agent runtime used at onboard. Supported values are `openclaw` and `hermes`. Override via the `AGENT_RUNTIME` environment variable. |
 | `AGENT_HOOKS_ENABLED` | `True` | Enables agent webhooks and generates a random `AGENT_HOOKS_TOKEN`. |
 | `AGENT_HOOKS_PATH` | `/hooks` | Webhook path under the agent dashboard forward. |

--- a/skills/vss-build-vision-ai/references/agent-harness.md
+++ b/skills/vss-build-vision-ai/references/agent-harness.md
@@ -225,9 +225,15 @@ that fires for every build rejects the supported paths that need no key:
 | Provider | Required at Q3 | Not required |
 |---|---|---|
 | (a) public OpenAI-compatible endpoint — the skill default | `NEMOCLAW_ENDPOINT_URL`, `NEMOCLAW_MODEL`, `COMPATIBLE_API_KEY` | `NVIDIA_API_KEY` |
-| (a) self-hosted endpoint, or one on a private address | `NEMOCLAW_ENDPOINT_URL`, `NEMOCLAW_MODEL` | a key — 3.1 sends the `EMPTY` placeholder for a blank one and the server ignores it |
+| (a) self-hosted endpoint, or one on a private address — including the build's own LLM NIM | `NEMOCLAW_ENDPOINT_URL`, `NEMOCLAW_MODEL`, `COMPATIBLE_API_KEY=EMPTY`, `NEMOCLAW_INFERENCE_PROXY=0` | a real bearer token — the server ignores the value |
 | (b) NemoClaw-managed local model | `NEMOCLAW_PROVIDER` (`install-vllm`, `ollama`, `nim-local`, …) | any API key; `HF_TOKEN` only for a gated `install-vllm` model |
 | (c) build.nvidia.com hosted model | `NVIDIA_API_KEY` | `COMPATIBLE_API_KEY`, `NEMOCLAW_ENDPOINT_URL` |
+
+`NEMOCLAW_INFERENCE_PROXY` follows the upstream's transport rather than the row
+above. Leave the default `1` when the endpoint is HTTPS on 443: it is inert for a
+public address, and it is what rescues a public name that corp or DGX DNS
+resolves to a private one — the case the proxy was built for. Set `0` when the
+upstream is plain HTTP or on another port, which the proxy cannot represent.
 
 Egress from the sandbox to the build is already allowed: the shipped policy's
 `vss-backend` entries cover the HAProxy origin (`7777`) along with each
@@ -235,6 +241,15 @@ backend's own host port. **A build that moves `HAPROXY_HOST_PORT` off `7777`
 has no matching policy entry**, so every call from the sandbox returns
 `CONNECT tunnel failed, response 403`. Report that as a blocker naming the port;
 the policy is a checked-in asset, not something to rewrite per build.
+
+The LLM NIM's published port is in the same position. `vss-backend` allowlists
+literal `host` + `port` pairs and interpolates nothing, and neither NIM port is
+among them — `30081`, which `LLM_PORT` resolves to, nor `30082` for a VLM NIM.
+A harness pointed at the build's NIM therefore relies on NemoClaw authorizing
+the inference endpoint it was onboarded with. A `403 CONNECT tunnel failed` on
+the harness's first turn is that missing entry rather than a deployment fault —
+report it naming the port, and do not fall back to a remote provider to get a
+working chat.
 
 ## Default provider
 
@@ -251,8 +266,40 @@ to the notebook's own (c) build.nvidia.com path:
 
 Override the default **only on an explicit request** for a local or different
 model. "Use a local model", "air-gapped", "use Nemotron", or a named endpoint of
-their own each move the build to (b) or (c) per section 1.2 — the choice is the
-user's, so carry it through rather than reasoning about which is better.
+their own each move the build off the remote default — the choice is the user's,
+so carry it through rather than reasoning about which is better. A local request
+has **two** destinations, not one:
+
+| Request | Route | Where the model runs |
+|---|---|---|
+| "reuse the deployment's LLM", "one model for both", "point it at the LLM NIM" | (a) `custom` against the build's own NIM | the build's `llm_local*` container — no additional GPU |
+| "use a local model", "air-gapped", with no server named | (b) a NemoClaw-managed server (`install-vllm`, `ollama`, `nim-local`) | a second server NemoClaw starts and owns, on its own GPU |
+| a named endpoint of their own | (a) `custom` against that endpoint | wherever they run it |
+
+**(a) against the build's own LLM NIM** is the cheapest local harness and the
+least obvious route, so it is spelled out here. It applies only to a build whose
+`LLM_MODE` resolved to `local` or `local_shared`; one resolved to a remote LLM
+has no local NIM to point at.
+
+| Variable | Value |
+|---|---|
+| `NEMOCLAW_PROVIDER` | `custom` |
+| `NEMOCLAW_ENDPOINT_URL` | `http://host.openshell.internal:<LLM_PORT>/v1`, with `LLM_PORT` read from the build's `resolved.yml` (`30081` on every current profile). Use that hostname rather than `HOST_IP` — the egress policy's entries are keyed on it |
+| `NEMOCLAW_MODEL` | the NIM's `NIM_SERVED_MODEL_NAME` from `resolved.yml`, e.g. `nvidia/nemotron-3.5-lightning-30b-a3b`; never assume the slug |
+| `COMPATIBLE_API_KEY` | `EMPTY` — set it explicitly, per the self-hosted failure mode below |
+| `NEMOCLAW_INFERENCE_PROXY` | `0` — required, per that same failure mode |
+
+Say what the route costs **before** taking it, so the user can pick (b) or the
+remote default instead: the harness adds no GPU but shares one NIM instance with
+the build's own LLM work, at `NIM_KVCACHE_PERCENT=0.3` and
+`NIM_MAX_MODEL_LEN=65536` on the shared-GPU profiles. On a build whose
+capabilities drive that NIM — `lvs` summarization, `search` critique — agent
+turns and the build's own requests contend for KV cache.
+
+[Ordering](#ordering) already covers the timing, and it matters more here: the
+NIM is the slowest service in the build on a cold cache, and it has to answer on
+that port before the notebook runs. Onboard is the only step that applies the
+endpoint, so changing it afterwards needs the sandbox recreated.
 
 Two failure modes to handle rather than paper over:
 
@@ -262,15 +309,26 @@ Two failure modes to handle rather than paper over:
   downstream could tell. Switching providers is the user's call to make on that
   report, not a fallback to take for them.
 - **A private or self-hosted endpoint.** Section 3.1 picks the transport from the
-  endpoint's address, not from the provider name, and a host resolving to a
-  private address gets the bundled proxy with a blank key sent as `EMPTY`. A
-  loopback-only server must be rebound to `0.0.0.0`, because the sandbox reaches
-  this host as `host.openshell.internal`.
+  endpoint's address, not from the provider name: a host resolving to a private
+  address gets the bundled proxy, and a blank key is sent as `EMPTY`. That proxy
+  reaches its upstream as `https://<host>` on 443 and drops the port, so it is
+  **wrong for an endpoint served over plain HTTP or on another port** — a local
+  NIM, vLLM, or Ollama. Export `NEMOCLAW_INFERENCE_PROXY=0` for those, and pass
+  `COMPATIBLE_API_KEY=EMPTY` yourself, since the placeholder is applied only on
+  the branch that export turns off. Disabling the proxy leaves NemoClaw's own
+  SSRF guard to accept the endpoint; an onboard that rejects it is the case the
+  proxy exists for — report it rather than re-aiming the harness at another
+  provider. A loopback-only server must be rebound to `0.0.0.0`, because the
+  sandbox reaches this host as `host.openshell.internal`.
 
 These four variables are exactly the parameter contract
 `run_setup_notebook.py` already carries for this notebook, so exporting them is
 sufficient — the injection re-reads them after the section 1.2 cells have run,
 which is what lets the export win over whichever provider cell executed last.
+`NEMOCLAW_INFERENCE_PROXY` is not in that table and must not be added to it:
+the injection assigns the raw environment string and section 3.1 accepts only a
+real bool. Section 1.3 reads it from the environment itself, so exporting `0`
+works the same way.
 
 ## Bring-up
 
@@ -288,7 +346,8 @@ Set the environment, then run the notebook:
 | `NEMOCLAW_SANDBOX_NAME` | one name per build | the default is `demo`; a second build under the same name reuses the first build's sandbox |
 | `NEMOCLAW_RECREATE_SANDBOX` | `0` | **the notebook default is `1`, which discards the sandbox and every agent session in it.** Pass `0` unless the user asked to rebuild the harness |
 | `AGENT_RUNTIME` | `openclaw` (default) or `hermes` | selects the harness profile; a change needs a fresh onboard |
-| `NEMOCLAW_PROVIDER`, `NEMOCLAW_MODEL`, `NEMOCLAW_ENDPOINT_URL`, `COMPATIBLE_API_KEY` | per [Default provider](#default-provider) | remote Claude Opus unless the user asked for local or another model |
+| `NEMOCLAW_PROVIDER`, `NEMOCLAW_MODEL`, `NEMOCLAW_ENDPOINT_URL`, `COMPATIBLE_API_KEY` | per [Default provider](#default-provider) | remote Claude Opus unless the user asked for local or another model. The block below spells out that remote route alone; every other route **replaces** these values rather than defaulting through them |
+| `NEMOCLAW_INFERENCE_PROXY` | unset, or `0` against a local endpoint | `0` is required when (a) points at the build's own LLM NIM, or at any plain-HTTP server: the default rewrites such an endpoint to an `https` upstream on 443 |
 | `ORCHESTRATOR_ENABLE_HTTPS` | `false` | leave at the default; the HTTPS MCP path is a separate opt-in |
 
 ```bash
@@ -300,13 +359,23 @@ export VSS_REPO_DIR="$REPO"
 export NEMOCLAW_SANDBOX_NAME="<build-name>"
 export NEMOCLAW_RECREATE_SANDBOX=0
 
-# Default harness LLM: notebook option (a), remote Claude Opus.
+# Default harness LLM: notebook option (a), remote Claude Opus. The `:-` form
+# lets an already-exported value win — right for a caller-supplied remote
+# endpoint, and exactly why these four lines must not be copied as-is for the
+# NIM route, where a stale remote endpoint and model would survive.
 export NEMOCLAW_PROVIDER=custom
 export NEMOCLAW_MODEL="${NEMOCLAW_MODEL:-claude-opus-4-6}"
 export NEMOCLAW_ENDPOINT_URL="${NEMOCLAW_ENDPOINT_URL:-https://api.anthropic.com/v1/}"
 # From the environment or the secret store; never a literal here.
 : "${COMPATIBLE_API_KEY:?bearer token for NEMOCLAW_ENDPOINT_URL is required}"
 export COMPATIBLE_API_KEY
+
+# Against the build's own LLM NIM, replace all four outright — plain
+# assignment, and never an inherited bearer token:
+#   export NEMOCLAW_ENDPOINT_URL="http://host.openshell.internal:<LLM_PORT>/v1"
+#   export NEMOCLAW_MODEL="<NIM_SERVED_MODEL_NAME from resolved.yml>"
+#   export COMPATIBLE_API_KEY=EMPTY
+#   export NEMOCLAW_INFERENCE_PROXY=0
 
 uv run --isolated --no-project --python 3.12 \
   --with nbformat --with nbclient --with ipykernel -- \


### PR DESCRIPTION
## Summary

`vss-build-vision-ai` can now stand up a NemoClaw harness that runs on the
deployment's **own** LLM NIM instead of a remote provider. Previously the
skill defaulted to remote Claude Opus and had no documented local route, so
"use a local model" could only mean a second, NemoClaw-managed server on its
own GPU. Reusing the build's NIM costs no additional GPU, needs no provider
API key, and requires no egress to a hosted model — the answer for an
air-gapped or key-less host.

What blocked it was mechanical: `NEMOCLAW_INFERENCE_PROXY` was assignable
only as a literal in the notebook's Section 1.3, so a non-interactive run
could not turn the bundled proxy off. That proxy always reaches its upstream
as `https://<host>` on 443, which cannot represent a NIM on plain HTTP on
`30081`.

## Plan

Make the toggle an environment override, then teach BVAI the route it
unlocks — including what it costs, so the user can still choose a separate
local server or the remote default.

The toggle is read from `SHELL_ENV` in the notebook's derived-settings cell
rather than added to `run_setup_notebook.py`'s `NOTEBOOK_PARAMETERS` table:
that table assigns the raw environment string and Section 3.1 accepts only a
real bool. Reading it in the derived cell stays idempotent across cell
re-runs and keeps the existing `True` default.

## Related Issue

N/A

## Changes

- **`skills/vss-build-vision-ai/references/agent-harness.md`** — the substance
  of the PR. A routing table separating "reuse the deployment's LLM" from "use
  a local model" (two different destinations, previously conflated); the four
  variables the NIM route needs, with `LLM_PORT` and `NIM_SERVED_MODEL_NAME`
  read from `resolved.yml` rather than assumed; the shared-KV-cache cost to
  report *before* taking the route, since agent turns then contend with the
  build's own `lvs` and `search` work; and a note that `vss-backend`
  allowlists literal host/port pairs with no entry for `30081` or `30082`, so
  a `403 CONNECT tunnel failed` on the first turn is that gap, not a
  deployment fault.
- **`deploy/docker/scripts/deploy_nemoclaw.ipynb`** — read
  `NEMOCLAW_INFERENCE_PROXY` from the environment, falling back to the 1.3
  literal; say in 1.3 and 3.1 when to disable it and that
  `COMPATIBLE_API_KEY=EMPTY` must then be passed explicitly, since the
  placeholder is applied only on the branch the override turns off.
- **`docs/nemoclaw-configuration.mdx`** — same guidance on that variable's row.

Four lines of executable change; the rest is skill and notebook prose. No
service, image, or Compose change, and the remote-provider default is
untouched.

## Validation

The remote route is unaffected and still works on this branch — the proxy
engages for `inference-api.nvidia.com`, which resolves to private addresses,
the case it exists for.

The local-NIM route is **not yet validated end to end**. It needs a deployed
build whose NIM answers on `30081` before onboarding, and the open question
is whether NemoClaw authorizes the inference endpoint it was onboarded with
given that `vss-backend` carries no entry for that port. The skill documents
that failure as a blocker to report rather than something to work around, so
a `403` there would mean adding a policy entry to `assets/vss_nemoclaw_policy.yaml`
in a follow-up.

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] I have installed and run pre-commit hooks locally.
- [x] Every commit on this PR is DCO sign-off'd.
- [ ] New or existing tests cover these changes. — n/a: notebook cells and
      skill references have no test harness.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.