### PR TITLE
fix: unblock Helm base/search installs and GB300 alerts GPU pinning

### DIFF
--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -99,6 +99,46 @@ function get_nvidia_smi_gpu_count() {
   echo "${_count}"
 }
 
+# Echoes a GPU index the host actually exposes, clamping one that is too high.
+#
+# Profiles pin services to explicit indices: alerts puts the local VLM and
+# RT-VLM on device 1 so they do not contend with the LLM on device 0. On a
+# board with a single GPU that index does not exist, and the NVIDIA container
+# runtime refuses the container before it starts:
+#
+#   nvidia-container-cli: device error: 1: unknown device: unknown
+#
+# which Compose reports only as exit_code=128. The edge boards already dodge
+# this by collapsing every placement onto device 0 further down; this covers
+# the remaining single-GPU hosts (GB300 alerts is the case that failed) without
+# hardcoding a board name, so a mistagged or newly-enrolled node degrades
+# instead of dying.
+#
+# A host with enough GPUs is never altered, so multi-GPU placement is
+# unchanged. The value is also passed through untouched when:
+#   - nvidia-smi reports no GPUs, i.e. a CPU-only host, --dry-run, or a broken
+#     driver: clamping there would paper over a real fault;
+#   - it is not a plain index. MIG UUIDs (MIG-GPU-...) are valid device_ids
+#     entries and carry no ordering to clamp against.
+function clamp_device_id_to_visible_gpus() {
+  local _label="${1}" _requested="${2}" _count _highest
+  if [[ ! "${_requested}" =~ ^[0-9]+$ ]]; then
+    echo "${_requested}"
+    return 0
+  fi
+  _count="$(get_nvidia_smi_gpu_count)"
+  if [[ "${_count}" -lt 1 ]] || [[ "${_requested}" -lt "${_count}" ]]; then
+    echo "${_requested}"
+    return 0
+  fi
+  _highest=$((_count - 1))
+  echo "[WARNING] ${_label}=${_requested} requests a GPU this host does not have;" \
+    "nvidia-smi reports ${_count} GPU(s) (indices 0-${_highest}). Using ${_highest}." >&2
+  echo "[WARNING] Pinning a service to a missing device fails as" \
+    "'nvidia-container-cli: device error: ${_requested}: unknown device' (exit 128)." >&2
+  echo "${_highest}"
+}
+
 # Returns the indices of GPUs whose product name matches the requested hardware
 # profile, one per line. This is used when a service-specific device ID cannot
 # identify the deployment GPU (for example, when both LLM and VLM are remote).
