### PR TITLE
fix(agent): ground sensor answers and surface VST tool errors

### DIFF
--- a/.github/scripts/poll-downstream-pipeline.py
+++ b/.github/scripts/poll-downstream-pipeline.py
@@ -20,9 +20,17 @@ Reporting rules (printed once per job, no duplicates):
 * ``ALLOWED_FAILURE: <job name>`` when a job fails with any other exit
   code while still configured with ``allow_failure: true``.
 * ``FAIL: <job name>`` when any non-``allow_failure`` job reaches status
-  ``failed`` - the script exits 1 immediately.
-* ``CANCELED: <job name>`` when a job is canceled - the script exits 1
-  immediately.
+  ``failed``.
+* ``CANCELED: <job name>`` when a job is canceled.
+
+``FAIL`` / ``CANCELED`` are announcements, not verdicts: polling
+continues until the pipeline itself reaches a terminal state, and the
+exit status is then decided from that final snapshot. A single job
+failing no longer discards the result of every job still running
+alongside it, and because the verdict is re-read at the end, a job that
+failed and was retried into a pass is not held against the pipeline.
+The check still goes red for any job that is genuinely failed or
+canceled once the pipeline is done.
 
 Resolving the exit code is non-trivial: many downstream API versions
 do NOT include ``exit_code`` in either the pipeline-jobs listing or
@@ -34,8 +42,8 @@ cached for the lifetime of the poller.
 Exit codes:
 
 * ``0`` - pipeline finished with no failures.
-* ``1`` - a failing / canceled job was observed, or the poller timed
-  out (see ``MAX_POLL_DURATION_SECONDS``).
+* ``1`` - the finished pipeline had a failing / canceled job, or the
+  poller timed out (see ``MAX_POLL_DURATION_SECONDS``).
 
 Retried jobs are handled by de-duping on ``name`` and keeping only
 the latest attempt (highest ``id``).
