### PR TITLE
docs(alert): document multi-core scaling for the Alerts Microservice

### DIFF
--- a/docs/agent-workflow-alert-verification.mdx
+++ b/docs/agent-workflow-alert-verification.mdx
@@ -670,6 +670,45 @@ If you would like to modify the workflow to work with other videos or usecases, 
 
   * Drop a Python module exposing a parser class with a `parse(self, raw_response: str) -> dict` method, then set `vlm.response_parser` in `config.yml` to its dotted path. Use this to replace the built-in YES/NO verification parsing with classification, analytics, or enrichment outputs. See [Pluggable Response Parser](/vss/system-components/analytics-microservices/alerts-microservice#pluggable-response-parser) for the full contract, examples, and error handling.
 
+#### Scale Alert processing across CPU cores
+
+A single Alerts Microservice process uses about one CPU core. Running the pipeline in several processes adds CPU capacity, and it helps when that process is consistently near one core while Kafka consumer lag keeps growing. A process below one core is limited by offered traffic, by the configured VLM concurrency, or by a downstream service, and gains nothing from additional processes.
+
+Edit the profile's Alerts Microservice configuration and redeploy:
+
+```text
+deploy/docker/developer-profiles/dev-profile-alerts/vlm-as-verifier/configs/config.yml
+```
+
+This setting is not available through `user-overrides.env`. A conservative four-process configuration that keeps the profile's instance-wide VLM and VIOS load unchanged:
+
+```yaml
+alert_agent:
+  pipeline_mode: event_loop
+  processes: 4
+  startup_timeout_seconds: 60
+  async_dispatch_max_in_flight: 4
+  async_io:
+    max_vlm_concurrent: 1
+    max_vst_concurrent: 2
+
+persistence:
+  enabled: true
+```
+
+Every per-process limit is multiplied by the process count, which is why the three limits above are divided by four from the one-process profile values of 16, 4, and 8.
+
+Before raising the process count, confirm the following:
+
+- `pipeline_mode` is `event_loop` and `persistence.enabled` is `true`. Both are the profile defaults.
+- Every Alert input topic has at least as many partitions as `replicas × processes`, counted per topic. The profile creates eight partitions per topic, so one replica can run four processes as shipped.
+- The host has about one CPU core per process, plus capacity for the parent and API processes.
+- The VLM and VIOS backends can serve `processes × max_vlm_concurrent` and `processes × max_vst_concurrent` requests concurrently.
+
+Startup refuses a combination the deployment cannot honor and names the reason. `/health` returns HTTP 503 until every process holds a Kafka assignment. Allow for `startup_timeout_seconds` before the instance reports ready.
+
+For pipeline modes, sizing, monitoring, and rollback, see [Scaling and Performance Tuning](/vss/system-components/analytics-microservices/alerts-microservice#scaling-and-performance-tuning) in the Alerts Microservice guide.
+
 ### Step 2: Add a video stream
 
 Add an RTSP stream by clicking the **+ Add RTSP** button on the **Video Management** tab in the agent UI. If you do not have an RTSP stream, you can use [NVStreamer](/vss/system-components/middleware/video-io-storage-vios/nvstreamer) at `http://<HOST_IP>:31000` to upload a video file and create an RTSP stream.

--- a/docs/agent-workflow-alert-verification.mdx
+++ b/docs/agent-workflow-alert-verification.mdx
@@ -696,13 +696,14 @@ persistence:
   enabled: true
 ```
 
-Every per-process limit is multiplied by the process count, which is why the three limits above are divided by four from the one-process profile values of 16, 4, and 8.
+Every per-process limit is multiplied by the process count, which is why the three limits above are divided by four from the one-process profile values of 16, 4, and 8. `max_vlm_concurrent` caps what each process offers the VLM backend and does not raise the backend's throughput. When the VLM is the limiting service, capacity comes from the VLM side, for example more replicas behind the same endpoint.
 
 Before raising the process count, confirm the following:
 
 - `pipeline_mode` is `event_loop` and `persistence.enabled` is `true`. Both are the profile defaults.
-- Every Alert input topic has at least as many partitions as `replicas × processes`, counted per topic. The profile creates eight partitions per topic, so one replica can run four processes as shipped.
-- The host has about one CPU core per process, plus capacity for the parent and API processes.
+- Every Alert input topic has at least as many partitions as the process count, counted per topic. The profile creates eight partitions per topic, so one instance can run four processes as shipped. When several Alerts Microservice instances share the consumer group, for example as replicas on Kubernetes, the bound applies to `instances × processes`.
+- At least as many active streams as processes. Every message of one stream carries the same `sensorId` and lands on one partition, so work is spread across processes at stream granularity. Fewer streams than processes leaves processes without work, and more streams spread the load more evenly.
+- The host has about one CPU core per process, plus capacity for the parent and API processes. Each process also holds its own Kafka consumers, HTTP connection pools to the VLM and VIOS backends, Elasticsearch clients, and memory, so connection, file-descriptor, and memory use grow with the process count.
 - The VLM and VIOS backends can serve `processes × max_vlm_concurrent` and `processes × max_vst_concurrent` requests concurrently.
 
 Startup refuses a combination the deployment cannot honor and names the reason. `/health` returns HTTP 503 until every process holds a Kafka assignment. Allow for `startup_timeout_seconds` before the instance reports ready.

--- a/docs/alert-verification-service.mdx
+++ b/docs/alert-verification-service.mdx
@@ -604,7 +604,7 @@ Verified alerts include the original fields plus an extended `info` section cont
 
 ## Scaling and Performance Tuning
 
-The Alerts Microservice scales along two independent dimensions: how many CPU cores one instance can use, and how many requests it keeps in flight against the VLM and VIOS backends. This section describes the pipeline modes that govern in-process concurrency, the settings that control each dimension, and how to tell which one is limiting a deployment before changing anything.
+The Alerts Microservice scales along two independent dimensions: how many pipeline processes one instance runs, each using about one CPU core, and how many requests it keeps in flight against the VLM and VIOS backends. This section describes the pipeline modes that govern in-process concurrency, the settings that control each dimension, and how to tell which one is limiting a deployment before changing anything.
 
 ### Pipeline Modes
 
@@ -641,9 +641,8 @@ The following settings control concurrency and CPU use:
 | `alert_agent.pipeline_mode` | `event_loop` in the shipped profile | — | Dispatch model, as described above. |
 | `alert_agent.async_io.max_vlm_concurrent` | `4` in the shipped profile | `event_loop` | VLM requests in flight per process. Keep at or below the VLM backend's measured ceiling. |
 | `alert_agent.async_io.max_vst_concurrent` | `8` in the shipped profile | `event_loop` | VIOS requests in flight per process. |
-| `alert_agent.async_dispatch_max_in_flight` | `16` in the shipped profile | `thread_bridge`, `event_loop` | Post-deduplication messages accepted but not finished, per process. Bounds memory and applies backpressure to the Kafka consumer. It does not raise the throughput ceiling. |
-| `alert_agent.num_workers` | `10` in the shipped profile | `sync` | Batch worker threads. The throughput control for `sync` mode only. |
-| `alert_agent.async_dispatch_workers` | `num_workers` | `thread_bridge` | Dispatch pool threads. The throughput control for `thread_bridge` mode only. |
+| `alert_agent.async_dispatch_max_in_flight` | `16` in the shipped profile | `thread_bridge`, `event_loop` | Post-deduplication messages accepted but not finished, per process. Offsets are committed when a record is read, so this bounds memory and the number of read-but-unfinished messages lost if a process exits. `max_vlm_concurrent` alone does not bound the messages waiting for a VLM slot. It does not raise the throughput ceiling. |
+| `alert_agent.num_workers` | `10` in the shipped profile | `sync` | Batch worker threads in `sync` mode only. The shipped `event_loop` mode does not use it. Kept for the `sync` rollback path. |
 | `alert_agent.startup_timeout_seconds` | `60` | All modes | Budget for the whole of startup: topic metadata, prompt seeding, VLM warmup, and every pipeline process joining its consumer group. Minimum 30. |
 
 ### Sizing VLM Concurrency
@@ -657,7 +656,7 @@ async_dispatch_max_in_flight ≈ 2 to 4 × max_vlm_concurrent
 
 The sustainable rate is `max_vlm_concurrent ÷ VLM_latency`. Below it, consumer lag stays flat. Above it, the in-flight bound applies backpressure to the consumer and lag grows by design.
 
-`max_vlm_concurrent` must not exceed what the VLM backend serves concurrently. Past that point requests queue inside the backend and per-call latency grows without adding throughput. To find the ceiling, ramp offered concurrency stepwise against the production backend, for at least 60 seconds per step, and record `alert_bridge_vlm_duration_seconds` at each step. The ceiling is the last step where per-call latency stays within about 120% of the low-concurrency baseline. In production, `alert_bridge_event_loop_vlm_in_flight` never exceeds the cap, and growth in `alert_bridge_capacity_wait_seconds` shows backpressure building.
+`max_vlm_concurrent` caps the load one process offers the VLM backend and is sized to what the backend serves concurrently. Above that capacity, requests queue inside the backend and per-call latency grows without adding throughput. When the VLM is the limiting service, capacity comes from the VLM side, for example more replicas behind the same endpoint, and the cap follows the new capacity; the instance-wide offered load is `processes × max_vlm_concurrent`. To find the capacity, ramp offered concurrency stepwise against the production backend, for at least 60 seconds per step, and record `alert_bridge_vlm_duration_seconds` at each step. The capacity is the last step where per-call latency stays within about 120% of the low-concurrency baseline. In production, `alert_bridge_event_loop_vlm_in_flight` never exceeds the cap, and growth in `alert_bridge_capacity_wait_seconds` shows backpressure building.
 
 ### Scaling Across CPU Cores
 
@@ -693,21 +692,22 @@ persistence:
   enabled: true
 ```
 
-The one-process profile sets these limits to 16, 4, and 8. Dividing them by four keeps the VLM and VIOS backends at the same offered load after enabling CPU scaling. Raise the per-process limits afterwards, once you have confirmed that the backends have headroom.
+The one-process profile sets these limits to 16, 4, and 8. Dividing them by four keeps the VLM and VIOS backends at the same offered load after enabling CPU scaling.
 
 #### Rules
 
 1. `processes` above `1` requires `pipeline_mode: event_loop`. The other modes hold their concurrency in threads, with no per-process cap on the load offered to the backends.
 2. `processes` above `1` requires shared alert-configuration storage: `persistence.enabled: true` with Elasticsearch reachable.
-3. Every input topic must have at least as many partitions as processes, counted per topic and not summed:
+3. Every input topic must have at least as many partitions as consumer-group members, counted per topic and not summed. The members are the pipeline processes of every Alerts Microservice instance that shares the consumer group, so with `replicas` instances:
 
    ```text
    replicas × processes ≤ partitions on every input topic
    ```
 
-   The developer profile creates eight partitions on each topic. One replica can run four processes without changing the Kafka layout; two replicas with four processes each use all eight assignments.
-4. Allocate about one CPU core per pipeline process, plus capacity for the parent and API processes.
-5. Redeploy after changing the process count.
+   The developer profile creates eight partitions on each topic. One instance can run four processes without changing the Kafka layout; two instances with four processes each use all eight assignments.
+4. Work is spread across processes at stream granularity. Every message of one stream carries the same `sensorId` and lands on one partition, so every process receives work only when there are at least as many active streams as processes, and the spread evens out as the stream count grows.
+5. Allocate about one CPU core per pipeline process, plus capacity for the parent and API processes. Each process holds its own Kafka consumers, HTTP connection pools to the VLM and VIOS backends, Elasticsearch clients, and memory, so connection, file-descriptor, and memory use grow with the process count.
+6. Redeploy after changing the process count.
 
 Startup validates the count against the mode, the persistence setting, and the live partition count of every input topic. A combination the deployment cannot honor fails startup with a message that names the topic and its partition count. The service never runs fewer processes than configured.
 
@@ -736,7 +736,7 @@ Set `processes: 1` and redeploy without overlapping the old and new instances. N
 
 ### Scaling Across Instances
 
-Multiple instances share `event_bridge.kafka_source.group_id`, and the broker distributes partitions across them. Consumer-group members are instances and processes together. The partition rule above applies to the product `replicas × processes`. Scale partitions before scaling either dimension. Instances share no state: deduplication follows the partition key (`sensorId`), and confirmed-verdict protection is stored in Elasticsearch.
+Multiple Alerts Microservice instances share `event_bridge.kafka_source.group_id`, and the broker distributes partitions across them. Consumer-group members are instances and processes together, so the partition rule above applies to the product `replicas × processes`. Instances share no state: deduplication follows the partition key (`sensorId`), and confirmed-verdict protection is stored in Elasticsearch.
 
 ### Monitoring
 

--- a/docs/alert-verification-service.mdx
+++ b/docs/alert-verification-service.mdx
@@ -604,70 +604,155 @@ Verified alerts include the original fields plus an extended `info` section cont
 
 ## Scaling and Performance Tuning
 
-The Alerts Microservice supports concurrent processing to maximize throughput. This section describes the key configuration parameters for scaling the service to meet your deployment requirements.
+The Alerts Microservice scales along two independent dimensions: how many CPU cores one instance can use, and how many requests it keeps in flight against the VLM and VIOS backends. This section describes the pipeline modes that govern in-process concurrency, the settings that control each dimension, and how to tell which one is limiting a deployment before changing anything.
 
-### Concurrency Model
+### Pipeline Modes
 
-The Alerts Microservice uses a main thread with a fixed-size worker pool for concurrent processing:
+`alert_agent.pipeline_mode` selects how each message is dispatched inside a process. Every mode has exactly one throughput control:
 
-1. **Main Thread**: Polls alerts from Kafka (or receives via HTTP API) and dispatches them to available workers.
-2. **Worker Threads**: Each worker processes an assigned alert through the full pipeline:
+| Mode | Dispatch | Throughput Control | Use |
+| --- | --- | --- | --- |
+| `sync` | Inline in the batch worker thread | `alert_agent.num_workers` | Reference and rollback mode |
+| `thread_bridge` | Dispatch thread pool with a blocking wait | `alert_agent.async_dispatch_workers` | Legacy asynchronous mode |
+| `event_loop` | One coroutine per message on a persistent event loop, with asynchronous VLM, VIOS, and Elasticsearch clients | `alert_agent.async_io.max_vlm_concurrent` | Shipped default. Kafka consumption is decoupled from VLM latency |
 
-   - Retrieves video URL from VIOS for the alert time window
-   - Renders the prompt with alert context
-   - Passes video URL, prompts and other required inputs to VLM backend for verification
-   - Publishes the verified result to configured sinks
+An invalid value fails startup. When the key is unset, the mode is derived from the deprecated `alert_agent.async_io.enabled` flag; set `pipeline_mode` explicitly instead.
 
-Workers operate independently, allowing multiple alerts to be processed in parallel. The main thread blocks when all workers are busy, providing natural backpressure. The end-to-end latency of external services (VLM, VIOS) directly bounds throughput per worker.
+The shipped Alerts developer profile uses `event_loop`. In that mode `num_workers` is not a throughput control, and raising it adds neither VLM concurrency nor CPU capacity.
 
-### Key Scaling Parameters
+Unset controls derive from one another. An explicitly set key is always honored, and a tuned deployment keeps its values:
 
-The following parameters control concurrency and throughput:
+```text
+async_dispatch_workers        = num_workers
+async_dispatch_max_in_flight  = 2 × async_dispatch_workers
+async_io.max_vlm_concurrent   = async_dispatch_workers
+async_io.max_vst_concurrent   = async_dispatch_workers
+```
 
-| Parameter | Default | Impact |
-| --- | --- | --- |
-| `alert_agent.num_workers` | `1` | Number of concurrent worker threads. Increasing this value scales alert processing throughput roughly linearly until constrained by CPU/memory or downstream service limits (VLM, VIOS). |
-| `alert_agent.chunk_size` | `1` | Number of alerts processed per batch within a worker. Higher values reduce overhead but increase memory usage. |
-| `kafka.max_poll_records` | `10` | Maximum records fetched per Kafka poll. Controls batch size for ingestion; higher values improve throughput but increase memory and latency variance. |
-| `kafka.poll_timeout` | `100` | Kafka consumer poll wait timeout (ms). Lower values reduce latency for sparse traffic; higher values reduce CPU usage. |
-| `kafka.max_poll_interval_ms` | `60000` | Maximum interval between polls before consumer is considered failed. Must exceed worst-case VLM processing time multiplied by batch size. |
+`alert_agent.chunk_size` is retired and ignored with a startup warning, as are the per-service switches `async_io.vst_enabled`, `async_io.elastic_enabled`, `async_io.dedup_enabled`, and `async_io.redis_enabled`. Remove them from tuning configuration.
 
-### Scaling Guidelines
+### Scaling Controls
 
-**Vertical Scaling (Single Instance)**
+The following settings control concurrency and CPU use:
 
-1. **Increase `num_workers`**: Start with the number of CPU cores available. Monitor CPU utilization and increase until VLM backend becomes the bottleneck.
+| Setting | Default | Applies To | Meaning |
+| --- | --- | --- | --- |
+| `alert_agent.processes` | `1` | All modes | Independent pipeline processes. The only setting that lets one instance run Python work on more than one CPU core. |
+| `alert_agent.pipeline_mode` | `event_loop` in the shipped profile | — | Dispatch model, as described above. |
+| `alert_agent.async_io.max_vlm_concurrent` | `4` in the shipped profile | `event_loop` | VLM requests in flight per process. Keep at or below the VLM backend's measured ceiling. |
+| `alert_agent.async_io.max_vst_concurrent` | `8` in the shipped profile | `event_loop` | VIOS requests in flight per process. |
+| `alert_agent.async_dispatch_max_in_flight` | `16` in the shipped profile | `thread_bridge`, `event_loop` | Post-deduplication messages accepted but not finished, per process. Bounds memory and applies backpressure to the Kafka consumer. It does not raise the throughput ceiling. |
+| `alert_agent.num_workers` | `10` in the shipped profile | `sync` | Batch worker threads. The throughput control for `sync` mode only. |
+| `alert_agent.async_dispatch_workers` | `num_workers` | `thread_bridge` | Dispatch pool threads. The throughput control for `thread_bridge` mode only. |
+| `alert_agent.startup_timeout_seconds` | `60` | All modes | Budget for the whole of startup: topic metadata, prompt seeding, VLM warmup, and every pipeline process joining its consumer group. Minimum 30. |
 
-2. **Tune `chunk_size`**: For high-volume deployments, increase to 2-4 to reduce per-message overhead. Keep at 1 for low-latency requirements.
+### Sizing VLM Concurrency
 
-3. **Adjust `max_poll_records`**: Match to `num_workers × chunk_size` for optimal batching. Avoid setting too high to prevent memory pressure.
+In `event_loop` mode, size `max_vlm_concurrent` against the survivor rate, meaning the events that pass deduplication and reach the VLM, not against raw ingest. Read the peak of `rate(alert_bridge_events_after_dedup_total)` and use:
 
-**Horizontal Scaling (Multiple Instances)**
+```text
+max_vlm_concurrent           ≈ peak_survivor_rate × VLM_latency_p95 × 1.4
+async_dispatch_max_in_flight ≈ 2 to 4 × max_vlm_concurrent
+```
 
-1. **Kafka Consumer Groups**: Multiple instances of the Alerts Microservice can share the same `event_bridge.kafka_source.group_id` to distribute load across partitions.
+The sustainable rate is `max_vlm_concurrent ÷ VLM_latency`. Below it, consumer lag stays flat. Above it, the in-flight bound applies backpressure to the consumer and lag grows by design.
 
-2. **Partition Alignment**: Ensure Kafka topic partitions `>=` number of consumer instances for effective load distribution.
+`max_vlm_concurrent` must not exceed what the VLM backend serves concurrently. Past that point requests queue inside the backend and per-call latency grows without adding throughput. To find the ceiling, ramp offered concurrency stepwise against the production backend, for at least 60 seconds per step, and record `alert_bridge_vlm_duration_seconds` at each step. The ceiling is the last step where per-call latency stays within about 120% of the low-concurrency baseline. In production, `alert_bridge_event_loop_vlm_in_flight` never exceeds the cap, and growth in `alert_bridge_capacity_wait_seconds` shows backpressure building.
 
-3. **Stateless Design**: The Alerts Microservice is stateless; scale horizontally by adding replicas behind Kubernetes or Docker instances.
+### Scaling Across CPU Cores
 
-### Performance Tuning Example
+The pipeline modes above run inside one Python process, and the interpreter lock allows one thread to execute Python code at a time. A single instance therefore uses about one CPU core regardless of the thread count or the host size. `alert_agent.processes` runs the consume and dispatch stack in that many independent operating system processes, each with its own Kafka consumers, event loop, clients, and interpreter lock.
 
-For a deployment targeting 10 alerts/second with average VLM latency of 0.5 seconds:
+#### When to use it
+
+Additional processes add CPU capacity only. They help when a single Alerts Microservice process is consistently near one CPU core and Kafka consumer lag continues to grow. A process below one core is limited by offered traffic, by `max_vlm_concurrent ÷ VLM_latency`, or by a downstream service. For that process, more processes add memory and consumer-group members without adding capacity.
+
+#### Configuration
+
+For the Alerts developer profile, edit the following file and redeploy:
+
+```text
+deploy/docker/developer-profiles/dev-profile-alerts/vlm-as-verifier/configs/config.yml
+```
+
+The process count is startup topology. It is not resized while the service runs, and the developer profile does not expose it through `user-overrides.env`.
+
+A conservative four-process configuration that keeps the profile's instance-wide concurrency limits where they are:
 
 ```yaml
 alert_agent:
-  num_workers: 5         # 10 alerts/sec × 0.5 sec latency = 5 concurrent
-  chunk_size: 1          # Process one alert at a time for consistent latency
+  pipeline_mode: event_loop
+  processes: 4
+  startup_timeout_seconds: 60
+  async_dispatch_max_in_flight: 4
+  async_io:
+    max_vlm_concurrent: 1
+    max_vst_concurrent: 2
 
-kafka:
-  max_poll_records: 5    # Match worker count
-  poll_timeout: 100      # Low latency polling
-  max_poll_interval_ms: 30000   # 30 seconds sufficient for fast VLM
+persistence:
+  enabled: true
 ```
 
-<Note>
-For Prometheus metric names, labels, and scrape configuration, see [Metrics](#metrics). In addition, monitor worker utilization (all workers busy indicates a need to scale up), Kafka consumer lag, and host CPU and memory.
-</Note>
+The one-process profile sets these limits to 16, 4, and 8. Dividing them by four keeps the VLM and VIOS backends at the same offered load after enabling CPU scaling. Raise the per-process limits afterwards, once you have confirmed that the backends have headroom.
+
+#### Rules
+
+1. `processes` above `1` requires `pipeline_mode: event_loop`. The other modes hold their concurrency in threads, with no per-process cap on the load offered to the backends.
+2. `processes` above `1` requires shared alert-configuration storage: `persistence.enabled: true` with Elasticsearch reachable.
+3. Every input topic must have at least as many partitions as processes, counted per topic and not summed:
+
+   ```text
+   replicas × processes ≤ partitions on every input topic
+   ```
+
+   The developer profile creates eight partitions on each topic. One replica can run four processes without changing the Kafka layout; two replicas with four processes each use all eight assignments.
+4. Allocate about one CPU core per pipeline process, plus capacity for the parent and API processes.
+5. Redeploy after changing the process count.
+
+Startup validates the count against the mode, the persistence setting, and the live partition count of every input topic. A combination the deployment cannot honor fails startup with a message that names the topic and its partition count. The service never runs fewer processes than configured.
+
+#### Aggregate concurrency
+
+Every per-process limit is multiplied by the process count. With `P = alert_agent.processes`:
+
+```text
+instance VLM concurrency     = P × max_vlm_concurrent
+instance VIOS concurrency    = P × max_vst_concurrent
+instance in-flight messages  = P × async_dispatch_max_in_flight
+```
+
+Raising only `processes` multiplies all three. Keep the instance VLM concurrency at or below the backend's measured ceiling, and size the in-flight bound at two to four times the effective VLM concurrency. Startup logs the resolved instance totals. Read them from the log to confirm what the backends are offered.
+
+#### Startup, readiness, and shutdown
+
+- `startup_timeout_seconds` covers topic metadata, prompt seeding, VLM warmup, and every process joining its consumer group. The default is 60 seconds and the minimum is 30. The startup watchdog stops the instance 5 seconds after the budget, so size a startup probe against 65 seconds at the default.
+- `/health` and `/ready` return HTTP 503 until every configured process holds a decided Kafka assignment, and again during a rebalance until the assignment is decided. Do not point a liveness probe at them.
+- The shipped Docker and Helm definitions allow 60 seconds for shutdown. Keep that grace period so in-flight work can drain.
+- A pipeline process that exits takes the instance down, and the orchestrator restarts it. Processes are not respawned individually.
+
+#### Rollback
+
+Set `processes: 1` and redeploy without overlapping the old and new instances. No data migration is needed.
+
+### Scaling Across Instances
+
+Multiple instances share `event_bridge.kafka_source.group_id`, and the broker distributes partitions across them. Consumer-group members are instances and processes together. The partition rule above applies to the product `replicas × processes`. Scale partitions before scaling either dimension. Instances share no state: deduplication follows the partition key (`sensorId`), and confirmed-verdict protection is stored in Elasticsearch.
+
+### Monitoring
+
+Monitor CPU, memory, Kafka consumer lag, and VLM latency, plus the following series when `processes` is above `1`:
+
+| Metric | Interpretation |
+| --- | --- |
+| `alert_bridge_pipeline_processes_configured` | Requested pipeline-process count. |
+| `alert_bridge_pipeline_processes_alive` | Processes currently running. Should equal the configured count. |
+| `alert_bridge_pipeline_processes_ready` | Processes with a decided Kafka assignment. |
+| `alert_bridge_assigned_partitions` | Partitions currently assigned to the instance. A value below the process count means some processes hold nothing. |
+| `alert_bridge_pipeline_process_exits_total{reason}` | Expected versus unexpected process exits. |
+| `alert_bridge_rebalance_drains_total{outcome}` | Whether revoked-partition work drained before the deadline. |
+| `alert_bridge_records_read_after_revoke_total` | Records observed after partition ownership changed. Investigate sustained growth. |
+
+Metric names, labels, and scrape configuration are described under [Metrics](#metrics).
 
 ## Metrics
 

--- a/docs/alert-verification-service.mdx
+++ b/docs/alert-verification-service.mdx
@@ -725,7 +725,7 @@ Raising only `processes` multiplies all three. Keep the instance VLM concurrency
 
 #### Startup, readiness, and shutdown
 
-- `startup_timeout_seconds` covers topic metadata, prompt seeding, VLM warmup, and every process joining its consumer group. The default is 60 seconds and the minimum is 30. The startup watchdog stops the instance 5 seconds after the budget, so size a startup probe against 65 seconds at the default.
+- `startup_timeout_seconds` covers topic metadata, prompt seeding, VLM warmup, and every process joining its consumer group. The default is 60 seconds and the minimum is 30. With one process, the startup watchdog stops the instance when the budget runs out. With more than one process, it stops the instance 5 seconds after the budget, so size a startup probe against 65 seconds at the default.
 - `/health` and `/ready` return HTTP 503 until every configured process holds a decided Kafka assignment, and again during a rebalance until the assignment is decided. Do not point a liveness probe at them.
 - The shipped Docker and Helm definitions allow 60 seconds for shutdown. Keep that grace period so in-flight work can drain.
 - A pipeline process that exits takes the instance down, and the orchestrator restarts it. Processes are not respawned individually.
@@ -748,8 +748,8 @@ Monitor CPU, memory, Kafka consumer lag, and VLM latency, plus the following ser
 | `alert_bridge_pipeline_processes_alive` | Processes currently running. Should equal the configured count. |
 | `alert_bridge_pipeline_processes_ready` | Processes with a decided Kafka assignment. |
 | `alert_bridge_assigned_partitions` | Partitions currently assigned to the instance. A value below the process count means some processes hold nothing. |
-| `alert_bridge_pipeline_process_exits_total{reason}` | Expected versus unexpected process exits. |
-| `alert_bridge_rebalance_drains_total{outcome}` | Whether revoked-partition work drained before the deadline. |
+| `alert_bridge_pipeline_process_exits_total{reason}` | Process exits. `reason` is `shutdown` for an exit that a stop requested, or `unexpected`. |
+| `alert_bridge_rebalance_drains_total{outcome}` | Drains of revoked partitions. `outcome` is `drained` when the work finished before the deadline, or `timed_out`. |
 | `alert_bridge_records_read_after_revoke_total` | Records observed after partition ownership changed. Investigate sustained growth. |
 
 Metric names, labels, and scrape configuration are described under [Metrics](#metrics).
@@ -851,6 +851,13 @@ Known `mode` values are `sync`, `async`, `sync_fallback`, and `async_submit`. Kn
 
 | Metric | Labels | Meaning |
 | --- | --- | --- |
+| `alert_bridge_pipeline_processes_configured` | (none) | Pipeline processes requested by `alert_agent.processes`. |
+| `alert_bridge_pipeline_processes_alive` | (none) | Pipeline processes currently running. |
+| `alert_bridge_pipeline_processes_ready` | (none) | Pipeline processes holding a decided Kafka assignment. |
+| `alert_bridge_assigned_partitions` | (none) | Source partitions currently assigned to the instance, summed across its processes. |
+| `alert_bridge_pipeline_process_exits_total` | `reason` | Pipeline process exits, labelled `shutdown` or `unexpected`. |
+| `alert_bridge_rebalance_drains_total` | `outcome` | Drains of revoked partitions, labelled `drained` or `timed_out`. |
+| `alert_bridge_records_read_after_revoke_total` | (none) | Records read for a partition after this member lost it. |
 | `alert_bridge_realtime_rules_active` | (none) | Current in-memory realtime rules registered with the service. |
 | `alert_bridge_realtime_rules_count` | (none) | Current durable realtime rules with `status=ACTIVE` in Elasticsearch. |
 | `alert_bridge_realtime_rules_created_total` | (none) | Realtime rules created and committed to the live registry. |
@@ -994,11 +1001,17 @@ VLM warmup runs automatically at startup by default and sends 3 inference rounds
 
 | Parameter | Default | Description |
 | --- | --- | --- |
-| `alert_agent.num_workers` | `10` | Number of worker threads for concurrent processing. |
+| `alert_agent.pipeline_mode` | `event_loop` | Dispatch model: `sync`, `thread_bridge`, or `event_loop`. See [Pipeline Modes](#pipeline-modes). |
+| `alert_agent.processes` | `1` | Independent pipeline processes. Values above `1` require `event_loop`, `persistence.enabled: true`, and enough Kafka partitions. See [Scaling Across CPU Cores](#scaling-across-cpu-cores). |
+| `alert_agent.startup_timeout_seconds` | `60` | Budget for the whole of startup. Minimum 30. |
+| `alert_agent.num_workers` | `10` | Worker threads in `sync` mode. Not a throughput control in the other modes. |
+| `alert_agent.async_dispatch_workers` | `num_workers` | Dispatch pool threads in `thread_bridge` mode. |
+| `alert_agent.async_dispatch_max_in_flight` | `16` | Post-deduplication messages accepted but not finished, per process. |
+| `alert_agent.async_io.max_vlm_concurrent` | `4` | VLM requests in flight per process in `event_loop` mode. |
+| `alert_agent.async_io.max_vst_concurrent` | `8` | VIOS requests in flight per process in `event_loop` mode. |
 | `alert_agent.max_allowed_stream_size` | `2` | Maximum stream size in minutes. |
 | `alert_agent.default_stream_interval` | `1` | Default stream interval in minutes. |
 | `alert_agent.vst_pass_through_mode` | `false` | Skip VIOS lookup; use local media files directly. |
-| `alert_agent.chunk_size` | `1` | Chunk size for processing. |
 | `alert_agent.enrichment.enabled` | `false` | Enable alert enrichment for generating detailed event descriptions after verification. |
 | `alert_agent.metrics.per_sensor_labels` | `false` | When `true`, emits the opt-in `sensorId` histogram and counter variants documented under [Metrics](#metrics). |
 

--- a/docs/alert-verification-service.mdx
+++ b/docs/alert-verification-service.mdx
@@ -749,7 +749,7 @@ Monitor CPU, memory, Kafka consumer lag, and VLM latency, plus the following ser
 | `alert_bridge_pipeline_processes_ready` | Processes with a decided Kafka assignment. |
 | `alert_bridge_assigned_partitions` | Partitions currently assigned to the instance. A value below the process count means some processes hold nothing. |
 | `alert_bridge_pipeline_process_exits_total{reason}` | Process exits. `reason` is `shutdown` for an exit that a stop requested, or `unexpected`. |
-| `alert_bridge_rebalance_drains_total{outcome}` | Drains of revoked partitions. `outcome` is `drained` when the work finished before the deadline, or `timed_out`. |
+| `alert_bridge_rebalance_drains_total{outcome}` | Drains of revoked partitions. `outcome` is `nothing_owed` when the partitions had no work in flight, `drained` when the work finished before the deadline, or `timed_out`. |
 | `alert_bridge_records_read_after_revoke_total` | Records observed after partition ownership changed. Investigate sustained growth. |
 
 Metric names, labels, and scrape configuration are described under [Metrics](#metrics).
@@ -856,7 +856,7 @@ Known `mode` values are `sync`, `async`, `sync_fallback`, and `async_submit`. Kn
 | `alert_bridge_pipeline_processes_ready` | (none) | Pipeline processes holding a decided Kafka assignment. |
 | `alert_bridge_assigned_partitions` | (none) | Source partitions currently assigned to the instance, summed across its processes. |
 | `alert_bridge_pipeline_process_exits_total` | `reason` | Pipeline process exits, labelled `shutdown` or `unexpected`. |
-| `alert_bridge_rebalance_drains_total` | `outcome` | Drains of revoked partitions, labelled `drained` or `timed_out`. |
+| `alert_bridge_rebalance_drains_total` | `outcome` | Drains of revoked partitions, labelled `nothing_owed`, `drained`, or `timed_out`. |
 | `alert_bridge_records_read_after_revoke_total` | (none) | Records read for a partition after this member lost it. |
 | `alert_bridge_realtime_rules_active` | (none) | Current in-memory realtime rules registered with the service. |
 | `alert_bridge_realtime_rules_count` | (none) | Current durable realtime rules with `status=ACTIVE` in Elasticsearch. |


### PR DESCRIPTION
Replace the stale Scaling and Performance Tuning section of the Alerts Microservice guide. It described a main thread with a fixed worker pool, presented num_workers as the vertical-scaling control, and recommended the retired chunk_size setting. The new section covers the three pipeline modes and their throughput controls, the alert_agent.processes setting that runs the pipeline across CPU cores, the aggregate concurrency the backends see, the startup validation rules, readiness and shutdown behaviour, rollback, and the multi-process metrics.

Add a subsection to the Alert Verification workflow page with the developer profile file to edit, a conservative four-process example that keeps the instance-wide VLM and VIOS load unchanged, the prerequisites, and a link to the full guide.

Removed the kafka.* rows from the scaling table; they remain in the configuration reference of the same page.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
