### PR TITLE
fix(rt-vlm): avoid retrying completed qtdemux decodes

### DIFF
--- a/services/rtvi/rt-vlm/src/vlm_pipeline/video_file_frame_getter.py
+++ b/services/rtvi/rt-vlm/src/vlm_pipeline/video_file_frame_getter.py
@@ -691,6 +691,26 @@ def _can_play_through_after_seek_failure(
     return True
 
 
+def _can_use_completed_frames_after_qtdemux_not_linked(
+    error_message: str | None,
+    *,
+    expected_frames: int,
+    actual_frames: int,
+    actual_timestamps: int,
+    audio_enabled: bool,
+) -> bool:
+    """Accept a completed fixed-frame decode despite a late qtdemux teardown error."""
+    return (
+        not audio_enabled
+        and expected_frames > 0
+        and actual_frames == expected_frames
+        and actual_timestamps == expected_frames
+        and error_message is not None
+        and "qtdemux" in error_message
+        and "reason not-linked" in error_message
+    )
+
+
 class VideoFileFrameGetter:
     """Get frames from a video file as a list of tensors."""
 
@@ -3137,10 +3157,25 @@ class VideoFileFrameGetter:
         except torch.OutOfMemoryError as exc:
             self._handle_cuda_oom(exc, "preprocessing decoded chunk frames")
             preprocessed_frames = []
+        expected_frame_count = len(self._frame_selector._selected_pts_array)
         self._frame_selector = frame_selector_backup
 
         with self._err_msg_lock:
             err_msg = self._err_msg
+        if _can_use_completed_frames_after_qtdemux_not_linked(
+            err_msg,
+            expected_frames=expected_frame_count,
+            actual_frames=len(cached_frames),
+            actual_timestamps=len(cached_frames_pts),
+            audio_enabled=enable_audio,
+        ):
+            logger.warning(
+                "Ignoring late qtdemux not-linked error after extracting all %d requested "
+                "frames for chunk %s",
+                expected_frame_count,
+                chunk,
+            )
+            err_msg = None
         return (
             preprocessed_frames,
             cached_frames_pts,

--- a/services/rtvi/rt-vlm/src/vlm_pipeline/video_file_frame_getter.py
+++ b/services/rtvi/rt-vlm/src/vlm_pipeline/video_file_frame_getter.py
@@ -2806,6 +2806,7 @@ class VideoFileFrameGetter:
         if frame_selector:
             self._frame_selector = frame_selector
         self._frame_selector.set_chunk(chunk)
+        expected_frame_count = self._frame_selector._num_frames
 
         if (
             self._pipeline
@@ -3157,7 +3158,6 @@ class VideoFileFrameGetter:
         except torch.OutOfMemoryError as exc:
             self._handle_cuda_oom(exc, "preprocessing decoded chunk frames")
             preprocessed_frames = []
-        expected_frame_count = len(self._frame_selector._selected_pts_array)
         self._frame_selector = frame_selector_backup
 
         with self._err_msg_lock:

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_decode_retry.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_decode_retry.py
@@ -377,6 +377,38 @@ def test_failed_seek_playthrough_only_when_pipeline_is_before_target(monkeypatch
 
 
 @pytest.mark.no_gpu
+@pytest.mark.parametrize(
+    ("error", "expected", "frames", "timestamps", "audio", "accepted"),
+    [
+        ("qtdemux: streaming stopped, reason not-linked (-1)", 20, 20, 20, False, True),
+        ("qtdemux: streaming stopped, reason not-linked (-1)", 20, 19, 20, False, False),
+        ("qtdemux: streaming stopped, reason not-linked (-1)", 20, 20, 19, False, False),
+        ("qtdemux: streaming stopped, reason not-linked (-1)", 20, 20, 20, True, False),
+        ("decoder failed", 20, 20, 20, False, False),
+    ],
+)
+def test_completed_frames_suppress_only_late_qtdemux_not_linked(
+    monkeypatch, error, expected, frames, timestamps, audio, accepted
+):
+    monkeypatch.setitem(sys.modules, "pyds", types.SimpleNamespace())
+
+    from vlm_pipeline.video_file_frame_getter import (
+        _can_use_completed_frames_after_qtdemux_not_linked,
+    )
+
+    assert (
+        _can_use_completed_frames_after_qtdemux_not_linked(
+            error,
+            expected_frames=expected,
+            actual_frames=frames,
+            actual_timestamps=timestamps,
+            audio_enabled=audio,
+        )
+        is accepted
+    )
+
+
+@pytest.mark.no_gpu
 def test_gst_property_setter_skips_properties_missing_on_jetson(monkeypatch):
     monkeypatch.setitem(sys.modules, "pyds", types.SimpleNamespace())
 

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_decode_retry.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_decode_retry.py
@@ -409,6 +409,43 @@ def test_completed_frames_suppress_only_late_qtdemux_not_linked(
 
 
 @pytest.mark.no_gpu
+def test_completed_frames_use_original_count_after_selector_consumption(monkeypatch):
+    monkeypatch.setitem(sys.modules, "pyds", types.SimpleNamespace())
+
+    from vlm_pipeline.video_file_frame_getter import (
+        DefaultFrameSelector,
+        _can_use_completed_frames_after_qtdemux_not_linked,
+    )
+
+    selector = DefaultFrameSelector(20, use_fps_for_chunking=False)
+    selector.set_chunk(ChunkInfo(file="video.mp4", start_pts=0, end_pts=20_000_000_000))
+    expected_frame_count = selector._num_frames
+    error = "qtdemux: streaming stopped, reason not-linked (-1)"
+
+    for pts in range(0, 10_000_000_000, 1_000_000_000):
+        assert selector.choose_frame(None, pts)
+    assert len(selector._selected_pts_array) == 10
+    assert not _can_use_completed_frames_after_qtdemux_not_linked(
+        error,
+        expected_frames=expected_frame_count,
+        actual_frames=10,
+        actual_timestamps=10,
+        audio_enabled=False,
+    )
+
+    for pts in range(10_000_000_000, 20_000_000_000, 1_000_000_000):
+        assert selector.choose_frame(None, pts)
+    assert not selector._selected_pts_array
+    assert _can_use_completed_frames_after_qtdemux_not_linked(
+        error,
+        expected_frames=expected_frame_count,
+        actual_frames=20,
+        actual_timestamps=20,
+        audio_enabled=False,
+    )
+
+
+@pytest.mark.no_gpu
 def test_gst_property_setter_skips_properties_missing_on_jetson(monkeypatch):
     monkeypatch.setitem(sys.modules, "pyds", types.SimpleNamespace())
 


### PR DESCRIPTION
## Summary

Avoid redundant file decode retries when GStreamer reports a late qtdemux not-linked error after fixed-frame extraction has already completed successfully.

## Plan

Keep the existing error-path pipeline teardown, but accept the extracted result only when the error is specifically from qtdemux with reason not-linked, audio is disabled, and both frame and timestamp counts exactly match the requested fixed-frame count.

## Related Issue

NVBug 6610429

## Changes

- Add a narrow predicate for completed fixed-frame qtdemux not-linked results.
- Return the completed frames without retrying while retaining pipeline teardown.
- Cover accepted and rejected conditions with parameterized unit tests.

## Validation

- Repository pre-commit hooks passed.
- Focused ARM64 runtime tests: 7 passed.
- GB300, Cosmos Reason 3 super NVFP4, batch size 32:
  - 3 rounds x 4 concurrent 5-minute files.
  - 360/360 chunks completed and all 12 streams reached DONE.
  - 11 late qtdemux not-linked events safely accepted.
  - 0 decode retries, 0 response errors, 0 exhausted decodes.
  - NVDEC remained active.

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] I have run pre-commit hooks locally.
- [x] Every commit on this PR is DCO sign-off'd.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.