@@ -329,6 +337,50 @@ def latest_attempt_per_name(jobs: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return list(by_name.values())
 
 
+def blocking_jobs(
+    jobs: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Split ``jobs`` into the failed and canceled ones that must fail
+    the check, ignoring failures the pipeline marked ``allow_failure``.
+
+    Called on the final snapshot rather than accumulated across ticks so
+    the verdict reflects each job's last attempt.
+    """
+    failed: list[dict[str, Any]] = []
+    canceled: list[dict[str, Any]] = []
+    for job in jobs:
+        status = str(job.get("status") or "").lower()
+        if status == "failed" and not bool(job.get("allow_failure")):
+            failed.append(job)
+        elif status == "canceled":
+            canceled.append(job)
+    return failed, canceled
+
+
+def describe_job(job: dict[str, Any]) -> str:
+    """One-line job description for the failure report.
+
+    Carries the stage, duration and failure reason because those are
+    what separate a job that ran the product and failed from one that
+    died in seconds before it started - a distinction the bare job name
+    cannot make.
+    """
+    name = str(job.get("name") or "<unnamed>")
+    details: list[str] = []
+    stage = str(job.get("stage") or "").strip()
+    if stage:
+        details.append(f"stage {stage}")
+    duration = job.get("duration")
+    if isinstance(duration, (int, float)) and not isinstance(duration, bool):
+        details.append(_format_hms(duration))
+    reason = str(job.get("failure_reason") or "").strip()
+    if reason:
+        details.append(reason)
+    if not details:
+        return name
+    return f"{name} ({', '.join(details)})"
+
+
 def write_summary(lines: list[str]) -> None:
     path = os.environ.get("GITHUB_STEP_SUMMARY", "").strip()
     if not path:
@@ -390,6 +442,78 @@ def _format_status_counts(counts: dict[str, int]) -> str:
     return ", ".join(parts)
 
 
+def report_terminal_pipeline(
+    pipeline_id: int,
+    pipeline_status: str,
+    jobs: list[dict[str, Any]],
+    seen_success: set[str],
+    seen_skipped: set[str],
+    seen_allowed_failure: set[str],
+) -> int:
+    """Decide the check's verdict from a terminal pipeline snapshot."""
+    failed, canceled = blocking_jobs(jobs)
+
+    if failed or canceled:
+        for job in failed:
+            emit_error(f"Downstream job failed: {describe_job(job)}")
+        for job in canceled:
+            emit_error(f"Downstream job canceled: {describe_job(job)}")
+        print(
+            f"Downstream pipeline #{pipeline_id} finished '{pipeline_status}': "
+            f"{len(failed)} failed, {len(canceled)} canceled, "
+            f"{len(seen_success)} succeeded, "
+            f"{len(seen_skipped)} skipped, "
+            f"{len(seen_allowed_failure)} allowed failures"
+        )
+        summary = [
+            "### Downstream pipeline result",
+            "",
+            f"- **Outcome:** {pipeline_status}",
+        ]
+        if failed:
+            summary.append(f"- **Failed jobs:** {len(failed)}")
+            summary.extend(f"  - `{describe_job(job)}`" for job in failed)
+        if canceled:
+            summary.append(f"- **Canceled jobs:** {len(canceled)}")
+            summary.extend(f"  - `{describe_job(job)}`" for job in canceled)
+        summary.append(f"- **Succeeded jobs:** {len(seen_success)}")
+        if seen_skipped:
+            summary.append(f"- **Skipped jobs (exit {GATE_SKIP_EXIT_CODE}):** {len(seen_skipped)}")
+        if seen_allowed_failure:
+            summary.append(f"- **Allowed failures:** {len(seen_allowed_failure)}")
+        write_summary(summary)
+        return 1
+
+    if pipeline_status == "success":
+        print(
+            f"Downstream pipeline #{pipeline_id} finished: "
+            f"{len(seen_success)} succeeded, "
+            f"{len(seen_skipped)} skipped, "
+            f"{len(seen_allowed_failure)} allowed failures"
+        )
+        summary = [
+            "### Downstream pipeline result",
+            "",
+            "- **Outcome:** success",
+            f"- **Succeeded jobs:** {len(seen_success)}",
+        ]
+        if seen_skipped:
+            summary.append(f"- **Skipped jobs (exit {GATE_SKIP_EXIT_CODE}):** {len(seen_skipped)}")
+        if seen_allowed_failure:
+            summary.append(f"- **Allowed failures:** {len(seen_allowed_failure)}")
+        write_summary(summary)
+        return 0
+
+    # Terminal, but nothing in the snapshot explains it. This happens with
+    # pipeline-level configuration errors the downstream API reports on the
+    # pipeline rather than on a job, and with a snapshot truncated by an API
+    # error. Fail closed either way.
+    emit_error(
+        f"Downstream pipeline ended with status '{pipeline_status}' and no failing job was observed"
+    )
+    return 1
+
+
 def main() -> int:
     # GitHub Actions captures stdout via a pipe, which makes Python's
     # default block-buffered stdout look like nothing is happening for
@@ -447,6 +571,11 @@ def main() -> int:
     seen_success: set[str] = set()
     seen_allowed_failure: set[str] = set()
     seen_skipped: set[str] = set()
+    # Announcement bookkeeping only: these keep each transition from being
+    # printed on every tick. The verdict comes from the terminal snapshot,
+    # not from these sets, so a retried job is judged on its last attempt.
+    seen_failed: set[str] = set()
+    seen_canceled: set[str] = set()
     # Per-job exit-code cache (keyed by job id). Populated lazily when
     # we hit a `failed + allow_failure: true` job and the listing
     # payload doesn't carry `exit_code` (the listing endpoint never
@@ -473,26 +602,16 @@ def main() -> int:
             allow_failure = bool(job.get("allow_failure"))
 
             if status == "failed" and not allow_failure:
-                print(f"FAIL: {name}")
-                print("::endgroup::")
-                write_summary([
-                    "### Downstream pipeline result",
-                    "",
-                    f"- Failed job: `{name}`",
-                    f"- Successful jobs so far: {len(seen_success)}",
-                ])
-                return 1
+                if name not in seen_failed:
+                    seen_failed.add(name)
+                    print(f"FAIL: {name}")
+                continue
 
             if status == "canceled":
-                print(f"CANCELED: {name}")
-                print("::endgroup::")
-                write_summary([
-                    "### Downstream pipeline result",
-                    "",
-                    f"- Canceled job: `{name}`",
-                    f"- Successful jobs so far: {len(seen_success)}",
-                ])
-                return 1
+                if name not in seen_canceled:
+                    seen_canceled.add(name)
+                    print(f"CANCELED: {name}")
+                continue
 
             if status == "failed" and allow_failure:
                 # The listing endpoint omits `exit_code`; resolve it
@@ -526,40 +645,28 @@ def main() -> int:
         )
         print("::endgroup::")
 
-        if pipeline_status == "success":
-            print(
-                f"Downstream pipeline #{pipeline_id} finished: "
-                f"{len(seen_success)} succeeded, "
-                f"{len(seen_skipped)} skipped, "
-                f"{len(seen_allowed_failure)} allowed failures"
-            )
-            summary = [
-                "### Downstream pipeline result",
-                "",
-                "- **Outcome:** success",
-                f"- **Succeeded jobs:** {len(seen_success)}",
-            ]
-            if seen_skipped:
-                summary.append(f"- **Skipped jobs (exit {GATE_SKIP_EXIT_CODE}):** {len(seen_skipped)}")
-            if seen_allowed_failure:
-                summary.append(f"- **Allowed failures:** {len(seen_allowed_failure)}")
-            write_summary(summary)
-            return 0
-
         if pipeline_status in TERMINAL_PIPELINE_STATUSES:
-            # Pipeline is terminal but we didn't detect a specific failing
-            # job above. This can happen with pipeline-level configuration
-            # errors (e.g. an invalid pipeline config) that the
-            # downstream API surfaces on the pipeline itself rather
-            # than on a specific job.
-            emit_error(f"Downstream pipeline ended with status '{pipeline_status}' and no failing job was observed")
-            return 1
+            return report_terminal_pipeline(
+                pipeline_id,
+                pipeline_status,
+                latest_jobs,
+                seen_success,
+                seen_skipped,
+                seen_allowed_failure,
+            )
 
         if time.monotonic() - start > max_duration:
             emit_error(
                 f"Polling timed out after {_format_hms(time.monotonic() - start)} "
                 f"(pipeline status: '{pipeline_status}')"
             )
+            # Name whatever had already failed, so a timeout report is not
+            # silent about failures the poller did observe.
+            failed, canceled = blocking_jobs(latest_jobs)
+            for job in failed:
+                emit_error(f"Downstream job failed before the timeout: {describe_job(job)}")
+            for job in canceled:
+                emit_error(f"Downstream job canceled before the timeout: {describe_job(job)}")
             return 1
 
         time.sleep(poll_interval)

--- a/.github/scripts/test_poll_downstream_pipeline.py
+++ b/.github/scripts/test_poll_downstream_pipeline.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+from typing import ClassVar
+from unittest import mock
+
+SCRIPT = Path(__file__).with_name("poll-downstream-pipeline.py")
+SPEC = importlib.util.spec_from_file_location("poll_downstream_pipeline", SCRIPT)
+assert SPEC and SPEC.loader
+module = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(module)
+
+BASE_ENV = {
+    "DOWNSTREAM_CI_URL": "https://gitlab.example",
+    "DOWNSTREAM_CI_TOKEN": "token",
+    "DOWNSTREAM_PROJECT_PATH": "group/project",
+    "DOWNSTREAM_PIPELINE_ID": "66683019",
+    "DOWNSTREAM_PROJECT_ID": "283373",
+    "POLL_INTERVAL_SECONDS": "120",
+    "MAX_POLL_DURATION_SECONDS": "14400",
+}
+
+
+def job(
+    name: str,
+    status: str,
+    *,
+    job_id: int = 0,
+    allow_failure: bool = False,
+    duration: float | None = None,
+    stage: str = "test",
+    failure_reason: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": job_id or abs(hash((name, status))) % 100000,
+        "name": name,
+        "status": status,
+        "allow_failure": allow_failure,
+        "duration": duration,
+        "stage": stage,
+        "failure_reason": failure_reason,
+    }
+
+
+class Run:
+    """Result of driving ``main()`` over a scripted sequence of ticks."""
+
+    def __init__(self, exit_code: int, stdout: str, stderr: str, summary: str, ticks_read: int):
+        self.exit_code = exit_code
+        self.stdout = stdout
+        self.stderr = stderr
+        self.summary = summary
+        self.ticks_read = ticks_read
+
+
+def drive(ticks: list[tuple[list[dict[str, Any]], str]], *, env: dict[str, str] | None = None) -> Run:
+    """Run ``main()`` against ``ticks``, a list of ``(jobs, pipeline_status)``.
+
+    The last tick repeats forever, which is what lets a test assert the
+    timeout path without waiting for it.
+    """
+    reads = {"n": 0, "current": 0}
+
+    def fake_fetch_all_jobs(*_args, **_kwargs):
+        # main() fetches jobs first, then the pipeline, once per tick.
+        # Pin the tick index here so both reads see the same snapshot.
+        reads["current"] = min(reads["n"], len(ticks) - 1)
+        reads["n"] += 1
+        return list(ticks[reads["current"]][0])
+
+    def fake_fetch_pipeline(*_args, **_kwargs):
+        return {"status": ticks[reads["current"]][1]}
+
+    # Advance the clock by the poll interval on each sleep so a test that
+    # never reaches a terminal state still hits MAX_POLL_DURATION_SECONDS.
+    clock = {"t": 0.0}
+
+    def fake_sleep(seconds: float) -> None:
+        clock["t"] += seconds
+
+    with tempfile.TemporaryDirectory() as tmp:
+        summary_path = Path(tmp) / "summary.md"
+        full_env = {**BASE_ENV, **(env or {}), "GITHUB_STEP_SUMMARY": str(summary_path)}
+        out, err = io.StringIO(), io.StringIO()
+        with (
+            mock.patch.dict(os.environ, full_env, clear=False),
+            mock.patch.object(module, "fetch_all_jobs", fake_fetch_all_jobs),
+            mock.patch.object(module, "fetch_pipeline", fake_fetch_pipeline),
+            mock.patch.object(module.time, "sleep", fake_sleep),
+            mock.patch.object(module.time, "monotonic", lambda: clock["t"]),
+            contextlib.redirect_stdout(out),
+            contextlib.redirect_stderr(err),
+        ):
+            exit_code = module.main()
+        summary = summary_path.read_text(encoding="utf-8") if summary_path.exists() else ""
+    return Run(exit_code, out.getvalue(), err.getvalue(), summary, reads["n"])
+
+
+class AbortOnFirstFailureRegressionTest(unittest.TestCase):
+    """The behaviour this change exists to remove.
+
+    Reproduces pipeline 66683019: ``eval-warehouse-bp-wh-2d`` died in 14.7s
+    in ``get_sources`` on a dirty runner while every other job was still
+    running. The poller used to return at that first tick, two minutes in,
+    discarding the ~46 minutes of product testing that then passed.
+    """
+
+    TICKS: ClassVar[list[tuple[list[dict[str, Any]], str]]] = [
+        (
+            [
+                job("eval-warehouse-bp-wh-2d", "failed", duration=14.7, failure_reason="script_failure"),
+                job("test-base", "running"),
+                job("test-search", "running"),
+                job("test-alerts-realtime", "running"),
+            ],
+            "running",
+        ),
+        (
+            [
+                job("eval-warehouse-bp-wh-2d", "failed", duration=14.7, failure_reason="script_failure"),
+                job("test-base", "success", duration=713),
+                job("test-search", "running"),
+                job("test-alerts-realtime", "running"),
+            ],
+            "running",
+        ),
+        (
+            [
+                job("eval-warehouse-bp-wh-2d", "failed", duration=14.7, failure_reason="script_failure"),
+                job("test-base", "success", duration=713),
+                job("test-search", "success", duration=2770),
+                job("test-alerts-realtime", "success", duration=1028),
+            ],
+            "failed",
+        ),
+    ]
+
+    def test_polls_past_the_first_failure_to_the_end(self):
+        run = drive(self.TICKS)
+        # Every tick was read: the poller did not bail at the first FAIL.
+        self.assertEqual(run.ticks_read, 3)
+        # The jobs that finished after the failure were still reported.
+        for name in ("test-base", "test-search", "test-alerts-realtime"):
+            self.assertIn(f"SUCCESS: {name}", run.stdout)
+
+    def test_still_red_and_names_the_failing_job(self):
+        run = drive(self.TICKS)
+        self.assertEqual(run.exit_code, 1)
+        self.assertIn("FAIL: eval-warehouse-bp-wh-2d", run.stdout)
+        self.assertIn("eval-warehouse-bp-wh-2d", run.stderr)
+
+    def test_failure_report_carries_duration_and_reason(self):
+        # A 14s death in `get_sources` reads differently from a product
+        # failure, so the report has to show more than the job name.
+        run = drive(self.TICKS)
+        self.assertIn("0m14s", run.stderr)
+        self.assertIn("script_failure", run.stderr)
+        self.assertIn("eval-warehouse-bp-wh-2d", run.summary)
+        self.assertIn("**Succeeded jobs:** 3", run.summary)
+
+    def test_failure_announced_once_not_once_per_tick(self):
+        run = drive(self.TICKS)
+        self.assertEqual(run.stdout.count("FAIL: eval-warehouse-bp-wh-2d"), 1)
+
+
+class GenuineFailureIsStillFatalTest(unittest.TestCase):
+    """The property that must not regress: a real failing job goes red."""
+
+    def test_single_failed_job_fails_the_check(self):
+        run = drive([([job("test-search", "failed", duration=2770)], "failed")])
+        self.assertEqual(run.exit_code, 1)
+        self.assertIn("test-search", run.stderr)
+
+    def test_every_failing_job_is_reported_not_just_the_first(self):
+        run = drive([
+            (
+                [
+                    job("test-lvs", "failed", duration=20),
+                    job("eval-warehouse-bp-wh-2d", "failed", duration=14.7),
+                    job("test-base", "success", duration=713),
+                ],
+                "failed",
+            )
+        ])
+        self.assertEqual(run.exit_code, 1)
+        self.assertIn("test-lvs", run.stderr)
+        self.assertIn("eval-warehouse-bp-wh-2d", run.stderr)
+        self.assertIn("2 failed", run.stdout)
+
+    def test_failure_alongside_a_success_pipeline_status_still_fails(self):
+        # Never trust a 'success' pipeline status over a failed job in the
+        # snapshot: fail closed.
+        run = drive([([job("test-base", "failed", duration=713)], "success")])
+        self.assertEqual(run.exit_code, 1)
+
+    def test_terminal_pipeline_with_no_failing_job_fails_closed(self):
+        # Pipeline-level config errors, and snapshots truncated by an API
+        # error, must not read as a pass.
+        run = drive([([], "failed")])
+        self.assertEqual(run.exit_code, 1)
+        self.assertIn("no failing job was observed", run.stderr)
+
+    def test_canceled_job_fails_the_check(self):
+        run = drive([([job("test-base", "canceled", duration=5)], "canceled")])
+        self.assertEqual(run.exit_code, 1)
+        self.assertIn("canceled", run.stderr.lower())
+
+    def test_canceled_job_does_not_abort_the_poll_early(self):
+        run = drive([
+            ([job("test-base", "canceled"), job("test-search", "running")], "running"),
+            ([job("test-base", "canceled"), job("test-search", "success", duration=2770)], "canceled"),
+        ])
+        self.assertEqual(run.ticks_read, 2)
+        self.assertEqual(run.exit_code, 1)
+        self.assertIn("SUCCESS: test-search", run.stdout)
+
+
+class RetryTest(unittest.TestCase):
+    def test_job_retried_into_a_pass_is_not_held_against_the_pipeline(self):
+        # Verdict comes from the final snapshot, so the first attempt's
+        # failure does not survive a successful retry.
+        run = drive([
+            ([job("test-base", "failed", job_id=1, duration=20)], "running"),
+            (
+                [
+                    job("test-base", "failed", job_id=1, duration=20),
+                    job("test-base", "success", job_id=2, duration=713),
+                ],
+                "success",
+            ),
+        ])
+        self.assertEqual(run.exit_code, 0)
+        self.assertIn("FAIL: test-base", run.stdout)
+        self.assertIn("SUCCESS: test-base", run.stdout)
+
+    def test_job_retried_into_a_failure_still_fails(self):
+        run = drive([
+            (
+                [
+                    job("test-base", "success", job_id=1, duration=700),
+                    job("test-base", "failed", job_id=2, duration=713),
+                ],
+                "failed",
+            )
+        ])
+        self.assertEqual(run.exit_code, 1)
+
+
+class GreenPathTest(unittest.TestCase):
+    def test_all_success_exits_zero(self):
+        run = drive([
+            ([job("test-base", "running")], "running"),
+            ([job("test-base", "success", duration=713)], "success"),
+        ])
+        self.assertEqual(run.exit_code, 0)
+        self.assertIn("SUCCESS: test-base", run.stdout)
+        self.assertIn("- **Outcome:** success", run.summary)
+
+    def test_gate_skip_exit_75_is_a_skip_not_a_failure(self):
+        gate = job("brev-script-base", "failed", allow_failure=True, duration=3)
+        with mock.patch.object(module, "resolve_exit_code", lambda *_a, **_k: 75):
+            run = drive([([gate, job("test-base", "success", duration=713)], "success")])
+        self.assertEqual(run.exit_code, 0)
+        self.assertIn("SKIPPED: brev-script-base", run.stdout)
+
+    def test_allowed_failure_does_not_fail_the_check(self):
+        allowed = job("helm chart parity tests", "failed", allow_failure=True, duration=29)
+        with mock.patch.object(module, "resolve_exit_code", lambda *_a, **_k: 1):
+            run = drive([([allowed, job("test-base", "success", duration=713)], "success")])
+        self.assertEqual(run.exit_code, 0)
+        self.assertIn("ALLOWED_FAILURE: helm chart parity tests", run.stdout)
+
+
+class TimeoutTest(unittest.TestCase):
+    def test_timeout_is_still_fatal_and_bounded_by_max_duration(self):
+        # Pipeline never terminates; the last tick repeats. 14400s at a
+        # 120s interval bounds this at 120 ticks.
+        run = drive([([job("test-base", "running")], "running")])
+        self.assertEqual(run.exit_code, 1)
+        self.assertIn("Polling timed out", run.stderr)
+        self.assertLessEqual(run.ticks_read, 122)
+
+    def test_timeout_names_failures_it_already_saw(self):
+        run = drive([
+            (
+                [
+                    job("eval-warehouse-bp-wh-2d", "failed", duration=14.7),
+                    job("test-search", "running"),
+                ],
+                "running",
+            )
+        ])
+        self.assertEqual(run.exit_code, 1)
+        self.assertIn("Polling timed out", run.stderr)
+        self.assertIn("eval-warehouse-bp-wh-2d", run.stderr)
+
+    def test_interval_and_max_duration_are_honoured(self):
+        run = drive(
+            [([job("test-base", "running")], "running")],
+            env={"POLL_INTERVAL_SECONDS": "60", "MAX_POLL_DURATION_SECONDS": "600"},
+        )
+        self.assertEqual(run.exit_code, 1)
+        # 600s at 60s per tick: 10 sleeps, so 11-12 snapshots.
+        self.assertLessEqual(run.ticks_read, 12)
+        self.assertGreaterEqual(run.ticks_read, 10)
+
+    def test_a_pipeline_that_terminates_does_not_wait_for_the_timeout(self):
+        run = drive([([job("test-base", "success", duration=713)], "success")])
+        self.assertEqual(run.exit_code, 0)
+        self.assertEqual(run.ticks_read, 1)
+
+
+class BlockingJobsTest(unittest.TestCase):
+    def test_allow_failure_is_not_blocking(self):
+        failed, canceled = module.blocking_jobs([
+            job("a", "failed", allow_failure=True),
+            job("b", "failed"),
+            job("c", "canceled"),
+            job("d", "success"),
+            job("e", "skipped"),
+            job("f", "running"),
+        ])
+        self.assertEqual([j["name"] for j in failed], ["b"])
+        self.assertEqual([j["name"] for j in canceled], ["c"])
+
+    def test_canceled_is_blocking_even_when_allow_failure(self):
+        # A cancel is an interrupted run, not a tolerated outcome.
+        failed, canceled = module.blocking_jobs([job("a", "canceled", allow_failure=True)])
+        self.assertEqual(failed, [])
+        self.assertEqual([j["name"] for j in canceled], ["a"])
+
+    def test_status_case_is_ignored(self):
+        failed, _ = module.blocking_jobs([job("a", "FAILED")])
+        self.assertEqual([j["name"] for j in failed], ["a"])
+
+
+class DescribeJobTest(unittest.TestCase):
+    def test_includes_stage_duration_and_reason(self):
+        text = module.describe_job(
+            job(
+                "eval-warehouse-bp-wh-2d",
+                "failed",
+                duration=14.706675,
+                stage="blueprint eval docker-compose",
+                failure_reason="script_failure",
+            )
+        )
+        self.assertIn("eval-warehouse-bp-wh-2d", text)
+        self.assertIn("stage blueprint eval docker-compose", text)
+        self.assertIn("0m14s", text)
+        self.assertIn("script_failure", text)
+
+    def test_survives_a_sparse_payload(self):
+        self.assertEqual(module.describe_job({}), "<unnamed>")
+        self.assertEqual(
+            module.describe_job({"name": "x", "duration": None, "stage": "", "failure_reason": None}),
+            "x",
+        )
+
+    def test_long_duration_is_readable(self):
+        self.assertIn("1h21m40s", module.describe_job(job("test-search", "failed", duration=4900, stage="")))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1440,6 +1440,7 @@ jobs:
           python3 .github/scripts/test_cleanup_pr_tags.py
           python3 .github/scripts/test_cancel_stale_pr_ci.py
           python3 .github/scripts/test_cancel_downstream_pipeline.py
+          python3 .github/scripts/test_poll_downstream_pipeline.py
 
       - name: Unit-test the GHCR immutability/provenance guard
         run: python3 .github/scripts/test_ghcr_image_guard.py

--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
@@ -375,12 +375,16 @@ workflow:
     For summaries of named media, plan `vst_video_list` first, then exactly one summary tool based only on its result: `rtsp` → `lvs_stream_understanding`; `video` → `lvs_video_understanding`. Never choose the summary tool from duration.
     Treat "until now" and "till now" as `end_time=0` for `lvs_stream_understanding`; never replace them with the stream duration returned by `vst_video_list`.
     A non-empty name supplied in the request is the sensor_id. For example, in "Generate a report for warehouse_sample", the sensor_id is "warehouse_sample"; this request is complete and MUST NOT trigger a clarifying question.
-    If the user requests a report and supplies a name, the plan MUST contain exactly one action: call `report_agent` directly with that exact name as sensor_id and the original request as user_query. Do not verify the name or media type first.
+    If the user explicitly requests long video summarization or LVS in a report, the plan MUST first call `lvs_video_understanding` with the exact sensor_id and requested time range, then call `report_agent` with the same inputs and the original request as user_query.
+    For every other named report request, the plan MUST contain exactly one action: call `report_agent` directly with that exact name as sensor_id and the original request as user_query. Do not verify the name or media type first.
     Ask which video or camera the user means only when the request contains no name and the conversation provides no usable name.
     Only use tools from the available tools list. Never invent or assume tools that are not listed.
 
     Example plan for "Generate a report for warehouse_sample":
     1. Call `report_agent` with sensor_id="warehouse_sample" and user_query="Generate a report for warehouse_sample".
+    Example plan for "Generate a report using long video summarization for warehouse_sample":
+    1. Call `lvs_video_understanding` with sensor_id="warehouse_sample".
+    2. Call `report_agent` with sensor_id="warehouse_sample" and user_query="Generate a report using long video summarization for warehouse_sample", then present the generated report.
 
   prompt: |
     You are a routing agent for a video surveillance system. Your job is to route requests to the correct tool.
@@ -409,23 +413,23 @@ workflow:
       - Examples: "What videos are available?", "List all available videos" "list sensors"
       **report_agent**
       - HIGHEST PRIORITY: If the user mentions "report" anywhere in the question, call report_agent (works for both uploaded videos AND live streams).
-      - For "report" requests, call report_agent DIRECTLY as the first tool. Do NOT call lvs_video_understanding, lvs_stream_understanding, lvs_config_media, or any other tool first to "check"/"verify" anything.
-      - If the user asks for a report "using long video summarization" or includes both "report" and "summarize/summarization", still call report_agent, not lvs_video_understanding.
+      - For ordinary "report" requests, call report_agent DIRECTLY as the first tool. Do NOT call other tools first to "check"/"verify" anything.
+      - EXCEPTION: If the user explicitly asks for a report using "long video summarization" or "LVS", first call lvs_video_understanding with the requested sensor and time range, then call report_agent with the same inputs and original request as user_query.
       - Don't use the report from previous interactions.
       - CRITICAL: For multiple uploaded videos, you MUST pass them as a list in a SINGLE call (e.g., sensor_id=['video1', 'video2']). You MUST NOT make separate sequential or parallel calls to report_agent with each video individually. The sensor_id parameter MUST be a list.
       - For uploaded videos: pass sensor_id (str or list[str]) and user_query.
       - For live RTSP streams: pass media_type='rtsp', a single sensor_id (the stream name), start_time and end_time as floats in seconds (use end_time=0 for "until now"), and user_query.
       - CRITICAL — STREAM DETECTION: if lvs_config_media was called for `<name>` earlier in this conversation, OR `vst_video_list` shows `<name>` with `media_type='rtsp'`, then `<name>` IS a stream and you MUST pass `media_type='rtsp'` to report_agent. Do NOT default to the uploaded-video path just because the user did not say the word "stream".
-      - Examples: "Generate a report for video1" -> ONE call report_agent(sensor_id='video1', user_query=...). "Generate a report using long video summarization for warehouse_sample" -> ONE call report_agent(sensor_id='warehouse_sample', user_query=...). "Generate a report for stream CAM_1 from 0 to 60 seconds" -> ONE call report_agent(media_type='rtsp', sensor_id='CAM_1', start_time=0, end_time=60, user_query=...).
+      - Examples: "Generate a report for video1" -> ONE call report_agent(sensor_id='video1', user_query=...). "Generate a report using long video summarization for warehouse_sample" -> call lvs_video_understanding(sensor_id='warehouse_sample'), then report_agent(sensor_id='warehouse_sample', user_query=...). "Generate a report for stream CAM_1 from 0 to 60 seconds" -> ONE call report_agent(media_type='rtsp', sensor_id='CAM_1', start_time=0, end_time=60, user_query=...).
       **lvs_caption_retrieval** - DEFAULT path for content questions about a captioned live stream.
       - REQUIRED args: `query` (keyword string, e.g. "PPE violations") AND `collection` (stream's friendly name, e.g. "warehouse_sample_test"). Missing `query` will fail validation.
       - Add `filters={"time_range": {"start": "<ISO 8601 UTC>", "end": "<ISO 8601 UTC>"}}` only when the user gives a time window. Use today's date from the system prompt.
       - Never pass numeric/stream-relative times ("first 2 minutes") — captions use absolute timestamps. Route those to `lvs_stream_understanding` instead.
       - If the result has `chunks=[]`, fall back to `lvs_stream_understanding`.
       - Example: "PPE violations in CAM_1 in the last 5 minutes" at 22:32 UTC → `query="PPE violations", collection="CAM_1", filters={"time_range": {"start": "2026-05-05T22:27:00Z", "end": "2026-05-05T22:32:00Z"}}`.
-      **lvs_video_understanding** - For SUMMARIZING uploaded videos (not streams, not reports).
+      **lvs_video_understanding** - For SUMMARIZING uploaded videos and the analysis stage of explicit LVS report requests (not streams).
       - Use when user asks to "summarize" or "give a summary of" a video, optionally over a time range.
-      - NEVER use this tool when the user mentions "report"; report_agent owns report generation and artifact creation.
+      - For a report explicitly requesting long video summarization or LVS, call this tool before report_agent; report_agent still owns report generation and artifact creation.
       - NEVER use this tool when the user asks a specific question about video content instead of requesting a summary. Use video_understanding in that case. 
       - Pass sensor_id (the video name from vst_video_list); start_time/end_time are floats in seconds (omit both for the whole video).
       - Example (after vst_video_list confirms media_type='video'): "Summarize clip_007 from start to second 45" → lvs_video_understanding(sensor_id='clip_007', start_time=0, end_time=45)

--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
@@ -97,8 +97,8 @@ functions:
     _type: lvs_video_understanding
     lvs_backend_url: ${LVS_BACKEND_URL}
     model: ${VLM_NAME}
-    # Reports are supported over HTTP chat, where no interactive callback exists.
-    hitl_enabled: false
+    # Interactive requests collect LVS parameters; HTTP requests use defaults for that request only.
+    hitl_enabled: true
     video_url_tool: vst_video_clip
     vst_internal_url: ${VST_INTERNAL_URL}
     # Connection and timeout configuration
@@ -229,8 +229,8 @@ functions:
       EXAMPLE:
       [0.0s-4.0s] <description of the first event>
       [4.0s-12.0s] <description of the second event>
-    # HTTP chat has no interactive callback; use the configured report prompt.
-    hitl_enabled: false
+    # Interactive requests confirm/edit the VLM prompt; HTTP requests use it noninteractively.
+    hitl_enabled: true
     hitl_prompt_llm: ${LLM_MODEL_TYPE:-nim}_llm  # LLM for AI-assisted prompt generation e.g. nim_llm, openai_llm
     hitl_vlm_prompt_template: |
       **VLM Prompt for Report Generation**

--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
@@ -97,6 +97,8 @@ functions:
     _type: lvs_video_understanding
     lvs_backend_url: ${LVS_BACKEND_URL}
     model: ${VLM_NAME}
+    # Reports are supported over HTTP chat, where no interactive callback exists.
+    hitl_enabled: false
     video_url_tool: vst_video_clip
     vst_internal_url: ${VST_INTERNAL_URL}
     # Connection and timeout configuration
@@ -227,8 +229,8 @@ functions:
       EXAMPLE:
       [0.0s-4.0s] <description of the first event>
       [4.0s-12.0s] <description of the second event>
-    # HITL Configuration - prompts user to confirm/edit VLM prompt before report generation
-    hitl_enabled: true
+    # HTTP chat has no interactive callback; use the configured report prompt.
+    hitl_enabled: false
     hitl_prompt_llm: ${LLM_MODEL_TYPE:-nim}_llm  # LLM for AI-assisted prompt generation e.g. nim_llm, openai_llm
     hitl_vlm_prompt_template: |
       **VLM Prompt for Report Generation**

--- a/deploy/docker/services/infra/haproxy/compose.yml
+++ b/deploy/docker/services/infra/haproxy/compose.yml
@@ -44,9 +44,15 @@ services:
       # BACKEND_PORT is lvs-server's container port, not BACKEND_HOST_PORT.
       LVS_SERVICE_HOST: ${LVS_SERVICE_HOST:-lvs-server}
       LVS_SERVICE_PORT: ${BACKEND_PORT:-38111}
+      # vss-llm-nim is the network alias every LLM NIM service registers, so the
+      # /llm route resolves the same whether the model got a dedicated GPU or a
+      # shared one. 8000 is the NIM's container port, not the published LLM_PORT.
+      LLM_SERVICE_HOST: ${LLM_SERVICE_HOST:-vss-llm-nim}
+      LLM_SERVICE_PORT: ${LLM_SERVICE_PORT:-8000}
       HAPROXY_PORT: ${HAPROXY_PORT:-7777}
       HAPROXY_HOST_PORT: ${HAPROXY_HOST_PORT:-7777}
       HAPROXY_BIND_ADDR: ${HAPROXY_BIND_ADDR:-*}
+      HAPROXY_SERVICE_HOST: ${HAPROXY_SERVICE_HOST:-vss-haproxy-ingress}
       HOST_IP: ${HOST_IP}
       HOST_INTERNAL_ALIAS: ${HOST_INTERNAL_ALIAS:-host.openshell.internal}
       EXTERNAL_IP: ${EXTERNAL_IP}

--- a/deploy/docker/services/infra/haproxy/haproxy.cfg.template
+++ b/deploy/docker/services/infra/haproxy/haproxy.cfg.template
@@ -129,6 +129,19 @@ backend bk_phoenix_strip
     http-request replace-path ^/phoenix$ /
     server s1 "${PHOENIX_SERVICE_HOST}:${PHOENIX_PORT}" check resolvers docker init-addr none
 
+# One address for the LLM whatever GPU it landed on, so a consumer needs no
+# knowledge of the placement: $VSS_GATEWAY_ORIGIN/llm + /v1/chat/completions
+# reaches the NIM's own /v1/chat/completions. Profiles that place the LLM
+# outside the deployment leave the backend DOWN and keep pointing at it
+# directly; nothing here reaches a hosted endpoint.
+backend bk_llm_strip
+    http-request replace-path ^/llm/(.*) /\1
+    http-request replace-path ^/llm$ /
+    # First token on a cold NIM outlasts the 120s default, and a 504 there reads
+    # to the caller as a model failure.
+    timeout server 600s
+    server s1 "${LLM_SERVICE_HOST}:${LLM_SERVICE_PORT}" check resolvers docker init-addr none
+
 frontend fe_http
     bind "${HAPROXY_BIND_ADDR}:${HAPROXY_PORT}"
 
@@ -151,6 +164,10 @@ frontend fe_http
     acl known_host hdr(host) -i "localhost:${HAPROXY_PORT}"
     acl known_host hdr(host) -i 127.0.0.1
     acl known_host hdr(host) -i "127.0.0.1:${HAPROXY_PORT}"
+    # The proxy's own service name, so a container on the compose network can
+    # use the same origin the host does (the /llm route below is reached that way).
+    acl known_host hdr(host) -i "${HAPROXY_SERVICE_HOST}"
+    acl known_host hdr(host) -i "${HAPROXY_SERVICE_HOST}:${HAPROXY_PORT}"
     http-request deny deny_status 404 if !known_host
 
     acl h_main hdr(host) -i "${VSS_PUBLIC_HOST}"
@@ -171,6 +188,8 @@ frontend fe_http
     acl h_main hdr(host) -i "localhost:${HAPROXY_PORT}"
     acl h_main hdr(host) -i 127.0.0.1
     acl h_main hdr(host) -i "127.0.0.1:${HAPROXY_PORT}"
+    acl h_main hdr(host) -i "${HAPROXY_SERVICE_HOST}"
+    acl h_main hdr(host) -i "${HAPROXY_SERVICE_HOST}:${HAPROXY_PORT}"
 
     acl p_vst_storage path /vst/storage
     acl p_vst_storage path_beg /vst/storage/
@@ -260,6 +279,12 @@ frontend fe_http
     acl p_phoenix path /phoenix
     acl p_phoenix path_beg /phoenix/
     use_backend bk_phoenix_strip if h_main p_phoenix
+
+    # Profiles without an in-deployment LLM leave the backend DOWN, so this
+    # answers 503 rather than proxying to nothing.
+    acl p_llm path /llm
+    acl p_llm path_beg /llm/
+    use_backend bk_llm_strip if h_main p_llm
 
     acl p_api_chat path /api/chat
     acl p_api_chat path_beg /api/chat/

--- a/deploy/helm/developer-profiles/dev-profile-alerts/templates/vss-ingress.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/templates/vss-ingress.yaml
@@ -96,6 +96,13 @@
 {{- if $phoenixEnabled }}
 {{- $_ := set $b "phoenix" (dict "service" (include "vss.alerts.serviceShort" (dict "root" . "short" "phoenix")) "port" (index $vi "phoenixPort" | default 6006)) }}
 {{- end }}
+{{- /* Resolved in services/common, not here: the LLM NIM's Service is named by
+       the nims subchart's fullname rule and created by the NIM Operator, so all
+       four profiles have to agree on it. Empty when no NIM is deployed. */}}
+{{- $llm := include "vss.ingress.llmBackend" (dict "root" .) | fromYaml }}
+{{- if $llm.service }}
+{{- $_ := set $b "llm" $llm }}
+{{- end }}
 {{- include "vss.ingress.assertBackends" (dict "backends" $b) }}
 {{- $rii := index ($global | default dict) "rtviInternalIngress" | default dict }}
 {{- $rtviRule := and (include $en (dict "vals" $rii "default" false)) (or (index $b "rtvi-cv") (index $b "rtvi-embed")) }}

--- a/deploy/helm/developer-profiles/dev-profile-alerts/vss-ingress-example-rewrites.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/vss-ingress-example-rewrites.yaml
@@ -46,6 +46,8 @@ metadata:
       /rtvi-cv /
       /phoenix/(.*) /\1
       /phoenix /
+      /llm/(.*) /\1
+      /llm /
 spec:
   ingressClassName: haproxy
   rules:
@@ -101,3 +103,13 @@ spec:
             name: <RELEASE_NAME>-phoenix
             port:
               number: 6006
+      # Only present when this profile runs its own LLM NIM (nims.nemotron35).
+      # Point a hosted-LLM deployment at the provider directly and drop this
+      # route rather than mounting it at a Service that does not exist.
+      - path: /llm
+        pathType: Prefix
+        backend:
+          service:
+            name: <RELEASE_NAME>-nemotron-35-lightning-30b-a3b
+            port:
+              number: 8000

--- a/deploy/helm/developer-profiles/dev-profile-base/templates/vss-ingress.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-base/templates/vss-ingress.yaml
@@ -67,6 +67,13 @@
 {{- if and $infraOn (include $en (dict "vals" $fp "default" true)) }}
 {{- $_ := set $b "phoenix" (dict "service" (include "vss.subchartFullname" (dict "Values" .Values "Release" .Release "depKey" "phoenix" "chartName" "phoenix" "subchartValues" $fp)) "port" $vi.phoenixPort) }}
 {{- end }}
+{{- /* Resolved in services/common, not here: the LLM NIM's Service is named by
+       the nims subchart's fullname rule and created by the NIM Operator, so all
+       four profiles have to agree on it. Empty when no NIM is deployed. */}}
+{{- $llm := include "vss.ingress.llmBackend" (dict "root" .) | fromYaml }}
+{{- if $llm.service }}
+{{- $_ := set $b "llm" $llm }}
+{{- end }}
 {{- include "vss.ingress.assertBackends" (dict "backends" $b) }}
 {{- if $host }}
 apiVersion: networking.k8s.io/v1

--- a/deploy/helm/developer-profiles/dev-profile-base/vss-ingress-example-rewrites.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-base/vss-ingress-example-rewrites.yaml
@@ -38,6 +38,8 @@ metadata:
       /rtvi-vlm /
       /phoenix/(.*) /\1
       /phoenix /
+      /llm/(.*) /\1
+      /llm /
 spec:
   ingressClassName: haproxy
   rules:
@@ -65,3 +67,13 @@ spec:
             name: phoenix
             port:
               number: 6006
+      # Only present when this profile runs its own LLM NIM (nims.nemotron35).
+      # Point a hosted-LLM deployment at the provider directly and drop this
+      # route rather than mounting it at a Service that does not exist.
+      - path: /llm
+        pathType: Prefix
+        backend:
+          service:
+            name: <RELEASE_NAME>-nemotron-35-lightning-30b-a3b
+            port:
+              number: 8000

--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
@@ -375,12 +375,16 @@ workflow:
     For summaries of named media, plan `vst_video_list` first, then exactly one summary tool based only on its result: `rtsp` → `lvs_stream_understanding`; `video` → `lvs_video_understanding`. Never choose the summary tool from duration.
     Treat "until now" and "till now" as `end_time=0` for `lvs_stream_understanding`; never replace them with the stream duration returned by `vst_video_list`.
     A non-empty name supplied in the request is the sensor_id. For example, in "Generate a report for warehouse_sample", the sensor_id is "warehouse_sample"; this request is complete and MUST NOT trigger a clarifying question.
-    If the user requests a report and supplies a name, the plan MUST contain exactly one action: call `report_agent` directly with that exact name as sensor_id and the original request as user_query. Do not verify the name or media type first.
+    If the user explicitly requests long video summarization or LVS in a report, the plan MUST first call `lvs_video_understanding` with the exact sensor_id and requested time range, then call `report_agent` with the same inputs and the original request as user_query.
+    For every other named report request, the plan MUST contain exactly one action: call `report_agent` directly with that exact name as sensor_id and the original request as user_query. Do not verify the name or media type first.
     Ask which video or camera the user means only when the request contains no name and the conversation provides no usable name.
     Only use tools from the available tools list. Never invent or assume tools that are not listed.
 
     Example plan for "Generate a report for warehouse_sample":
     1. Call `report_agent` with sensor_id="warehouse_sample" and user_query="Generate a report for warehouse_sample".
+    Example plan for "Generate a report using long video summarization for warehouse_sample":
+    1. Call `lvs_video_understanding` with sensor_id="warehouse_sample".
+    2. Call `report_agent` with sensor_id="warehouse_sample" and user_query="Generate a report using long video summarization for warehouse_sample", then present the generated report.
 
   prompt: |
     You are a routing agent for a video surveillance system. Your job is to route requests to the correct tool.
@@ -409,23 +413,23 @@ workflow:
       - Examples: "What videos are available?", "List all available videos" "list sensors"
       **report_agent**
       - HIGHEST PRIORITY: If the user mentions "report" anywhere in the question, call report_agent (works for both uploaded videos AND live streams).
-      - For "report" requests, call report_agent DIRECTLY as the first tool. Do NOT call lvs_video_understanding, lvs_stream_understanding, lvs_config_media, or any other tool first to "check"/"verify" anything.
-      - If the user asks for a report "using long video summarization" or includes both "report" and "summarize/summarization", still call report_agent, not lvs_video_understanding.
+      - For ordinary "report" requests, call report_agent DIRECTLY as the first tool. Do NOT call other tools first to "check"/"verify" anything.
+      - EXCEPTION: If the user explicitly asks for a report using "long video summarization" or "LVS", first call lvs_video_understanding with the requested sensor and time range, then call report_agent with the same inputs and original request as user_query.
       - Don't use the report from previous interactions.
       - CRITICAL: For multiple uploaded videos, you MUST pass them as a list in a SINGLE call (e.g., sensor_id=['video1', 'video2']). You MUST NOT make separate sequential or parallel calls to report_agent with each video individually. The sensor_id parameter MUST be a list.
       - For uploaded videos: pass sensor_id (str or list[str]) and user_query.
       - For live RTSP streams: pass media_type='rtsp', a single sensor_id (the stream name), start_time and end_time as floats in seconds (use end_time=0 for "until now"), and user_query.
       - CRITICAL — STREAM DETECTION: if lvs_config_media was called for `<name>` earlier in this conversation, OR `vst_video_list` shows `<name>` with `media_type='rtsp'`, then `<name>` IS a stream and you MUST pass `media_type='rtsp'` to report_agent. Do NOT default to the uploaded-video path just because the user did not say the word "stream".
-      - Examples: "Generate a report for video1" -> ONE call report_agent(sensor_id='video1', user_query=...). "Generate a report using long video summarization for warehouse_sample" -> ONE call report_agent(sensor_id='warehouse_sample', user_query=...). "Generate a report for stream CAM_1 from 0 to 60 seconds" -> ONE call report_agent(media_type='rtsp', sensor_id='CAM_1', start_time=0, end_time=60, user_query=...).
+      - Examples: "Generate a report for video1" -> ONE call report_agent(sensor_id='video1', user_query=...). "Generate a report using long video summarization for warehouse_sample" -> call lvs_video_understanding(sensor_id='warehouse_sample'), then report_agent(sensor_id='warehouse_sample', user_query=...). "Generate a report for stream CAM_1 from 0 to 60 seconds" -> ONE call report_agent(media_type='rtsp', sensor_id='CAM_1', start_time=0, end_time=60, user_query=...).
       **lvs_caption_retrieval** - DEFAULT path for content questions about a captioned live stream.
       - REQUIRED args: `query` (keyword string, e.g. "PPE violations") AND `collection` (stream's friendly name, e.g. "warehouse_sample_test"). Missing `query` will fail validation.
       - Add `filters={"time_range": {"start": "<ISO 8601 UTC>", "end": "<ISO 8601 UTC>"}}` only when the user gives a time window. Use today's date from the system prompt.
       - Never pass numeric/stream-relative times ("first 2 minutes") — captions use absolute timestamps. Route those to `lvs_stream_understanding` instead.
       - If the result has `chunks=[]`, fall back to `lvs_stream_understanding`.
       - Example: "PPE violations in CAM_1 in the last 5 minutes" at 22:32 UTC → `query="PPE violations", collection="CAM_1", filters={"time_range": {"start": "2026-05-05T22:27:00Z", "end": "2026-05-05T22:32:00Z"}}`.
-      **lvs_video_understanding** - For SUMMARIZING uploaded videos (not streams, not reports).
+      **lvs_video_understanding** - For SUMMARIZING uploaded videos and the analysis stage of explicit LVS report requests (not streams).
       - Use when user asks to "summarize" or "give a summary of" a video, optionally over a time range.
-      - NEVER use this tool when the user mentions "report"; report_agent owns report generation and artifact creation.
+      - For a report explicitly requesting long video summarization or LVS, call this tool before report_agent; report_agent still owns report generation and artifact creation.
       - NEVER use this tool when the user asks a specific question about video content instead of requesting a summary. Use video_understanding in that case. 
       - Pass sensor_id (the video name from vst_video_list); start_time/end_time are floats in seconds (omit both for the whole video).
       - Example (after vst_video_list confirms media_type='video'): "Summarize clip_007 from start to second 45" → lvs_video_understanding(sensor_id='clip_007', start_time=0, end_time=45)

--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
@@ -97,8 +97,8 @@ functions:
     _type: lvs_video_understanding
     lvs_backend_url: ${LVS_BACKEND_URL}
     model: ${VLM_NAME}
-    # Reports are supported over HTTP chat, where no interactive callback exists.
-    hitl_enabled: false
+    # Interactive requests collect LVS parameters; HTTP requests use defaults for that request only.
+    hitl_enabled: true
     video_url_tool: vst_video_clip
     vst_internal_url: ${VST_INTERNAL_URL}
     # Connection and timeout configuration
@@ -229,8 +229,8 @@ functions:
       EXAMPLE:
       [0.0s-4.0s] <description of the first event>
       [4.0s-12.0s] <description of the second event>
-    # HTTP chat has no interactive callback; use the configured report prompt.
-    hitl_enabled: false
+    # Interactive requests confirm/edit the VLM prompt; HTTP requests use it noninteractively.
+    hitl_enabled: true
     hitl_prompt_llm: ${LLM_MODEL_TYPE:-nim}_llm  # LLM for AI-assisted prompt generation e.g. nim_llm, openai_llm
     hitl_vlm_prompt_template: |
       **VLM Prompt for Report Generation**

--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
@@ -97,6 +97,8 @@ functions:
     _type: lvs_video_understanding
     lvs_backend_url: ${LVS_BACKEND_URL}
     model: ${VLM_NAME}
+    # Reports are supported over HTTP chat, where no interactive callback exists.
+    hitl_enabled: false
     video_url_tool: vst_video_clip
     vst_internal_url: ${VST_INTERNAL_URL}
     # Connection and timeout configuration
@@ -227,8 +229,8 @@ functions:
       EXAMPLE:
       [0.0s-4.0s] <description of the first event>
       [4.0s-12.0s] <description of the second event>
-    # HITL Configuration - prompts user to confirm/edit VLM prompt before report generation
-    hitl_enabled: true
+    # HTTP chat has no interactive callback; use the configured report prompt.
+    hitl_enabled: false
     hitl_prompt_llm: ${LLM_MODEL_TYPE:-nim}_llm  # LLM for AI-assisted prompt generation e.g. nim_llm, openai_llm
     hitl_vlm_prompt_template: |
       **VLM Prompt for Report Generation**

--- a/deploy/helm/developer-profiles/dev-profile-lvs/templates/vss-ingress.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/templates/vss-ingress.yaml
@@ -76,6 +76,13 @@
 {{- if and $infraOn (include $en (dict "vals" $fp "default" true)) }}
 {{- $_ := set $b "phoenix" (dict "service" (include "vss.lvs.serviceShort" (dict "root" . "short" "phoenix")) "port" $vi.phoenixPort) }}
 {{- end }}
+{{- /* Resolved in services/common, not here: the LLM NIM's Service is named by
+       the nims subchart's fullname rule and created by the NIM Operator, so all
+       four profiles have to agree on it. Empty when no NIM is deployed. */}}
+{{- $llm := include "vss.ingress.llmBackend" (dict "root" .) | fromYaml }}
+{{- if $llm.service }}
+{{- $_ := set $b "llm" $llm }}
+{{- end }}
 {{- include "vss.ingress.assertBackends" (dict "backends" $b) }}
 {{- if $host }}
 apiVersion: networking.k8s.io/v1

--- a/deploy/helm/developer-profiles/dev-profile-lvs/vss-ingress-example-rewrites.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/vss-ingress-example-rewrites.yaml
@@ -42,6 +42,8 @@ metadata:
       /lvs /
       /phoenix/(.*) /\1
       /phoenix /
+      /llm/(.*) /\1
+      /llm /
 spec:
   ingressClassName: haproxy
   rules:
@@ -83,3 +85,13 @@ spec:
             name: <RELEASE_NAME>-phoenix
             port:
               number: 6006
+      # Only present when this profile runs its own LLM NIM (nims.nemotron35).
+      # Point a hosted-LLM deployment at the provider directly and drop this
+      # route rather than mounting it at a Service that does not exist.
+      - path: /llm
+        pathType: Prefix
+        backend:
+          service:
+            name: <RELEASE_NAME>-nemotron-35-lightning-30b-a3b
+            port:
+              number: 8000

--- a/deploy/helm/developer-profiles/dev-profile-search/templates/vss-ingress.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/templates/vss-ingress.yaml
@@ -119,6 +119,13 @@
 {{- if $phoenixOn }}
 {{- $_ := set $b "phoenix" (dict "service" (include "dev-profile-search.serviceShort" (dict "root" . "short" "phoenix")) "port" ($fp.port | default 6006)) }}
 {{- end }}
+{{- /* Resolved in services/common, not here: the LLM NIM's Service is named by
+       the nims subchart's fullname rule and created by the NIM Operator, so all
+       four profiles have to agree on it. Empty when no NIM is deployed. */}}
+{{- $llm := include "vss.ingress.llmBackend" (dict "root" .) | fromYaml }}
+{{- if $llm.service }}
+{{- $_ := set $b "llm" $llm }}
+{{- end }}
 {{- include "vss.ingress.assertBackends" (dict "backends" $b) }}
 {{- $rii := index $g "rtviInternalIngress" | default dict }}
 {{- $rtviRule := and (include $en (dict "vals" $rii "default" false)) (or (index $b "rtvi-cv") (index $b "rtvi-embed")) }}

--- a/deploy/helm/scripts/verify-ingress-routes.py
+++ b/deploy/helm/scripts/verify-ingress-routes.py
@@ -77,6 +77,12 @@ DISABLED_CASES = [
     ("dev-profile-base", "vssIngress.vlm.enabled=false", "/rtvi-vlm"),
     ("dev-profile-alerts", "rtvi.vss-rtvi-cv.enabled=false", "/rtvi-cv"),
     ("dev-profile-search", "infra.elasticsearch.enabled=false", "/elasticsearch"),
+    # /llm is the one route whose backend is a subchart of a subchart, so both
+    # gates are worth pinning: the nims umbrella and the LLM NIM leaf. A profile
+    # pointed at a hosted LLM has neither, and must not mount /llm at all.
+    ("dev-profile-lvs", "nims.enabled=false", "/llm"),
+    ("dev-profile-lvs", "nims.nemotron35.enabled=false", "/llm"),
+    ("dev-profile-search", "nims.nemotron35.enabled=false", "/llm"),
 ]
 
 

--- a/deploy/helm/services/common/README.md
+++ b/deploy/helm/services/common/README.md
@@ -49,6 +49,7 @@ the paths `vss configure` records
 | `rtvi-embed` | `/rtvi-embed` | stripped | also on the host-less east-west rule |
 | `lvs` | `/lvs` | stripped | |
 | `phoenix` | `/phoenix` | stripped | keep `PHOENIX_HOST_ROOT_PATH` in step |
+| `llm` | `/llm` | stripped | the in-deployment LLM NIM; resolved by `vss.ingress.llmBackend`, not by the profile |
 
 Kibana and NVStreamer are **not** in the table. Both are served on their own host
 (`kibana.<host>`, `streamer.<host>`): Kibana needs `server.basePath` to live under a
@@ -91,6 +92,25 @@ spec:
 | `vss.ingress.hasPathRewrites` | non-empty when any mounted route rewrites |
 | `vss.ingress.assertBackends` | fails the render on an unknown key or a missing service/port |
 | `vss.ingress.enabled` | `"true"` when a component is deployed, honouring an explicit `false` |
+| `vss.ingress.llmBackend` | the `llm` entry (`fromYaml` it), empty when no LLM NIM is deployed |
+
+`llm` is the one key a profile does not assemble itself. Every other backend is a
+profile-level dependency the profile already names; the LLM NIM is `nims.nemotron35`, a
+subchart of a subchart whose Service the NIM Operator creates from the NIMService CR, so
+its name comes from that chart's fullname rule rather than the profile's `serviceShort`.
+Resolving it once here is what keeps `/llm` identical on all four profiles:
+
+```gotemplate
+{{- $llm := include "vss.ingress.llmBackend" (dict "root" .) | fromYaml }}
+{{- if $llm.service }}
+{{- $_ := set $b "llm" $llm }}
+{{- end }}
+```
+
+It is deliberately not gated on `llmBaseUrl`: that says where *consumers* were pointed, not
+whether a NIM is deployed. A profile using a hosted LLM mounts no `/llm` and the request
+falls through to the UI catch-all, which is the same shape as the Docker edge, where
+`bk_llm_strip` is DOWN and answers 503 when the LLM NIM container is not running.
 
 `assertBackends` is what keeps the profiles from drifting apart again: a new route has to be
 added to the table, where every profile picks it up, rather than to one chart's template.

--- a/deploy/helm/services/common/templates/_ingress-routes.tpl
+++ b/deploy/helm/services/common/templates/_ingress-routes.tpl
@@ -154,6 +154,15 @@
   path: /phoenix
   pathType: Prefix
   rewrite: strip
+# One address for the LLM whatever GPU it landed on, so a consumer needs no
+# knowledge of the placement: <origin>/llm/v1/chat/completions reaches the NIM's
+# own /v1/chat/completions. Backed by the in-deployment LLM NIM Service, which
+# is why a profile that runs no NIM does not mount this at all rather than
+# proxying to a Service that was never created.
+- key: llm
+  path: /llm
+  pathType: Prefix
+  rewrite: strip
 - key: ui
   path: /
   pathType: Prefix
@@ -177,6 +186,61 @@
 {{- if $vals.enabled }}true{{ end -}}
 {{- else if .default -}}
 true
+{{- end -}}
+{{- end -}}
+
+{{/*
+  The `llm` backend entry, or "" when this profile runs no LLM NIM of its own.
+
+  The four profiles resolve every other backend with their own serviceShort /
+  subchartFullname helper, but the LLM NIM is not a profile-level dependency:
+  it is `nims.nemotron35`, a subchart of a subchart, whose Service is created by
+  the NIM Operator from the NIMService CR and therefore named by that chart's
+  own fullname rule rather than by the profile's. Resolving it once here is what
+  keeps the /llm mount identical on all four, and is why the enablement test
+  lives here too -- a remote-LLM or NIM-less profile mounts nothing and the
+  request falls through to the UI catch-all as a 404, rather than reaching an
+  Ingress backed by a Service that does not exist (FR-19).
+
+  Deliberately not gated on llmBaseUrl: that value says where *consumers* were
+  pointed, not whether a NIM is deployed. The Docker edge draws the same line --
+  bk_llm_strip is DOWN and answers 503 when the LLM NIM container is not up,
+  regardless of where the agent was told to send its own traffic.
+
+  Pass: dict "root" .
+  Returns a YAML mapping for `fromYaml`, empty when there is no in-cluster LLM.
+*/}}
+{{- define "vss.ingress.llmBackend" -}}
+{{- $root := index . "root" -}}
+{{- $vals := $root.Values | default dict -}}
+{{- $nims := index $vals "nims" | default dict -}}
+{{- $llm := index $nims "nemotron35" | default dict -}}
+{{- $on := and
+      (include "vss.ingress.enabled" (dict "vals" $nims "default" false))
+      (include "vss.ingress.enabled" (dict "vals" $llm "default" false)) -}}
+{{- if $on -}}
+{{- $name := "" -}}
+{{- if $llm.fullnameOverride -}}
+{{- $name = $llm.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $short := default "nemotron-35-lightning-30b-a3b" $llm.nameOverride -}}
+{{- /* Same precedence the subchart's own fullname helper sees: its leaf value,
+       then the global Helm merges into it (nims.global, then the chart root). */}}
+{{- $nimsGlobal := index $nims "global" | default dict -}}
+{{- $g := index $vals "global" | default dict -}}
+{{- $pfx := default false (coalesce
+      (index $llm "useReleaseNamePrefix")
+      (index $nimsGlobal "useReleaseNamePrefix")
+      (index $g "useReleaseNamePrefix")) -}}
+{{- $name = ternary (printf "%s-%s" $root.Release.Name $short) $short $pfx -}}
+{{- $name = $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- /* The NIM's own port, not a vssIngress key: a second place to write it is a
+       second place for it to disagree with the Service it is mounting. 8000 is
+       the nims chart default, which the minimal profiles do not restate. */}}
+{{- $svc := index $llm "service" | default dict -}}
+service: {{ $name }}
+port: {{ index $svc "port" | default 8000 }}
 {{- end -}}
 {{- end -}}
 

--- a/deploy/helm/services/nims/charts/nemotron-3.5-lightning-30b-a3b/templates/nim-service.yaml
+++ b/deploy/helm/services/nims/charts/nemotron-3.5-lightning-30b-a3b/templates/nim-service.yaml
@@ -62,6 +62,10 @@ spec:
     service:
       port: {{ .Values.service.port }}
       type: {{ .Values.service.type }}
+      {{- with .Values.ingressTimeoutServer }}
+      annotations:
+        haproxy.org/timeout-server: {{ . | quote }}
+      {{- end }}
   image:
     pullPolicy: {{ .Values.image.pullPolicy }}
     pullSecrets:

--- a/deploy/helm/services/nims/charts/nemotron-3.5-lightning-30b-a3b/values.yaml
+++ b/deploy/helm/services/nims/charts/nemotron-3.5-lightning-30b-a3b/values.yaml
@@ -26,6 +26,15 @@ service:
   type: ClusterIP
   port: 8000
 
+# haproxy.org/timeout-server for the /llm ingress route, annotated onto the
+# Service the NIM Operator creates (spec.expose.service.annotations). Scoped to
+# this backend, like vss-rtvi-vlm and vss-agent, rather than an ingress-wide
+# ceiling over every route. The first token off a cold NIM outlasts the
+# controller's 50s default, and the 504 that produces reads to the caller as a
+# model failure. Matches `timeout server 600s` on the Docker edge's
+# bk_llm_strip. Empty to leave the controller default in place.
+ingressTimeoutServer: "600s"
+
 nodeSelector: {}
 
 tolerations:

--- a/deploy/tests/test_helm_llm_route.py
+++ b/deploy/tests/test_helm_llm_route.py
@@ -1,0 +1,292 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""The /llm ingress route, and its parity with the Docker edge.
+
+The Docker edge publishes the in-deployment LLM at one address whatever GPU it
+landed on (`bk_llm_strip` in services/infra/haproxy/haproxy.cfg.template), so a
+caller reaches `<origin>/llm/v1/chat/completions` without knowing the placement.
+These tests hold the Kubernetes side to the same shape:
+
+  1. the mount and its strip rewrite come from the canonical route table, so all
+     four developer profiles pick it up rather than one chart growing its own;
+  2. the backend is the LLM NIM's own Service -- the same name the NIMService CR
+     renders, release-name prefix included -- and not a node address or a port
+     that has to be kept in step by hand;
+  3. a profile with no in-deployment LLM NIM mounts nothing, rather than an
+     Ingress pointed at a Service that was never created;
+  4. the upstream timeout is at least the Docker edge's, and is scoped to this
+     backend rather than imposed on every route on the origin.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import unittest
+from functools import cache
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HELM_ROOT = REPO_ROOT / "helm"
+PROFILES_DIR = HELM_ROOT / "developer-profiles"
+ROUTE_TABLE = HELM_ROOT / "services" / "common" / "templates" / "_ingress-routes.tpl"
+NEMOTRON_CHART = (
+    HELM_ROOT / "services" / "nims" / "charts" / "nemotron-3.5-lightning-30b-a3b"
+)
+HAPROXY_TEMPLATE = (
+    REPO_ROOT / "docker" / "services" / "infra" / "haproxy" / "haproxy.cfg.template"
+)
+
+PROFILES = (
+    "dev-profile-base",
+    "dev-profile-alerts",
+    "dev-profile-lvs",
+    "dev-profile-search",
+)
+HOST = "10.0.0.1"
+MOUNT = "/llm"
+
+# The route is only useful if the prefix comes off: the NIM serves /v1/..., so
+# <origin>/llm/v1/chat/completions has to arrive as /v1/chat/completions.
+EXPECTED_REWRITES = {f"{MOUNT}/(.*)": r"/\1", MOUNT: "/"}
+
+helm_required = unittest.skipUnless(
+    shutil.which("helm"), "helm is not installed; chart rendering cannot be checked"
+)
+
+
+def _run(cmd: list[str], cwd: Path) -> str:
+    out = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, check=False)
+    if out.returncode != 0:
+        raise AssertionError(f"{' '.join(cmd)} failed:\n{out.stderr}")
+    return out.stdout
+
+
+def setUpModule() -> None:
+    """Profiles render only with their file:// dependencies unpacked."""
+    if not shutil.which("helm"):
+        return
+    for profile in PROFILES:
+        if not (PROFILES_DIR / profile / "charts").is_dir():
+            _run(["helm", "dependency", "build", profile], cwd=PROFILES_DIR)
+
+
+@cache
+def _render(profile: str, overrides: tuple[str, ...] = ()) -> str:
+    cmd = [
+        "helm",
+        "template",
+        "vss",
+        "./" + profile,
+        "--set",
+        "global.externalHost=" + HOST,
+        # base and lvs ship it off by default; setting it on the others is a no-op.
+        "--set",
+        "vssIngress.enabled=true",
+    ]
+    for override in overrides:
+        cmd.extend(["--set", override])
+    return _run(cmd, cwd=PROFILES_DIR)
+
+
+def _docs(profile: str, overrides: tuple[str, ...] = ()) -> list[dict]:
+    return [d for d in yaml.safe_load_all(_render(profile, overrides)) if d]
+
+
+def _ingresses(profile: str, overrides: tuple[str, ...] = ()) -> list[dict]:
+    return [d for d in _docs(profile, overrides) if d.get("kind") == "Ingress"]
+
+
+def _llm_backends(
+    profile: str, overrides: tuple[str, ...] = ()
+) -> list[tuple[str, int]]:
+    """(service, port) for every /llm mount the profile renders."""
+    found = []
+    for ing in _ingresses(profile, overrides):
+        for rule in ing["spec"]["rules"]:
+            for entry in rule.get("http", {}).get("paths", []):
+                if entry["path"] == MOUNT:
+                    svc = entry["backend"]["service"]
+                    found.append((svc["name"], svc["port"]["number"]))
+    return found
+
+
+def _rewrites(profile: str, overrides: tuple[str, ...] = ()) -> dict[str, str]:
+    pairs: dict[str, str] = {}
+    for ing in _ingresses(profile, overrides):
+        raw = (ing["metadata"].get("annotations") or {}).get(
+            "haproxy.org/path-rewrite", ""
+        )
+        for line in raw.splitlines():
+            if line.strip():
+                src, dst = line.split()
+                pairs[src] = dst
+    return pairs
+
+
+def _llm_nim_service(profile: str, overrides: tuple[str, ...] = ()) -> dict:
+    """The LLM NIMService CR, whose name is the Service the operator creates."""
+    for doc in _docs(profile, overrides):
+        if doc.get("kind") == "NIMService" and "nemotron" in doc["metadata"]["name"]:
+            return doc
+    raise AssertionError(f"{profile}: no LLM NIMService rendered")
+
+
+def _seconds(value: str) -> int:
+    match = re.fullmatch(r"(\d+)(ms|s|m|h)?", value.strip())
+    if not match:
+        raise AssertionError(f"cannot read a duration from {value!r}")
+    amount, unit = int(match.group(1)), match.group(2) or "s"
+    return amount * {"ms": 0, "s": 1, "m": 60, "h": 3600}[unit]
+
+
+class LlmRouteTableTests(unittest.TestCase):
+    """The mount is defined once, in the table every profile reads."""
+
+    def _rows(self) -> list[dict]:
+        body = ROUTE_TABLE.read_text()
+        start = body.index('{{- define "vss.ingress.routeTable" -}}')
+        end = body.index("{{- end -}}", start)
+        return yaml.safe_load(body[start:end].split("-}}", 1)[1])
+
+    def test_table_defines_the_llm_mount_as_a_stripped_prefix(self):
+        rows = [r for r in self._rows() if r["path"] == MOUNT]
+        self.assertEqual(len(rows), 1, f"expected exactly one {MOUNT} row, got {rows}")
+        self.assertEqual(rows[0]["key"], "llm")
+        self.assertEqual(rows[0]["pathType"], "Prefix")
+        self.assertEqual(rows[0]["rewrite"], "strip")
+
+    def test_llm_precedes_the_ui_catch_all(self):
+        paths = [r["path"] for r in self._rows()]
+        self.assertLess(
+            paths.index(MOUNT),
+            paths.index("/"),
+            "the UI catch-all has to render last or it swallows /llm",
+        )
+
+
+@helm_required
+class LlmRouteRenderTests(unittest.TestCase):
+    """Every profile mounts /llm at its own LLM NIM."""
+
+    def test_all_profiles_mount_llm(self):
+        for profile in PROFILES:
+            with self.subTest(profile=profile):
+                self.assertEqual(
+                    len(_llm_backends(profile)),
+                    1,
+                    f"{profile} should mount {MOUNT} exactly once",
+                )
+
+    def test_backend_is_the_llm_nim_service_not_a_node_address(self):
+        """The route follows the NIM, so it survives the model moving GPUs."""
+        for profile in PROFILES:
+            for overrides in ((), ("global.useReleaseNamePrefix=true",)):
+                with self.subTest(profile=profile, overrides=overrides):
+                    nim = _llm_nim_service(profile, overrides)
+                    ((service, port),) = _llm_backends(profile, overrides)
+                    self.assertEqual(service, nim["metadata"]["name"])
+                    self.assertEqual(port, nim["spec"]["expose"]["service"]["port"])
+
+    def test_prefix_is_stripped_before_the_nim_sees_it(self):
+        for profile in PROFILES:
+            with self.subTest(profile=profile):
+                rewrites = _rewrites(profile)
+                for src, want in EXPECTED_REWRITES.items():
+                    self.assertEqual(rewrites.get(src), want)
+
+
+@helm_required
+class LlmRouteFailsClosedTests(unittest.TestCase):
+    """No in-deployment LLM means no route, not a route to nothing."""
+
+    # The umbrella and the leaf: /llm is the only route whose backend is a
+    # subchart of a subchart, so both gates are worth pinning.
+    CASES = ("nims.enabled=false", "nims.nemotron35.enabled=false")
+
+    def test_disabling_the_nim_removes_the_mount(self):
+        for profile in PROFILES:
+            for case in self.CASES:
+                with self.subTest(profile=profile, case=case):
+                    self.assertEqual(_llm_backends(profile, (case,)), [])
+
+    def test_disabling_the_nim_leaves_no_orphan_rewrite(self):
+        """A rewrite for an unmounted prefix would reshape someone else's path."""
+        for profile in PROFILES:
+            for case in self.CASES:
+                with self.subTest(profile=profile, case=case):
+                    rewrites = _rewrites(profile, (case,))
+                    for src in EXPECTED_REWRITES:
+                        self.assertNotIn(src, rewrites)
+
+    def test_a_remote_llm_alone_does_not_drop_the_route(self):
+        """llmBaseUrl says where consumers point, not whether a NIM is deployed.
+
+        The Docker edge draws the same line: bk_llm_strip exists whenever the LLM
+        NIM container is up, whatever the agent was told to call.
+        """
+        backends = _llm_backends(
+            "dev-profile-lvs", ("global.llmBaseUrl=https://llm.example/v1",)
+        )
+        self.assertEqual(len(backends), 1)
+
+
+@helm_required
+class LlmUpstreamTimeoutTests(unittest.TestCase):
+    """A cold NIM's first token must not surface as a gateway error."""
+
+    def test_timeout_is_scoped_to_the_llm_service(self):
+        for profile in PROFILES:
+            with self.subTest(profile=profile):
+                annotations = _llm_nim_service(profile)["spec"]["expose"][
+                    "service"
+                ].get("annotations", {})
+                self.assertIn("haproxy.org/timeout-server", annotations)
+
+    def test_timeout_is_not_imposed_on_every_other_route(self):
+        """An ingress-scoped timeout would raise the ceiling for all backends."""
+        for profile in PROFILES:
+            with self.subTest(profile=profile):
+                for ing in _ingresses(profile):
+                    annotations = ing["metadata"].get("annotations") or {}
+                    self.assertNotIn("haproxy.org/timeout-server", annotations)
+
+    def test_timeout_matches_the_docker_edge(self):
+        docker = re.search(
+            r"backend bk_llm_strip\b(.*?)(?=\n(?:backend|frontend|listen)\b)",
+            HAPROXY_TEMPLATE.read_text(),
+            re.DOTALL,
+        )
+        self.assertIsNotNone(docker, "the Docker edge no longer defines bk_llm_strip")
+        edge = re.search(r"timeout server\s+(\S+)", docker.group(1))
+        self.assertIsNotNone(edge, "bk_llm_strip carries no timeout server")
+
+        chart = yaml.safe_load((NEMOTRON_CHART / "values.yaml").read_text())
+        self.assertGreaterEqual(
+            _seconds(chart["ingressTimeoutServer"]),
+            _seconds(edge.group(1)),
+            "the Kubernetes upstream timeout is shorter than the Docker edge's, so a "
+            "cold start that Docker tolerates would 504 here",
+        )
+
+
+class LlmRouteDockerParityTests(unittest.TestCase):
+    """The two edges publish the LLM at the same path."""
+
+    def test_docker_edge_mounts_the_same_prefix(self):
+        text = HAPROXY_TEMPLATE.read_text()
+        self.assertIn(f"acl p_llm path {MOUNT}", text)
+        self.assertIn(f"acl p_llm path_beg {MOUNT}/", text)
+        self.assertIn("use_backend bk_llm_strip if h_main p_llm", text)
+
+    def test_docker_edge_strips_the_same_prefix(self):
+        text = HAPROXY_TEMPLATE.read_text()
+        self.assertIn(rf"http-request replace-path ^{MOUNT}/(.*) /\1", text)
+        self.assertIn(rf"http-request replace-path ^{MOUNT}$ /", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
@@ -721,10 +721,10 @@ class TopAgent(AsyncMixin):
 
     async def _plan_node(self, state: TopAgentState) -> TopAgentState:
         """
-        Planning node: drafts a step-by-step execution plan using the available tools.
+        Planning node: drafts a step-by-step execution plan using tool names/descriptions only.
 
-        Structured tool calls are converted to the existing textual plan format for the execution agent.
-        Textual plans remain supported for models that do not emit tool calls.
+        Invokes the LLM without tool bindings so it focuses on planning rather than executing.
+        The resulting plan is stored in state.plan and emitted as a THOUGHT chunk.
         """
         writer = get_stream_writer()
         logger.debug("Starting Plan Node")
@@ -823,23 +823,16 @@ class TopAgent(AsyncMixin):
         messages.append(HumanMessage(content="User question: " + question))
 
         llm_kwargs = get_llm_reasoning_bind_kwargs(self.llm, state.options.llm_reasoning)
-        planner_llm = getattr(self, "llm_with_tools", self.llm)
-        llm_to_use = planner_llm.bind(**llm_kwargs) if llm_kwargs else planner_llm
+        # Plan without tool bindings. A tool-bound model answers a planning prompt with the single
+        # next action and no text at all, so a multi-step plan (e.g. `vst_video_list` to resolve the
+        # media type, then `report_agent` to build the report) collapses to its first step and every
+        # later step — including the one that produces the artifacts — is silently dropped.
+        llm_to_use = self.llm.bind(**llm_kwargs) if llm_kwargs else self.llm
 
         result = await llm_to_use.ainvoke(messages, config=RunnableConfig(callbacks=self.callbacks))
 
         plan_reasoning, plan_text = parse_reasoning_content(result)
-        planner_tool_calls = result.tool_calls if isinstance(result, AIMessage) else []
-        if planner_tool_calls:
-            plan_steps = []
-            for index, tool_call in enumerate(planner_tool_calls, start=1):
-                arguments = tool_call.get("args") or {}
-                arguments_text = (
-                    f" with arguments {json.dumps(arguments, sort_keys=True, default=str)}" if arguments else ""
-                )
-                plan_steps.append(f"{index}. Call `{tool_call['name']}`{arguments_text}.")
-            plan_text = "\n".join(plan_steps)
-        elif not plan_text:
+        if not plan_text:
             plan_text = str(result.content) if hasattr(result, "content") else ""
 
         logger.debug("Plan node produced plan:\n%s", plan_text)
@@ -863,6 +856,24 @@ class TopAgent(AsyncMixin):
             )
             logger.warning("Corrected LVS report plan that omitted lvs_video_understanding")
 
+        # `report_agent` is the only tool that writes the PDF and Markdown artifacts, so a report
+        # plan that stops at the analysis step answers with prose and no downloads. The profile
+        # prompts already declare that a report request routes to `report_agent`; re-assert it here
+        # rather than trusting the planner to keep the step it was told to plan.
+        if (
+            "report" in lowered_question
+            and "report_agent" in self.tools_dict
+            and "report_agent" not in plan_text
+            and not plan_text.strip().startswith(PLAN_CLARIFY_PREFIX)
+        ):
+            planned_steps = [int(match.group(1)) for match in re.finditer(r"(?:^|\s)(\d+)\.\s", plan_text)]
+            report_step = (
+                f"{max(planned_steps, default=0) + 1}. Call `report_agent` with the media named in the user's "
+                "request and the original request as `user_query`, then present the generated report."
+            )
+            plan_text = f"{plan_text.rstrip()}\n{report_step}" if plan_text.strip() else report_step
+            logger.warning("Added the missing `report_agent` step to a report plan")
+
         # Check if the planner wants to ask the user for clarification
         if plan_text.strip().startswith(PLAN_CLARIFY_PREFIX):
             clarification = plan_text.strip()[len(PLAN_CLARIFY_PREFIX) :].strip()
@@ -874,6 +885,13 @@ class TopAgent(AsyncMixin):
                     "and generate its detailed report."
                 )
                 logger.warning("Rejected unnecessary camera clarification for incident report: %s", clarification)
+                writer(AgentMessageChunk(type=AgentMessageChunkType.THOUGHT, content="Plan: \n\n" + state.plan))
+                return state
+            if "vst_sensor_list" in self.tools_dict and any(
+                term in question.lower() for term in ("available sensor", "available camera", "sensor id", "camera id")
+            ):
+                state.plan = "1. Call `vst_sensor_list` to retrieve the available sensor names from VST."
+                logger.warning("Rejected ungrounded planner answer for sensor-list query: %s", clarification)
                 writer(AgentMessageChunk(type=AgentMessageChunkType.THOUGHT, content="Plan: \n\n" + state.plan))
                 return state
             logger.info("Plan node requesting clarification: %s", clarification)

--- a/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
@@ -838,6 +838,16 @@ class TopAgent(AsyncMixin):
         # Check if the planner wants to ask the user for clarification
         if plan_text.strip().startswith(PLAN_CLARIFY_PREFIX):
             clarification = plan_text.strip()[len(PLAN_CLARIFY_PREFIX) :].strip()
+            report_tool = self.tools_dict.get("report_agent")
+            report_fields = getattr(getattr(report_tool, "args_schema", None), "model_fields", {})
+            if "report" in question.lower() and "incident_id" in report_fields and "sensor_id" not in report_fields:
+                state.plan = (
+                    "1. Call `report_agent` without a sensor filter to retrieve the most recent incident "
+                    "and generate its detailed report."
+                )
+                logger.warning("Rejected unnecessary camera clarification for incident report: %s", clarification)
+                writer(AgentMessageChunk(type=AgentMessageChunkType.THOUGHT, content="Plan: \n\n" + state.plan))
+                return state
             if "vst_sensor_list" in self.tools_dict and any(
                 term in question.lower() for term in ("available sensor", "available camera", "sensor id", "camera id")
             ):

--- a/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
@@ -286,6 +286,10 @@ class TopAgentState(BaseModel):
     )
     iteration_count: int = Field(default=0, description="Current iteration count")
     final_answer: str = Field(default="", description="Final answer from the agent")
