### PR TITLE
Potential deploy script fixes for GB300

### DIFF
--- a/deploy/docker/scripts/blueprint-deploy.sh
+++ b/deploy/docker/scripts/blueprint-deploy.sh
@@ -32,6 +32,8 @@ llm=""
 vlm=""
 llm_device_id=""
 vlm_device_id=""
+gpu_device_id=""
+hardware_device_id=""
 llm_base_url=""
 vlm_base_url=""
 llm_model_type=""
@@ -463,6 +465,8 @@ function usage() {
   echo ""
   echo "  [LLM/VLM - for 2d only: warehouse bp_wh (NIM + agents)]"
   echo "  -H, --hardware-profile          H100, L40S, RTXPRO6000BW, DGX-SPARK, etc."
+  echo "  --gpu-device-id                 GPU device ID for all GB300-consuming services."
+  echo "                                   Required when GB300 auto-detection cannot access nvidia-smi."
   echo "  --llm                           LLM model (e.g. nvidia/nemotron-3.5-lightning-30b-a3b)"
   echo "  --vlm                           VLM model (e.g. nvidia/cosmos3-reasoner)"
   echo "  --llm-device-id                 GPU device ID for LLM"
@@ -516,7 +520,7 @@ function validate_args() {
   _args=("${@}")
   _all_good=0
 
-  _valid_args=$(getopt -q -o d:m:p:H:i:e:s:D:E: --long deployment:,mode:,bp-profile:,hardware-profile:,host-ip:,external-ip:,sample-video-dataset:,elasticsearch-mode:,es:,llm:,vlm:,llm-device-id:,vlm-device-id:,use-remote-llm,use-remote-vlm,llm-model-type:,vlm-model-type:,llm-env-file:,vlm-env-file:,use-sbsa-images,minimal,playback,data-dir:,data-directory:,dry-run,skip-revert-from-oldest-backup,help -- "${_args[@]}")
+  _valid_args=$(getopt -q -o d:m:p:H:i:e:s:D:E: --long deployment:,mode:,bp-profile:,hardware-profile:,gpu-device-id:,host-ip:,external-ip:,sample-video-dataset:,elasticsearch-mode:,es:,llm:,vlm:,llm-device-id:,vlm-device-id:,use-remote-llm,use-remote-vlm,llm-model-type:,vlm-model-type:,llm-env-file:,vlm-env-file:,use-sbsa-images,minimal,playback,data-dir:,data-directory:,dry-run,skip-revert-from-oldest-backup,help -- "${_args[@]}")
   if [[ $? -ne 0 ]]; then
     echo "[ERROR] Invalid usage: $(mask_external_ip_args "${_args[@]}")"
     ((_all_good++))
@@ -550,12 +554,85 @@ function validate_args() {
   fi
 }
 
+# Return whether nvidia-smi can inspect the host GPU inventory. An unavailable
+# inventory is distinct from an invalid individual device ID.
+function nvidia_smi_is_available() {
+  command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi --query-gpu=index --format=csv,noheader >/dev/null 2>&1
+}
+
+# Return the selected GB300 index. An explicit GPU/LLM/VLM device ID selects
+# the deployment GPU; otherwise exactly one detected GB300 is required.
+function resolve_gb300_device_id() {
+  local _gpu_selector="${gpu_device_id}" _llm_selector="" _vlm_selector="" _device_id _gpu_name _is_explicit=0
+  # Remote models do not consume a local GPU, so their device IDs
+  # must not participate in choosing or conflicting with the shared GB300.
+  if contains_element "llm-device-id" "${options_provided[@]}" && ! contains_element "use-remote-llm" "${options_provided[@]}"; then
+    _llm_selector="${llm_device_id}"
+  fi
+  if contains_element "vlm-device-id" "${options_provided[@]}" && ! contains_element "use-remote-vlm" "${options_provided[@]}"; then
+    _vlm_selector="${vlm_device_id}"
+  fi
+  if [[ -n "${_gpu_selector}" ]]; then
+    _is_explicit=1
+    if [[ -n "${_llm_selector}" ]] && [[ "${_llm_selector}" != "${_gpu_selector}" ]] || [[ -n "${_vlm_selector}" ]] && [[ "${_vlm_selector}" != "${_gpu_selector}" ]]; then
+      echo "[ERROR] --gpu-device-id must match any supplied --llm-device-id or --vlm-device-id for GB300" >&2
+      return 1
+    fi
+  elif [[ -n "${_llm_selector}" ]] && [[ -n "${_vlm_selector}" ]] && [[ "${_llm_selector}" != "${_vlm_selector}" ]]; then
+    echo "[ERROR] GB300 requires --llm-device-id and --vlm-device-id to select the same GPU" >&2
+    return 1
+  elif [[ -n "${_llm_selector}" || -n "${_vlm_selector}" ]]; then
+    _is_explicit=1
+  fi
+  _device_id="${_gpu_selector:-${_llm_selector:-${_vlm_selector}}}"
+
+  if [[ -z "${_device_id}" ]]; then
+    local _gb300_matches=()
+    local _index _name _lower
+    while IFS=, read -r _index _name; do
+      _index="${_index#"${_index%%[![:space:]]*}"}"
+      _index="${_index%"${_index##*[![:space:]]}"}"
+      [[ -n "${_index}" && -n "${_name}" ]] || continue
+      _lower="${_name,,}"
+      if [[ "${_lower}" == *gb300* || "${_lower}" == *b300* ]]; then
+        _gb300_matches+=("${_index}")
+      fi
+    done < <(nvidia-smi --query-gpu=index,name --format=csv,noheader 2>/dev/null)
+    if [[ "${#_gb300_matches[@]}" -eq 1 ]]; then
+      _device_id="${_gb300_matches[0]}"
+    elif [[ "${#_gb300_matches[@]}" -eq 0 ]]; then
+      echo "[ERROR] Hardware profile 'GB300' was selected, but no GB300 GPU was detected. Pass --gpu-device-id <id> when nvidia-smi is unavailable." >&2
+      return 1
+    else
+      echo "[ERROR] Multiple GB300 GPUs were detected; select the deployment GPU with --llm-device-id or --vlm-device-id" >&2
+      return 1
+    fi
+  fi
+
+  _gpu_name="$(nvidia-smi --id="${_device_id}" --query-gpu=name --format=csv,noheader 2>/dev/null | head -n1)"
+  _gpu_name="${_gpu_name,,}"
+  if [[ -z "${_gpu_name}" ]] && [[ "${_is_explicit}" -eq 1 ]]; then
+    if nvidia_smi_is_available; then
+      echo "[ERROR] Selected GPU device ID '${_device_id}' does not exist or cannot be queried" >&2
+      return 1
+    fi
+    echo "[WARN] nvidia-smi is unavailable; using explicit GB300 device ID ${_device_id}" >&2
+    echo "${_device_id}"
+    return 0
+  fi
+  if [[ "${_gpu_name}" != *gb300* && "${_gpu_name}" != *b300* ]]; then
+    echo "[ERROR] Selected GPU device ID '${_device_id}' is not a GB300" >&2
+    return 1
+  fi
+  echo "${_device_id}"
+}
+
 function process_args() {
   local _args _valid_args _all_good
   _args=("${@}")
   _all_good=0
 
-  _valid_args=$(getopt -q -o d:m:p:H:i:e:s:D:E: --long deployment:,mode:,bp-profile:,hardware-profile:,host-ip:,external-ip:,sample-video-dataset:,elasticsearch-mode:,es:,llm:,vlm:,llm-device-id:,vlm-device-id:,use-remote-llm,use-remote-vlm,llm-model-type:,vlm-model-type:,llm-env-file:,vlm-env-file:,use-sbsa-images,minimal,playback,data-dir:,data-directory:,dry-run,skip-revert-from-oldest-backup,help -- "${_args[@]}")
+  _valid_args=$(getopt -q -o d:m:p:H:i:e:s:D:E: --long deployment:,mode:,bp-profile:,hardware-profile:,gpu-device-id:,host-ip:,external-ip:,sample-video-dataset:,elasticsearch-mode:,es:,llm:,vlm:,llm-device-id:,vlm-device-id:,use-remote-llm,use-remote-vlm,llm-model-type:,vlm-model-type:,llm-env-file:,vlm-env-file:,use-sbsa-images,minimal,playback,data-dir:,data-directory:,dry-run,skip-revert-from-oldest-backup,help -- "${_args[@]}")
   eval set -- "${_valid_args}"
 
   while true; do
@@ -592,6 +669,12 @@ function process_args() {
         shift
         hardware_profile="${1}"
         options_provided+=("hardware-profile")
+        shift
+        ;;
+      --gpu-device-id)
+        shift
+        gpu_device_id="${1}"
+        options_provided+=("gpu-device-id")
         shift
         ;;
       --llm)
@@ -863,6 +946,18 @@ function process_args() {
         fi
         if ! contains_element "vlm-model-type" "${options_provided[@]}"; then
           vlm_model_type="$(get_env_value_from_files "VLM_MODEL_TYPE" "${_deploy_env}" "${_deploy_overrides_env}")"
+        fi
+      fi
+
+      # Resolve the single GB300 that every GPU-consuming warehouse service
+      # shares. Profile defaults describe multi-GPU systems and must not choose
+      # a different physical GPU on GB300.
+      if [[ "${hardware_profile}" == "GB300" ]]; then
+        if ! hardware_device_id="$(resolve_gb300_device_id)"; then
+          ((_all_good++))
+        else
+          llm_device_id="${hardware_device_id}"
+          vlm_device_id="${hardware_device_id}"
         fi
       fi
 
@@ -1242,6 +1337,16 @@ function state_up() {
     echo "[INFO] Warehouse COMPOSE_PROFILES=\${${compose_profiles_selector}}"
   fi
 
+  # All GPU-consuming warehouse services share the resolved GB300 device.
+  if [[ "${hardware_profile}" == "GB300" ]]; then
+    set_env_var "LLM_DEVICE_ID" "${hardware_device_id}"
+    set_env_var "VLM_DEVICE_ID" "${hardware_device_id}"
+    set_env_var "SHARED_LLM_VLM_DEVICE_ID" "${hardware_device_id}"
+    set_env_var "FIXED_SHARED_DEVICE_IDS" "${hardware_device_id}"
+    set_env_var "RT_CV_DEVICE_ID" "${hardware_device_id}"
+    set_env_var "RT_VLM_DEVICE_ID" "${hardware_device_id}"
+    set_env_var "RT_EMBED_DEVICE_ID" "${hardware_device_id}"
+  fi
 
   echo "[INFO] Generated environment file: ${_generated_env}"
 

--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -931,12 +931,10 @@ function process_args() {
         _vlm_is_remote=1
       fi
 
-      # Search places every local model on one shared GB300, so it resolves a
-      # single deployment GPU from an explicitly selected local model, or
-      # auto-detects it when exactly one GB300 is present (including
-      # remote+remote). Other profiles carry their own GB300 handling and must
-      # not be routed through this resolution.
-      if [[ "${hardware_profile}" == "GB300" ]] && [[ "${profile}" == "search" ]]; then
+      # Every profile places its GPU-consuming services on one selected GB300.
+      # Resolve that GPU from an explicitly selected local model, or auto-detect
+      # it when exactly one GB300 is present (including remote+remote).
+      if [[ "${hardware_profile}" == "GB300" ]]; then
         # Device IDs reach here from the CLI or from the profile environment, and
         # only a CLI value is an explicit selection. The profile defaults describe
         # the two-GPU layout (LLM on 1, VLM on 0), which cannot apply to a single
@@ -962,7 +960,7 @@ function process_args() {
           # A conflict the user actually expressed is an error; one inherited
           # wholly from the profile environment is not.
           if [[ "${_llm_id_is_cli}" -eq 1 ]] || [[ "${_vlm_id_is_cli}" -eq 1 ]]; then
-            echo "[ERROR] GB300 search requires local LLM and VLM device IDs to select the same GPU"
+            echo "[ERROR] GB300 requires local LLM and VLM device IDs to select the same GPU"
             ((_all_good++))
           fi
         else
@@ -992,9 +990,9 @@ function process_args() {
         if [[ "${_vlm_is_remote}" -eq 0 ]]; then
           vlm_device_id="${hardware_device_id}"
         fi
-        if [[ "${_llm_is_remote}" -eq 0 ]] && contains_element "llm" "${options_provided[@]}" \
+        if [[ "${profile}" == "search" ]] && [[ "${_llm_is_remote}" -eq 0 ]] && contains_element "llm" "${options_provided[@]}" \
           && [[ "${llm}" != "nvidia/nemotron-3.5-lightning-30b-a3b" ]]; then
-          echo "[ERROR] GB300 search supports only the local LLM nvidia/nemotron-3.5-lightning-30b-a3b"
+          echo "[ERROR] The search profile on GB300 supports only the locally hosted LLM nvidia/nemotron-3.5-lightning-30b-a3b"
           ((_all_good++))
         fi
       fi
@@ -1017,6 +1015,9 @@ function process_args() {
         _gpu_name="$(get_nvidia_smi_gpu_name "${_hardware_check_device_id}")"
         if [[ -z "${_gpu_name}" ]]; then
           echo "[ERROR] Hardware profile '${hardware_profile}' does not match detected hardware (no NVIDIA GPU detected)."
+          ((_all_good++))
+        elif [[ "${hardware_profile}" == "GB300" ]] && [[ "$(get_detected_hardware_profile "${_gpu_name}")" != "GB300" ]]; then
+          echo "[ERROR] Selected GPU device ID '${_hardware_check_device_id}' is not a GB300."
           ((_all_good++))
         elif ! host_has_detected_hardware_profile "$(get_canonical_hardware_profile "${hardware_profile}")"; then
           echo "[ERROR] Hardware profile '${hardware_profile}' does not match any detected NVIDIA GPU."
@@ -1161,9 +1162,9 @@ function process_args() {
         fi
       fi
 
-      # Every local model on the single selected GB300 shares that GPU with the
-      # search runtime services, even when the other model uses a remote endpoint.
-      if [[ "${hardware_profile}" == "GB300" ]] && [[ "${profile}" == "search" ]]; then
+      # Every local model on the single selected GB300 shares that GPU with
+      # the profile runtime services, even when the other model is remote.
+      if [[ "${hardware_profile}" == "GB300" ]]; then
         [[ "${llm_mode}" != "remote" ]] && llm_mode="local_shared"
         [[ "${vlm_mode}" != "remote" ]] && vlm_mode="local_shared"
       fi
@@ -1232,8 +1233,9 @@ function process_args() {
       fi
 
       # Device IDs must not be in profile RESERVED_DEVICE_IDS (comma-separated list; may be empty).
-      # Exception: DGX-SPARK, IGX-THOR, AGX-THOR are exempt (device ID options not accepted).
-      if ! contains_element "${hardware_profile}" "${edge_hardware_profiles[@]}"; then
+      # Edge boards and GB300 are exempt: their resolved device is the shared
+      # deployment GPU, so it intentionally supersedes profile reservations.
+      if [[ "${hardware_profile}" != "GB300" ]] && ! contains_element "${hardware_profile}" "${edge_hardware_profiles[@]}"; then
         if [[ -n "${profile}" ]] && [[ -f "${deployment_directory}/developer-profiles/dev-profile-${profile}/.env" ]]; then
           local _profile_env_reserved="${deployment_directory}/developer-profiles/dev-profile-${profile}/.env"
           local _profile_overrides_env_reserved="${deployment_directory}/developer-profiles/dev-profile-${profile}/overrides.env"
@@ -1711,7 +1713,7 @@ function state_up() {
       set_env_var "VLM_DEVICE_ID" "${vlm_device_id}"
     fi
   fi
-  if [[ "${profile}" == "search" ]] && [[ "${hardware_profile}" == "GB300" ]]; then
+  if [[ "${hardware_profile}" == "GB300" ]]; then
     local _gb300_device_id="${hardware_device_id}"
     set_env_var "SHARED_LLM_VLM_DEVICE_ID" "${_gb300_device_id}"
     set_env_var "FIXED_SHARED_DEVICE_IDS" "${_gb300_device_id}"
@@ -1854,9 +1856,9 @@ function state_up() {
       else
         set_env_var "RT_VLM_DEVICE_ID" "${vlm_device_id}"
       fi
-      # RT-VLM remains a local proxy for remote VLM endpoints on GB300 search,
-      # which is the only profile that resolves a single deployment GPU.
-      if [[ "${hardware_profile}" == "GB300" ]] && [[ "${profile}" == "search" ]]; then
+      # RT-VLM remains a local proxy for remote VLM endpoints on GB300, so it
+      # follows the selected deployment GPU for every profile.
+      if [[ "${hardware_profile}" == "GB300" ]]; then
         set_env_var "RT_VLM_DEVICE_ID" "${hardware_device_id}"
       fi
     fi

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -1830,6 +1830,13 @@ run_dry_run_up_and_check_generated_env "generated.env Search keeps Nemotron 3.5 
 EXPECTED_STDOUT="Managed container tag suffix: -sbsa" run_dry_run_up_and_check_generated_env "generated.env Base GB300 selects the centralized SBSA suffix" "base" \
  -i 127.0.0.1 -H GB300 --llm-device-id 1 --vlm-device-id 1 -d -- \
   "HARDWARE_PROFILE" "GB300" \
+  "LLM_DEVICE_ID" "1" \
+  "VLM_DEVICE_ID" "1" \
+  "SHARED_LLM_VLM_DEVICE_ID" "1" \
+  "FIXED_SHARED_DEVICE_IDS" "1" \
+  "RT_CV_DEVICE_ID" "1" \
+  "RT_VLM_DEVICE_ID" "1" \
+  "RT_EMBED_DEVICE_ID" "1" \
   "LLM_NAME" "nvidia/nemotron-3.5-lightning-30b-a3b" \
   "LLM_NAME_SLUG" "nemotron-3.5-lightning-30b-a3b" \
 


### PR DESCRIPTION
## Summary

Generalize GB300 GPU placement so all GPU-consuming services use the resolved GB300 device across dev profiles and warehouse blueprint deployments.

## Plan

- Resolve or validate the selected GB300 device.
- Apply that device ID consistently to model and runtime services.
- Preserve local LLM support and search-specific model validation.
- Cover non-search dev-profile placement.

## Changes

dev-profile.sh
- Extends GB300 device resolution and shared-GPU configuration from search to all profiles.
- Assigns the resolved device to LLM, VLM, RT-CV, RT-Embed, RT-VLM, and shared NIM settings.
- Validates that the selected device is actually a GB300.
- Clarifies the search-profile local LLM restriction message.

blueprint-deploy.sh
- Adds GB300 device resolution from matching explicit device IDs or unique hardware detection.
- Applies the resolved device ID to all warehouse GPU-consuming services.

test-dev-profile.sh
- Adds GB300 base-profile assertions for all GPU device assignments.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.