@@ -1704,10 +1744,15 @@ function state_up() {
       set_env_var "FIXED_SHARED_DEVICE_IDS" "0"
     fi
   else
+    # Clamp before writing, and keep the clamped value in the caller-visible
+    # variable: RT_VLM_DEVICE_ID is derived from vlm_device_id further down and
+    # has to name the same GPU as VLM_DEVICE_ID.
     if [[ "${llm_mode}" != "remote" ]] && [[ -n "${llm_device_id}" ]]; then
+      llm_device_id="$(clamp_device_id_to_visible_gpus "LLM_DEVICE_ID" "${llm_device_id}")"
       set_env_var "LLM_DEVICE_ID" "${llm_device_id}"
     fi
     if [[ "${vlm_mode}" != "remote" ]] && [[ -n "${vlm_device_id}" ]]; then
+      vlm_device_id="$(clamp_device_id_to_visible_gpus "VLM_DEVICE_ID" "${vlm_device_id}")"
       set_env_var "VLM_DEVICE_ID" "${vlm_device_id}"
     fi
   fi
@@ -1848,11 +1893,16 @@ function state_up() {
       if [[ "${vlm_mode}" == "local_shared" ]]; then
         local _shared_rt_dev_id
         _shared_rt_dev_id="$(get_env_value_from_files "SHARED_LLM_VLM_DEVICE_ID" "${_source_env}" "${_overrides_env}")"
-        set_env_var "RT_VLM_DEVICE_ID" "${_shared_rt_dev_id:-${vlm_device_id}}"
+        set_env_var "RT_VLM_DEVICE_ID" \
+          "$(clamp_device_id_to_visible_gpus "RT_VLM_DEVICE_ID" "${_shared_rt_dev_id:-${vlm_device_id}}")"
       elif [[ "${vlm_mode}" == "remote" ]]; then
         set_env_var "RT_VLM_DEVICE_ID" "0"
       else
-        set_env_var "RT_VLM_DEVICE_ID" "${vlm_device_id}"
+        # Clamped again rather than trusting vlm_device_id: the edge branch above
+        # rewrites VLM_DEVICE_ID to 0 without touching the variable, so DGX-SPARK
+        # alerts would otherwise still place RT-VLM on the missing device 1.
+        set_env_var "RT_VLM_DEVICE_ID" \
+          "$(clamp_device_id_to_visible_gpus "RT_VLM_DEVICE_ID" "${vlm_device_id}")"
       fi
       # RT-VLM remains a local proxy for remote VLM endpoints on GB300 search,
       # which is the only profile that resolves a single deployment GPU.

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -741,6 +741,60 @@ run_dry_run_up_and_check_generated_env "generated.env alerts RTXPRO6000BW local 
 run_dry_run_up_and_check_generated_env "generated.env alerts L40S local RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.8" "alerts" \
   -i 127.0.0.1 -m verification -H L40S --llm-device-id 2 --vlm-device-id 1 -d -- \
   "RTVI_VLLM_GPU_MEMORY_UTILIZATION" "0.8"
+
+# --- Device index clamped to the GPUs the host actually has ---
+# The alerts profile pins LLM, VLM and RT-VLM to device 1 so they do not contend
+# on device 0. On a single-GPU host that index does not exist and the NVIDIA
+# runtime refuses the container before it starts:
+#   nvidia-container-cli: device error: 1: unknown device
+# which Compose reports only as exit_code=128 -- the GB300 alerts sanity failure
+# in nightly pipeline 66564139. A host with 2+ GPUs must keep device 1, since
+# clamping there would put the VLM back on top of the LLM.
+_mock_clamp_one_gpu_dir="$(mktemp -d)"
+CLEANUP_DIRS+=("${_mock_clamp_one_gpu_dir}")
+cat > "${_mock_clamp_one_gpu_dir}/nvidia-smi" <<'EOF'
+#!/bin/bash
+if [[ "$*" == *"--query-gpu=index"* ]]; then
+  printf '0\n'
+else
+  printf 'NVIDIA H100 80GB HBM3\n'
+fi
+EOF
+chmod +x "${_mock_clamp_one_gpu_dir}/nvidia-smi"
+_mock_clamp_two_gpu_dir="$(mktemp -d)"
+CLEANUP_DIRS+=("${_mock_clamp_two_gpu_dir}")
+cat > "${_mock_clamp_two_gpu_dir}/nvidia-smi" <<'EOF'
+#!/bin/bash
+if [[ "$*" == *"--query-gpu=index"* ]]; then
+  printf '0\n1\n'
+else
+  printf 'NVIDIA H100 80GB HBM3\nNVIDIA H100 80GB HBM3\n'
+fi
+EOF
+chmod +x "${_mock_clamp_two_gpu_dir}/nvidia-smi"
+# nvidia-smi reporting nothing (CPU-only host, or a broken driver) must leave the
+# profile's request untouched, so a real fault is not masked by a silent clamp.
+_mock_clamp_no_gpu_dir="$(mktemp -d)"
+CLEANUP_DIRS+=("${_mock_clamp_no_gpu_dir}")
+cat > "${_mock_clamp_no_gpu_dir}/nvidia-smi" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+chmod +x "${_mock_clamp_no_gpu_dir}/nvidia-smi"
+PATH="${_mock_clamp_one_gpu_dir}:${PATH}" run_dry_run_up_and_check_generated_env "generated.env alerts 1 visible GPU clamps device 1 to 0" "alerts" \
+  -i 127.0.0.1 -m verification -H H100 -d -- \
+  "LLM_DEVICE_ID" "0" "VLM_DEVICE_ID" "0" "RT_VLM_DEVICE_ID" "0"
+PATH="${_mock_clamp_two_gpu_dir}:${PATH}" run_dry_run_up_and_check_generated_env "generated.env alerts 2 visible GPUs keep device 1" "alerts" \
+  -i 127.0.0.1 -m verification -H H100 -d -- \
+  "LLM_DEVICE_ID" "1" "VLM_DEVICE_ID" "1" "RT_VLM_DEVICE_ID" "1"
+# An explicit --vlm-device-id is clamped too: the flag cannot conjure a device.
+# (Device 0 is in the alerts profile's RESERVED_DEVICE_IDS, so the LLM stays on 1.)
+PATH="${_mock_clamp_two_gpu_dir}:${PATH}" run_dry_run_up_and_check_generated_env "generated.env alerts clamps an out-of-range --vlm-device-id" "alerts" \
+  -i 127.0.0.1 -m verification -H H100 --vlm-device-id 7 -d -- \
+  "LLM_DEVICE_ID" "1" "VLM_DEVICE_ID" "1" "RT_VLM_DEVICE_ID" "1"
+PATH="${_mock_clamp_no_gpu_dir}:${PATH}" run_dry_run_up_and_check_generated_env "generated.env alerts no visible GPU leaves device 1 untouched" "alerts" \
+  -i 127.0.0.1 -m verification -H H100 -d -- \
+  "LLM_DEVICE_ID" "1" "VLM_DEVICE_ID" "1" "RT_VLM_DEVICE_ID" "1"
 run_dry_run_up_and_check_generated_env "generated.env alerts RTXPRO4500BW RTVI tuning" "alerts" \
   -i 127.0.0.1 -m verification -H RTXPRO4500BW -d -- \
   "RTVI_VLLM_GPU_MEMORY_UTILIZATION" "0.8" "RTVI_VLM_MAX_MODEL_LEN" "18000" "RTVI_VLM_MODEL_PATH" "ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final" "VLM_NAME" "nim_nvidia_cosmos3-nano-reasoner_bf16-final"

--- a/deploy/helm/services/ui/templates/deployment.yaml
+++ b/deploy/helm/services/ui/templates/deployment.yaml
@@ -202,12 +202,22 @@ spec:
               value: {{ (default 900 $adapter.backendTimeoutSeconds) | quote }}
             - name: AGENT_RUN_RETENTION_SECONDS
               value: {{ (default 3600 $adapter.runRetentionSeconds) | quote }}
+            {{- /*
+              int64 before quote: Helm decodes values.yaml numbers as float64,
+              and `quote` formats those with %v, so 20000000 renders "2e+07".
+              Kubernetes accepts the quoted form, but re-serialising the
+              manifest drops the quotes (2e+07 is not a YAML 1.1 number, so
+              round-trippers emit it plain) and the API server then rejects
+              `value` as a number where a string is required. int64 keeps the
+              digits, matching the compose defaults in
+              deploy/docker/services/ui/compose.yml.
+            */}}
             - name: AGENT_MAX_EVENT_CHARS_PER_RUN
-              value: {{ (default 20000000 $adapter.maxEventCharsPerRun) | quote }}
+              value: {{ (default 20000000 $adapter.maxEventCharsPerRun) | int64 | quote }}
             - name: AGENT_MAX_THREAD_STATE_CHARS
-              value: {{ (default 20000000 $adapter.maxThreadStateChars) | quote }}
+              value: {{ (default 20000000 $adapter.maxThreadStateChars) | int64 | quote }}
             - name: AGENT_MAX_RETAINED_CHARS
-              value: {{ (default 64000000 $adapter.maxRetainedChars) | quote }}
+              value: {{ (default 64000000 $adapter.maxRetainedChars) | int64 | quote }}
             - name: NEXT_PUBLIC_AGENT_ADAPTER_ENABLED
               value: {{ $adapterEnabled | quote }}
             {{- $forceHttp := $adapter.forceHttpChatTransport }}

--- a/deploy/tests/test_helm_env_value_types.py
+++ b/deploy/tests/test_helm_env_value_types.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Container env values must render as digits, not float exponent notation.
+
+Helm decodes values.yaml numbers as float64, and `quote` formats those with
+%v, so a plain `{{ .Values.x | quote }}` renders 20000000 as "2e+07".
+Kubernetes accepts that quoted form, but it is not a YAML 1.1 number, so a
+round-trip through a YAML library re-emits it unquoted and the API server
+then rejects `env.value` as a number where a string is required:
+
+    Deployment in version "v1" cannot be handled as a Deployment: json:
+    cannot unmarshal number into Go struct field EnvVar...env.value of type
+    string
+
+That is a whole-release failure -- nothing installs -- so it is worth pinning
+on every chart rather than only on the one that regressed.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import unittest
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HELM_ROOT = REPO_ROOT / "deploy" / "helm"
+
+# Charts that render standalone (no `helm dependency build` network access).
+STANDALONE_CHARTS = (
+    HELM_ROOT / "services" / "ui",
+    HELM_ROOT / "services" / "alert",
+    HELM_ROOT / "services" / "video-summarization",
+)
+
+# Go's %v on a float64 switches to exponent form for values like 2e+07.
+EXPONENT = re.compile(r"^[-+]?[0-9]+(\.[0-9]+)?[eE][-+]?[0-9]+$")
+
+
+def _helm_template(chart: Path) -> str:
+    result = subprocess.run(
+        ["helm", "template", "vss", str(chart), "--set", "enabled=true"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def _env_values(rendered: str):
+    """Yield (kind, name, container, env_name, env_value) for every env value."""
+    for document in yaml.safe_load_all(rendered):
+        if not isinstance(document, dict):
+            continue
+        spec = document.get("spec", {}) or {}
+        pod_spec = (spec.get("template", {}) or {}).get("spec", {}) or {}
+        containers = list(pod_spec.get("containers") or [])
+        containers += list(pod_spec.get("initContainers") or [])
+        for container in containers:
+            for entry in container.get("env") or []:
+                if not isinstance(entry, dict) or "value" not in entry:
+                    continue
+                yield (
+                    document.get("kind"),
+                    (document.get("metadata") or {}).get("name"),
+                    container.get("name"),
+                    entry.get("name"),
+                    entry["value"],
+                )
+
+
+class HelmEnvValueTypeTests(unittest.TestCase):
+    def test_env_values_are_strings(self):
+        """A bare number under `value:` is rejected by the API server outright."""
+        for chart in STANDALONE_CHARTS:
+            rendered = _helm_template(chart)
+            for kind, name, container, env_name, value in _env_values(rendered):
+                with self.subTest(chart=chart.name, env=env_name):
+                    self.assertIsInstance(
+                        value,
+                        str,
+                        f"{kind}/{name} container {container}: {env_name} "
+                        f"renders as {type(value).__name__} {value!r}; "
+                        "Kubernetes requires a string",
+                    )
+
+    def test_env_values_avoid_exponent_notation(self):
+        """`value: "2e+07"` installs, but loses its quotes on any YAML round-trip."""
+        for chart in STANDALONE_CHARTS:
+            rendered = _helm_template(chart)
+            for kind, name, container, env_name, value in _env_values(rendered):
+                if not isinstance(value, str) or not EXPONENT.match(value):
+                    continue
+                self.fail(
+                    f"{kind}/{name} container {container}: {env_name}={value!r} "
+                    "is float exponent notation. Helm renders values.yaml "
+                    "numbers through float64, so pipe the value through "
+                    "`int64` before `quote` to keep the digits."
+                )
+
+    def test_ui_adapter_char_limits_render_as_digits(self):
+        """Pins the three limits that regressed, including their exact values."""
+        rendered = _helm_template(HELM_ROOT / "services" / "ui")
+        found = {
+            env_name: value
+            for _, _, _, env_name, value in _env_values(rendered)
+            if env_name
+            in {
+                "AGENT_MAX_EVENT_CHARS_PER_RUN",
+                "AGENT_MAX_THREAD_STATE_CHARS",
+                "AGENT_MAX_RETAINED_CHARS",
+            }
+        }
+        self.assertEqual(
+            found,
+            {
+                "AGENT_MAX_EVENT_CHARS_PER_RUN": "20000000",
+                "AGENT_MAX_THREAD_STATE_CHARS": "20000000",
+                "AGENT_MAX_RETAINED_CHARS": "64000000",
+            },
+        )
+
+    def test_env_values_survive_a_yaml_round_trip_as_strings(self):
+        """Re-serialise, reload, values stay strings.
+
+        Round-tripping is what the CI post-renderer does, and what kustomize,
+        Argo CD and `kubectl get -o yaml | kubectl apply -f -` do. Note this
+        catches only values PyYAML itself resolves as numbers: `2e+07` is a
+        string under YAML 1.1 and a number under the YAML 1.2 core schema Go
+        implements, so PyYAML re-reads its own unquoted output as a string
+        while the API server rejects it. Exponent notation is caught by
+        test_env_values_avoid_exponent_notation instead.
+        """
+        for chart in STANDALONE_CHARTS:
+            rendered = _helm_template(chart)
+            documents = [
+                document
+                for document in yaml.safe_load_all(rendered)
+                if isinstance(document, dict)
+            ]
+            round_tripped = yaml.safe_dump_all(documents, sort_keys=False)
+            for kind, name, container, env_name, value in _env_values(round_tripped):
+                with self.subTest(chart=chart.name, env=env_name):
+                    self.assertIsInstance(
+                        value,
+                        str,
+                        f"{kind}/{name} container {container}: {env_name} "
+                        f"became {type(value).__name__} {value!r} after a YAML "
+                        "round-trip; the API server rejects the manifest",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two nightly failures, each reproduced before the fix and verified after it. Both are product defects; neither needs the shared LLM endpoint to be healthy, so both are verifiable today.

Evidence is from nightly pipeline `66564139` (`develop-2026-09-06`, CI commit `695ae59f`, product submodule `07e8f3b13`), plus before/after runs on a 2× RTX PRO 6000 host and a throwaway `kind` cluster.

---

## 1. `fix(helm)`: UI adapter char limits rendered as `2e+07`, so nothing installs

**Rows addressed: 44.** Helm `base` reported 0/12 and Helm `search` 0/32, because `helm install` itself exited 1 before creating a single object:

```
Error: 1 error occurred:
	* Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal
	  number into Go struct field EnvVar.spec.template.spec.containers.env.value of type string
```

Jobs [428618302](https://gitlab-master.nvidia.com/metromind/ci-vss-oss/-/jobs/428618302) (base) and [428618344](https://gitlab-master.nvidia.com/metromind/ci-vss-oss/-/jobs/428618344) (search).

### Why

Helm decodes `values.yaml` numbers as `float64`, and `quote` formats those with `%v`. So `agentAdapter.maxEventCharsPerRun: 20000000` renders as:

```yaml
- name: AGENT_MAX_EVENT_CHARS_PER_RUN
  value: "2e+07"
```

That quoted form is valid, which is why the bug stayed latent — it only bites once the manifest is re-serialised. `2e+07` is **not** a number under YAML 1.1, so a YAML library re-emits it as a plain scalar; it **is** a number under the YAML 1.2 core schema Go implements, so the API server then refuses to decode `env.value` as a string.

That also explains the exact failure pattern: only `base` and `search` pass `--post-renderer`, and the post-renderer round-trips every manifest. `alerts`, `warehouse` and `lvs` pass no post-renderer, and install cleanly with the identical chart. Verified across all five jobs:

| Job | post-renderer | `helm install` |
|---|---|---|
| base 428618302 | yes | fails |
| search 428618344 | yes | fails |
| alerts-verification 428618379 | no | installs |
| alerts-real-time 428618421 | no | installs |
| warehouse-2d 428618463 | no | installs |

kustomize, Argo CD and `kubectl get -o yaml \| kubectl apply -f -` do the same round-trip, so this is not only a CI-shaped problem.

### Fix

`int64` before `quote` on the three limits, so they render as digits — matching the compose defaults in `deploy/docker/services/ui/compose.yml`, which were already correct. `AGENT_MAX_RETAINED_CHARS` rendered `"6.4e+07"`, which happens to survive because PyYAML keeps its quotes, but it is the same defect and is fixed with its siblings.

Rendering every profile shows these three template lines are the **only** exponent-form values in any chart, so this is the whole class, not just the instance that fired.

The UI itself was unaffected: `config.ts` parses with `Number()`, and `Number("2e+07") === 20000000`.

### Proof — before/after, same command, real cluster

`helm upgrade --install` with the job's exact values file, `--set` list and post-renderer, against a throwaway `kind` cluster. `--dry-run` is not enough: it skips the typed decode that fails, so these are real installs.

**Before** (pristine `develop`):

```
----- BEFORE: helm upgrade --install  (base) -----
rc=1
Error: 1 error occurred:
	* Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal number into Go struct field EnvVar.spec.template.spec.containers.env.value of type string

----- BEFORE: helm upgrade --install  (search) -----
rc=1
Error: 1 error occurred:
	* Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal number into Go struct field EnvVar.spec.template.spec.containers.env.value of type string
```

Byte-identical to the nightly. **After:**

```
----- AFTER: helm upgrade --install  (base) -----
rc=0
----- AFTER: helm upgrade --install  (search) -----
rc=0
```

And as stored by the API server:

```
vss-base-proof   AGENT_MAX_EVENT_CHARS_PER_RUN=20000000
                 AGENT_MAX_THREAD_STATE_CHARS=20000000
                 AGENT_MAX_RETAINED_CHARS=64000000
vss-search-proof AGENT_MAX_EVENT_CHARS_PER_RUN=20000000
                 AGENT_MAX_THREAD_STATE_CHARS=20000000
                 AGENT_MAX_RETAINED_CHARS=64000000
```

Render diff, before → after, all four dev profiles:

```
before:  value: "2e+07"    after:  value: "20000000"
before:  value: "2e+07"    after:  value: "20000000"
before:  value: "6.4e+07"  after:  value: "64000000"
```

`deploy/tests/test_helm_env_value_types.py` renders the charts and asserts env values are strings, carry no exponent notation, and survive a YAML round-trip. It fails on the unfixed chart (`AGENT_MAX_EVENT_CHARS_PER_RUN='2e+07' is float exponent notation`) and passes on the fixed one.

---

## 2. `fix(deploy)`: alerts pins GPU index 1 on a single-GPU node

**Rows addressed: GB300 alerts sanity.** `vss-rtvi-vlm` reports `state=created`, `exit_code=128`. From job [428751315](https://gitlab-master.nvidia.com/metromind/ci-vss-oss/-/jobs/428751315) (GB300 child pipeline `66579882`):

```
[gpu-preflight] OK — 1 GPU(s) visible
[INFO] Set HARDWARE_PROFILE=GB300
[INFO] Set VLM_DEVICE_ID=1
[INFO] Set RT_VLM_DEVICE_ID=1
...
nvidia-container-cli: device error: 1: unknown device: unknown
| vss-rtvi-vlm | FAIL | image=nvcr.io/nvstaging/vss-core/vss-rt-vlm:nightly-20260906-sbsa; state=created; exit_code=128 |
```

`dev-profile-alerts/overrides.env` pins LLM, VLM and RT-VLM to device 1 so they do not contend on device 0 — correct on the multi-GPU boards the profile was written for. GB300 exposes one GPU, so device 1 does not exist and the NVIDIA runtime refuses the container before it starts. Compose surfaces that only as `exit_code=128`. GB300 `base` and `lvs` pin device 0 and both pass in the same run.

`dev-profile.sh` already knows this failure mode — the edge boards collapse every placement onto device 0, with a comment saying a `device_ids` entry of `1` is a hard startup failure — but GB300 is not an edge profile and only the `search` profile has a GB300 branch, so `alerts` keeps device 1.

**On the earlier reading of this failure.** The 2026-09-04 triage attributed the same `exit_code=128` to a hardcoded `vss-rt-vlm:3.3.0-26.08.2-sbsa` tag. That tag was a real and separate defect, and PR #1834 fixed it: the run above shows the correct `nightly-20260906-sbsa` image and the promotion-reconcile rows resolved. The device-index bug is what remains behind it.

### Fix

Clamp rather than rewrite the profile. A requested index at or above the visible GPU count degrades to the highest real index; a host with enough GPUs is never touched. That keeps multi-GPU placement identical, hardcodes no board name, and lets a mistagged or newly-enrolled single-GPU node degrade instead of dying.

Deliberately left untouched when `nvidia-smi` reports no GPUs — a CPU-only host, `--dry-run` or a broken driver should not be papered over — and when the value is a MIG UUID, which has no ordering. The clamped value is kept in `vlm_device_id` because `RT_VLM_DEVICE_ID` derives from it and has to name the same GPU.

### Proof — both directions, on 2× RTX PRO 6000

The runtime behaviour the clamp exists to avoid, with real containers:

```
0, NVIDIA RTX PRO 6000 Blackwell Server Edition
1, NVIDIA RTX PRO 6000 Blackwell Server Edition
visible GPU count: 2

--- device 1 (exists: the multi-GPU case that must keep working) ---
  docker run rc=0
  (no error output -- container created and exited cleanly)

--- device 2 (does NOT exist: the GB300 case) ---
  docker run rc=125
  nvidia-container-cli: device error: 2: unknown device
```

And the clamp itself, against the real `nvidia-smi` and against stubs:

```
--- against the real nvidia-smi (2 GPUs) ---
  PASS  multi-GPU placement untouched: requested 1 -> 1
  PASS  index 0 untouched:             requested 0 -> 0
  PASS  out-of-range clamped:          requested 5 -> 1
--- against a stub reporting 1 GPU (the GB300 alerts case) ---
  PASS  alerts device 1 degrades to 0: requested 1 -> 0
          [WARNING] VLM_DEVICE_ID=1 requests a GPU this host does not have;
                    nvidia-smi reports 1 GPU(s) (indices 0-0). Using 0.
--- against a stub reporting no GPUs (CPU-only / broken driver) ---
  PASS  request left untouched:        requested 1 -> 1
--- a MIG UUID is not an orderable index ---
  PASS  MIG UUID untouched:            MIG-GPU-abc123 -> MIG-GPU-abc123
```

Four end-to-end cases added to `deploy/docker/test-scripts/test-dev-profile.sh`, driving `dev-profile.sh --dry-run` with a mocked `nvidia-smi` (the pattern the suite already uses):

```
PASS: generated.env alerts 1 visible GPU clamps device 1 to 0
PASS: generated.env alerts 2 visible GPUs keep device 1
PASS: generated.env alerts clamps an out-of-range --vlm-device-id
PASS: generated.env alerts no visible GPU leaves device 1 untouched
```

---

## What this does **not** fix

- **Report generation stays broken, and it is not a code problem.** The shared LLM endpoint `10.86.6.214:32088` is running without `--enable-auto-tool-choice` and `--tool-call-parser`. `/v1/models` returns 200, but every tool-bound call returns HTTP 400, so the agent cannot invoke a single tool. That is the direct cause of report rows returning no link. It needs an **infra owner to relaunch the endpoint**; the same model with those flags returns 200 and `finish_reason=tool_calls` on an identical payload. Nothing in this PR changes it, and no product change can.
- **LVS "start captioning" HITL.** Not a product defect and not the endpoint. The API eval stage runs before the Playwright suite against the same agent process and captions its own stream; the UI suite then adopted that stream and `lvs_config_media` short-circuited on an already-configured one, so no HITL modal ever opened. The fix belongs to the UI e2e suite in `ci-vss-oss`, not here.
- **The stray `Camera` sensor** (12 warehouse `GET /behavior?sensorId` rows) and the **`sample-warehouse-ladder` `actual events=0`** rows. Their child pipelines were still running, so whether they recur in this run is unknown; nothing here is built on the assumption that they do.
- **The `camera_add` webhook gap.** Registration emits `camera_add`, the webhook that notifies rt-cv is gated on `camera_streaming`, and the only `camera_add` webhook is disabled, so rt-cv is never told a sensor exists while VIOS reports it `online`. Root cause is established, but enabling the trigger risks double-adding in SDRC mode, where the SDR controller also drives subscription. That could not be proven safe on the test host — its NGC key is invalid, so rt-cv cannot start there — so it is deliberately excluded rather than guessed.
- **Helm Base pod scheduling** (`state=missing, node=unassigned`) and **Warehouse 3D GPU availability**. Cluster capacity, not code.

## Checks

- `services/agent` unit tests: **2419 passed**.
- `ruff check src/` clean; `ruff format --check src/` — 134 files already formatted.
- `mypy src/vss_agents/`: 81 errors, **identical to untouched `develop`** (verified in a clean worktree of both). This PR changes no Python under `services/agent`.
- `deploy/tests/test_helm_env_value_types.py`: 4 passed, 288 subtests.
- `deploy/docker/test-scripts/test-dev-profile.sh`: 132 passed, and the 13 failures are byte-identical to the pre-existing set on `develop` (128 passed / 13 failed there) — no new failures.

One pre-existing issue found and deliberately **not** touched, since it is unrelated to either fix: a stray line continuation at `deploy/docker/test-scripts/test-dev-profile.sh:966` swallows the `_mock_brev_one_gpu_dir` assignment, so the script aborts under `set -e` at line 969 and roughly 1700 lines of later tests never run on `develop`. The tests added here are placed before that point so they actually execute. Worth its own change.