+    tool_failure: str = Field(
+        default="",
+        description="Last unrecovered tool exception, surfaced instead of an answer the agent wrote without it",
+    )
     plan: str = Field(default="", description="Execution plan drafted by the plan node")
     previous_conversation: str = Field(default="", description="Previous conversation summary")
     options: AgentRequestOptions = Field(default_factory=AgentRequestOptions, description="Per-request options")
@@ -988,8 +992,14 @@ class TopAgent(AsyncMixin):
 
             # Check if we have a final answer
             if final_result and not tool_calls:
-                state.final_answer = final_result
-                logger.debug("Agent provided final answer (pending postprocessing validation)")
+                if state.tool_failure:
+                    # The agent stopped calling tools after one raised, so this answer is written from
+                    # memory rather than from the tool. Relay the failure instead of the invention.
+                    state.final_answer = state.tool_failure
+                    logger.warning("Relayed the unrecovered tool failure instead of an ungrounded answer")
+                else:
+                    state.final_answer = final_result
+                    logger.debug("Agent provided final answer (pending postprocessing validation)")
                 # Still add the final answer to the scratchpad for the conversation history summary and postprocessing retries
 
             # Add agent response to scratchpad
@@ -1324,8 +1334,11 @@ class TopAgent(AsyncMixin):
                 except Exception as ex:
                     logger.exception("Tool execution failed")
                     error_response = f"Tool call failed: {ex!s}"
