### PR TITLE
fix(rtvi-vlm): [RTVI-VLM][3.3.0][GHCR]: List live stream API is failing when CV Stream is added to the server with id not being UUID

### DIFF
--- a/services/rtvi/rt-vlm/src/api_models/live_stream.py
+++ b/services/rtvi/rt-vlm/src/api_models/live_stream.py
@@ -235,7 +235,11 @@ class DeleteLiveStreamsResponse(CommonBaseModel):
 class LiveStreamInfo(CommonBaseModel):
     """Live Stream Information."""
 
-    id: UUID = Field(description="Unique identifier for the live stream")
+    id: str = Field(
+        description="Unique identifier for the live stream",
+        max_length=256,
+        pattern=ANY_CHAR_PATTERN,
+    )
     liveStreamUrl: str = Field(
         description="Live stream RTSP URL",
         max_length=256,

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_rtvi_vlm_server.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_rtvi_vlm_server.py
@@ -419,6 +419,35 @@ class TestLiveStreamEndpoints:
         data = response.json()
         assert isinstance(data, list)
 
+    def test_list_cv_live_stream_with_non_uuid_id(self, test_client, rtvi_server):
+        """CV camera identifiers remain valid when returned by the legacy list API."""
+        stream_id = rtvi_server._asset_manager.add_live_stream(
+            "rtsp://example.com/live",
+            description="camera-01",
+            stream_id="camera-01",
+            camera_id="camera-01",
+        )
+
+        response = test_client.get(f"{API_PREFIX}/streams/get-stream-info")
+
+        assert response.status_code == 200
+        assert response.json() == [
+            {
+                "id": stream_id,
+                "liveStreamUrl": "rtsp://example.com/live",
+                "description": "camera-01",
+                "chunk_duration": 0,
+                "chunk_overlap_duration": 0,
+                "place_name": "",
+                "place_type": "",
+                "place_lat": None,
+                "place_lon": None,
+                "place_alt": None,
+                "place_coordinate_x": None,
+                "place_coordinate_y": None,
+            }
+        ]
+
     def test_add_live_stream_missing_url(self, test_client):
         """Test adding live stream without URL"""
         response = test_client.post(


### PR DESCRIPTION
## Summary

Changed LiveStreamInfo.id from UUID-only validation to the bounded string identifier supported by the asset manager, and added a regression test for a CV stream using camera-01. The rebuilt runtime passed the recorded CV-add and legacy-list reproduction.

## Plan

Reproduce NVBug 6735416, apply the minimal scoped fix, and validate it against the recorded reproduction and configured tests.

## Related Issue

NVBug 6735416

## Changes

- Changed LiveStreamInfo.id from UUID-only validation to the bounded string identifier supported by the asset manager, and added a regression test for a CV stream using camera-01. The rebuilt runtime passed the recorded CV-add and legacy-list reproduction.

## Validation

- Baseline reproduction and fixed-worktree validation: PASS