### PR TITLE
Serialize NvJpegEncLoader singleton creation

### DIFF
--- a/services/vios/src/framework/media/video_source/encoders/nvjpegenc_loader.cpp
+++ b/services/vios/src/framework/media/video_source/encoders/nvjpegenc_loader.cpp
@@ -31,9 +31,15 @@ constexpr int JPEG_DEFAULT_QUALITY = 75;
 #define ROUND_UP_4(num)  (((num) + 3) & ~3)
 
 std::unique_ptr<NvJpegEncLoader> NvJpegEncLoader::m_instance = nullptr;
+std::mutex NvJpegEncLoader::m_instanceLock;
 
 NvJpegEncLoader* NvJpegEncLoader::getInstance()
 {
+    // The first JPEG encode of the process is typically several concurrent
+    // thumbnail requests. An unguarded check-then-create lets each of them
+    // construct a loader and delete the previous one while other threads are
+    // still encoding through it, which crashes in nvjpegEncodeFromFd.
+    std::lock_guard<std::mutex> lock(m_instanceLock);
     if (m_instance == nullptr)
     {
         m_instance.reset(new NvJpegEncLoader());
@@ -43,6 +49,7 @@ NvJpegEncLoader* NvJpegEncLoader::getInstance()
 
 void NvJpegEncLoader::deleteInstance()
 {
+    std::lock_guard<std::mutex> lock(m_instanceLock);
     m_instance.reset();
 }
 

--- a/services/vios/src/framework/media/video_source/encoders/nvjpegenc_loader.h
+++ b/services/vios/src/framework/media/video_source/encoders/nvjpegenc_loader.h
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <memory>
+#include <mutex>
 #include "libjpeg-8b/jpeglib.h"
 
 namespace nv_vms {
@@ -69,6 +70,7 @@ private:
     friend struct std::default_delete<NvJpegEncLoader>;
 
     static std::unique_ptr<NvJpegEncLoader> m_instance;
+    static std::mutex m_instanceLock;
     bool m_error;
     nv_vms::SharedLibrary* m_handleNvJpeg;
 


### PR DESCRIPTION
* Guard getInstance and deleteInstance with a static mutex so the loader is constructed exactly once.
* Concurrent first-time image captures previously each built a loader and deleted the previous one while other threads were still encoding through it, which segfaulted in nvjpegEncodeFromFd.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.