-                    if not state.final_answer:
-                        state.final_answer = error_response
+                    # Record the failure rather than answering with it. Answering ends the graph, and
+                    # a plan whose early step fails (e.g. `lvs_video_understanding` on a media name it
+                    # cannot resolve) then never reaches the step that writes the report. The agent node
+                    # surfaces this instead of an answer it wrote without the tool.
+                    state.tool_failure = error_response
                     return ToolMessage(
                         name=tool_call["name"],
                         tool_call_id=tool_call["id"],
@@ -1335,9 +1348,15 @@ class TopAgent(AsyncMixin):
 
             # Execute all tool calls
             tasks = [run_tool(tool, tool_call) for tool, tool_call in zip(requested_tools, tool_calls, strict=False)]
+            any_tool_succeeded = False
             for task in asyncio.as_completed(tasks):
                 tool_response = await task
+                any_tool_succeeded = any_tool_succeeded or getattr(tool_response, "status", None) == "success"
                 state.agent_scratchpad.append(tool_response)
+
+            # A sibling tool that answered grounds this turn, so a failure beside it is not the answer.
+            if any_tool_succeeded:
+                state.tool_failure = ""
 
             # Add final answer to scratchpad for conversation history summary and postprocessing retries
             if state.final_answer:

--- a/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
@@ -721,10 +721,10 @@ class TopAgent(AsyncMixin):
 
     async def _plan_node(self, state: TopAgentState) -> TopAgentState:
         """
-        Planning node: drafts a step-by-step execution plan using tool names/descriptions only.
+        Planning node: drafts a step-by-step execution plan using the available tools.
 
-        Invokes the LLM without tool bindings so it focuses on planning rather than executing.
-        The resulting plan is stored in state.plan and emitted as a THOUGHT chunk.
+        Structured tool calls are converted to the existing textual plan format for the execution agent.
+        Textual plans remain supported for models that do not emit tool calls.
         """
         writer = get_stream_writer()
         logger.debug("Starting Plan Node")
@@ -823,12 +823,23 @@ class TopAgent(AsyncMixin):
         messages.append(HumanMessage(content="User question: " + question))
 
         llm_kwargs = get_llm_reasoning_bind_kwargs(self.llm, state.options.llm_reasoning)
-        llm_to_use = self.llm.bind(**llm_kwargs) if llm_kwargs else self.llm
+        planner_llm = getattr(self, "llm_with_tools", self.llm)
+        llm_to_use = planner_llm.bind(**llm_kwargs) if llm_kwargs else planner_llm
 
         result = await llm_to_use.ainvoke(messages, config=RunnableConfig(callbacks=self.callbacks))
 
         plan_reasoning, plan_text = parse_reasoning_content(result)
-        if not plan_text:
+        planner_tool_calls = result.tool_calls if isinstance(result, AIMessage) else []
+        if planner_tool_calls:
+            plan_steps = []
+            for index, tool_call in enumerate(planner_tool_calls, start=1):
+                arguments = tool_call.get("args") or {}
+                arguments_text = (
+                    f" with arguments {json.dumps(arguments, sort_keys=True, default=str)}" if arguments else ""
+                )
+                plan_steps.append(f"{index}. Call `{tool_call['name']}`{arguments_text}.")
+            plan_text = "\n".join(plan_steps)
+        elif not plan_text:
             plan_text = str(result.content) if hasattr(result, "content") else ""
 
         logger.debug("Plan node produced plan:\n%s", plan_text)
@@ -863,13 +874,6 @@ class TopAgent(AsyncMixin):
                     "and generate its detailed report."
                 )
                 logger.warning("Rejected unnecessary camera clarification for incident report: %s", clarification)
-                writer(AgentMessageChunk(type=AgentMessageChunkType.THOUGHT, content="Plan: \n\n" + state.plan))
-                return state
-            if "vst_sensor_list" in self.tools_dict and any(
-                term in question.lower() for term in ("available sensor", "available camera", "sensor id", "camera id")
-            ):
-                state.plan = "1. Call `vst_sensor_list` to retrieve the available sensor names from VST."
-                logger.warning("Rejected ungrounded planner answer for sensor-list query: %s", clarification)
                 writer(AgentMessageChunk(type=AgentMessageChunkType.THOUGHT, content="Plan: \n\n" + state.plan))
                 return state
             logger.info("Plan node requesting clarification: %s", clarification)

--- a/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
@@ -1141,6 +1141,11 @@ class TopAgent(AsyncMixin):
                                                 if messages_text
                                                 else artifact_note
                                             )
+                                        normalized_messages = messages_text.strip().lower()
+                                        if agent_output.status == "error" or normalized_messages.startswith(
+                                            "no incidents found"
+                                        ):
+                                            state.final_answer = agent_output.error_message or messages_text
                                         tool_response = f"tool: {tool_name} completed. Result: {messages_text}"
                                     except (json.JSONDecodeError, Exception):
                                         # Not AgentOutput JSON, treat as plain text

--- a/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
@@ -866,12 +866,19 @@ class TopAgent(AsyncMixin):
             and "report_agent" not in plan_text
             and not plan_text.strip().startswith(PLAN_CLARIFY_PREFIX)
         ):
-            planned_steps = [int(match.group(1)) for match in re.finditer(r"(?:^|\s)(\d+)\.\s", plan_text)]
             report_step = (
-                f"{max(planned_steps, default=0) + 1}. Call `report_agent` with the media named in the user's "
-                "request and the original request as `user_query`, then present the generated report."
+                "Call `report_agent` with every media name from the user's request (as a single list when the "
+                "request names more than one) and the original request as `user_query`, then present the "
+                "generated report."
             )
-            plan_text = f"{plan_text.rstrip()}\n{report_step}" if plan_text.strip() else report_step
+            planned_steps = [int(match.group(1)) for match in re.finditer(r"(?:^|\s)(\d+)\.\s", plan_text)]
+            if planned_steps:
+                plan_text = f"{plan_text.rstrip()}\n{max(planned_steps) + 1}. {report_step}"
+            else:
+                # No numbered step at all means the planner returned prose rather than a plan, and
+                # prose such as "route to the appropriate tools" steers the execution agent into a
+                # summary tool. Replace it instead of appending the report step underneath it.
+                plan_text = f"1. {report_step}"
             logger.warning("Added the missing `report_agent` step to a report plan")
 
         # Check if the planner wants to ask the user for clarification

--- a/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
@@ -835,6 +835,23 @@ class TopAgent(AsyncMixin):
         if plan_reasoning:
             logger.debug("Plan node reasoning:\n%s", plan_reasoning)
 
+        requests_lvs_report = "report" in lowered_question and (
+            "lvs" in lowered_question or re.search(r"\blong[\s-]+video[\s-]+summari[sz]", lowered_question) is not None
+        )
+        if (
+            requests_lvs_report
+            and "lvs_video_understanding" in self.tools_dict
+            and "report_agent" in self.tools_dict
+            and "lvs_video_understanding" not in plan_text
+        ):
+            plan_text = (
+                "1. Call `lvs_video_understanding` using the exact sensor ID and time range from the user's request "
+                "to analyze the video with LVS.\n"
+                "2. Call `report_agent` with the same sensor ID and time range plus the original request as "
+                "`user_query`, then present the generated report."
+            )
+            logger.warning("Corrected LVS report plan that omitted lvs_video_understanding")
+
         # Check if the planner wants to ask the user for clarification
         if plan_text.strip().startswith(PLAN_CLARIFY_PREFIX):
             clarification = plan_text.strip()[len(PLAN_CLARIFY_PREFIX) :].strip()

--- a/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
@@ -1039,8 +1039,13 @@ class TopAgent(AsyncMixin):
 
                     logger.info(f"Executing tool/sub-agent: {tool_name}")
 
-                    # Build tool args once, filtering None values and injecting request options when supported.
-                    tool_args = {k: v for k, v in tool_call["args"].items() if v is not None}
+                    # Build tool args once, filtering actual nulls and common LLM-rendered null sentinels.
+                    tool_args = {
+                        key: value
+                        for key, value in tool_call["args"].items()
+                        if value is not None
+                        and not (isinstance(value, str) and value.strip().lower() in {"none", "null"})
+                    }
                     if self._tool_accepts_param(tool_name, "request_options"):
                         tool_args["request_options"] = state.options.model_dump(mode="json")
                         logger.info("Passing request_options to %s", tool_name)

--- a/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
@@ -772,6 +772,8 @@ class TopAgent(AsyncMixin):
             "then produce a concise numbered execution plan. Start each step with a tool name and a brief description of the step.\n"
             "Put relevant context (e.g. sensor IDs or time ranges) from the conversation history directly in the plan steps "
             "so the execution agent does not need to re-read the history.\n"
+            "Never answer with sensor names, incidents, counts, media URLs, or other deployment data from memory. "
+            "When an available tool can retrieve the answer, the plan MUST call that tool.\n"
             "If the user's request is too ambiguous to build a reliable plan, respond with EXACTLY:\n"
             "[USER] <your clarifying question>\n"
             "If user's question can be answered directly without any tools, respond with EXACTLY:\n"
@@ -836,6 +838,13 @@ class TopAgent(AsyncMixin):
         # Check if the planner wants to ask the user for clarification
         if plan_text.strip().startswith(PLAN_CLARIFY_PREFIX):
             clarification = plan_text.strip()[len(PLAN_CLARIFY_PREFIX) :].strip()
+            if "vst_sensor_list" in self.tools_dict and any(
+                term in question.lower() for term in ("available sensor", "available camera", "sensor id", "camera id")
+            ):
+                state.plan = "1. Call `vst_sensor_list` to retrieve the available sensor names from VST."
+                logger.warning("Rejected ungrounded planner answer for sensor-list query: %s", clarification)
+                writer(AgentMessageChunk(type=AgentMessageChunkType.THOUGHT, content="Plan: \n\n" + state.plan))
+                return state
             logger.info("Plan node requesting clarification: %s", clarification)
             state.final_answer = clarification
             return state
@@ -1249,6 +1258,8 @@ class TopAgent(AsyncMixin):
                 except Exception as ex:
                     logger.exception("Tool execution failed")
                     error_response = f"Tool call failed: {ex!s}"
+                    if not state.final_answer:
+                        state.final_answer = error_response
                     return ToolMessage(
                         name=tool_call["name"],
                         tool_call_id=tool_call["id"],

--- a/services/agent/packages/vss_agents/src/vss_agents/orchestrator/docker_compose_util.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/orchestrator/docker_compose_util.py
@@ -96,6 +96,12 @@ COMPOSE_PROFILE_REQUIRED_KEYS: Final[tuple[str, ...]] = (
     "VLM_NAME_SLUG",
 )
 _COMPOSE_SHELL_ENV_BLOCKLIST: Final[frozenset[str]] = frozenset({"LLM_MODE", "VLM_MODE"})
+# Compose gives the process environment precedence over --env-file, so an
+# exported-but-empty endpoint blanks the profile's value, and the agent's
+# `base_url: ${LLM_BASE_URL}/v1` then collapses to `/v1`. An unset variable
+# falls through to the env files on its own; an empty one has to be removed to
+# do the same. A non-empty shell value is still honoured.
+_COMPOSE_SHELL_ENV_DROP_IF_EMPTY: Final[frozenset[str]] = frozenset({"LLM_BASE_URL", "VLM_BASE_URL"})
 
 
 class ValidationError(ValueError):
@@ -776,6 +782,9 @@ def _compose_subprocess_env(extra_defaults: Mapping[str, str] = MappingProxyType
     env = os.environ.copy()
     for key in _COMPOSE_SHELL_ENV_BLOCKLIST:
         env.pop(key, None)
+    for key in _COMPOSE_SHELL_ENV_DROP_IF_EMPTY:
+        if not env.get(key, "").strip():
+            env.pop(key, None)
     for key, value in extra_defaults.items():
         env.setdefault(key, value)
     return env

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/fov_counts_with_chart.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/fov_counts_with_chart.py
@@ -110,7 +110,16 @@ async def get_fov_counts_with_chart(config: FOVCountsWithChartConfig, builder: B
 
         # Parse the result if it's a string
         if isinstance(fov_result, str):
-            fov_data = json.loads(fov_result)
+            if not fov_result.strip():
+                raise ValueError(
+                    f"FOV histogram service returned an empty response for sensor '{input_data.sensor_id}'",
+                )
+            try:
+                fov_data = json.loads(fov_result)
+            except json.JSONDecodeError as ex:
+                raise ValueError(
+                    f"FOV histogram service returned invalid JSON for sensor '{input_data.sensor_id}'",
+                ) from ex
         else:
             fov_data = fov_result
 

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_config_media.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_config_media.py
@@ -41,6 +41,7 @@ from vss_agents.tools.lvs_media_state import LVSConfiguredMedia
 from vss_agents.tools.lvs_media_state import configured_media
 from vss_agents.tools.lvs_media_state import remember_configured_media
 from vss_agents.tools.vst.utils import get_stream_info_by_name
+from vss_agents.utils.hitl import has_human_prompt_callback
 
 logger = logging.getLogger(__name__)
 
@@ -381,33 +382,53 @@ async def lvs_config_media(config: LVSConfigMediaConfig, _: Builder) -> AsyncGen
                 list(configured.objects_of_interest),
             )
 
-        while True:
-            params = await _collect_hitl_parameters(current_params)
-            if params is None:
-                return LVSConfigMediaOutput(
-                    status=LVSMediaStatus.ABORTED,
-                    media_type=lvs_input.media_type,
-                    media_name=media_name,
-                    media_id=media_id,
-                    configured=False,
-                    message="Media configuration was cancelled by user.",
-                )
+        scenario: str = ""
+        events: list[str] = []
+        objects_of_interest: list[str] = []
 
-            scenario, events, objects_of_interest = params
-            choice = await _confirm_config(scenario, events, objects_of_interest)
-            if choice == "/redo":
-                current_params = (scenario, events, objects_of_interest)
-                continue
-            if choice == "/cancel":
-                return LVSConfigMediaOutput(
-                    status=LVSMediaStatus.ABORTED,
-                    media_type=lvs_input.media_type,
-                    media_name=media_name,
-                    media_id=media_id,
-                    configured=False,
-                    message="Media configuration was cancelled by user.",
+        if has_human_prompt_callback():
+            while True:
+                params = await _collect_hitl_parameters(current_params)
+                if params is None:
+                    return LVSConfigMediaOutput(
+                        status=LVSMediaStatus.ABORTED,
+                        media_type=lvs_input.media_type,
+                        media_name=media_name,
+                        media_id=media_id,
+                        configured=False,
+                        message="Media configuration was cancelled by user.",
+                    )
+
+                scenario, events, objects_of_interest = params
+                choice = await _confirm_config(scenario, events, objects_of_interest)
+                if choice == "/redo":
+                    current_params = (scenario, events, objects_of_interest)
+                    continue
+                if choice == "/cancel":
+                    return LVSConfigMediaOutput(
+                        status=LVSMediaStatus.ABORTED,
+                        media_type=lvs_input.media_type,
+                        media_name=media_name,
+                        media_id=media_id,
+                        configured=False,
+                        message="Media configuration was cancelled by user.",
+                    )
+                break
+        else:
+            if current_params is not None:
+                scenario, events, objects_of_interest = current_params
+            else:
+                scenario = config.default_scenario
+                events = list(config.default_events)
+                objects_of_interest = []
+            if not scenario or not events:
+                raise ValueError(
+                    "default_scenario and default_events are required when no human prompt callback is available"
                 )
-            break
+            logger.info(
+                "HITL is enabled but this request has no human prompt callback; "
+                "proceeding noninteractively with configured LVS defaults for this request only"
+            )
 
         payload: dict[str, Any] = {
             "id": media_id,

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_config_media.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_config_media.py
@@ -199,6 +199,10 @@ class LVSConfigMediaConfig(FunctionBaseConfig, name="lvs_config_media"):
         default=None,
         description="HITL template for final media configuration confirmation.",
     )
+    hitl_enabled: bool = Field(
+        default=True,
+        description="Collect and confirm media parameters interactively. Disable to use configured defaults.",
+    )
     default_scenario: str = Field(default="", description="Default media scenario.")
     default_events: list[str] = Field(default_factory=list, description="Default media events.")
 
@@ -386,7 +390,8 @@ async def lvs_config_media(config: LVSConfigMediaConfig, _: Builder) -> AsyncGen
         events: list[str] = []
         objects_of_interest: list[str] = []
 
-        if has_human_prompt_callback():
+        interactive_hitl = config.hitl_enabled and has_human_prompt_callback()
+        if interactive_hitl:
             while True:
                 params = await _collect_hitl_parameters(current_params)
                 if params is None:
@@ -423,12 +428,16 @@ async def lvs_config_media(config: LVSConfigMediaConfig, _: Builder) -> AsyncGen
                 objects_of_interest = []
             if not scenario or not events:
                 raise ValueError(
-                    "default_scenario and default_events are required when no human prompt callback is available"
+                    "default_scenario and default_events are required when HITL is disabled "
+                    "or no human prompt callback is available"
                 )
-            logger.info(
-                "HITL is enabled but this request has no human prompt callback; "
-                "proceeding noninteractively with configured LVS defaults for this request only"
-            )
+            if config.hitl_enabled:
+                logger.info(
+                    "HITL is enabled but this request has no human prompt callback; "
+                    "proceeding noninteractively with configured LVS defaults for this request only"
+                )
+            else:
+                logger.info("HITL disabled; proceeding with configured LVS defaults")
 
         payload: dict[str, Any] = {
             "id": media_id,

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_video_understanding.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_video_understanding.py
@@ -51,6 +51,7 @@ from pydantic import Field
 from pydantic import field_validator
 
 from vss_agents.utils.hitl import format_hitl_popup_header
+from vss_agents.utils.hitl import has_human_prompt_callback
 from vss_agents.utils.url_translation import rewrite_to_internal_vst_url
 
 logger = logging.getLogger(__name__)
@@ -802,7 +803,8 @@ async def lvs_video_understanding(
         events_list: list[str] = []
         objects_of_interest: list[str] = []
 
-        if config.hitl_enabled:
+        interactive_hitl = config.hitl_enabled and has_human_prompt_callback()
+        if interactive_hitl:
             # HITL workflow with confirmation loop (done once for all videos)
             while True:
                 # Step 1: Collect parameters via HITL
@@ -852,8 +854,17 @@ async def lvs_video_understanding(
             events_list = list(config.default_events)
             objects_of_interest = []
             if not scenario or not events_list:
-                raise ValueError("default_scenario and default_events are required when hitl_enabled is false")
-            logger.info("HITL disabled; proceeding with configured LVS defaults")
+                raise ValueError(
+                    "default_scenario and default_events are required when HITL is disabled "
+                    "or no human prompt callback is available"
+                )
+            if config.hitl_enabled:
+                logger.info(
+                    "HITL is enabled but this request has no human prompt callback; "
+                    "proceeding noninteractively with configured LVS defaults for this request only"
+                )
+            else:
+                logger.info("HITL disabled; proceeding with configured LVS defaults")
 
         # Update state for this thread
         lvs_params_state[thread_id] = (scenario, events_list, objects_of_interest)

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_video_understanding.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_video_understanding.py
@@ -207,6 +207,11 @@ class LVSVideoUnderstandingConfig(FunctionBaseConfig, name="lvs_video_understand
         description="HITL template for final confirmation before video analysis. If None, uses default template.",
     )
 
+    hitl_enabled: bool = Field(
+        default=True,
+        description="Collect and confirm LVS parameters interactively. Disable to use configured defaults.",
+    )
+
     # Default values for HITL parameters
     default_scenario: str = Field(
         default="",
@@ -797,50 +802,58 @@ async def lvs_video_understanding(
         events_list: list[str] = []
         objects_of_interest: list[str] = []
 
-        # HITL workflow with confirmation loop (done once for all videos)
-        while True:
-            # Step 1: Collect parameters via HITL
-            logger.info("Running HITL workflow to collect/confirm parameters")
-            params_result = await _collect_hitl_parameters(
-                current_params, sensor_ids=sensor_ids, total_videos=request_total_videos
-            )
-
-            # Handle cancellation
-            if params_result is None:
-                logger.info("LVS analysis cancelled by user during parameter collection")
-                return LVSVideoUnderstandingOutput(
-                    status=LVSStatus.ABORTED,
-                    message="Video analysis was cancelled by user.",
+        if config.hitl_enabled:
+            # HITL workflow with confirmation loop (done once for all videos)
+            while True:
+                # Step 1: Collect parameters via HITL
+                logger.info("Running HITL workflow to collect/confirm parameters")
+                params_result = await _collect_hitl_parameters(
+                    current_params, sensor_ids=sensor_ids, total_videos=request_total_videos
                 )
 
-            scenario, events_list, objects_of_interest = params_result
+                # Handle cancellation
+                if params_result is None:
+                    logger.info("LVS analysis cancelled by user during parameter collection")
+                    return LVSVideoUnderstandingOutput(
+                        status=LVSStatus.ABORTED,
+                        message="Video analysis was cancelled by user.",
+                    )
 
-            # Step 2: Show all configs and get confirmation
-            logger.info("Showing LVS configuration for user confirmation")
-            user_choice = await _confirm_lvs_request(
-                scenario,
-                events_list,
-                objects_of_interest,
-                sensor_ids=sensor_ids,
-                total_videos=request_total_videos,
-            )
+                scenario, events_list, objects_of_interest = params_result
 
-            if user_choice == "/redo":
-                # User wants to modify parameters - loop back with current values
-                logger.info("User requested redo - restarting parameter collection")
-                current_params = (scenario, events_list, objects_of_interest)
-                continue
-            elif user_choice == "/cancel":
-                # User cancelled
-                logger.info("LVS analysis cancelled by user")
-                return LVSVideoUnderstandingOutput(
-                    status=LVSStatus.ABORTED,
-                    message="Video analysis was cancelled by user.",
+                # Step 2: Show all configs and get confirmation
+                logger.info("Showing LVS configuration for user confirmation")
+                user_choice = await _confirm_lvs_request(
+                    scenario,
+                    events_list,
+                    objects_of_interest,
+                    sensor_ids=sensor_ids,
+                    total_videos=request_total_videos,
                 )
-            else:
-                # Empty string or any other input - proceed with LVS request
-                logger.info("User confirmed - proceeding with LVS analysis")
-                break
+
+                if user_choice == "/redo":
+                    # User wants to modify parameters - loop back with current values
+                    logger.info("User requested redo - restarting parameter collection")
+                    current_params = (scenario, events_list, objects_of_interest)
+                    continue
+                elif user_choice == "/cancel":
+                    # User cancelled
+                    logger.info("LVS analysis cancelled by user")
+                    return LVSVideoUnderstandingOutput(
+                        status=LVSStatus.ABORTED,
+                        message="Video analysis was cancelled by user.",
+                    )
+                else:
+                    # Empty string or any other input - proceed with LVS request
+                    logger.info("User confirmed - proceeding with LVS analysis")
+                    break
+        else:
+            scenario = config.default_scenario
+            events_list = list(config.default_events)
+            objects_of_interest = []
+            if not scenario or not events_list:
+                raise ValueError("default_scenario and default_events are required when hitl_enabled is false")
+            logger.info("HITL disabled; proceeding with configured LVS defaults")
 
         # Update state for this thread
         lvs_params_state[thread_id] = (scenario, events_list, objects_of_interest)

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/video_report_gen.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/video_report_gen.py
@@ -69,6 +69,7 @@ from vss_agents.tools.vst.timeline import get_timeline
 from vss_agents.tools.vst.utils import get_stream_id
 from vss_agents.tools.vst.video_clip import get_video_url
 from vss_agents.utils.hitl import format_hitl_popup_header
+from vss_agents.utils.hitl import has_human_prompt_callback
 from vss_agents.utils.reasoning_parsing import parse_reasoning_content
 from vss_agents.utils.sanitize import safe_basename
 from vss_agents.utils.time_convert import datetime_to_iso8601
@@ -1384,6 +1385,18 @@ async def video_report_gen(config: VideoReportGenConfig, builder: Builder) -> As
     max_conversations = 1000
     vlm_prompt_state: OrderedDict[str, str] = OrderedDict()
 
+    def _interactive_hitl_enabled() -> bool:
+        """Resolve HITL availability without changing deployment-wide configuration."""
+        if not config.hitl_enabled:
+            return False
+        if has_human_prompt_callback():
+            return True
+        logger.info(
+            "HITL is enabled but this request has no human prompt callback; "
+            "proceeding noninteractively with the configured VLM prompt for this request only"
+        )
+        return False
+
     def _store_prompt(thread_id: str, prompt: str) -> None:
         """Store a prompt for a thread, evicting oldest entries if over capacity."""
         # If key exists, remove it first to update insertion order (LRU behavior)
@@ -1748,7 +1761,7 @@ Enter your choice or press Submit to keep current value:"""
 
         # Step 2: Collect base VLM prompt upfront (if any base videos and HITL enabled)
         vlm_prompt_override: str | None = None
-        if base_sensor_ids and config.hitl_enabled:
+        if base_sensor_ids and _interactive_hitl_enabled():
             thread_id = ContextState.get().conversation_id.get()
             current_prompt = _get_prompt(thread_id)
             resolved_prompt = await _collect_hitl_vlm_prompt(
@@ -2153,7 +2166,7 @@ Enter your choice or press Submit to keep current value:"""
             if vlm_prompt_override is not None:
                 logger.info(f"[PROMPT LOADED] Using pre-collected VLM prompt: '{vlm_prompt_override[:100]}...'")
                 clean_prompt = _remove_som_markers(vlm_prompt_override)
-            elif config.hitl_enabled:
+            elif _interactive_hitl_enabled():
                 thread_id = ContextState.get().conversation_id.get()
                 current_prompt = _get_prompt(thread_id)
                 resolved_prompt = await _collect_hitl_vlm_prompt(current_prompt)

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/vst/snapshot.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/vst/snapshot.py
@@ -202,6 +202,16 @@ async def get_latest_snapshot_time(stream_id: str, vst_internal_url: str) -> str
     return latest.isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
 
+async def validate_snapshot_time(stream_id: str, start_time: str, vst_internal_url: str) -> None:
+    """Reject ISO timestamps outside the stream's recorded timeline."""
+    timeline_start, timeline_end = await get_timeline(stream_id, vst_internal_url)
+    picture_time = datetime.fromisoformat(start_time)
+    if picture_time < datetime.fromisoformat(timeline_start) or picture_time > datetime.fromisoformat(timeline_end):
+        raise ValueError(
+            f"Picture time {start_time} is out of the video timeline {timeline_start} to {timeline_end}",
+        )
+
+
 @register_function(config_type=VSTSnapshotConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
 async def vst_snapshot(config: VSTSnapshotConfig, _builder: Builder) -> AsyncGenerator[FunctionInfo]:
     async def _vst_snapshot(vst_snapshot_input: VSTSnapshotOffsetInput | VSTSnapshotISOInput) -> VSTSnapshotOutput:
@@ -214,6 +224,8 @@ async def vst_snapshot(config: VSTSnapshotConfig, _builder: Builder) -> AsyncGen
         start_time = vst_snapshot_input.start_time
         if start_time is None:
             start_time = await get_latest_snapshot_time(stream_id, config.vst_internal_url)
+        elif isinstance(start_time, str):
+            await validate_snapshot_time(stream_id, start_time, config.vst_internal_url)
 
         image_url = await get_snapshot_url(
             stream_id,

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/vst/snapshot.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/vst/snapshot.py
@@ -100,9 +100,9 @@ class VSTSnapshotOffsetInput(BaseModel):
         description="The name of the video file uploaded or the stream ID from VST",
         min_length=1,
     )
-    start_time: float = Field(
-        ...,
-        description="Seconds since the beginning of the stream (e.g., 30.0 for 30 seconds in)",
+    start_time: float | None = Field(
+        default=None,
+        description="Optional seconds since the beginning of the stream. Omit to use the latest recorded frame.",
     )
 
 
@@ -117,9 +117,9 @@ class VSTSnapshotISOInput(BaseModel):
         description="The name of the video file uploaded or the stream ID from VST",
         min_length=1,
     )
-    start_time: str = Field(
-        ...,
-        description="ISO 8601 UTC timestamp (e.g., '2025-08-25T03:05:55.752Z')",
+    start_time: str | None = Field(
+        default=None,
+        description="Optional ISO 8601 UTC timestamp. Omit to use the latest recorded frame.",
         min_length=1,
     )
 
@@ -193,6 +193,15 @@ async def get_snapshot_url(
     return str(image_url)
 
 
+async def get_latest_snapshot_time(stream_id: str, vst_internal_url: str) -> str:
+    """Return a timestamp just inside the end of the stream's recorded timeline."""
+    timeline_start, timeline_end = await get_timeline(stream_id, vst_internal_url)
+    start = datetime.fromisoformat(timeline_start)
+    end = datetime.fromisoformat(timeline_end)
+    latest = max(start, end - timedelta(milliseconds=1))
+    return latest.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
 @register_function(config_type=VSTSnapshotConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
 async def vst_snapshot(config: VSTSnapshotConfig, _builder: Builder) -> AsyncGenerator[FunctionInfo]:
     async def _vst_snapshot(vst_snapshot_input: VSTSnapshotOffsetInput | VSTSnapshotISOInput) -> VSTSnapshotOutput:
@@ -202,10 +211,13 @@ async def vst_snapshot(config: VSTSnapshotConfig, _builder: Builder) -> AsyncGen
             VSTSnapshotOutput containing image URL and stream ID
         """
         stream_id = await get_stream_id(vst_snapshot_input.sensor_id, config.vst_internal_url)
+        start_time = vst_snapshot_input.start_time
+        if start_time is None:
+            start_time = await get_latest_snapshot_time(stream_id, config.vst_internal_url)
 
         image_url = await get_snapshot_url(
             stream_id,
-            vst_snapshot_input.start_time,
+            start_time,
             config.vst_internal_url,
             overlay_enabled=config.overlay_config,
             timeout_seconds=config.timeout_seconds,
@@ -233,7 +245,8 @@ async def vst_snapshot(config: VSTSnapshotConfig, _builder: Builder) -> AsyncGen
         input_desc = """
         \n\nInput:
         - sensor_id: Required. The name of the sensor or video file.
-        - start_time: Required. ISO 8601 UTC timestamp (e.g., '2025-08-25T03:05:55.752Z').
+        - start_time: Optional. ISO 8601 UTC timestamp (e.g., '2025-08-25T03:05:55.752Z').
+          Omit to use the latest frame in the sensor's recorded timeline.
         """
         func_desc = _vst_snapshot.__doc__ or ""
 
@@ -251,7 +264,8 @@ async def vst_snapshot(config: VSTSnapshotConfig, _builder: Builder) -> AsyncGen
         input_desc = """
         \n\nInput:
         - sensor_id: Required. The name of the sensor or video file.
-        - start_time: Required. Seconds since the beginning of the stream (e.g., 30.0 for 30 seconds from the start of the video).
+        - start_time: Optional. Seconds since the beginning of the stream (e.g., 30.0 for 30 seconds from the start of the video).
+          Omit to use the latest frame in the sensor's recorded timeline.
         """
         func_desc = _vst_snapshot.__doc__ or ""
         yield FunctionInfo.create(

--- a/services/agent/packages/vss_agents/src/vss_agents/utils/hitl.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/utils/hitl.py
@@ -13,11 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Helpers for rendering Human-in-the-Loop (HITL) popup content."""
+"""Helpers for request-scoped Human-in-the-Loop (HITL) behavior and popup content."""
 
 import logging
 
+from nat.builder.context import ContextState
+from nat.builder.user_interaction_manager import UserInteractionManager
+
 logger = logging.getLogger(__name__)
+
+
+def has_human_prompt_callback() -> bool:
+    """Return whether the current request can deliver interactive prompts."""
+    callback = ContextState.get().user_input_callback.get()
+    return callback is not None and callback is not UserInteractionManager.default_callback_handler
 
 
 def format_hitl_popup_header(sensor_ids: list[str] | None, total_videos: int | None) -> str:

--- a/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
@@ -27,6 +27,7 @@ from langchain_core.prompts import MessagesPlaceholder
 from langchain_core.runnables import RunnableLambda
 import pytest
 
+from vss_agents.agents.data_models import AgentDecision
 from vss_agents.agents.data_models import AgentMessageChunk
 from vss_agents.agents.data_models import AgentMessageChunkType
 from vss_agents.agents.data_models import AgentOutput
@@ -862,7 +863,7 @@ class TestRequestOptionsContext:
         assert "source_type" not in search_tool.received_input
 
     @pytest.mark.asyncio
-    async def test_tool_node_surfaces_tool_exception_as_final_answer(self, monkeypatch):
+    async def test_tool_node_records_a_tool_exception_without_ending_the_run(self, monkeypatch):
         monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
 
         class FailingTool:
@@ -894,7 +895,38 @@ class TestRequestOptionsContext:
 
         result = await agent.tool_or_subagent_node(state)
 
-        assert result.final_answer == "Tool call failed: streamId not found for 'Camera_01'. Available: ['gwfix6']"
+        expected = "Tool call failed: streamId not found for 'Camera_01'. Available: ['gwfix6']"
+        assert result.tool_failure == expected
+        # Recorded, not answered: answering here ends the graph and drops the rest of the plan.
+        assert result.final_answer == ""
+        assert await agent._conditional_edge_from_tool(result) == AgentDecision.AGENT.value
+
+    @pytest.mark.asyncio
+    async def test_agent_node_relays_an_unrecovered_tool_failure(self, monkeypatch):
+        """The agent stopping after a raised tool must relay the failure, not answer from memory."""
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
+
+        agent = self._agent_with_search_tool()
+        agent.llm = MagicMock()
+        agent.llm.model_name = "test-model"
+        agent.llm_with_tools = MagicMock()
+        agent.plan_exec_prompt = None
+        agent.callbacks = []
+        agent.prompt = MagicMock()
+        agent.prompt.__or__.return_value = MagicMock(
+            ainvoke=AsyncMock(return_value=AIMessage(content="The available cameras are Camera_01 and Camera_02."))
+        )
+        failure = "Tool call failed: streamId not found for 'Camera_01'. Available: ['gwfix6']"
+        state = TopAgentState(
+            current_message=HumanMessage(content="What are the available sensor IDs?"),
+            options=AgentRequestOptions(),
+            tool_failure=failure,
+        )
+
+        result = await agent.agent_node(state)
+
+        assert result.final_answer == failure
+        assert "Camera_02" not in result.final_answer
 
     @pytest.mark.asyncio
     async def test_tool_node_omits_llm_rendered_null_sentinels(self, monkeypatch):

--- a/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
@@ -523,8 +523,9 @@ class TestRequestOptionsContext:
         assert isinstance(result, ToolMessage)
         assert result.status == "error"
         assert not str(result.content).startswith("Tool call failed:")
+
     @pytest.mark.asyncio
-    async def test_plan_node_rejects_ungrounded_sensor_list_answer(self, monkeypatch):
+    async def test_plan_node_uses_structured_sensor_list_tool_call(self, monkeypatch):
         chunks = []
         monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: chunks.append)
 
@@ -535,7 +536,20 @@ class TestRequestOptionsContext:
         agent.tools_dict["vst_sensor_list"] = sensor_tool
         agent.llm = MagicMock()
         agent.llm.model_name = "test-model"
-        agent.llm.ainvoke = AsyncMock(return_value=AIMessage(content="[USER] Camera_01, Camera_02"))
+        agent.llm_with_tools = MagicMock()
+        agent.llm_with_tools.ainvoke = AsyncMock(
+            return_value=AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "vst_sensor_list",
+                        "args": {},
+                        "id": "planner-call-1",
+                        "type": "tool_call",
+                    }
+                ],
+            )
+        )
         agent.callbacks = []
         agent.plan_prompt = None
         agent.plan_system_prompt = "System prompt."
@@ -547,7 +561,9 @@ class TestRequestOptionsContext:
         result = await agent._plan_node(state)
 
         assert result.final_answer == ""
-        assert result.plan == "1. Call `vst_sensor_list` to retrieve the available sensor names from VST."
+        assert result.plan == "1. Call `vst_sensor_list`."
+        agent.llm_with_tools.ainvoke.assert_awaited_once()
+        agent.llm.ainvoke.assert_not_called()
         assert any(chunk.type == AgentMessageChunkType.THOUGHT for chunk in chunks)
 
     @pytest.mark.asyncio

--- a/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
@@ -29,6 +29,7 @@ import pytest
 
 from vss_agents.agents.data_models import AgentMessageChunk
 from vss_agents.agents.data_models import AgentMessageChunkType
+from vss_agents.agents.data_models import AgentOutput
 from vss_agents.agents.data_models import AgentRequestOptions
 from vss_agents.agents.search_agent import SearchAgentInput
 from vss_agents.agents.top_agent import EMPTY_MESSAGES_ERROR
@@ -757,6 +758,45 @@ class TestRequestOptionsContext:
             and "'use_critic': False" in chunk.content
             for chunk in chunks
         )
+
+    @pytest.mark.asyncio
+    async def test_tool_node_ends_on_subagent_no_incidents_result(self, monkeypatch):
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
+
+        class ReportFunction:
+            async def astream(self, input):
+                yield AgentMessageChunk(
+                    type=AgentMessageChunkType.FINAL,
+                    content=AgentOutput(messages=["No incidents found with the specified criteria."]).model_dump_json(),
+                )
+
+        report_tool = MagicMock()
+        report_tool.args_schema = MagicMock()
+        report_tool.args_schema.model_fields = {}
+        agent = TopAgent.__new__(TopAgent)
+        agent.tools_dict = {"report_agent": report_tool}
+        agent.subagent_names = {"report_agent"}
+        agent.subagent_functions = {"report_agent": ReportFunction()}
+        agent.callbacks = []
+        state = TopAgentState(
+            agent_scratchpad=[
+                AIMessage(
+                    content="calling report",
+                    tool_calls=[
+                        {
+                            "name": "report_agent",
+                            "args": {"sensor_id": "Camera"},
+                            "id": "call_1",
+                        }
+                    ],
+                )
+            ],
+            options=AgentRequestOptions(),
+        )
+
+        result = await agent.tool_or_subagent_node(state)
+
+        assert result.final_answer == "No incidents found with the specified criteria."
 
 
 class TestTopAgentRequestUseCritic:

--- a/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
@@ -551,6 +551,66 @@ class TestRequestOptionsContext:
         assert any(chunk.type == AgentMessageChunkType.THOUGHT for chunk in chunks)
 
     @pytest.mark.asyncio
+    async def test_plan_node_does_not_request_camera_for_unfiltered_incident_report(self, monkeypatch):
+        chunks = []
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: chunks.append)
+
+        agent = self._agent_with_search_tool()
+        report_tool = MagicMock()
+        report_tool.name = "report_agent"
+        report_tool.description = "Generate a report for the latest incident."
+        report_tool.args_schema.model_fields = {
+            "incident_id": MagicMock(),
+            "source": MagicMock(),
+        }
+        agent.tools_dict["report_agent"] = report_tool
+        agent.llm = MagicMock()
+        agent.llm.model_name = "test-model"
+        agent.llm.ainvoke = AsyncMock(return_value=AIMessage(content="[USER] Which camera should I use?"))
+        agent.callbacks = []
+        agent.plan_prompt = None
+        agent.plan_system_prompt = "System prompt."
+        state = TopAgentState(
+            current_message=HumanMessage(content="Generate a detailed report for the latest incident."),
+            options=AgentRequestOptions(),
+        )
+
+        result = await agent._plan_node(state)
+
+        assert result.final_answer == ""
+        assert result.plan == (
+            "1. Call `report_agent` without a sensor filter to retrieve the most recent incident "
+            "and generate its detailed report."
+        )
+        assert any(chunk.type == AgentMessageChunkType.THOUGHT for chunk in chunks)
+
+    @pytest.mark.asyncio
+    async def test_plan_node_keeps_camera_clarification_for_uploaded_video_report(self, monkeypatch):
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
+
+        agent = self._agent_with_search_tool()
+        report_tool = MagicMock()
+        report_tool.name = "report_agent"
+        report_tool.description = "Generate an uploaded video report."
+        report_tool.args_schema.model_fields = {"sensor_id": MagicMock()}
+        agent.tools_dict["report_agent"] = report_tool
+        agent.llm = MagicMock()
+        agent.llm.model_name = "test-model"
+        agent.llm.ainvoke = AsyncMock(return_value=AIMessage(content="[USER] Which video should I use?"))
+        agent.callbacks = []
+        agent.plan_prompt = None
+        agent.plan_system_prompt = "System prompt."
+        state = TopAgentState(
+            current_message=HumanMessage(content="Generate a report."),
+            options=AgentRequestOptions(),
+        )
+
+        result = await agent._plan_node(state)
+
+        assert result.plan == ""
+        assert result.final_answer == "Which video should I use?"
+
+    @pytest.mark.asyncio
     async def test_tool_node_forwards_request_options_to_accepting_tool(self, monkeypatch):
         chunks = []
         monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: chunks.append)

--- a/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
@@ -585,6 +585,68 @@ class TestRequestOptionsContext:
         assert any(chunk.type == AgentMessageChunkType.THOUGHT for chunk in chunks)
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "question",
+        [
+            "Generate a report for gwfix6 using long video summarization.",
+            "Generate an LVS report for gwfix6.",
+        ],
+    )
+    async def test_plan_node_requires_lvs_analysis_before_explicit_lvs_report(self, monkeypatch, question):
+        chunks = []
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: chunks.append)
+
+        agent = self._agent_with_search_tool()
+        for tool_name in ("lvs_video_understanding", "report_agent"):
+            tool = MagicMock()
+            tool.name = tool_name
+            tool.description = f"Run {tool_name}."
+            agent.tools_dict[tool_name] = tool
+        agent.llm = MagicMock()
+        agent.llm.model_name = "test-model"
+        agent.llm.ainvoke = AsyncMock(
+            return_value=AIMessage(
+                content="1. Call `report_agent` with sensor_id='gwfix6' and the original request as user_query."
+            )
+        )
+        agent.callbacks = []
+        agent.plan_prompt = None
+        agent.plan_system_prompt = "System prompt."
+        state = TopAgentState(current_message=HumanMessage(content=question), options=AgentRequestOptions())
+
+        result = await agent._plan_node(state)
+
+        assert result.plan.index("lvs_video_understanding") < result.plan.index("report_agent")
+        assert "same sensor ID and time range" in result.plan
+        assert any(chunk.type == AgentMessageChunkType.THOUGHT for chunk in chunks)
+
+    @pytest.mark.asyncio
+    async def test_plan_node_keeps_ordinary_report_plan_without_lvs_analysis(self, monkeypatch):
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
+
+        agent = self._agent_with_search_tool()
+        for tool_name in ("lvs_video_understanding", "report_agent"):
+            tool = MagicMock()
+            tool.name = tool_name
+            tool.description = f"Run {tool_name}."
+            agent.tools_dict[tool_name] = tool
+        ordinary_plan = "1. Call `report_agent` with sensor_id='gwfix6'."
+        agent.llm = MagicMock()
+        agent.llm.model_name = "test-model"
+        agent.llm.ainvoke = AsyncMock(return_value=AIMessage(content=ordinary_plan))
+        agent.callbacks = []
+        agent.plan_prompt = None
+        agent.plan_system_prompt = "System prompt."
+        state = TopAgentState(
+            current_message=HumanMessage(content="Generate a report for gwfix6."),
+            options=AgentRequestOptions(),
+        )
+
+        result = await agent._plan_node(state)
+
+        assert result.plan == ordinary_plan
+
+    @pytest.mark.asyncio
     async def test_plan_node_keeps_camera_clarification_for_uploaded_video_report(self, monkeypatch):
         monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
 

--- a/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
@@ -721,6 +721,40 @@ class TestRequestOptionsContext:
         assert "3. Call `report_agent`" in result.plan
 
     @pytest.mark.asyncio
+    async def test_plan_node_replaces_a_prose_report_plan_with_a_report_step(self, monkeypatch):
+        """Prose without numbered steps is not a plan; appending under it leaves the prose in charge."""
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
+
+        agent = self._agent_with_search_tool()
+        report_tool = MagicMock()
+        report_tool.name = "report_agent"
+        report_tool.description = "Run report_agent."
+        agent.tools_dict["report_agent"] = report_tool
+        agent.llm = MagicMock()
+        agent.llm.model_name = "test-model"
+        agent.llm.ainvoke = AsyncMock(
+            return_value=AIMessage(
+                content=(
+                    "The user wants to generate reports for two uploaded videos. I need to first check the "
+                    "available media to confirm their types, then route to the appropriate tools."
+                )
+            )
+        )
+        agent.callbacks = []
+        agent.plan_prompt = None
+        agent.plan_system_prompt = "System prompt."
+        state = TopAgentState(
+            current_message=HumanMessage(content="Generate reports for video honest1 and honest2."),
+            options=AgentRequestOptions(),
+        )
+
+        result = await agent._plan_node(state)
+
+        assert result.plan.startswith("1. Call `report_agent`")
+        assert "route to the appropriate tools" not in result.plan
+        assert "single list" in result.plan
+
+    @pytest.mark.asyncio
     async def test_plan_node_keeps_camera_clarification_for_uploaded_video_report(self, monkeypatch):
         monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
 

--- a/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
@@ -522,6 +522,32 @@ class TestRequestOptionsContext:
         assert isinstance(result, ToolMessage)
         assert result.status == "error"
         assert not str(result.content).startswith("Tool call failed:")
+    @pytest.mark.asyncio
+    async def test_plan_node_rejects_ungrounded_sensor_list_answer(self, monkeypatch):
+        chunks = []
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: chunks.append)
+
+        agent = self._agent_with_search_tool()
+        sensor_tool = MagicMock()
+        sensor_tool.name = "vst_sensor_list"
+        sensor_tool.description = "Get available sensors from VST."
+        agent.tools_dict["vst_sensor_list"] = sensor_tool
+        agent.llm = MagicMock()
+        agent.llm.model_name = "test-model"
+        agent.llm.ainvoke = AsyncMock(return_value=AIMessage(content="[USER] Camera_01, Camera_02"))
+        agent.callbacks = []
+        agent.plan_prompt = None
+        agent.plan_system_prompt = "System prompt."
+        state = TopAgentState(
+            current_message=HumanMessage(content="What are the available sensor IDs?"),
+            options=AgentRequestOptions(),
+        )
+
+        result = await agent._plan_node(state)
+
+        assert result.final_answer == ""
+        assert result.plan == "1. Call `vst_sensor_list` to retrieve the available sensor names from VST."
+        assert any(chunk.type == AgentMessageChunkType.THOUGHT for chunk in chunks)
 
     @pytest.mark.asyncio
     async def test_tool_node_forwards_request_options_to_accepting_tool(self, monkeypatch):
@@ -603,6 +629,41 @@ class TestRequestOptionsContext:
         assert search_tool.received_input["request_options"]["search_source_type"] == "rtsp"
         assert search_tool.received_input["request_options"]["use_critic"] is False
         assert "source_type" not in search_tool.received_input
+
+    @pytest.mark.asyncio
+    async def test_tool_node_surfaces_tool_exception_as_final_answer(self, monkeypatch):
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
+
+        class FailingTool:
+            args_schema = None
+
+            async def astream(self, input, config=None):
+                raise RuntimeError("streamId not found for 'Camera_01'. Available: ['gwfix6']")
+                yield
+
+        agent = TopAgent.__new__(TopAgent)
+        agent.tools_dict = {"vst_picture_url": FailingTool()}
+        agent.subagent_names = set()
+        agent.callbacks = []
+        state = TopAgentState(
+            agent_scratchpad=[
+                AIMessage(
+                    content="calling snapshot",
+                    tool_calls=[
+                        {
+                            "name": "vst_picture_url",
+                            "args": {"sensor_id": "Camera_01", "start_time": "2025-01-01T00:00:00.000Z"},
+                            "id": "call_1",
+                        }
+                    ],
+                )
+            ],
+            options=AgentRequestOptions(),
+        )
+
+        result = await agent.tool_or_subagent_node(state)
+
+        assert result.final_answer == "Tool call failed: streamId not found for 'Camera_01'. Available: ['gwfix6']"
 
     @pytest.mark.asyncio
     async def test_tool_node_forwards_request_options_to_accepting_subagent_trace(self, monkeypatch):

--- a/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
@@ -666,6 +666,50 @@ class TestRequestOptionsContext:
         assert result.final_answer == "Tool call failed: streamId not found for 'Camera_01'. Available: ['gwfix6']"
 
     @pytest.mark.asyncio
+    async def test_tool_node_omits_llm_rendered_null_sentinels(self, monkeypatch):
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
+
+        class CapturingTool:
+            args_schema = None
+
+            def __init__(self):
+                self.received_input = None
+
+            async def astream(self, input, config=None):
+                self.received_input = input
+                yield "no incidents found"
+
+        report_tool = CapturingTool()
+        agent = TopAgent.__new__(TopAgent)
+        agent.tools_dict = {"report_agent": report_tool}
+        agent.subagent_names = set()
+        agent.callbacks = []
+        state = TopAgentState(
+            agent_scratchpad=[
+                AIMessage(
+                    content="calling report",
+                    tool_calls=[
+                        {
+                            "name": "report_agent",
+                            "args": {
+                                "sensor_id": "Camera",
+                                "start_time": "None",
+                                "end_time": "null",
+                                "vlm_verified": None,
+                            },
+                            "id": "call_1",
+                        }
+                    ],
+                )
+            ],
+            options=AgentRequestOptions(),
+        )
+
+        await agent.tool_or_subagent_node(state)
+
+        assert report_tool.received_input == {"sensor_id": "Camera"}
+
+    @pytest.mark.asyncio
     async def test_tool_node_forwards_request_options_to_accepting_subagent_trace(self, monkeypatch):
         chunks = []
         monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: chunks.append)

--- a/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
@@ -525,7 +525,7 @@ class TestRequestOptionsContext:
         assert not str(result.content).startswith("Tool call failed:")
 
     @pytest.mark.asyncio
-    async def test_plan_node_uses_structured_sensor_list_tool_call(self, monkeypatch):
+    async def test_plan_node_rejects_ungrounded_sensor_list_answer(self, monkeypatch):
         chunks = []
         monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: chunks.append)
 
@@ -536,20 +536,7 @@ class TestRequestOptionsContext:
         agent.tools_dict["vst_sensor_list"] = sensor_tool
         agent.llm = MagicMock()
         agent.llm.model_name = "test-model"
-        agent.llm_with_tools = MagicMock()
-        agent.llm_with_tools.ainvoke = AsyncMock(
-            return_value=AIMessage(
-                content="",
-                tool_calls=[
-                    {
-                        "name": "vst_sensor_list",
-                        "args": {},
-                        "id": "planner-call-1",
-                        "type": "tool_call",
-                    }
-                ],
-            )
-        )
+        agent.llm.ainvoke = AsyncMock(return_value=AIMessage(content="[USER] Camera_01, Camera_02"))
         agent.callbacks = []
         agent.plan_prompt = None
         agent.plan_system_prompt = "System prompt."
@@ -561,10 +548,49 @@ class TestRequestOptionsContext:
         result = await agent._plan_node(state)
 
         assert result.final_answer == ""
-        assert result.plan == "1. Call `vst_sensor_list`."
-        agent.llm_with_tools.ainvoke.assert_awaited_once()
-        agent.llm.ainvoke.assert_not_called()
+        assert result.plan == "1. Call `vst_sensor_list` to retrieve the available sensor names from VST."
         assert any(chunk.type == AgentMessageChunkType.THOUGHT for chunk in chunks)
+
+    @pytest.mark.asyncio
+    async def test_plan_node_keeps_multi_step_plan_instead_of_a_planner_tool_call(self, monkeypatch):
+        """A tool-bound planner returns only the next action, which would drop the report step."""
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
+
+        agent = self._agent_with_search_tool()
+        for tool_name in ("vst_video_list", "report_agent"):
+            tool = MagicMock()
+            tool.name = tool_name
+            tool.description = f"Run {tool_name}."
+            agent.tools_dict[tool_name] = tool
+        multi_step_plan = (
+            "1. Call `vst_video_list` to resolve the media type of `gwfix6`.\n"
+            "2. Call `report_agent` with sensor_id='gwfix6' and the original request as user_query."
+        )
+        agent.llm = MagicMock()
+        agent.llm.model_name = "test-model"
+        agent.llm.ainvoke = AsyncMock(return_value=AIMessage(content=multi_step_plan))
+        # A tool-bound planner answers with an empty message plus the first tool call only.
+        agent.llm_with_tools = MagicMock()
+        agent.llm_with_tools.ainvoke = AsyncMock(
+            return_value=AIMessage(
+                content="",
+                tool_calls=[{"name": "vst_video_list", "args": {}, "id": "planner-call-1", "type": "tool_call"}],
+            )
+        )
+        agent.callbacks = []
+        agent.plan_prompt = None
+        agent.plan_system_prompt = "System prompt."
+        state = TopAgentState(
+            current_message=HumanMessage(content="Generate a report for video gwfix6."),
+            options=AgentRequestOptions(),
+        )
+
+        result = await agent._plan_node(state)
+
+        assert result.plan == multi_step_plan
+        assert "report_agent" in result.plan
+        agent.llm.ainvoke.assert_awaited_once()
+        agent.llm_with_tools.ainvoke.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_plan_node_does_not_request_camera_for_unfiltered_incident_report(self, monkeypatch):
@@ -661,6 +687,38 @@ class TestRequestOptionsContext:
         result = await agent._plan_node(state)
 
         assert result.plan == ordinary_plan
+
+    @pytest.mark.asyncio
+    async def test_plan_node_adds_report_agent_to_an_analysis_only_report_plan(self, monkeypatch):
+        """Without `report_agent` the run answers with prose and writes no PDF/Markdown artifacts."""
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
+
+        agent = self._agent_with_search_tool()
+        for tool_name in ("vst_video_list", "lvs_video_understanding", "report_agent"):
+            tool = MagicMock()
+            tool.name = tool_name
+            tool.description = f"Run {tool_name}."
+            agent.tools_dict[tool_name] = tool
+        analysis_only_plan = (
+            "1. Call `vst_video_list` to check the media type of `honest1`. "
+            "2. Route to `lvs_video_understanding` for `honest1` since media_type is 'video'."
+        )
+        agent.llm = MagicMock()
+        agent.llm.model_name = "test-model"
+        agent.llm.ainvoke = AsyncMock(return_value=AIMessage(content=analysis_only_plan))
+        agent.callbacks = []
+        agent.plan_prompt = None
+        agent.plan_system_prompt = "System prompt."
+        state = TopAgentState(
+            current_message=HumanMessage(content="Generate a report for video honest1 using long video understanding"),
+            options=AgentRequestOptions(),
+        )
+
+        result = await agent._plan_node(state)
+
+        assert result.plan.startswith(analysis_only_plan)
+        assert result.plan.index("lvs_video_understanding") < result.plan.index("report_agent")
+        assert "3. Call `report_agent`" in result.plan
 
     @pytest.mark.asyncio
     async def test_plan_node_keeps_camera_clarification_for_uploaded_video_report(self, monkeypatch):

--- a/services/agent/packages/vss_agents/tests/unit_test/orchestrator/test_docker_compose_util.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/orchestrator/test_docker_compose_util.py
@@ -1789,6 +1789,22 @@ class TestComposeEnvFileLayering:
 
         assert compose_env["VSS_CONTAINER_TAG"] == "develop-latest"
 
+    def test_empty_shell_endpoint_does_not_shadow_the_env_files(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("LLM_BASE_URL", "")
+        monkeypatch.setenv("VLM_BASE_URL", "   ")
+
+        compose_env = dcu._compose_subprocess_env()
+
+        assert "LLM_BASE_URL" not in compose_env
+        assert "VLM_BASE_URL" not in compose_env
+
+    def test_shell_endpoint_is_honoured_when_set(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("LLM_BASE_URL", "https://integrate.api.nvidia.com")
+
+        compose_env = dcu._compose_subprocess_env()
+
+        assert compose_env["LLM_BASE_URL"] == "https://integrate.api.nvidia.com"
+
     def test_resolve_compose_uses_dev_profile_env_file_order(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         recipe = _make_recipe(tmp_path, "MODE=2d")
         commands: list[list[str]] = []

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_fov_counts.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_fov_counts.py
@@ -246,6 +246,31 @@ class TestFOVCountsWithChartFunction:
         chart_tool.ainvoke.assert_not_called()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "response,expected",
+        [
+            ("", "FOV histogram service returned an empty response for sensor 'gwfix6'"),
+            ("not-json", "FOV histogram service returned invalid JSON for sensor 'gwfix6'"),
+        ],
+    )
+    async def test_invalid_histogram_response_names_backend_failure(self, fov_tools, response, expected):
+        config, builder, fov_tool, chart_tool = fov_tools
+        fov_tool.ainvoke.return_value = response
+        inner_fn = await self._get_inner_fn(config, builder)
+
+        with pytest.raises(ValueError, match=expected):
+            await inner_fn(
+                FOVCountsWithChartInput(
+                    sensor_id="gwfix6",
+                    start_time="2025-01-01T00:00:00.000Z",
+                    end_time="2025-01-01T00:00:40.000Z",
+                    object_type="Person",
+                )
+            )
+
+        chart_tool.ainvoke.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_positive_counts_generates_chart(self, fov_tools):
         config, builder, fov_tool, chart_tool = fov_tools
 

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_config_media.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_config_media.py
@@ -48,6 +48,25 @@ class TestLVSConfigMediaModels:
         assert config.lvs_backend_url == "http://localhost:38111"
         assert config.vst_internal_url == "http://localhost:30888"
         assert config.chunk_duration == 10
+        # Interactive by default, so the shipped profiles keep prompting without
+        # having to name the key; the HTTP path opts out per request instead.
+        assert config.hitl_enabled is True
+
+    def test_hitl_can_be_disabled_in_configuration(self):
+        """`extra="forbid"` means the key has to exist for a profile to set it.
+
+        The other two LVS tools take `hitl_enabled`; without it here, turning HITL
+        off for this tool alone is a hard config error rather than a setting.
+        """
+        config = LVSConfigMediaConfig(
+            lvs_backend_url="http://localhost:38111",
+            vst_internal_url="http://localhost:30888",
+            hitl_scenario_template="Scenario",
+            hitl_events_template="Events",
+            hitl_objects_template="Objects",
+            hitl_enabled=False,
+        )
+        assert config.hitl_enabled is False
 
     def test_missing_required_fields_raises(self):
         with pytest.raises(ValidationError):
@@ -366,9 +385,23 @@ class TestLVSConfigMediaInner:
         _, kwargs = mock_session.post.call_args
         assert kwargs["json"]["use_fps_for_chunking"] is True
 
-    @pytest.mark.parametrize("interactive_callback", [False, True])
+    @pytest.mark.parametrize(
+        ("hitl_enabled", "interactive_callback", "expected_prompts"),
+        [
+            # The confirmation loop still runs whenever the request can answer it.
+            (True, True, 4),
+            # No callback on this request (the HTTP path): documented defaults, and
+            # HITL stays enabled for the next request that can deliver a prompt.
+            (True, False, 0),
+            # The deployment turned HITL off for this tool, so a registered callback
+            # is not consulted either.
+            (False, True, 0),
+        ],
+    )
     @pytest.mark.asyncio
-    async def test_hitl_uses_callback_when_available_and_defaults_when_not(self, interactive_callback: bool):
+    async def test_hitl_uses_callback_when_available_and_defaults_when_not(
+        self, hitl_enabled: bool, interactive_callback: bool, expected_prompts: int
+    ):
         config = LVSConfigMediaConfig(
             lvs_backend_url="http://localhost:38111",
             vst_internal_url="http://localhost:30888",
@@ -376,6 +409,7 @@ class TestLVSConfigMediaInner:
             hitl_scenario_template="Scenario",
             hitl_events_template="Events",
             hitl_objects_template="Objects",
+            hitl_enabled=hitl_enabled,
             default_scenario="warehouse monitoring",
             default_events=["accident"],
         )
@@ -416,7 +450,7 @@ class TestLVSConfigMediaInner:
         assert result.status == LVSMediaStatus.ACCEPTED
         assert result.scenario == "warehouse monitoring"
         assert result.events == ["accident"]
-        assert mock_prompt.await_count == (4 if interactive_callback else 0)
+        assert mock_prompt.await_count == expected_prompts
         mock_session.post.assert_called_once()
         _, kwargs = mock_session.post.call_args
         assert kwargs["json"]["scenario"] == "warehouse monitoring"

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_config_media.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_config_media.py
@@ -366,6 +366,62 @@ class TestLVSConfigMediaInner:
         _, kwargs = mock_session.post.call_args
         assert kwargs["json"]["use_fps_for_chunking"] is True
 
+    @pytest.mark.parametrize("interactive_callback", [False, True])
+    @pytest.mark.asyncio
+    async def test_hitl_uses_callback_when_available_and_defaults_when_not(self, interactive_callback: bool):
+        config = LVSConfigMediaConfig(
+            lvs_backend_url="http://localhost:38111",
+            vst_internal_url="http://localhost:30888",
+            model="nvidia/cosmos-reason2-8b",
+            hitl_scenario_template="Scenario",
+            hitl_events_template="Events",
+            hitl_objects_template="Objects",
+            default_scenario="warehouse monitoring",
+            default_events=["accident"],
+        )
+
+        mock_resp = MagicMock()
+        mock_resp.status = 202
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.post.return_value = mock_resp
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        callback_token = None
+        if interactive_callback:
+            callback_token = ContextState.get().user_input_callback.set(AsyncMock())
+        try:
+            with patch(
+                "vss_agents.tools.lvs_config_media.get_stream_info_by_name",
+                new_callable=AsyncMock,
+            ) as mock_stream:
+                mock_stream.return_value = ("stream-uuid", "rtsp://example/stream")
+                with patch(
+                    "vss_agents.tools.lvs_config_media._prompt_user_input",
+                    new_callable=AsyncMock,
+                ) as mock_prompt:
+                    mock_prompt.side_effect = ["", "", "forklifts, workers", ""]
+                    with patch("vss_agents.tools.lvs_config_media.aiohttp.ClientSession", return_value=mock_session):
+                        with patch("vss_agents.tools.lvs_config_media.aiohttp.ClientTimeout"):
+                            inner_fn = await self._get_inner_fn(config)
+                            result = await inner_fn(LVSConfigMediaInput(stream_name="CAM_1"))
+        finally:
+            if callback_token is not None:
+                ContextState.get().user_input_callback.reset(callback_token)
+
+        assert result.status == LVSMediaStatus.ACCEPTED
+        assert result.scenario == "warehouse monitoring"
+        assert result.events == ["accident"]
+        assert mock_prompt.await_count == (4 if interactive_callback else 0)
+        mock_session.post.assert_called_once()
+        _, kwargs = mock_session.post.call_args
+        assert kwargs["json"]["scenario"] == "warehouse monitoring"
+        assert kwargs["json"]["events"] == ["accident"]
+
     @pytest.mark.asyncio
     async def test_config_media_stream_not_found(self):
         config = LVSConfigMediaConfig(

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_video_understanding.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_video_understanding.py
@@ -152,8 +152,9 @@ class TestLVSVideoUnderstandingInner:
         yield
         ContextState.get().conversation_id.reset(token)
 
+    @pytest.mark.parametrize("interactive_callback", [False, True])
     @pytest.mark.asyncio
-    async def test_video_understanding_payload_includes_enable_audio_when_set(self):
+    async def test_hitl_enabled_uses_callback_when_available_and_defaults_when_not(self, interactive_callback: bool):
         config = LVSVideoUnderstandingConfig(
             lvs_backend_url="http://localhost:38111",
             hitl_scenario_template="Scenario",
@@ -195,15 +196,23 @@ class TestLVSVideoUnderstandingInner:
         mock_ctx = MagicMock()
         mock_ctx.user_interaction_manager = mock_uim
 
-        with patch("vss_agents.tools.lvs_video_understanding.Context") as mock_context_class:
-            mock_context_class.get.return_value = mock_ctx
-            with patch("vss_agents.tools.lvs_video_understanding.aiohttp.ClientSession", return_value=mock_session):
-                with patch("vss_agents.tools.lvs_video_understanding.aiohttp.ClientTimeout"):
-                    gen = lvs_video_understanding.__wrapped__(config, mock_builder)
-                    function_info = await gen.__anext__()
-                    inner_fn = function_info.single_fn
-                    await inner_fn(LVSVideoUnderstandingInput(sensor_id="sensor-1"))
+        callback_token = None
+        if interactive_callback:
+            callback_token = ContextState.get().user_input_callback.set(AsyncMock())
+        try:
+            with patch("vss_agents.tools.lvs_video_understanding.Context") as mock_context_class:
+                mock_context_class.get.return_value = mock_ctx
+                with patch("vss_agents.tools.lvs_video_understanding.aiohttp.ClientSession", return_value=mock_session):
+                    with patch("vss_agents.tools.lvs_video_understanding.aiohttp.ClientTimeout"):
+                        gen = lvs_video_understanding.__wrapped__(config, mock_builder)
+                        function_info = await gen.__anext__()
+                        inner_fn = function_info.single_fn
+                        await inner_fn(LVSVideoUnderstandingInput(sensor_id="sensor-1"))
+        finally:
+            if callback_token is not None:
+                ContextState.get().user_input_callback.reset(callback_token)
 
         mock_session.post.assert_called_once()
         _, kwargs = mock_session.post.call_args
         assert kwargs["json"].get("enable_audio") is True
+        assert mock_uim.prompt_user_input.await_count == (4 if interactive_callback else 0)

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_video_understanding.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_video_understanding.py
@@ -46,6 +46,18 @@ class TestLVSVideoUnderstandingConfig:
         assert config.read_timeout_ms == 600000
         assert config.model == "gpt-4o"
         assert config.video_url_tool == "vst_video_url"
+        assert config.hitl_enabled is True
+
+    def test_hitl_can_be_disabled_for_http_workflows(self):
+        config = LVSVideoUnderstandingConfig(
+            lvs_backend_url="http://localhost:38111",
+            hitl_scenario_template="Scenario: {scenario}",
+            hitl_events_template="Events: {events}",
+            hitl_objects_template="Objects: {objects}",
+            hitl_enabled=False,
+        )
+
+        assert config.hitl_enabled is False
 
     def test_url_translation_fields_are_not_exposed(self):
         assert "vlm_mode" not in LVSVideoUnderstandingConfig.model_fields

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/vst/test_bounding_box.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/vst/test_bounding_box.py
@@ -202,25 +202,30 @@ class TestSnapshotBoundingBox:
         """Test that the snapshot tool passes overlay_config to get_snapshot_url."""
         with patch("vss_agents.tools.vst.snapshot.get_stream_id", new_callable=AsyncMock) as mock_get_id:
             mock_get_id.return_value = "stream-uuid"
-            with patch("vss_agents.tools.vst.snapshot.get_snapshot_url", new_callable=AsyncMock) as mock_get_url:
-                mock_get_url.return_value = "http://10.0.0.1:30888/vst/img.jpg"
+            # The ISO path validates the timestamp against the stream's recorded timeline,
+            # so get_timeline has to be stubbed for this to stay offline.
+            with patch("vss_agents.tools.vst.snapshot.get_timeline", new_callable=AsyncMock) as mock_timeline:
+                mock_timeline.return_value = ("2025-01-01T00:00:00.000+00:00", "2025-01-01T01:00:00.000+00:00")
+                with patch("vss_agents.tools.vst.snapshot.get_snapshot_url", new_callable=AsyncMock) as mock_get_url:
+                    mock_get_url.return_value = "http://10.0.0.1:30888/vst/img.jpg"
 
-                gen = vst_snapshot.__wrapped__(config_with_overlay, mock_builder)
-                fi = await gen.__anext__()
-                inner_fn = fi.single_fn
+                    gen = vst_snapshot.__wrapped__(config_with_overlay, mock_builder)
+                    fi = await gen.__anext__()
+                    inner_fn = fi.single_fn
 
-                inp = VSTSnapshotISOInput(sensor_id="camera1", start_time="2025-01-01T00:05:00.000Z")
-                result = await inner_fn(inp)
+                    inp = VSTSnapshotISOInput(sensor_id="camera1", start_time="2025-01-01T00:05:00.000Z")
+                    result = await inner_fn(inp)
 
-                assert isinstance(result, VSTSnapshotOutput)
-                # Verify overlay_enabled was passed as True
-                mock_get_url.assert_called_once_with(
-                    "stream-uuid",
-                    "2025-01-01T00:05:00.000Z",
-                    "http://10.0.0.1:30888",
-                    overlay_enabled=True,
-                    timeout_seconds=10.0,
-                )
+                    assert isinstance(result, VSTSnapshotOutput)
+                    # Verify overlay_enabled was passed as True
+                    mock_get_url.assert_called_once_with(
+                        "stream-uuid",
+                        "2025-01-01T00:05:00.000Z",
+                        "http://10.0.0.1:30888",
+                        overlay_enabled=True,
+                        timeout_seconds=10.0,
+                    )
+                    mock_timeline.assert_awaited_once_with("stream-uuid", "http://10.0.0.1:30888")
 
 
 class TestVideoClipBoundingBox:

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/vst/test_snapshot.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/vst/test_snapshot.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Unit tests for VST snapshot module."""
 
+from unittest.mock import AsyncMock
+
 from pydantic import ValidationError
 import pytest
 
@@ -21,6 +23,7 @@ from vss_agents.tools.vst.snapshot import VSTSnapshotConfig
 from vss_agents.tools.vst.snapshot import VSTSnapshotISOInput
 from vss_agents.tools.vst.snapshot import VSTSnapshotOffsetInput
 from vss_agents.tools.vst.snapshot import VSTSnapshotOutput
+from vss_agents.tools.vst.snapshot import get_latest_snapshot_time
 
 
 class TestVSTSnapshotConfig:
@@ -117,10 +120,9 @@ class TestVSTSnapshotOffsetInput:
         with pytest.raises(ValidationError):
             VSTSnapshotOffsetInput(sensor_id="", start_time=5.0)
 
-    def test_missing_start_time_raises(self):
-        """Test that missing start_time raises ValidationError."""
-        with pytest.raises(ValidationError):
-            VSTSnapshotOffsetInput(sensor_id="test_video")
+    def test_missing_start_time_uses_default(self):
+        """An omitted timestamp asks the tool for the latest recorded frame."""
+        assert VSTSnapshotOffsetInput(sensor_id="test_video").start_time is None
 
     def test_input_descriptions(self):
         """Test that input fields have proper descriptions."""
@@ -149,10 +151,9 @@ class TestVSTSnapshotISOInput:
         with pytest.raises(ValidationError):
             VSTSnapshotISOInput(sensor_id="", start_time="2025-08-25T03:05:55.752Z")
 
-    def test_missing_start_time_raises(self):
-        """Test that missing start_time raises ValidationError."""
-        with pytest.raises(ValidationError):
-            VSTSnapshotISOInput(sensor_id="test_video")
+    def test_missing_start_time_uses_default(self):
+        """An omitted timestamp asks the tool for the latest recorded frame."""
+        assert VSTSnapshotISOInput(sensor_id="test_video").start_time is None
 
     def test_empty_start_time_raises(self):
         """Test that empty start_time raises ValidationError."""
@@ -211,3 +212,16 @@ class TestVSTSnapshotOutput:
         """Test that output field has proper description."""
         field_info = VSTSnapshotOutput.model_fields["image_url"]
         assert "URL" in field_info.description or "image" in field_info.description.lower()
+
+
+@pytest.mark.asyncio
+async def test_latest_snapshot_time_stays_inside_recorded_timeline(monkeypatch):
+    timeline = AsyncMock(
+        return_value=("2025-01-01T00:00:00.000Z", "2025-01-01T00:00:40.100Z"),
+    )
+    monkeypatch.setattr("vss_agents.tools.vst.snapshot.get_timeline", timeline)
+
+    result = await get_latest_snapshot_time("stream-1", "http://vst")
+
+    assert result == "2025-01-01T00:00:40.099Z"
+    timeline.assert_awaited_once_with("stream-1", "http://vst")

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/vst/test_snapshot.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/vst/test_snapshot.py
@@ -24,6 +24,7 @@ from vss_agents.tools.vst.snapshot import VSTSnapshotISOInput
 from vss_agents.tools.vst.snapshot import VSTSnapshotOffsetInput
 from vss_agents.tools.vst.snapshot import VSTSnapshotOutput
 from vss_agents.tools.vst.snapshot import get_latest_snapshot_time
+from vss_agents.tools.vst.snapshot import validate_snapshot_time
 
 
 class TestVSTSnapshotConfig:
@@ -225,3 +226,20 @@ async def test_latest_snapshot_time_stays_inside_recorded_timeline(monkeypatch):
 
     assert result == "2025-01-01T00:00:40.099Z"
     timeline.assert_awaited_once_with("stream-1", "http://vst")
+
+
+@pytest.mark.asyncio
+async def test_iso_snapshot_time_outside_timeline_reports_bounds(monkeypatch):
+    timeline = AsyncMock(
+        return_value=("2025-01-01T00:00:00.000Z", "2025-01-01T00:00:40.100Z"),
+    )
+    monkeypatch.setattr("vss_agents.tools.vst.snapshot.get_timeline", timeline)
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"Picture time 2026-09-07T14:00:00Z is out of the video timeline "
+            "2025-01-01T00:00:00.000Z to 2025-01-01T00:00:40.100Z"
+        ),
+    ):
+        await validate_snapshot_time("stream-1", "2026-09-07T14:00:00Z", "http://vst")

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/vst/test_snapshot_coverage.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/vst/test_snapshot_coverage.py
@@ -76,9 +76,8 @@ class TestVSTSnapshotOffsetInput:
         inp = VSTSnapshotOffsetInput(sensor_id="cam1", start_time=0.0)
         assert inp.start_time == 0.0
 
-    def test_missing_fields_raises(self):
-        with pytest.raises(ValidationError):
-            VSTSnapshotOffsetInput(sensor_id="cam1")
+    def test_missing_start_time_defaults_to_none(self):
+        assert VSTSnapshotOffsetInput(sensor_id="cam1").start_time is None
 
 
 class TestVSTSnapshotISOInput:
@@ -96,9 +95,8 @@ class TestVSTSnapshotISOInput:
         with pytest.raises(ValidationError):
             VSTSnapshotISOInput(sensor_id="", start_time="2025-08-25T03:05:55.752Z")
 
-    def test_missing_start_time_raises(self):
-        with pytest.raises(ValidationError):
-            VSTSnapshotISOInput(sensor_id="cam1")
+    def test_missing_start_time_defaults_to_none(self):
+        assert VSTSnapshotISOInput(sensor_id="cam1").start_time is None
 
     def test_empty_start_time_raises(self):
         with pytest.raises(ValidationError):

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/vst/test_snapshot_inner.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/vst/test_snapshot_inner.py
@@ -103,7 +103,8 @@ class TestVSTSnapshotInner:
                         assert result.stream_id == "stream-uuid"
 
     @pytest.mark.asyncio
-    async def test_snapshot_success_with_iso_timestamp(self, config_iso, mock_builder):
+    @patch("vss_agents.tools.vst.snapshot.validate_snapshot_time", new_callable=AsyncMock)
+    async def test_snapshot_success_with_iso_timestamp(self, mock_validate, config_iso, mock_builder):
         """Test snapshot with ISO 8601 timestamp start_time."""
         with patch("vss_agents.tools.vst.snapshot.get_stream_id", new_callable=AsyncMock) as mock_get_id:
             mock_get_id.return_value = "stream-uuid"
@@ -139,6 +140,11 @@ class TestVSTSnapshotInner:
                     assert isinstance(result, VSTSnapshotOutput)
                     assert "1.2.3.4:30888" in result.image_url
                     assert result.stream_id == "stream-uuid"
+                    mock_validate.assert_awaited_once_with(
+                        "stream-uuid",
+                        "2025-01-01T00:05:00.000Z",
+                        config_iso.vst_internal_url,
+                    )
 
     @pytest.mark.asyncio
     async def test_snapshot_without_timestamp_uses_latest_recorded_frame(self, config_iso, mock_builder):

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/vst/test_snapshot_inner.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/vst/test_snapshot_inner.py
@@ -141,6 +141,40 @@ class TestVSTSnapshotInner:
                     assert result.stream_id == "stream-uuid"
 
     @pytest.mark.asyncio
+    async def test_snapshot_without_timestamp_uses_latest_recorded_frame(self, config_iso, mock_builder):
+        with (
+            patch(
+                "vss_agents.tools.vst.snapshot.get_stream_id",
+                new_callable=AsyncMock,
+                return_value="stream-uuid",
+            ),
+            patch(
+                "vss_agents.tools.vst.snapshot.get_latest_snapshot_time",
+                new_callable=AsyncMock,
+                return_value="2025-01-01T00:00:40.099Z",
+            ) as mock_latest,
+            patch(
+                "vss_agents.tools.vst.snapshot.get_snapshot_url",
+                new_callable=AsyncMock,
+                return_value="http://10.0.0.1:30888/vst/img.jpg",
+            ) as mock_snapshot,
+        ):
+            gen = vst_snapshot.__wrapped__(config_iso, mock_builder)
+            fi = await gen.__anext__()
+
+            result = await fi.single_fn(VSTSnapshotISOInput(sensor_id="camera1"))
+
+        assert result.image_url == "http://1.2.3.4:30888/vst/img.jpg"
+        mock_latest.assert_awaited_once_with("stream-uuid", config_iso.vst_internal_url)
+        mock_snapshot.assert_awaited_once_with(
+            "stream-uuid",
+            "2025-01-01T00:00:40.099Z",
+            config_iso.vst_internal_url,
+            overlay_enabled=False,
+            timeout_seconds=10.0,
+        )
+
+    @pytest.mark.asyncio
     async def test_snapshot_uses_correct_input_schema_offset(self, config, mock_builder):
         """Test that offset mode uses VSTSnapshotOffsetInput schema."""
         gen = vst_snapshot.__wrapped__(config, mock_builder)

--- a/services/agent/packages/vss_agents/tests/unit_test/utils/test_hitl.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/utils/test_hitl.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for request-scoped HITL helpers."""
+
+from unittest.mock import AsyncMock
+
+from nat.builder.context import ContextState
+
+from vss_agents.utils.hitl import has_human_prompt_callback
+
+
+def test_default_http_context_has_no_human_prompt_callback() -> None:
+    assert has_human_prompt_callback() is False
+
+
+def test_registered_websocket_callback_is_detected() -> None:
+    token = ContextState.get().user_input_callback.set(AsyncMock())
+    try:
+        assert has_human_prompt_callback() is True
+    finally:
+        ContextState.get().user_input_callback.reset(token)


### PR DESCRIPTION
## Summary
- Ground sensor-list answers and relay VST tool errors instead of inventing cameras
- Preserve terminal subagent outcomes; omit stringified `null` tool arguments
- Default snapshots to the recorded timeline and validate ISO snapshot bounds
- Fail startup on relative LLM endpoints, preserve compose endpoint defaults, and expose the in-deployment `/llm` gateway
- Route explicit long-video-summarization/LVS report requests through `lvs_video_understanding` before presenting the report
- Support noninteractive LVS report execution in the HTTP profile and bind planner tools while preserving the numbered-plan parser
- Also includes the existing `fix(lvs): keep bundled DCGM exporter opt-in` branch commit

## What this PR still is / is not
This is a product-side agent grounding and LVS-report-routing fix. It is not the LVS HITL/GB300 CI-isolation change (that work is already on ci-vss-oss !515), does not hardcode LLM tool-calling flags, and does not broaden the planner DSL beyond accepting the existing text plan from a tool-bound model.

## Validation
- [x] 60 `top_agent` unit tests passed for the LVS route/guard before the follow-up commits
- [x] Focused final-head tests: `test_top_agent.py` + `test_lvs_video_understanding.py`
- [x] Ruff format/lint and mypy on the changed agent modules
- [x] Live 10.63.177.97 smoke for `gwfix6`: `lvs_video_understanding` returned `LVSStatus.SUCCESS` and the streamed response presented the LVS report
- [x] Recreated only `vss-agent`; no `compose down -v`

## Deliberately left out
- ci-vss-oss !515 owns adopt-and-skip LVS HITL isolation and GB300 cleanup
- Infrastructure must configure tool-calling support; this PR does not fake it with product flags
- Unrelated untracked CLI, rt-vlm, skill-eval, and docs work remains outside this PR