### PR TITLE
Feat/search eval skill

### DIFF
--- a/services/agent/packages/vss_agents/src/vss_agents/tools/search.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/search.py
@@ -69,7 +69,9 @@ Extract the following parameters from the user query:
 - source_type: "rtsp" if referring to live/camera streams, "video_file" if referring to uploaded video files (default: "video_file")
 - timestamp_start: Start time in ISO format (e.g., "2025-01-01T13:00:00Z"). Use 2025-01-01 as the base date.
 - timestamp_end: End time in ISO format (e.g., "2025-01-01T14:00:00Z"). Use 2025-01-01 as the base date.
-- attributes: List of person with attributes, ONLY. Don't include other objects, don't just put "person".
+- attributes: List of person appearance descriptors only (clothing, colours, worn or
+  carried items). Never include actions or verbs, never other object classes, and never
+  bare "person". Empty list if the query describes no appearance details.
 - has_action: REQUIRED boolean. Set to True if the query explicitly mentions an action/event/activity (e.g., running, walking, carrying, pushing, entering, leaving, moving). Set to False if the query only describes visual/physical attributes (what someone/something LOOKS LIKE) without any action. Examples: "person" → false, "person walking" → true, "red car" → false, "person carrying box" → true, "forklift" → false.
 - object_ids: List of integer object IDs if explicitly mentioned in the query (e.g., "find object 5" → [5], "search for objects 10, 20" → [10, 20]). null if no object IDs are mentioned.
 - top_k: Number of results to return (integer, only if explicitly mentioned, e.g., "top 5", "first 10")
@@ -116,7 +118,15 @@ Output: {{"query": "object ids 5, 6", "object_ids": [5, 6], "has_action": false}
 
 Example 10:
 User query: "find more objects like object 42 near warehouse entrance"
-Output: {{"query": "objects like object 42 near warehouse entrance", "object_ids": [42], "video_sources": ["warehouse entrance"], "has_action": false}}"""
+Output: {{"query": "objects like object 42 near warehouse entrance", "object_ids": [42], "video_sources": ["warehouse entrance"], "has_action": false}}
+
+Example 11:
+User query: "person physically assaulting someone"
+Output: {{"query": "person physically assaulting someone", "attributes": [], "has_action": true}}
+
+Example 12:
+User query: "people running near a doorway"
+Output: {{"query": "people running near a doorway", "attributes": [], "has_action": true}}"""
 
 
 class DecomposedQuery(BaseModel):

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_search.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_search.py
@@ -409,6 +409,66 @@ class TestQueryDecompositionPrompt:
         assert "{few_shot_examples}" in QUERY_DECOMPOSITION_PROMPT
         assert "{user_query}" in QUERY_DECOMPOSITION_PROMPT
 
+    def test_attributes_has_an_empty_case_clause(self):
+        """The fix for the bug that routed every action query to fusion.
+
+        `attributes` was the only field in the prompt with no empty-case clause,
+        so the model filled it with the query's action phrase ("physically
+        assaulting someone"). A non-empty `attributes` routes to fusion or
+        attribute, never embed -- measured at 9/9 on the warehouse set, costing
+        mAP -25%, HIT@1 halved and +59% latency.
+
+        Asserted on the clause itself because the failure is a model behaviour:
+        nothing downstream can detect a decomposition that is well-formed and
+        wrong.
+        """
+        prompt = QUERY_DECOMPOSITION_PROMPT
+
+        attributes_line = next(
+            (line for line in prompt.splitlines() if line.strip().startswith("- attributes:")),
+            None,
+        )
+        assert attributes_line is not None, "the attributes field lost its description"
+        # The clause may wrap, so read to the next field bullet.
+        lines = prompt.splitlines()
+        start = lines.index(attributes_line)
+        clause = " ".join(lines[start : start + 4]).split("- has_action")[0]
+        assert "empty" in clause.lower(), (
+            "attributes must say what to emit when the query describes no appearance; "
+            "without it the model emits the action phrase and every action query routes to fusion"
+        )
+
+    def test_at_least_one_example_shows_empty_attributes(self):
+        """A clause the examples contradict is a clause the model ignores.
+
+        All nine original few-shot examples had a non-empty `attributes`, so the
+        model had never seen the empty case demonstrated regardless of what the
+        instructions said.
+        """
+        from vss_agents.tools.search import DEFAULT_FEW_SHOT_EXAMPLES
+
+        assert '"attributes": []' in DEFAULT_FEW_SHOT_EXAMPLES, (
+            "no few-shot example demonstrates the empty case, so the instruction is unmodelled"
+        )
+
+    def test_an_action_only_example_keeps_the_action_in_query_not_attributes(self):
+        """The exact shape that was being mis-decomposed."""
+        import json
+        import re
+
+        from vss_agents.tools.search import DEFAULT_FEW_SHOT_EXAMPLES
+
+        # The examples are a .format() template, so every brace is doubled.
+        literal = DEFAULT_FEW_SHOT_EXAMPLES.replace("{{", "{").replace("}}", "}")
+        outputs = [json.loads(m) for m in re.findall(r"Output: (\{.*?\})\n", literal + "\n")]
+        # `== []` deliberately, not `not o.get(...)`: the pre-fix examples
+        # omitted `attributes` altogether, which is falsy for the wrong reason
+        # and would let this pass against the prompt it is meant to catch.
+        action_only = [o for o in outputs if o.get("has_action") and o.get("attributes") == []]
+        assert action_only, "no example pairs has_action=true with an explicit attributes=[]"
+        for example in action_only:
+            assert example["query"], "the action belongs in query, not attributes"
+
     def test_prompt_contains_instructions(self):
         assert "query" in QUERY_DECOMPOSITION_PROMPT.lower()
         assert "video_sources" in QUERY_DECOMPOSITION_PROMPT

--- a/services/agent/packages/vss_cli/src/vss_cli/search/group.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/search/group.py
@@ -79,6 +79,20 @@ class _Common(BaseModel):
     # ignore a misspelled key and silently use the default.
     model_config = ConfigDict(extra="forbid")
 
+    # What the user actually asked, before whatever decomposed it produced the
+    # arguments on this command line. Retrieval never reads it; the critic does.
+    #
+    # A decomposed request is lossy in one direction that matters: `run
+    # attribute --attribute "white jacket"` is a perfectly good retrieval
+    # request but a poor question to verify against, and the host reconstructs
+    # one by pasting the attributes back onto the query string. That
+    # reconstruction is a guess, and it is the CLI's fault it has to guess --
+    # the caller had the sentence and dropped it at the argv boundary. Pass it
+    # here and the critic is asked the user's question instead.
+    original_query: str | None = Field(
+        None,
+        description="The user's question before decomposition; used for result verification, not retrieval.",
+    )
     source_type: Literal["video_file", "rtsp"] | None = Field(None, description="Media source type.")
     video_sources: list[str] = Field(
         default_factory=list,

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_root.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_root.py
@@ -81,6 +81,53 @@ def test_each_action_accepts_only_its_own_fields(capsys: pytest.CaptureFixture[s
     assert "--query" not in attribute_help
 
 
+def test_every_path_accepts_the_pre_decomposition_question(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`--original-query` is on `_Common`, so it is on all five paths.
+
+    Retrieval never reads it. The critic does: without it the host has to
+    rebuild a question out of `--query` and `--attribute`, which is a guess, and
+    on `object` -- which sends no text at all -- the guess is empty and
+    verification is skipped outright. Callers that decomposed the question are
+    the ones that still have it, so this is the field where they hand it back.
+    """
+    for path in ("embed", "attribute", "tag", "fusion", "object"):
+        assert cli.main(["search", "run", path, "--help"]) == 0
+        assert "--original-query" in capsys.readouterr().out, path
+
+
+def test_the_question_reaches_the_library_request_unchanged() -> None:
+    """Through model_dump into SearchInput, which is extra=forbid."""
+    from vss_cli.search.group import AttributeInput
+    from vss_core.search_core.models.search import SearchInput
+
+    asked = "is anyone in a white jacket near the loading door?"
+    payload = AttributeInput(attributes=["white jacket"], original_query=asked).model_dump(
+        exclude_none=True, exclude_defaults=True
+    )
+    payload["search_mode"] = "attribute"
+    request = SearchInput(**payload)
+    request.validate_semantics()
+    assert request.original_query == asked
+    # Retrieval is untouched: the attribute leg still sees only its attributes.
+    assert request.query == ""
+    assert request.attributes == ["white jacket"]
+
+
+def test_an_omitted_question_leaves_the_request_exactly_as_before() -> None:
+    """Default None must not become an empty string in the payload.
+
+    `""` is falsy in the host's `if inp.original_query and ...` guard, so it
+    would behave the same -- but it would also appear in persisted memory as a
+    question the user never asked.
+    """
+    from vss_cli.search.group import EmbedInput
+
+    payload = EmbedInput(query="forklift").model_dump(exclude_none=True, exclude_defaults=True)
+    assert payload == {"query": "forklift"}
+
+
 def test_run_needs_a_configured_deployment(
     tmp_path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/services/agent/packages/vss_core/src/vss_core/_foundation/time_measure.py
+++ b/services/agent/packages/vss_core/src/vss_core/_foundation/time_measure.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""TimeMeasure context manager.
+
+Times a block of code and logs the elapsed duration. The PERF and STATUS log
+levels are registered here so their level names resolve consistently wherever
+this helper's log records are emitted.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+import logging
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+logger = logging.getLogger(__name__)
+
+LOG_PERF_LEVEL = 15
+LOG_STATUS_LEVEL = 16
+
+logging.addLevelName(LOG_PERF_LEVEL, "PERF")
+logging.addLevelName(LOG_STATUS_LEVEL, "STATUS")
+
+#: Slack before calling a negative self time "overlapping children" rather than
+#: float noise from summing many small durations.
+_CONCURRENCY_EPSILON = 1e-6
+
+#: Active timing collector, if a caller opened one.
+#:
+#: A ContextVar rather than a parameter so no ``TimeMeasure`` call site has to
+#: change: measured blocks are spread across the search primitives and their
+#: helpers, and threading a sink through every signature would be a large,
+#: churn-heavy diff for something callers usually do not want. asyncio tasks
+#: inherit a copy of the context, and the copy still references the same dict,
+#: so concurrent legs inside one search accumulate into the same collector.
+_timing_collector: ContextVar[dict[str, dict[str, float]] | None] = ContextVar("vss_timing_collector", default=None)
+
+#: Labels currently on the stack, innermost last. Used to attribute a block's
+#: duration to its parent so callers can separate self time from inclusive time.
+_timing_stack: ContextVar[tuple[str, ...]] = ContextVar("vss_timing_stack", default=())
+
+
+def _new_entry() -> dict[str, float]:
+    return {"total_s": 0.0, "_children_s": 0.0, "calls": 0.0}
+
+
+@contextmanager
+def collect_timings() -> Iterator[dict[str, dict[str, float]]]:
+    """Collect every ``TimeMeasure`` duration in this context, in seconds.
+
+    Each label maps to ``{"total_s", "self_s", "calls"}``:
+
+    * ``total_s`` is inclusive -- the block and everything measured inside it.
+    * ``self_s`` excludes nested measured blocks. This is what a "where did the
+      time go" table wants; ``total_s`` alone makes a parent and its children
+      look like separate costs. Self times sum to real elapsed work only where
+      blocks did not overlap -- see ``concurrent_children``.
+    * ``calls`` counts entries, because some blocks run per hit rather than
+      once per search.
+    * ``concurrent_children`` is 1.0 when nested blocks overlapped -- their
+      summed duration exceeded the parent's own elapsed time, which happens
+      whenever children run under ``asyncio.gather`` (fusion runs its embedding
+      and attribute legs that way). Self time is not meaningful for such a
+      block: it is clamped to 0.0 rather than reported negative, and this flag
+      says why.
+
+    Blocks that run more than once accumulate rather than overwrite.
+    """
+    sink: dict[str, dict[str, float]] = {}
+    token = _timing_collector.set(sink)
+    stack_token = _timing_stack.set(())
+    try:
+        yield sink
+    finally:
+        _timing_collector.reset(token)
+        _timing_stack.reset(stack_token)
+        # Derive self time once every block has closed. Doing it incrementally
+        # is order-dependent: children close before their parent, so the parent
+        # would be clamped before it had added its own elapsed time.
+        for entry in sink.values():
+            children = entry.pop("_children_s", 0.0)
+            self_s = entry["total_s"] - children
+            entry["concurrent_children"] = 1.0 if self_s < -_CONCURRENCY_EPSILON else 0.0
+            entry["self_s"] = max(self_s, 0.0)
+
+
+class TimeMeasure:
+    """Measures the execution time of a block of code as a context manager."""
+
+    def __init__(self, string: str, print: bool = True) -> None:
+        self._string = string
+        self._print = print
+
+    def __enter__(self) -> TimeMeasure:
+        self._start_time = time.perf_counter()
+        if _timing_collector.get() is not None:
+            self._stack_token = _timing_stack.set((*_timing_stack.get(), self._string))
+        logger.debug("[START] " + self._string)
+        return self
+
+    def __exit__(
+        self,
+        type: type[BaseException] | None,
+        value: BaseException | None,
+        traceback: object,
+    ) -> None:
+        self._end_time = time.perf_counter()
+        logger.debug("[END]   " + self._string)
+        if self._print:
+            exec_time = self._end_time - self._start_time
+            if exec_time > 1:
+                exec_time, unit = exec_time, "sec"
+            elif exec_time > 0.001:
+                exec_time, unit = exec_time * 1000.0, "millisec"
+            elif exec_time > 1e-6:
+                exec_time, unit = exec_time * 1e6, "usec"
+            else:
+                exec_time, unit = exec_time * 1e9, "nanosec"
+            logger.log(
+                LOG_PERF_LEVEL,
+                f"{self._string:s} execution time = {exec_time:.3f} {unit:s}",
+            )
+            logger.debug(f"{self._string} start={self._start_time!s} end={self._end_time!s}")
+
+        # Collected regardless of `print`: the caller asked for timings by
+        # opening a collector, which is independent of log verbosity.
+        sink = _timing_collector.get()
+        if sink is None:
+            return
+
+        elapsed = self._end_time - self._start_time
+        stack = _timing_stack.get()
+        _timing_stack.reset(self._stack_token)
+
+        entry = sink.setdefault(self._string, _new_entry())
+        entry["total_s"] += elapsed
+        entry["calls"] += 1
+
+        # Accumulate against whichever measured block encloses this one; self
+        # time is derived from it when the collector closes.
+        if len(stack) > 1:
+            parent = sink.setdefault(stack[-2], _new_entry())
+            parent["_children_s"] += elapsed
+
+    @property
+    def execution_time(self) -> float:
+        return self._end_time - self._start_time
+
+    @property
+    def current_execution_time(self) -> float:
+        return time.perf_counter() - self._start_time

--- a/services/agent/packages/vss_core/src/vss_core/critic/critic.py
+++ b/services/agent/packages/vss_core/src/vss_core/critic/critic.py
@@ -35,6 +35,7 @@ from typing import TYPE_CHECKING
 from vss_core._foundation.errors import BackendUnreachableError
 from vss_core._foundation.errors import ConfigurationError
 from vss_core._foundation.time import datetime_to_iso8601
+from vss_core._foundation.time_measure import TimeMeasure
 from vss_core.vios.client import map_interval_to_timeline
 
 from .models import CriticAgentInput
@@ -308,13 +309,14 @@ class CriticAgent:
                 else:
                     # offset-time: convert ISO timestamps to seconds-since-stream-start
                     # using VST's timeline endpoint.
-                    stream_id = await self._vst.resolve_stream_id(video.sensor_id)
-                    if stream_id is None:
-                        raise BackendUnreachableError(
-                            "vst",
-                            f"stream_id resolution failed for sensor {video.sensor_id}",
-                        )
-                    clip_start_iso, clip_end_iso = await self._vst.get_timeline(stream_id)
+                    with TimeMeasure("critic: resolve VST timeline"):
+                        stream_id = await self._vst.resolve_stream_id(video.sensor_id)
+                        if stream_id is None:
+                            raise BackendUnreachableError(
+                                "vst",
+                                f"stream_id resolution failed for sensor {video.sensor_id}",
+                            )
+                        clip_start_iso, clip_end_iso = await self._vst.get_timeline(stream_id)
                     clip_start_dt = _parse_iso(clip_start_iso)
                     # File-search hits use a synthetic midnight-anchored date,
                     # while VST records the same file at ingestion wall-clock,

--- a/services/agent/packages/vss_core/src/vss_core/critic/critic.py
+++ b/services/agent/packages/vss_core/src/vss_core/critic/critic.py
@@ -262,10 +262,16 @@ class CriticAgent:
             if isinstance(outcome, BaseException) and not isinstance(outcome, Exception):
                 raise outcome
             if isinstance(outcome, Exception):
+                # The message carries the actual cause -- an HTTP status, an
+                # SSRF rejection, a bad endpoint -- and the type alone does not.
+                # A misconfiguration that fails every candidate identically then
+                # reads as isolated noise, and the only way to the real reason is
+                # the VLM container's own logs.
                 logger.error(
-                    "Unexpected critic failure for candidate %d (%s); marking only that candidate unverified",
+                    "Unexpected critic failure for candidate %d (%s: %s); marking only that candidate unverified",
                     index,
                     type(outcome).__name__,
+                    outcome,
                 )
                 results.append(
                     VideoResult(

--- a/services/agent/packages/vss_core/src/vss_core/search_core/_internal/time_measure.py
+++ b/services/agent/packages/vss_core/src/vss_core/search_core/_internal/time_measure.py
@@ -12,67 +12,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""TimeMeasure context manager.
+"""Re-export of the shared timing helper.
 
-Times a block of code and logs the elapsed duration. The PERF and STATUS log
-levels are registered here so their level names resolve consistently wherever
-this helper's log records are emitted.
+``TimeMeasure`` moved to ``vss_core._foundation`` when the critic and VLM paths
+needed it too: it is a cross-cutting utility, and reaching into another
+package's ``_internal`` for it would have been the first such breach. Existing
+``search_core._internal.time_measure`` imports keep working through here.
 """
 
-from __future__ import annotations
+from vss_core._foundation.time_measure import LOG_PERF_LEVEL
+from vss_core._foundation.time_measure import LOG_STATUS_LEVEL
+from vss_core._foundation.time_measure import TimeMeasure
+from vss_core._foundation.time_measure import collect_timings
 
-import logging
-import time
-
-logger = logging.getLogger(__name__)
-
-LOG_PERF_LEVEL = 15
-LOG_STATUS_LEVEL = 16
-
-logging.addLevelName(LOG_PERF_LEVEL, "PERF")
-logging.addLevelName(LOG_STATUS_LEVEL, "STATUS")
-
-
-class TimeMeasure:
-    """Measures the execution time of a block of code as a context manager."""
-
-    def __init__(self, string: str, print: bool = True) -> None:
-        self._string = string
-        self._print = print
-
-    def __enter__(self) -> TimeMeasure:
-        self._start_time = time.perf_counter()
-        logger.debug("[START] " + self._string)
-        return self
-
-    def __exit__(
-        self,
-        type: type[BaseException] | None,
-        value: BaseException | None,
-        traceback: object,
-    ) -> None:
-        self._end_time = time.perf_counter()
-        logger.debug("[END]   " + self._string)
-        if self._print:
-            exec_time = self._end_time - self._start_time
-            if exec_time > 1:
-                exec_time, unit = exec_time, "sec"
-            elif exec_time > 0.001:
-                exec_time, unit = exec_time * 1000.0, "millisec"
-            elif exec_time > 1e-6:
-                exec_time, unit = exec_time * 1e6, "usec"
-            else:
-                exec_time, unit = exec_time * 1e9, "nanosec"
-            logger.log(
-                LOG_PERF_LEVEL,
-                f"{self._string:s} execution time = {exec_time:.3f} {unit:s}",
-            )
-            logger.debug(f"{self._string} start={self._start_time!s} end={self._end_time!s}")
-
-    @property
-    def execution_time(self) -> float:
-        return self._end_time - self._start_time
-
-    @property
-    def current_execution_time(self) -> float:
-        return time.perf_counter() - self._start_time
+__all__ = ["LOG_PERF_LEVEL", "LOG_STATUS_LEVEL", "TimeMeasure", "collect_timings"]

--- a/services/agent/packages/vss_core/src/vss_core/search_core/host.py
+++ b/services/agent/packages/vss_core/src/vss_core/search_core/host.py
@@ -26,15 +26,18 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from typing import TYPE_CHECKING
 from typing import Any
 
+from ._internal.time_measure import collect_timings
 from .models.attribute_search import AttributeSearchInput
 from .models.attribute_search import AttributeSearchOutput
 from .models.embed_search import EmbedSearchInput
 from .models.embed_search import EmbedSearchOutput
 from .models.search import SearchInput
 from .models.search import SearchOutput
+from .models.search import SearchTimings
 from .models.tag_search import TagSearchInput
 from .models.tag_search import TagSearchOutput
 from .primitives.attribute_search import AttributeSearch
@@ -133,8 +136,22 @@ class VSSSearch:
         if self._search is None:
             self._search = self._build_search()
         inp = SearchInput(**kw)
-        output = await self._search.run(inp)
-        return await self._verify_results(output, inp)
+
+        # Collect around retrieval AND verification: the critic is often the
+        # larger share of a search, so timing only retrieval would explain the
+        # smaller half of the wall clock.
+        started = time.perf_counter()
+        with collect_timings() as stages:
+            output = await self._search.run(inp)
+            output = await self._verify_results(output, inp)
+
+        output.timings = SearchTimings(
+            stages={
+                label: {metric: round(value, 6) for metric, value in entry.items()} for label, entry in stages.items()
+            },
+            total_s=round(time.perf_counter() - started, 6),
+        )
+        return output
 
     async def _verify_results(self, output: SearchOutput, inp: SearchInput) -> SearchOutput:
         """Best-effort critic pass over retrieved intervals.

--- a/services/agent/packages/vss_core/src/vss_core/search_core/models/search.py
+++ b/services/agent/packages/vss_core/src/vss_core/search_core/models/search.py
@@ -124,12 +124,43 @@ class SearchResult(BaseModel):
     verification: SearchVerification = Field(default_factory=SearchVerification)
 
 
+class SearchTimings(BaseModel):
+    """Per-stage wall-clock for one search, in seconds.
+
+    The stages are the ``TimeMeasure`` blocks already present in the retrieval
+    primitives -- embedding generation, ES query build and execution, hit
+    processing, attribute lookups, fusion rerank. They were previously only
+    logged at a custom PERF level, which the CLI never configured a handler
+    for, so callers had no way to see where a search spent its time.
+
+    ``stages`` keys are the measured block labels, which are namespaced by
+    convention ("embed_search: ES search execution"). Each maps to:
+
+    * ``total_s`` -- inclusive: the block and everything measured inside it.
+    * ``self_s`` -- exclusive: nested measured blocks subtracted. A "where did
+      the time go" table wants this; ``total_s`` alone double counts a parent
+      against its children. Sums to real elapsed work only where blocks did
+      not overlap.
+    * ``calls`` -- entries, since some blocks run per hit rather than per search.
+    * ``concurrent_children`` -- 1.0 when nested blocks overlapped (they ran
+      under ``asyncio.gather``, as fusion's two legs do). Self time is not
+      meaningful for such a block and is reported as 0.0 rather than negative.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    stages: dict[str, dict[str, float]] = Field(default_factory=dict)
+    total_s: float = 0.0
+
+
 class SearchOutput(BaseModel):
     """Output envelope from Search.run()."""
 
     model_config = ConfigDict(extra="forbid")
     data: list[SearchResult] = Field(default_factory=list)
     search_messages: list[str] = Field(default_factory=list)
+    #: Optional so every existing producer and consumer is unaffected: absent
+    #: means nobody collected, not "the search took no time".
+    timings: SearchTimings | None = None
 
     @property
     def results(self) -> list[SearchResult]:

--- a/services/agent/packages/vss_core/src/vss_core/search_core/primitives/_search_helpers.py
+++ b/services/agent/packages/vss_core/src/vss_core/search_core/primitives/_search_helpers.py
@@ -357,15 +357,20 @@ async def fusion_search_rerank(
     # No return_exceptions: a systemic LibraryError from any video propagates.
     results_list = await asyncio.gather(*[_get_attribute_results(er) for er in embed_results])
 
-    candidates = _fusion.build_fusion_candidates(list(results_list), len(attributes))
-    final_results = _fusion.apply_fusion(
-        candidates,
-        fusion_method,
-        rrf_k=rrf_k,
-        rrf_w=rrf_w,
-        w_embed=w_embed,
-        w_attribute=w_attribute,
-    )
+    # Timed separately from the enclosing rerank stage: that one wraps the
+    # concurrent per-video attribute lookups, so its own self time is zero and
+    # the actual score combination -- the "fusion" in fusion search -- was not
+    # attributable to anything.
+    with TimeMeasure("search: fusion score combination"):
+        candidates = _fusion.build_fusion_candidates(list(results_list), len(attributes))
+        final_results = _fusion.apply_fusion(
+            candidates,
+            fusion_method,
+            rrf_k=rrf_k,
+            rrf_w=rrf_w,
+            w_embed=w_embed,
+            w_attribute=w_attribute,
+        )
     logger.info(f"{fusion_method.upper()} fusion reranking complete: {len(final_results)} videos reranked")
     return final_results
 

--- a/services/agent/packages/vss_core/src/vss_core/vlm/openai.py
+++ b/services/agent/packages/vss_core/src/vss_core/vlm/openai.py
@@ -29,6 +29,7 @@ from vss_core._foundation.errors import BackendUnreachableError
 from vss_core._foundation.errors import ConfigurationError
 from vss_core._foundation.retry import create_retry_strategy
 from vss_core._foundation.sanitize import scrub_log
+from vss_core._foundation.time_measure import TimeMeasure
 
 if TYPE_CHECKING:
     from vss_core.vios.protocols import VSTSnapshot
@@ -119,19 +120,26 @@ class OpenAIVLMAnalyzer:
     ) -> str:
         """Analyze a VST clip and return the VLM's text response."""
         try:
-            clip_url = await self._vst.get_video_clip_url(
-                sensor_id=sensor_id,
-                start_timestamp=start_timestamp,
-                end_timestamp=end_timestamp,
-                time_format=time_format,
-                internal=self._video_url_scope == "internal",
-                disable_audio=self._disable_audio,
-            )
+            # VST work, not model work: this asks VST to cut the clip window and
+            # hand back a playable URL. Timed separately because it is easily
+            # mistaken for inference cost when reading a "vlm:" prefixed stage.
+            with TimeMeasure("vlm: resolve VST clip url"):
+                clip_url = await self._vst.get_video_clip_url(
+                    sensor_id=sensor_id,
+                    start_timestamp=start_timestamp,
+                    end_timestamp=end_timestamp,
+                    time_format=time_format,
+                    internal=self._video_url_scope == "internal",
+                    disable_audio=self._disable_audio,
+                )
             duration_seconds = _duration_seconds(start_timestamp, end_timestamp, time_format)
-            content = await self._build_content(
-                prompt=prompt,
-                clip_url=clip_url,
-            )
+            # Cost depends entirely on media_mode: video_url passes a link and is
+            # free, while the base64 modes download the clip and encode it.
+            with TimeMeasure("vlm: prepare media"):
+                content = await self._build_content(
+                    prompt=prompt,
+                    clip_url=clip_url,
+                )
             payload = {
                 "model": self._model,
                 "temperature": 0,
@@ -147,9 +155,10 @@ class OpenAIVLMAnalyzer:
             if self._api_key:
                 headers["Authorization"] = f"Bearer {self._api_key}"
 
-            response = await self._request_with_retries(
-                "POST", self._chat_completions_url, headers=headers, json=payload
-            )
+            with TimeMeasure("vlm: inference"):
+                response = await self._request_with_retries(
+                    "POST", self._chat_completions_url, headers=headers, json=payload
+                )
             answer = _extract_chat_content(response.json())
             if not answer.strip():
                 raise ValueError("VLM response contained no text content")

--- a/services/agent/packages/vss_core/tests/unit_test/lib/search_core/test_timing_collection.py
+++ b/services/agent/packages/vss_core/tests/unit_test/lib/search_core/test_timing_collection.py
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Timing collection around ``TimeMeasure``."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from vss_core.search_core._internal.time_measure import TimeMeasure
+from vss_core.search_core._internal.time_measure import collect_timings
+from vss_core.search_core.models.search import SearchOutput
+from vss_core.search_core.models.search import SearchTimings
+
+
+def test_no_collector_means_no_overhead_and_no_error() -> None:
+    """The default path must be unchanged: measure, log, collect nothing."""
+    with TimeMeasure("standalone block"):
+        pass  # must not raise with no collector open
+
+
+def test_collector_records_measured_blocks() -> None:
+    with collect_timings() as stages:
+        with TimeMeasure("embed_search: ES search execution"):
+            pass
+        with TimeMeasure("embed_search: build ES query"):
+            pass
+
+    assert set(stages) == {"embed_search: ES search execution", "embed_search: build ES query"}
+    assert all(v["total_s"] >= 0.0 for v in stages.values())
+    assert all(v["calls"] == 1 for v in stages.values())
+
+
+def test_repeated_labels_accumulate() -> None:
+    """Some blocks run per hit; the useful number is what the stage cost in total."""
+    with collect_timings() as stages:
+        for _ in range(3):
+            with TimeMeasure("attribute_search: frame lookups"):
+                pass
+
+    assert len(stages) == 1
+    assert stages["attribute_search: frame lookups"]["calls"] == 3
+
+
+def test_collector_does_not_leak_out_of_its_context() -> None:
+    with collect_timings() as inner:
+        with TimeMeasure("inside"):
+            pass
+    with TimeMeasure("outside"):
+        pass
+
+    assert "inside" in inner
+    assert "outside" not in inner
+
+
+def test_nested_collectors_are_isolated() -> None:
+    with collect_timings() as outer:
+        with TimeMeasure("outer block"):
+            pass
+        with collect_timings() as inner:
+            with TimeMeasure("inner block"):
+                pass
+        with TimeMeasure("outer block again"):
+            pass
+
+    assert set(inner) == {"inner block"}
+    assert set(outer) == {"outer block", "outer block again"}
+
+
+def test_concurrent_tasks_share_one_collector() -> None:
+    """asyncio copies the context but not the dict, so parallel legs accumulate.
+
+    Fusion runs its embedding and attribute legs concurrently; both must land
+    in the same collector or the breakdown silently loses one of them.
+    """
+
+    async def leg(label: str) -> None:
+        with TimeMeasure(label):
+            await asyncio.sleep(0)
+
+    async def main() -> dict[str, float]:
+        with collect_timings() as stages:
+            await asyncio.gather(leg("leg a"), leg("leg b"))
+        return stages
+
+    stages = asyncio.run(main())
+    assert set(stages) == {"leg a", "leg b"}
+
+
+def test_search_output_timings_default_to_absent() -> None:
+    """Absent means nobody collected -- not that the search took no time."""
+    assert SearchOutput().timings is None
+
+
+def test_search_output_accepts_timings() -> None:
+    out = SearchOutput(timings=SearchTimings(stages={"a": {"total_s": 1.5, "self_s": 1.5, "calls": 1}}, total_s=2.0))
+    dumped = out.model_dump()
+    assert dumped["timings"]["stages"]["a"]["total_s"] == 1.5
+    assert dumped["timings"]["total_s"] == 2.0
+
+
+def test_self_time_excludes_nested_blocks() -> None:
+    """The point of self_s: a parent must not be charged for its children.
+
+    Without this, a flat table double counts -- "search: embed search" and the
+    "embed_search: ..." stages it wraps look like separate costs.
+    """
+    with collect_timings() as stages:
+        with TimeMeasure("outer"):
+            with TimeMeasure("inner"):
+                time.sleep(0.02)
+
+    outer, inner = stages["outer"], stages["inner"]
+    assert outer["total_s"] >= inner["total_s"]
+    # Outer's own work was negligible, so nearly all its time was the child's.
+    assert outer["self_s"] < inner["total_s"]
+    assert inner["self_s"] == inner["total_s"]
+    assert outer["concurrent_children"] == 0.0
+
+
+def test_self_times_sum_to_the_real_elapsed_work() -> None:
+    """Self times are additive; inclusive totals are not."""
+    with collect_timings() as stages:
+        with TimeMeasure("parent"):
+            with TimeMeasure("child a"):
+                time.sleep(0.01)
+            with TimeMeasure("child b"):
+                time.sleep(0.01)
+
+    self_sum = sum(v["self_s"] for v in stages.values())
+    assert self_sum == pytest.approx(stages["parent"]["total_s"], abs=0.01)
+
+
+def test_overlapping_children_are_flagged_not_negative() -> None:
+    """Fusion runs its legs under asyncio.gather, so children can outlast the parent.
+
+    Subtracting them would drive self time negative; report 0.0 and say why.
+    """
+
+    async def leg() -> None:
+        with TimeMeasure("child"):
+            await asyncio.sleep(0.05)
+
+    async def main() -> dict[str, dict[str, float]]:
+        with collect_timings() as stages:
+            with TimeMeasure("parent"):
+                await asyncio.gather(leg(), leg(), leg())
+        return stages
+
+    stages = asyncio.run(main())
+    parent = stages["parent"]
+    assert stages["child"]["calls"] == 3
+    assert stages["child"]["total_s"] > parent["total_s"]  # overlapped
+    assert parent["self_s"] == 0.0
+    assert parent["concurrent_children"] == 1.0
+
+
+def test_siblings_are_not_treated_as_nested() -> None:
+    with collect_timings() as stages:
+        with TimeMeasure("first"):
+            time.sleep(0.01)
+        with TimeMeasure("second"):
+            time.sleep(0.01)
+
+    assert stages["first"]["self_s"] == stages["first"]["total_s"]
+    assert stages["second"]["self_s"] == stages["second"]["total_s"]
+
+
+def test_timings_field_does_not_disturb_the_existing_envelope() -> None:
+    """Existing consumers read data/search_messages and must be unaffected."""
+    dumped = SearchOutput().model_dump()
+    assert dumped["data"] == []
+    assert dumped["search_messages"] == []
+    assert dumped["timings"] is None

--- a/skills/benchmarking/benchmark-video-search/.gitignore
+++ b/skills/benchmarking/benchmark-video-search/.gitignore
@@ -1,0 +1,10 @@
+# Run outputs: a result describes one deployment at one moment, not source.
+scripts/cli_eval_result/
+
+# Datasets and media are licensed content and are never committed here.
+data/
+datasets/
+
+# Python bytecode caches
+__pycache__/
+*.pyc

--- a/skills/benchmarking/benchmark-video-search/.gitignore
+++ b/skills/benchmarking/benchmark-video-search/.gitignore
@@ -8,3 +8,6 @@ datasets/
 # Python bytecode caches
 __pycache__/
 *.pyc
+
+# pytest cache
+.pytest_cache/

--- a/skills/benchmarking/benchmark-video-search/SKILL.md
+++ b/skills/benchmarking/benchmark-video-search/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: benchmark-video-search
+description: Measure retrieval quality and latency of a deployed VSS search profile — ingest a labelled dataset, run queries through the vss CLI across the embed/attribute/fusion/object paths, and report precision, recall, mAP, HIT@k and a per-stage latency breakdown.
+license: Apache-2.0
+metadata:
+  version: "3.3.0"
+  author: "NVIDIA Video Search and Summarization Team"
+  github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
+  tags: "nvidia blueprint search retrieval benchmarking evaluation"
+---
+
+## Instructions
+
+Run the steps below in order on a first run. For repeat runs against an already
+ingested deployment, skip to **Query only**. Reference material lives in
+`references/`; the runner and its backends live in `scripts/`.
+
+This benchmark drives the **`vss` CLI**, which is the path the product uses:
+the agent adapter shells out to `vss search run <mode> --raw` for every search.
+Measuring the CLI therefore measures what ships, and the numbers stay valid as
+the UI and agent layers change around it.
+
+### 1. Check what you need
+
+- A deployed **search profile** — agent on `:8000`, unified origin on `:7777`.
+- A checkout of this repo (the CLI runs from source via `uv`).
+- A dataset directory laid out as `<data-dir>/<dataset>/dataset.json` plus
+  `<data-dir>/<dataset>/videos/`. See `references/dataset-format.md`.
+
+Confirm the CLI resolves before anything else:
+
+```bash
+vss search run --help
+```
+
+### 2. See what a run would do, without touching the deployment
+
+```bash
+python3 scripts/run_eval_flows.py --endpoint http://HOST:8000 \
+    --data-dir /path/to/datasets --dataset warehouse --dry-run
+```
+
+### 3. Ingest and query
+
+```bash
+python3 scripts/run_eval_flows.py --endpoint http://HOST:8000 \
+    --data-dir /path/to/datasets --dataset warehouse --concurrency 3
+```
+
+Ingestion is the slow and failure-prone half. `POST /complete` returns 502
+intermittently and is retried; a `Duplicate Camera id` warning from RT-CV does
+**not** mean failure. See `references/troubleshooting.md`.
+
+### Query only
+
+Against media already indexed:
+
+```bash
+python3 scripts/run_eval_flows.py --endpoint http://HOST:8000 \
+    --data-dir /path/to/datasets --dataset warehouse \
+    --skip-download --skip-ingest --concurrency 3 --name my-run
+```
+
+### 4. Read the results
+
+Written to `scripts/cli_eval_result/<name>.json`, or
+`<dataset>_<subset>_<timestamp>.json` when `--name` is absent.
+
+Report **Recall** and **HIT@k** as the quality signal. Precision and mAP are
+dominated by `--top-k` — five results against roughly one relevant segment keeps
+them low no matter how good retrieval is — so they compare runs, they do not
+grade a deployment. `references/reading-results.md` explains the stage-latency
+table and what each stage name means; `references/flags.md` covers which flags
+change what a run means and which are escape hatches.
+
+## Conventions
+
+- **Never** report critic-filtered metrics as `0` when the response carried no
+  verification block; the runner prints `NA` instead, and that distinction is
+  the difference between "the critic rejected everything" and "the critic never
+  ran".
+- Queries do not merge adjacent windows by default. Upstream merging averages
+  the scores of merged windows and changes the precision denominator, so a
+  merged run is not comparable to an unmerged baseline.
+- A non-zero CLI exit aborts the run rather than scoring 0.0. A stale virtualenv
+  exits 1 on every invocation, and scoring that as "no results" would report a
+  broken environment as a quality regression.
+- The critic is an LLM and is not deterministic. Raw metrics repeat exactly;
+  critic-filtered ones move a few points between runs. Gate on raw.

--- a/skills/benchmarking/benchmark-video-search/SKILL.md
+++ b/skills/benchmarking/benchmark-video-search/SKILL.md
@@ -11,79 +11,153 @@ metadata:
 
 ## Instructions
 
-Run the steps below in order on a first run. For repeat runs against an already
-ingested deployment, skip to **Query only**. Reference material lives in
-`references/`; the runner and its backends live in `scripts/`.
+Follow the routing table, then the numbered steps. Execute each step in order on
+a first run; for a repeat run against an already-indexed deployment go straight
+to **Step 5**. Reference material is in `references/`, the runner is in
+`scripts/`.
 
-This benchmark drives the **`vss` CLI**, which is the path the product uses:
-the agent adapter shells out to `vss search run <mode> --raw` for every search.
-Measuring the CLI therefore measures what ships, and the numbers stay valid as
-the UI and agent layers change around it.
+## Purpose
 
-### 1. Check what you need
+Answers two questions about a **search profile** deployment: does retrieval find
+the right footage, and where does a query's time go. It drives the `vss` CLI —
+the same path the product uses, since the agent adapter shells out to
+`vss search run <mode> --raw` for every search — so the numbers describe what
+ships rather than a REST endpoint that is being retired.
 
-- A deployed **search profile** — agent on `:8000`, unified origin on `:7777`.
-- A checkout of this repo (the CLI runs from source via `uv`).
-- A dataset directory laid out as `<data-dir>/<dataset>/dataset.json` plus
-  `<data-dir>/<dataset>/videos/`. See `references/dataset-format.md`.
+## Routing
 
-Confirm the CLI resolves before anything else:
+| Situation | Action |
+|---|---|
+| No search profile deployed in this session | Deploy with `vss-deploy-profile -p search`, note the endpoint it returns, then return here |
+| User did not give an endpoint | Ask for it. Do not guess, and do not default to localhost |
+| User did not give a dataset | Ask which dataset and where its `--data-dir` is. Do not invent one |
+| Elasticsearch has no `mdx-*` indices | Ingestion has not completed. Run **Step 4**; do not report zero scores as a quality result |
+| Media already ingested and indexed | Skip to **Step 5** with `--skip-ingest` |
+| User asks to analyse an existing result file | Skip to **Step 6**; read the JSON, run nothing |
+| Every query returns 0 hits | Stop. Diagnose with **Step 3** before reporting anything — this is nearly always missing indices, not poor retrieval |
+
+## Prerequisites
+
+| Requirement | How to check |
+|---|---|
+| Search profile agent reachable | `curl -sf ${ENDPOINT}/health` returns 200 |
+| Unified origin routes the services | `curl -sf ${ORIGIN}/vst/api/v1/sensor/version` returns 200 (ORIGIN is usually the endpoint host on port 7777) |
+| `vss` CLI runs from this checkout | `vss search run --help` exits 0 |
+| CLI points at the right origin | `vss configure show` reports the ORIGIN above |
+| Dataset present locally | `test -f ${DATA_DIR}/${DATASET}/dataset.json` — layout in `references/dataset-format.md` |
+| Python 3.10+ | `python3 --version` |
+| LLM reachable, **only if** decomposing | `curl -sf ${LLM_URL}/v1/models` returns 200 |
+
+## Step 1 — Configure the CLI
+
+The CLI reads `~/.vss/config.json`, which is separate state from `--endpoint`
+and points at a **different port**: it discovers services by path prefix on the
+unified origin, which the agent port does not route. Getting this wrong makes
+every query exit 4.
 
 ```bash
-vss search run --help
+vss configure --base-url http://HOST:7777
+vss configure show
 ```
 
-### 2. See what a run would do, without touching the deployment
+## Step 2 — Dry run
+
+Reports what would happen and contacts nothing.
 
 ```bash
 python3 scripts/run_eval_flows.py --endpoint http://HOST:8000 \
-    --data-dir /path/to/datasets --dataset warehouse --dry-run
+    --data-dir /path/to/datasets --dataset DATASET --dry-run
 ```
 
-### 3. Ingest and query
+## Step 3 — Verify the deployment is actually indexed
+
+Registration with VST is **not** ingestion. A deployment can list every sensor
+and still have an empty Elasticsearch, in which case every query returns zero
+hits and every metric reads 0.0000 — which looks like catastrophic retrieval
+quality and is not.
+
+```bash
+curl -s "http://HOST:7777/elasticsearch/_cat/indices?h=index,docs.count"
+```
+
+Expect `mdx-embed-filtered-*`, `mdx-behavior-*` and `mdx-raw-*` with non-zero
+counts. `mdx-behavior-*` is what the `attribute` and `fusion` paths read; if it
+is missing, only `embed` can score. If the indices are absent, go to Step 4.
+
+## Step 4 — Ingest
+
+Three steps per video against the agent API: `POST /api/v1/videos` for an upload
+URL, the chunked upload, then `POST /api/v1/videos/{sensor_id}/complete`, which
+is what triggers perception.
 
 ```bash
 python3 scripts/run_eval_flows.py --endpoint http://HOST:8000 \
-    --data-dir /path/to/datasets --dataset warehouse --concurrency 3
+    --data-dir /path/to/datasets --dataset DATASET --skip-download --skip-existing
 ```
 
-Ingestion is the slow and failure-prone half. `POST /complete` returns 502
-intermittently and is retried; a `Duplicate Camera id` warning from RT-CV does
-**not** mean failure. See `references/troubleshooting.md`.
+Expect this to be slow and occasionally noisy:
 
-### Query only
+- `POST /complete` returns 502 intermittently and is retried. A retry that
+  succeeds is a success — do not report it as a failure.
+- `Duplicate Camera id` from RT-CV does **not** mean the ingest failed;
+  embeddings still generate.
+- Use `--skip-existing` so a shared deployment is not re-uploaded.
+- Never pass `--clear` unless the user explicitly asked to wipe the deployment.
+  It deletes every source, including other people's.
 
-Against media already indexed:
+Then re-run Step 3. Indices are lazy; they appear after `/complete`, not after
+upload.
+
+## Step 5 — Run the benchmark
 
 ```bash
 python3 scripts/run_eval_flows.py --endpoint http://HOST:8000 \
-    --data-dir /path/to/datasets --dataset warehouse \
-    --skip-download --skip-ingest --concurrency 3 --name my-run
+    --data-dir /path/to/datasets --dataset DATASET --subset SUBSET \
+    --skip-download --skip-ingest --concurrency 3 --name RUN_NAME
 ```
 
-### 4. Read the results
+Add `--llm-url http://HOST:30081` to decompose each query live, which is what
+the deployment's agent does: an LLM turns the sentence into
+`{query, attributes, has_action, ...}` and that decides which path runs. Without
+it every query uses `--search-path` and routing is not exercised.
 
-Written to `scripts/cli_eval_result/<name>.json`, or
-`<dataset>_<subset>_<timestamp>.json` when `--name` is absent.
+`--name` makes the result file findable; without it the name is
+`<dataset>_<subset>_<timestamp>`.
+
+## Step 6 — Report
+
+Results land in `scripts/cli_eval_result/<name>.json`.
 
 Report **Recall** and **HIT@k** as the quality signal. Precision and mAP are
 dominated by `--top-k` — five results against roughly one relevant segment keeps
-them low no matter how good retrieval is — so they compare runs, they do not
-grade a deployment. `references/reading-results.md` explains the stage-latency
-table and what each stage name means; `references/flags.md` covers which flags
-change what a run means and which are escape hatches.
+them low however good retrieval is — so they compare runs; they do not grade a
+deployment.
+
+State these alongside any number, because each one changes what it means:
+
+- **Which paths ran.** `Search paths:` in the summary. A run that was all
+  `embed` says nothing about `attribute`.
+- **Whether decomposition was live.** If so, give its share of query time and
+  what it `Routed to:` — a routing shift changes what was measured.
+- **Whether the critic ran.** Critic-filtered metrics print `NA` when the
+  response carried no verification block. `NA` is not `0`.
+
+`references/reading-results.md` explains the stage-latency table and each stage
+name; `references/flags.md` covers which flags change what a run means; and
+`references/troubleshooting.md` covers ingestion failures and CLI exit codes.
 
 ## Conventions
 
-- **Never** report critic-filtered metrics as `0` when the response carried no
-  verification block; the runner prints `NA` instead, and that distinction is
-  the difference between "the critic rejected everything" and "the critic never
-  ran".
+- **Never report 0.0000 as a quality result without checking Step 3 first.** An
+  unindexed deployment and a broken retriever look identical in the metrics and
+  are not the same finding.
+- A non-zero CLI exit aborts the run rather than scoring 0.0. A stale virtualenv
+  exits 1 on every invocation, and scoring that as "no results" would report a
+  broken environment as an accuracy regression.
 - Queries do not merge adjacent windows by default. Upstream merging averages
   the scores of merged windows and changes the precision denominator, so a
   merged run is not comparable to an unmerged baseline.
-- A non-zero CLI exit aborts the run rather than scoring 0.0. A stale virtualenv
-  exits 1 on every invocation, and scoring that as "no results" would report a
-  broken environment as a quality regression.
 - The critic is an LLM and is not deterministic. Raw metrics repeat exactly;
   critic-filtered ones move a few points between runs. Gate on raw.
+- Live decomposition is not deterministic either. The same query can route
+  differently between runs, so compare `Routed to:` before comparing scores.

--- a/skills/benchmarking/benchmark-video-search/SKILL.md
+++ b/skills/benchmarking/benchmark-video-search/SKILL.md
@@ -3,7 +3,7 @@ name: benchmark-video-search
 description: Measure retrieval quality and latency of a deployed VSS search profile — ingest a labelled dataset, run queries through the vss CLI across the embed/attribute/fusion/object paths, and report precision, recall, mAP, HIT@k and a per-stage latency breakdown.
 license: Apache-2.0
 metadata:
-  version: "3.5.0"
+  version: "3.6.0"
   author: "NVIDIA Video Search and Summarization Team"
   github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
   tags: "nvidia blueprint search retrieval benchmarking evaluation"
@@ -57,9 +57,15 @@ Three defaults, each load-bearing:
 - **Live decomposition is on by default.** The LLM origin is derived from
   `--endpoint` (same host, port 30081), so there is no flag to forget. Every
   query is decomposed the way the deployed agent decomposes it, and that choice
-  picks the retrieval path. If the NIM is unreachable the run **stops** rather
-  than quietly falling back to one path. Override with `--llm-url` /
-  `--llm-port`; turn it off only with `--no-decompose`.
+  picks the retrieval path. Override with `--llm-url` / `--llm-port`; turn it
+  off only with `--no-decompose`.
+
+  If the NIM is unreachable the run continues, in this order: decompositions the
+  dataset carries, then its `devset_provenance.json` answer key, then
+  `--search-path`. The first two still route per query, so every path is still
+  exercised. The third measures **one** path — the run warns loudly and the
+  result file records `live_decomposition.fell_back_to`. Read that field before
+  quoting any number.
 - **Concurrency stays at 1** (the script's default). Concurrent queries contend
   for the same VLM and embedding services, so per-stage latencies inflate and
   stop describing a single query.
@@ -83,7 +89,7 @@ says so.
 | CLI points at the right origin | `vss configure show` reports the ORIGIN above |
 | Dataset present locally | `test -f ${DATA_DIR}/${DATASET}/dataset.json` — layout in `references/dataset-format.md` |
 | Python 3.10+ | `python3 --version` |
-| LLM reachable — **required**; the run aborts without it | `curl -sf http://HOST:30081/v1/models` returns 200 |
+| LLM reachable (else the run falls back and says so) | `curl -sf http://HOST:30081/v1/models` returns 200 |
 | ORIGIN reachable **from inside** the containers | `docker exec vss-rtvi-vlm curl -sf -o /dev/null -w '%{http_code}\n' ${ORIGIN}/vst/api/v1/sensor/version` returns 200. `localhost` fails this even when it passes from the host |
 
 ## Step 1 — Configure the CLI
@@ -166,8 +172,13 @@ python3 scripts/run_eval_flows.py --endpoint http://HOST:8000 \
 Decomposition needs no flag. An LLM turns the sentence into
 `{query, attributes, has_action, ...}` and that decides which path runs — the
 same call the deployed agent makes. The script derives the NIM origin from
-`--endpoint` and aborts if it cannot reach it, so a run either decomposes or
-tells you why it did not.
+`--endpoint`; if it cannot reach it the run falls back rather than stopping, and
+says which fallback it took.
+
+`fusion` cannot be a fallback. It needs an attribute per query and there is
+nothing to supply one without decomposition — and feeding it the whole query as
+its attribute is the failure this eval already measured: mAP −25%, HIT@1 halved,
+latency +59%.
 
 Leave `--concurrency` alone unless asked. It defaults to 1 because concurrent
 queries contend for the same VLM and embedding services, which inflates every

--- a/skills/benchmarking/benchmark-video-search/SKILL.md
+++ b/skills/benchmarking/benchmark-video-search/SKILL.md
@@ -3,7 +3,7 @@ name: benchmark-video-search
 description: Measure retrieval quality and latency of a deployed VSS search profile — ingest a labelled dataset, run queries through the vss CLI across the embed/attribute/fusion/object paths, and report precision, recall, mAP, HIT@k and a per-stage latency breakdown.
 license: Apache-2.0
 metadata:
-  version: "3.6.0"
+  version: "3.7.0"
   author: "NVIDIA Video Search and Summarization Team"
   github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
   tags: "nvidia blueprint search retrieval benchmarking evaluation"
@@ -60,12 +60,16 @@ Three defaults, each load-bearing:
   picks the retrieval path. Override with `--llm-url` / `--llm-port`; turn it
   off only with `--no-decompose`.
 
-  If the NIM is unreachable the run continues, in this order: decompositions the
-  dataset carries, then its `devset_provenance.json` answer key, then
-  `--search-path`. The first two still route per query, so every path is still
-  exercised. The third measures **one** path — the run warns loudly and the
-  result file records `live_decomposition.fell_back_to`. Read that field before
-  quoting any number.
+  If the NIM is unreachable the run continues on `--search-path embed` — the one
+  path that needs nothing but the query text. It warns loudly and records
+  `live_decomposition.fell_back_to` in the result file. **That run measures one
+  path, not routing**; read the field before quoting any number from it.
+
+  A dataset that carries its own decompositions still routes per query, because
+  that is the dataset's stated intent. Nothing else is inferred: a
+  `devset_provenance.json` answer key is used only when you pass
+  `--decompositions` explicitly, since scoring against perfect routing is a
+  different experiment from scoring the live decomposer.
 - **Concurrency stays at 1** (the script's default). Concurrent queries contend
   for the same VLM and embedding services, so per-stage latencies inflate and
   stop describing a single query.

--- a/skills/benchmarking/benchmark-video-search/SKILL.md
+++ b/skills/benchmarking/benchmark-video-search/SKILL.md
@@ -35,6 +35,7 @@ ships rather than a REST endpoint that is being retired.
 | Media already ingested and indexed | Skip to **Step 5** with `--skip-ingest` |
 | User asks to analyse an existing result file | Skip to **Step 6**; read the JSON, run nothing |
 | Every query returns 0 hits | Stop. Diagnose with **Step 3** before reporting anything — this is nearly always missing indices, not poor retrieval |
+| Critic-filtered metrics are all `NA` | The critic never ran. Check the clip-URL prerequisite below before concluding anything about verification quality |
 
 ## Prerequisites
 
@@ -47,6 +48,7 @@ ships rather than a REST endpoint that is being retired.
 | Dataset present locally | `test -f ${DATA_DIR}/${DATASET}/dataset.json` — layout in `references/dataset-format.md` |
 | Python 3.10+ | `python3 --version` |
 | LLM reachable, **only if** decomposing | `curl -sf ${LLM_URL}/v1/models` returns 200 |
+| ORIGIN reachable **from inside** the containers | `docker exec vss-rtvi-vlm curl -sf -o /dev/null -w '%{http_code}\n' ${ORIGIN}/vst/api/v1/sensor/version` returns 200. `localhost` fails this even when it passes from the host |
 
 ## Step 1 — Configure the CLI
 
@@ -59,6 +61,13 @@ every query exit 4.
 vss configure --base-url http://HOST:7777
 vss configure show
 ```
+
+**If you are running on the deployment host, do not use `localhost`.** Use the
+host's LAN IP anyway. The critic hands the VST clip URL to RT-VLM, which is a
+*container*: `localhost` there resolves to the container itself, the fetch
+fails, and because verification is best-effort every hit stays `unverified`
+while retrieval looks perfectly healthy. Running off-host hides this, because
+nothing but a routable address works in the first place.
 
 ## Step 2 — Dry run
 

--- a/skills/benchmarking/benchmark-video-search/SKILL.md
+++ b/skills/benchmarking/benchmark-video-search/SKILL.md
@@ -82,6 +82,18 @@ Three defaults, each load-bearing:
   A `vss` older than the flag is detected by one `--help` probe at startup and
   the run continues without it, with a warning. Do not quote critic-filtered
   metrics from a run that printed that warning.
+- **Ingest goes through the agent** (`--ingest-flow agent-3step`). The UI has
+  moved to `vst-direct` — upload to VIOS, let its webhooks drive perception —
+  and that flow exists here too, but it is not the default and should not be
+  until two things are checked on the deployment. `/complete` is the only step
+  that returns a chunk count, and the only step that pins the
+  `2025-01-01T00:00:00` anchor every dataset's ground truth is written against;
+  the webhook request bodies are empty `{}`, so VIOS picks the anchor instead.
+  If it picks wall-clock time, every query scores zero and it reads as a
+  retrieval collapse. `VstDirectIngest.verify_anchor()` checks one video's
+  timeline; do that before scoring a `vst-direct` run. Also confirm
+  `webhooks.enabled` — it is true in the Docker search profile and **false** in
+  the Helm chart.
 - **Concurrency stays at 1** (the script's default). Concurrent queries contend
   for the same VLM and embedding services, so per-stage latencies inflate and
   stop describing a single query.

--- a/skills/benchmarking/benchmark-video-search/SKILL.md
+++ b/skills/benchmarking/benchmark-video-search/SKILL.md
@@ -3,7 +3,7 @@ name: benchmark-video-search
 description: Measure retrieval quality and latency of a deployed VSS search profile — ingest a labelled dataset, run queries through the vss CLI across the embed/attribute/fusion/object paths, and report precision, recall, mAP, HIT@k and a per-stage latency breakdown.
 license: Apache-2.0
 metadata:
-  version: "3.7.0"
+  version: "3.8.0"
   author: "NVIDIA Video Search and Summarization Team"
   github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
   tags: "nvidia blueprint search retrieval benchmarking evaluation"
@@ -70,6 +70,18 @@ Three defaults, each load-bearing:
   `devset_provenance.json` answer key is used only when you pass
   `--decompositions` explicitly, since scoring against perfect routing is a
   different experiment from scoring the live decomposer.
+- **The pre-decomposition question is sent with every query** as
+  `--original-query`. Retrieval ignores it; the critic verifies against it
+  instead of a question the library rebuilds out of `--query` and `--attribute`.
+  Without it the CLI's critic is asked a different question from the REST
+  flow's, so the two flows' rejection rates are not comparable — and on the
+  `object` path there is no question at all, so verification is skipped
+  outright. Turn it off only with `--no-original-query`, and only to reproduce
+  a result file captured before this existed.
+
+  A `vss` older than the flag is detected by one `--help` probe at startup and
+  the run continues without it, with a warning. Do not quote critic-filtered
+  metrics from a run that printed that warning.
 - **Concurrency stays at 1** (the script's default). Concurrent queries contend
   for the same VLM and embedding services, so per-stage latencies inflate and
   stop describing a single query.

--- a/skills/benchmarking/benchmark-video-search/SKILL.md
+++ b/skills/benchmarking/benchmark-video-search/SKILL.md
@@ -3,7 +3,7 @@ name: benchmark-video-search
 description: Measure retrieval quality and latency of a deployed VSS search profile — ingest a labelled dataset, run queries through the vss CLI across the embed/attribute/fusion/object paths, and report precision, recall, mAP, HIT@k and a per-stage latency breakdown.
 license: Apache-2.0
 metadata:
-  version: "3.4.0"
+  version: "3.5.0"
   author: "NVIDIA Video Search and Summarization Team"
   github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
   tags: "nvidia blueprint search retrieval benchmarking evaluation"
@@ -45,7 +45,7 @@ about the rest.
 ```bash
 python3 scripts/run_eval_flows.py --endpoint http://HOST:8000 \
     --data-dir /path/to/datasets --dataset DATASET \
-    --only-dataset --llm-url http://HOST:30081 --name RUN_NAME
+    --only-dataset --name RUN_NAME
 ```
 
 Three defaults, each load-bearing:
@@ -54,16 +54,24 @@ Three defaults, each load-bearing:
   videos, then ingests. A foreign source cannot be retrieved by any query in the
   dataset, so it adds nothing but false-positive surface and ingest time. Report
   how many sources will be deleted before it runs.
-- **`--llm-url`** decomposes each query live, which is what the deployed agent
-  does. Without it every query takes `--search-path` and routing is never
-  exercised — a run that looks fine and measured one path.
+- **Live decomposition is on by default.** The LLM origin is derived from
+  `--endpoint` (same host, port 30081), so there is no flag to forget. Every
+  query is decomposed the way the deployed agent decomposes it, and that choice
+  picks the retrieval path. If the NIM is unreachable the run **stops** rather
+  than quietly falling back to one path. Override with `--llm-url` /
+  `--llm-port`; turn it off only with `--no-decompose`.
 - **Concurrency stays at 1** (the script's default). Concurrent queries contend
   for the same VLM and embedding services, so per-stage latencies inflate and
   stop describing a single query.
 
 Deviate only on request: `--skip-ingest` to reuse what is there, `--clear` to
 wipe the whole deployment, `--subset` to narrow the slice, `--concurrency N` to
-trade latency fidelity for wall-clock.
+trade latency fidelity for wall-clock, `--no-decompose` for a single-path
+baseline.
+
+Never add `--no-decompose` to a run the user called an eval. It measures one
+retrieval path instead of the product's routing, and nothing in the metrics
+says so.
 
 ## Prerequisites
 
@@ -75,7 +83,7 @@ trade latency fidelity for wall-clock.
 | CLI points at the right origin | `vss configure show` reports the ORIGIN above |
 | Dataset present locally | `test -f ${DATA_DIR}/${DATASET}/dataset.json` — layout in `references/dataset-format.md` |
 | Python 3.10+ | `python3 --version` |
-| LLM reachable (the default run decomposes) | `curl -sf ${LLM_URL}/v1/models` returns 200 |
+| LLM reachable — **required**; the run aborts without it | `curl -sf http://HOST:30081/v1/models` returns 200 |
 | ORIGIN reachable **from inside** the containers | `docker exec vss-rtvi-vlm curl -sf -o /dev/null -w '%{http_code}\n' ${ORIGIN}/vst/api/v1/sensor/version` returns 200. `localhost` fails this even when it passes from the host |
 
 ## Step 1 — Configure the CLI
@@ -152,13 +160,14 @@ upload.
 ```bash
 python3 scripts/run_eval_flows.py --endpoint http://HOST:8000 \
     --data-dir /path/to/datasets --dataset DATASET --subset SUBSET \
-    --skip-download --skip-ingest --llm-url http://HOST:30081 --name RUN_NAME
+    --skip-download --skip-ingest --name RUN_NAME
 ```
 
-`--llm-url` is not optional in a default run. An LLM turns the sentence into
+Decomposition needs no flag. An LLM turns the sentence into
 `{query, attributes, has_action, ...}` and that decides which path runs — the
-same call the deployed agent makes. Drop it and every query takes
-`--search-path`, so one path is measured and routing is not exercised at all.
+same call the deployed agent makes. The script derives the NIM origin from
+`--endpoint` and aborts if it cannot reach it, so a run either decomposes or
+tells you why it did not.
 
 Leave `--concurrency` alone unless asked. It defaults to 1 because concurrent
 queries contend for the same VLM and embedding services, which inflates every

--- a/skills/benchmarking/benchmark-video-search/SKILL.md
+++ b/skills/benchmarking/benchmark-video-search/SKILL.md
@@ -84,16 +84,16 @@ Three defaults, each load-bearing:
   metrics from a run that printed that warning.
 - **Ingest goes through the agent** (`--ingest-flow agent-3step`). The UI has
   moved to `vst-direct` — upload to VIOS, let its webhooks drive perception —
-  and that flow exists here too, but it is not the default and should not be
-  until two things are checked on the deployment. `/complete` is the only step
-  that returns a chunk count, and the only step that pins the
-  `2025-01-01T00:00:00` anchor every dataset's ground truth is written against;
-  the webhook request bodies are empty `{}`, so VIOS picks the anchor instead.
-  If it picks wall-clock time, every query scores zero and it reads as a
-  retrieval collapse. `VstDirectIngest.verify_anchor()` checks one video's
-  timeline; do that before scoring a `vst-direct` run. Also confirm
-  `webhooks.enabled` — it is true in the Docker search profile and **false** in
-  the Helm chart.
+  and that flow works here too; the timestamp anchor rides in the upload
+  metadata, not in anything `/complete` does, so scores are comparable. It is
+  not the default only because `/complete` is the one step that returns
+  `chunks_processed`, and without it "nothing indexed" and "nothing matched"
+  produce the same result file. On a Docker search profile `vst-direct` is the
+  more faithful flow; prefer it when you want to measure what the UI does, and
+  read the readiness poll rather than a chunk count. Two checks first:
+  `webhooks.enabled` is true in Docker and **false** in the Helm chart, and
+  `VstDirectIngest.verify_anchor()` confirms one video's timeline landed on
+  `2025-01-01`.
 - **Concurrency stays at 1** (the script's default). Concurrent queries contend
   for the same VLM and embedding services, so per-stage latencies inflate and
   stop describing a single query.

--- a/skills/benchmarking/benchmark-video-search/SKILL.md
+++ b/skills/benchmarking/benchmark-video-search/SKILL.md
@@ -3,7 +3,7 @@ name: benchmark-video-search
 description: Measure retrieval quality and latency of a deployed VSS search profile — ingest a labelled dataset, run queries through the vss CLI across the embed/attribute/fusion/object paths, and report precision, recall, mAP, HIT@k and a per-stage latency breakdown.
 license: Apache-2.0
 metadata:
-  version: "3.8.0"
+  version: "3.9.0"
   author: "NVIDIA Video Search and Summarization Team"
   github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
   tags: "nvidia blueprint search retrieval benchmarking evaluation"
@@ -82,18 +82,24 @@ Three defaults, each load-bearing:
   A `vss` older than the flag is detected by one `--help` probe at startup and
   the run continues without it, with a warning. Do not quote critic-filtered
   metrics from a run that printed that warning.
-- **Ingest goes through the agent** (`--ingest-flow agent-3step`). The UI has
-  moved to `vst-direct` — upload to VIOS, let its webhooks drive perception —
-  and that flow works here too; the timestamp anchor rides in the upload
-  metadata, not in anything `/complete` does, so scores are comparable. It is
-  not the default only because `/complete` is the one step that returns
-  `chunks_processed`, and without it "nothing indexed" and "nothing matched"
-  produce the same result file. On a Docker search profile `vst-direct` is the
-  more faithful flow; prefer it when you want to measure what the UI does, and
-  read the readiness poll rather than a chunk count. Two checks first:
-  `webhooks.enabled` is true in Docker and **false** in the Helm chart, and
-  `VstDirectIngest.verify_anchor()` confirms one video's timeline landed on
-  `2025-01-01`.
+- **Ingest is `vst-direct`**: upload to VIOS, let its webhooks drive
+  perception. That is what the UI does — it stopped calling the agent's ingest
+  API — and it is the only flow that also triggers RT-VLM tagging. The
+  timestamp anchor rides in the upload metadata, not in anything `/complete`
+  does, so scores stay comparable with `agent-3step` baselines.
+
+  What `agent-3step` gave for free was proof: `/complete` returns
+  `chunks_processed`, and a zero failed the upload. `vst-direct` has no such
+  step, so a **post-ingest index probe** replaces it — one embed query, retried,
+  before the real run starts. Registered in VST is not the same as indexed in
+  Elasticsearch, and without this check an unindexed deployment scores 0.0
+  across the board and reads as a retrieval collapse.
+
+  If the probe aborts a run, check `webhooks.enabled` (true in the Docker
+  search profile, **false** in the Helm chart) and that `RTVI_EMBED_MODEL`
+  matches the webhook's model string — RT-Embed answers a mismatch with HTTP
+  200 and `inference: false`. Fall back with `--ingest-flow agent-3step`.
+  Never pass `--skip-index-probe` on a run whose numbers you intend to quote.
 - **Concurrency stays at 1** (the script's default). Concurrent queries contend
   for the same VLM and embedding services, so per-stage latencies inflate and
   stop describing a single query.

--- a/skills/benchmarking/benchmark-video-search/SKILL.md
+++ b/skills/benchmarking/benchmark-video-search/SKILL.md
@@ -3,7 +3,7 @@ name: benchmark-video-search
 description: Measure retrieval quality and latency of a deployed VSS search profile — ingest a labelled dataset, run queries through the vss CLI across the embed/attribute/fusion/object paths, and report precision, recall, mAP, HIT@k and a per-stage latency breakdown.
 license: Apache-2.0
 metadata:
-  version: "3.3.0"
+  version: "3.4.0"
   author: "NVIDIA Video Search and Summarization Team"
   github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
   tags: "nvidia blueprint search retrieval benchmarking evaluation"
@@ -32,10 +32,38 @@ ships rather than a REST endpoint that is being retired.
 | User did not give an endpoint | Ask for it. Do not guess, and do not default to localhost |
 | User did not give a dataset | Ask which dataset and where its `--data-dir` is. Do not invent one |
 | Elasticsearch has no `mdx-*` indices | Ingestion has not completed. Run **Step 4**; do not report zero scores as a quality result |
-| Media already ingested and indexed | Skip to **Step 5** with `--skip-ingest` |
+| User asks to reuse what is already ingested | Add `--skip-ingest`. Otherwise the default re-ingests |
 | User asks to analyse an existing result file | Skip to **Step 6**; read the JSON, run nothing |
 | Every query returns 0 hits | Stop. Diagnose with **Step 3** before reporting anything — this is nearly always missing indices, not poor retrieval |
 | Critic-filtered metrics are all `NA` | The critic never ran. Check the clip-URL prerequisite below before concluding anything about verification quality |
+
+## The default run
+
+Unless the user says otherwise, this is the run. Ask which dataset; do not ask
+about the rest.
+
+```bash
+python3 scripts/run_eval_flows.py --endpoint http://HOST:8000 \
+    --data-dir /path/to/datasets --dataset DATASET \
+    --only-dataset --llm-url http://HOST:30081 --name RUN_NAME
+```
+
+Three defaults, each load-bearing:
+
+- **`--only-dataset`** deletes every source that is not one of this dataset's
+  videos, then ingests. A foreign source cannot be retrieved by any query in the
+  dataset, so it adds nothing but false-positive surface and ingest time. Report
+  how many sources will be deleted before it runs.
+- **`--llm-url`** decomposes each query live, which is what the deployed agent
+  does. Without it every query takes `--search-path` and routing is never
+  exercised — a run that looks fine and measured one path.
+- **Concurrency stays at 1** (the script's default). Concurrent queries contend
+  for the same VLM and embedding services, so per-stage latencies inflate and
+  stop describing a single query.
+
+Deviate only on request: `--skip-ingest` to reuse what is there, `--clear` to
+wipe the whole deployment, `--subset` to narrow the slice, `--concurrency N` to
+trade latency fidelity for wall-clock.
 
 ## Prerequisites
 
@@ -47,7 +75,7 @@ ships rather than a REST endpoint that is being retired.
 | CLI points at the right origin | `vss configure show` reports the ORIGIN above |
 | Dataset present locally | `test -f ${DATA_DIR}/${DATASET}/dataset.json` — layout in `references/dataset-format.md` |
 | Python 3.10+ | `python3 --version` |
-| LLM reachable, **only if** decomposing | `curl -sf ${LLM_URL}/v1/models` returns 200 |
+| LLM reachable (the default run decomposes) | `curl -sf ${LLM_URL}/v1/models` returns 200 |
 | ORIGIN reachable **from inside** the containers | `docker exec vss-rtvi-vlm curl -sf -o /dev/null -w '%{http_code}\n' ${ORIGIN}/vst/api/v1/sensor/version` returns 200. `localhost` fails this even when it passes from the host |
 
 ## Step 1 — Configure the CLI
@@ -110,9 +138,11 @@ Expect this to be slow and occasionally noisy:
   succeeds is a success — do not report it as a failure.
 - `Duplicate Camera id` from RT-CV does **not** mean the ingest failed;
   embeddings still generate.
-- Use `--skip-existing` so a shared deployment is not re-uploaded.
-- Never pass `--clear` unless the user explicitly asked to wipe the deployment.
-  It deletes every source, including other people's.
+- `--only-dataset` is the default and deletes only foreign sources. On a shared
+  deployment say what it will delete before it runs.
+- `--clear` deletes **every** source including other people's. Only on request.
+- `--skip-existing` is the conservative middle: ingest what is missing, delete
+  nothing.
 
 Then re-run Step 3. Indices are lazy; they appear after `/complete`, not after
 upload.
@@ -122,13 +152,17 @@ upload.
 ```bash
 python3 scripts/run_eval_flows.py --endpoint http://HOST:8000 \
     --data-dir /path/to/datasets --dataset DATASET --subset SUBSET \
-    --skip-download --skip-ingest --concurrency 3 --name RUN_NAME
+    --skip-download --skip-ingest --llm-url http://HOST:30081 --name RUN_NAME
 ```
 
-Add `--llm-url http://HOST:30081` to decompose each query live, which is what
-the deployment's agent does: an LLM turns the sentence into
-`{query, attributes, has_action, ...}` and that decides which path runs. Without
-it every query uses `--search-path` and routing is not exercised.
+`--llm-url` is not optional in a default run. An LLM turns the sentence into
+`{query, attributes, has_action, ...}` and that decides which path runs — the
+same call the deployed agent makes. Drop it and every query takes
+`--search-path`, so one path is measured and routing is not exercised at all.
+
+Leave `--concurrency` alone unless asked. It defaults to 1 because concurrent
+queries contend for the same VLM and embedding services, which inflates every
+per-stage latency in the report.
 
 `--name` makes the result file findable; without it the name is
 `<dataset>_<subset>_<timestamp>`.

--- a/skills/benchmarking/benchmark-video-search/references/dataset-format.md
+++ b/skills/benchmarking/benchmark-video-search/references/dataset-format.md
@@ -1,0 +1,105 @@
+# What a dataset must contain
+
+Ground truth, decompositions, and the layout the runner expects.
+
+## The dataset
+
+Two files per dataset, under `<--data-dir>/<--dataset>/`:
+
+```
+<data-dir>/warehouse/dataset.json     queries, ground truth, decompositions
+<data-dir>/warehouse/videos/          the .mp4 files to ingest
+```
+
+`--data-dir` defaults to `/tmp/vss-devx-search` (where DSS downloads land).
+`--subset` selects a different JSON file in the same folder; **all subsets share
+one `videos/` directory.**
+
+
+### Two supported shapes
+
+**Legacy** — the value *is* the ground-truth segment list. Every existing
+dataset. Works as-is, but every query uses one fixed retrieval path:
+
+```json
+{"queries": {
+  "Person dropping a box": [
+    {"video_name": "warehouse_sample",
+     "start_time": "2025-01-01T00:00:05Z",
+     "end_time": "2025-01-01T00:00:10Z"}
+  ]
+}}
+```
+
+**Extended** — adds the decomposition, which is what enables per-query routing:
+
+```json
+{"schema_version": 2,
+ "queries": {
+  "Person wearing a hardhat dropping a box": {
+    "segments": [
+      {"video_name": "warehouse_sample",
+       "start_time": "2025-01-01T00:00:05Z",
+       "end_time": "2025-01-01T00:00:10Z"}
+    ],
+    "decomposition": {
+      "query": "person dropping a box wearing a hardhat",
+      "attributes": ["person wearing a hardhat"],
+      "has_action": true,
+      "source_type": "video_file"
+    },
+    "expected_path": "fusion"
+  }
+}}
+```
+
+Both load. The script normalizes them, so the scoring code never learns which
+form it came from. **Note `run_eval.py` cannot read the extended shape** — it
+expects the value to be the segment list.
+
+### Why decompositions exist
+
+The agent runs an **LLM query-decomposition step** before retrieval. The CLI
+does not — it takes an already-structured request. So feeding raw natural
+language to the CLI would compare *"decomposed then retrieved"* against
+*"retrieved raw"*, which is not a retrieval comparison at all.
+
+The decomposition is what the agent would have produced. Its contract is
+`QUERY_DECOMPOSITION_PROMPT` in `vss_agents/tools/search.py`:
+
+| field | meaning |
+|---|---|
+| `query` | rewritten description — actions **and** attributes |
+| `attributes` | person-appearance only; never bare `"person"` |
+| `has_action` | true when an action/event is described |
+| `video_sources` | named sources, empty if none |
+| `source_type` | `video_file` or `rtsp` |
+| `timestamp_start` / `timestamp_end` | ISO-8601, base date 2025-01-01 |
+| `object_ids` | explicit tracked-object ids |
+| `top_k` | only when the query says so |
+
+### How the path is chosen
+
+Derived from the decomposition — no guessing:
+
+| `object_ids` | `attributes` | `has_action` | → path |
+|---|---|---|---|
+| present | — | — | `object` |
+| — | present | `true` | `fusion` |
+| — | present | `false` | `attribute` |
+| — | empty | — | `embed` |
+
+`attribute` is the no-action case because that path cannot express an action.
+`fusion` is the both case: the embedding leg carries the action, the attribute
+leg re-ranks by appearance. A decomposition missing `has_action` routes to
+`fusion`, because fusion still returns the embedding leg's candidates while
+`attribute` would silently drop every action-based match.
+
+> **Attributes are matched semantically, not literally.** Attribute search
+> embeds your attribute text with RTVI-CV and runs kNN against per-object visual
+> embeddings. There is no attribute vocabulary to match against, and none is
+> needed. This also means `--attribute person` is useless: it is close to every
+> detected person, so it ranks nothing.
+
+---
+

--- a/skills/benchmarking/benchmark-video-search/references/dataset-format.md
+++ b/skills/benchmarking/benchmark-video-search/references/dataset-format.md
@@ -11,7 +11,9 @@ Two files per dataset, under `<--data-dir>/<--dataset>/`:
 <data-dir>/warehouse/videos/          the .mp4 files to ingest
 ```
 
-`--data-dir` defaults to `/tmp/vss-devx-search` (where DSS downloads land).
+`--data-dir` defaults to `~/.cache/vss-devx-search` (where DSS downloads land;
+honours `XDG_CACHE_HOME`). It used to be `/tmp/vss-devx-search` — if you have
+data there, `mv /tmp/vss-devx-search ~/.cache/` rather than re-downloading.
 `--subset` selects a different JSON file in the same folder; **all subsets share
 one `videos/` directory.**
 

--- a/skills/benchmarking/benchmark-video-search/references/flags.md
+++ b/skills/benchmarking/benchmark-video-search/references/flags.md
@@ -1,0 +1,80 @@
+# Flags
+
+The flags that change what a run means, and the ones that do not.
+
+## Querying
+
+`--query-flow cli` is the only backend today.
+
+Runs `vss search run <path>` as a subprocess per query. Before the first query
+the script resolves the CLI, runs `vss --version` to catch a broken install,
+and points `~/.vss/config.json` at this deployment.
+
+With a dataset carrying decompositions it routes per query. Without them, every
+query uses `--search-path` (default `embed`).
+
+Any non-zero exit **aborts the run**. There is no exit code meaning "this query
+failed but the rest are fine" — continuing would just manufacture zeros that
+read as a retrieval collapse.
+
+
+### Merging
+
+Upstream merges contiguous same-sensor windows by default and reports the mean
+of their scores. That changes the number of scored segments — the denominator
+of precision — so this script passes `--no-merge-adjacent` by default to stay
+comparable with the REST baseline. `--merge-adjacent` opts back in.
+
+---
+
+
+## Flags not covered here
+
+This document explains the flags that change what a run *means*. The rest are
+tuning and escape hatches -- retry budgets, readiness timeouts, explicit service
+URLs, preflight skips -- and are described by `--help`:
+
+```
+--min-cosine-similarity  --source-type          --decompositions
+--upload-timestamp       --complete-backoff     --complete-retries
+--readiness-timeout      --skip-readiness-wait  --skip-vss-preflight
+--skip-vss-configure     --vst-port             --vst-url
+--vss-origin-port        --vss-base-url
+```
+
+Reach for them when a default is wrong for your deployment, not routinely: each
+one moves a run further from the baseline everything else is compared against.
+
+
+## Cookbook
+
+```bash
+# Everything: ingest + routed CLI queries
+--dataset warehouse
+
+# Query only
+--dataset warehouse --skip-download --skip-ingest
+
+# Use a local dataset instead of DSS
+--data-dir ~/Desktop/vss-eval-datasets --dataset warehouse --skip-download
+
+# Fresh index (destructive)
+--dataset warehouse --clear
+
+# Shared box — do not touch others' data
+--dataset warehouse --skip-existing
+
+# One fixed path instead of routing
+--search-path fusion --attribute "person wearing a hardhat"
+
+# Name the results file, for comparing two runs deliberately
+--dataset warehouse --skip-download --name embed-baseline
+
+# See what would run, touching nothing
+--dry-run
+```
+
+Add `--concurrency 3` — the default is 1, and CLI queries take ~8 s each.
+
+---
+

--- a/skills/benchmarking/benchmark-video-search/references/flags.md
+++ b/skills/benchmarking/benchmark-video-search/references/flags.md
@@ -70,6 +70,9 @@ one moves a run further from the baseline everything else is compared against.
 # One fixed path instead of routing (baseline only -- not an eval)
 --no-decompose --search-path fusion --attribute "person wearing a hardhat"
 
+# Ask the critic the reconstructed question, as runs before 3.8.0 did
+--no-original-query
+
 # Name the results file, for comparing two runs deliberately
 --dataset warehouse --skip-download --name embed-baseline
 

--- a/skills/benchmarking/benchmark-video-search/references/flags.md
+++ b/skills/benchmarking/benchmark-video-search/references/flags.md
@@ -73,10 +73,11 @@ one moves a run further from the baseline everything else is compared against.
 # Ask the critic the reconstructed question, as runs before 3.8.0 did
 --no-original-query
 
-# What the UI does: upload to VIOS, webhooks drive perception.
-# Same timestamp anchor, so scores compare -- but no chunk count comes back,
-# so an unindexed run looks like an unmatched one. Needs webhooks.enabled.
---ingest-flow vst-direct
+# The older agent-mediated ingest, when webhooks are off (e.g. Helm)
+--ingest-flow agent-3step
+
+# Longer wait for webhook-driven perception to populate the index
+--index-probe-attempts 20 --index-probe-backoff 30
 
 # Name the results file, for comparing two runs deliberately
 --dataset warehouse --skip-download --name embed-baseline

--- a/skills/benchmarking/benchmark-video-search/references/flags.md
+++ b/skills/benchmarking/benchmark-video-search/references/flags.md
@@ -58,7 +58,10 @@ one moves a run further from the baseline everything else is compared against.
 # Use a local dataset instead of DSS
 --data-dir ~/Desktop/vss-eval-datasets --dataset warehouse --skip-download
 
-# Fresh index (destructive)
+# Default: index holds exactly this dataset
+--dataset warehouse --only-dataset
+
+# Fresh index, wipes everyone's data (destructive)
 --dataset warehouse --clear
 
 # Shared box — do not touch others' data
@@ -74,7 +77,11 @@ one moves a run further from the baseline everything else is compared against.
 --dry-run
 ```
 
-Add `--concurrency 3` — the default is 1, and CLI queries take ~8 s each.
+`--concurrency` defaults to 1 and should stay there for any run whose latency
+numbers you intend to read: concurrent queries contend for the same VLM and
+embedding services, so every per-stage figure inflates. Raise it only when you
+want wall-clock and are reporting retrieval quality alone — CLI queries take
+~8 s each, so a 673-query set is hours at 1.
 
 ---
 

--- a/skills/benchmarking/benchmark-video-search/references/flags.md
+++ b/skills/benchmarking/benchmark-video-search/references/flags.md
@@ -74,8 +74,8 @@ one moves a run further from the baseline everything else is compared against.
 --no-original-query
 
 # What the UI does: upload to VIOS, webhooks drive perception.
-# No chunk count comes back and VIOS chooses the timestamp anchor -- verify one
-# video's timeline before scoring the run.
+# Same timestamp anchor, so scores compare -- but no chunk count comes back,
+# so an unindexed run looks like an unmatched one. Needs webhooks.enabled.
 --ingest-flow vst-direct
 
 # Name the results file, for comparing two runs deliberately

--- a/skills/benchmarking/benchmark-video-search/references/flags.md
+++ b/skills/benchmarking/benchmark-video-search/references/flags.md
@@ -73,6 +73,11 @@ one moves a run further from the baseline everything else is compared against.
 # Ask the critic the reconstructed question, as runs before 3.8.0 did
 --no-original-query
 
+# What the UI does: upload to VIOS, webhooks drive perception.
+# No chunk count comes back and VIOS chooses the timestamp anchor -- verify one
+# video's timeline before scoring the run.
+--ingest-flow vst-direct
+
 # Name the results file, for comparing two runs deliberately
 --dataset warehouse --skip-download --name embed-baseline
 

--- a/skills/benchmarking/benchmark-video-search/references/flags.md
+++ b/skills/benchmarking/benchmark-video-search/references/flags.md
@@ -67,8 +67,8 @@ one moves a run further from the baseline everything else is compared against.
 # Shared box — do not touch others' data
 --dataset warehouse --skip-existing
 
-# One fixed path instead of routing
---search-path fusion --attribute "person wearing a hardhat"
+# One fixed path instead of routing (baseline only -- not an eval)
+--no-decompose --search-path fusion --attribute "person wearing a hardhat"
 
 # Name the results file, for comparing two runs deliberately
 --dataset warehouse --skip-download --name embed-baseline

--- a/skills/benchmarking/benchmark-video-search/references/reading-results.md
+++ b/skills/benchmarking/benchmark-video-search/references/reading-results.md
@@ -1,0 +1,184 @@
+# Reading the results
+
+Which metrics mean what, and how to read the per-stage latency breakdown.
+
+## Reading the results
+
+Results are written to `scripts/cli_eval_result/`, beside the
+script rather than relative to your shell, so a run is findable regardless of
+where it was started. The filename is `--name` if given, otherwise
+`<dataset>_<subset>_<timestamp>`. `--output-file` overrides both with an exact
+path. The directory is gitignored: a result describes one deployment at one
+moment, and is not source.
+
+Use `--name` when comparing runs deliberately -- `--name embed-baseline` and
+`--name embed-after-fix` read better in a diff than two timestamps.
+
+```
+Search paths:       embed=6  fusion=3
+
+                    Raw         Critic Filtered
+mAP:                0.6449      0.4074
+MRR:                0.7130      0.5556
+Avg Recall:         0.9444      0.4167
+HIT@5:              1.0000      0.5556
+```
+
+Each hit is split into 5-second segments (ground truth is 5s-aligned), matched
+in rank order on video name + start time, then scored. Every metric is computed
+twice: once on everything (**Raw**), once with critic-rejected hits removed
+(**Critic Filtered**).
+
+| metric | reading |
+|---|---|
+| **Recall / HIT@k** | the meaningful signals — did it find the right footage |
+| **Precision / mAP** | dominated by `--top-k`; 5 results × ~5 segments vs ~1 relevant keeps these low by construction |
+| **Critic Filtered** | `NA` when the response carried no verification block at all — deliberately not zero |
+
+Two caveats worth internalising:
+
+- **Recall is identical across retrieval paths when they find the same
+  material.** If Raw recall matches between CLI and REST but mAP differs, that
+  is usually the merge asymmetry, not a quality difference.
+- **The critic is an LLM and is not deterministic.** Raw metrics repeat exactly
+  run to run; critic-filtered ones move by a few points. Gate on Raw, or use
+  repeats and a tolerance band.
+
+### Where query latency goes
+
+The `Latency` block splits each query into the part `search()` accounts for and
+the part it cannot:
+
+```
+Latency (client-observed):
+  Mean:             8.970s
+    of which:
+      search:       7.675s
+      CLI startup:  1.295s
+```
+
+`CLI startup` is `latency_s` minus the search's own `total_s` — Python process
+launch, imports, and the `~/.vss/config.json` read. It is harness cost: a
+long-running caller would pay it once, not per query. It only appears when the
+run reports timings; with nothing to subtract, the split is omitted rather
+than guessed.
+
+### Stage latency
+
+Each query also reports where its time went, and the run prints an aggregate:
+
+```
+Stage latency (9 queries reported)
+  stage                                               mean       total  queries
+  --------------------------------------------  ----------  ----------  -------
+  vlm: resolve VST clip url                         7.503s     67.528s        9
+  vlm: inference                                    7.011s     63.101s        9
+  critic: resolve VST timeline                      4.912s     44.207s        9
+  attribute_search: generate text embedding         5.471s     16.412s        3
+  embed_search: ES search execution                 1.058s      9.527s        9
+```
+
+### What the stage names mean
+
+Read them as `component: action`. The prefix says which part of the system did
+the work.
+
+| Stage | What it does |
+|---|---|
+| `embed_search: generate query embedding` | RT-Embed turns the query text into a vector |
+| `embed_search: build ES query` | Assembles the kNN request (microseconds) |
+| `embed_search: ES search execution` | The kNN lookup against video-chunk embeddings in `mdx-embed-filtered-*` |
+| `embed_search: process search hits` | Parses the response into results — merging windows, building URLs |
+| `attribute_search: generate text embedding` | RT-**CV**'s text encoder turns the attribute into a vector (a different service from the query embedder) |
+| `attribute_search: search behavior embeddings` | kNN against per-detected-object embeddings in `mdx-behavior-*` |
+| `attribute_search: frame lookups` | Frame-level detail from `mdx-raw-*`, once per candidate |
+| `attribute_search: deduplication` | Collapses several hits on the same tracked object |
+| `search: fusion score combination` | Merges the embed and attribute rankings into one ordering (RRF or weighted-linear) |
+| `critic: resolve VST timeline` | Looks up when the video was actually recorded, so clip offsets map onto real timestamps |
+| `vlm: resolve VST clip url` | Asks VST to cut the clip's time window and return a playable URL |
+| `vlm: prepare media` | Prepares the clip for the model — free with `media_mode=video_url`, a download and encode otherwise |
+| `vlm: inference` | Sends clip and question to the vision model, reads back the verdict |
+
+Three prefixes, three phases:
+
+* **`embed_search:`** — matching the query against video chunks. Every query.
+* **`attribute_search:`** — matching an attribute against detected people. Only
+  `fusion` / `attribute` queries, which is why their `queries` count is lower.
+* **`vlm:` / `critic:`** — verification: showing each hit to the vision model
+  and reading back confirmed / rejected.
+
+Three things to know when reading it:
+
+* Times are **self time** -- what the stage spent itself, nested stages
+  excluded. Wrapper stages (`search: embed search` merely contains the three
+  `embed_search:` ones) therefore contribute ~0 and are not listed.
+* `queries` is the denominator of `mean`. Attribute stages run only on fusion
+  queries, so a 5.5s mean over 3 is not comparable to a 7.5s mean over 9.
+* Stages **overlap** -- verification checks its hits under `asyncio.gather` --
+  so they do not sum to query latency. The column shows where effort went, not
+  a timeline.
+
+One measured result worth knowing before reading the table: **fusion scoring is
+free.** `search: fusion score combination` is ~0.2ms. Where a fusion query is
+slow, it is waiting on the attribute leg (`attribute_search:` stages), never on
+the merge itself.
+
+#### Whose code produced these numbers
+
+The CLI runs as `uv run --project <repo> ... vss`, so `search_core` executes
+**locally, from your working tree** -- not on the host in `--endpoint`. That
+host supplies RT-Embed, RT-CV, Elasticsearch, VST and the VLM; the search
+orchestration, and therefore every stage timing, is local.
+
+Two consequences:
+
+* Editing `search_core` takes effect on the next run. No deploy, no push, not
+  even a commit -- the working tree is what runs.
+* A stage timing measures **your** code against **their** services. Comparing
+  two runs is only meaningful if the checkout is the same; comparing across
+  checkouts measures the diff, not the deployment.
+
+The REST path is the opposite -- there the timings come from whatever the host
+is running, and appear only once the deployment carries this change.
+
+This is the CLI-path replacement for the Phoenix span breakdown, which does not
+exist here — `search_core` is NAT-free and emits no OTel spans. It is finer
+than Phoenix was (`embed_search` was one span there, four stages here) and
+attributable to a specific query rather than joined back by timestamp.
+
+The JSON keeps the full picture per stage — `self_total_s`, `inclusive_total_s`,
+`calls` (some stages run per hit, not per query) and `concurrent_children` (set
+when nested stages ran under `asyncio.gather`, as fusion's two legs do, where
+self time is not meaningful). On a deployment without the change the section is
+simply absent — never zero.
+
+Results JSON carries `summary`, `config`, `query_results` (per-query, including
+which ground-truth segments were missed and its `timings`) and `flow` (which
+backends ran, ingest timings, readiness).
+
+---
+
+
+## How it fits together
+
+Three independent stages. Each of the first two is swappable; the third never
+changes, which is the whole point of the design.
+
+```
+   dataset            ingest                    query                  score
+ ┌──────────┐   ┌──────────────────┐   ┌────────────────────┐   ┌──────────────┐
+ │ videos   │──▶│ agent-3step      │──▶│ cli                │──▶│ normalize    │
+ │ queries  │   │ legacy-put       │   │                    │   │ → metrics    │
+ │ ground   │   │                  │   │                    │   │              │
+ │  truth   │   │ (webhook, vst-   │   │ (openclaw—pending) │   │ flows/       │
+ └──────────┘   │  direct — later) │   └────────────────────┘   │  metrics.py  │
+                └──────────────────┘                            └──────────────┘
+                  --ingest-flow            --query-flow
+```
+
+Why the split: ingest and query are changing independently in the product, so
+each gets its own axis. Adding a new ingest flow (webhook, say) is one class
+plus one registry line — no metric or runner changes.
+
+---
+

--- a/skills/benchmarking/benchmark-video-search/references/troubleshooting.md
+++ b/skills/benchmarking/benchmark-video-search/references/troubleshooting.md
@@ -1,0 +1,89 @@
+# Troubleshooting
+
+Ingestion failures, CLI exit codes, and the gaps this benchmark does not cover.
+
+## Ingestion
+
+`--ingest-flow`, default **`agent-3step`**.
+
+### `agent-3step` (default)
+
+```
+POST {agent}/api/v1/videos                     → {"url": ...}
+POST {url}          (bytes, nvstreamer-* hdrs) → {"sensorId": ...}
+POST {agent}/api/v1/videos/{sensor}/complete   → {"chunks_processed": N}
+```
+
+Step 2 goes **browser → VST directly**, bypassing the agent. Step 3 is where
+indexing happens (RTVI-CV stream add and RTVI-Embed embedding generation, run
+in parallel). Each phase is timed separately, so you can see whether time went
+to transfer or to processing.
+
+`/complete` is intermittently flaky (502 on the first call, 200 on a retry), so
+it retries with backoff — `--complete-retries`, default 3.
+
+### `legacy-put`
+
+`PUT /api/v1/videos-for-search/{name}` — one request. **Deprecated upstream**,
+and its removal is gated on this repo migrating away from it. Kept so a
+baseline can still be captured while it exists. It runs the same post-upload
+pipeline internally, so it is not more reliable — just less observable.
+
+### After ingest
+
+A 200 from `/complete` is **not** readiness — indexing continues afterwards.
+The script polls VST until every source registers before querying, because
+querying early returns empty results that look exactly like a retrieval
+regression.
+
+### On a shared deployment
+
+```bash
+--skip-existing    # do not re-upload what VST already lists
+--clear            # ⚠️  deletes ALL videos on the endpoint, including others'
+```
+
+---
+
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Could not find a vss CLI` | none of the four sources resolved | the error lists each one and why; see [Getting a `vss` CLI](#getting-a-vss-cli) |
+| `vss exited 4 ... does not expose` | CLI pointed at the agent port | let the script configure it, or `--vss-base-url http://host:7777` |
+| `vss exited 1 ... ModuleNotFoundError` | stale virtualenv | rebuild it, or use `--vss-repo-root` |
+| `vss exited 5` | nothing ingested | drop `--skip-ingest` |
+| `/complete` 502 | known flakiness | retried automatically; raise `--complete-retries` |
+| `Duplicate Camera id` | RTVI-CV already has that stream | treated as done — embeddings still generate |
+| Everything scores 0.0 | usually an empty index | check VST lists your sources |
+| Header says `fallback_path` | routing is active; that is the path for unrouted queries | look at `planned_paths` |
+
+---
+
+## Known gaps
+
+- **`openclaw` query flow** — the full new UI flow end to end: chat → OpenClaw
+  agent → skill → CLI. It would measure **routing** quality (does the agent pick
+  the right path and attributes?) rather than the **retrieval** quality
+  everything here measures with the routing supplied. Needs a NemoClaw sandbox,
+  an LLM in the loop, and a decision about whether CI takes that dependency.
+  Not called "agent" because the NAT agent behind `POST /api/v1/search` runs
+  its own decomposition — a different decision-maker. That path was removed
+  from this script; `run_eval.py` still queries it.
+- **`vst-direct` / webhook ingest** — the UI has moved past `agent-3step`;
+  the contract is not documented yet, so the registry slot is deliberately empty.
+- **The route is supplied, never measured** — decompositions come from the
+  dataset, so every number here is retrieval quality *given a correct route*.
+  Whether the agent would pick that route is the `openclaw` gap above. How a
+  dataset's decompositions were produced therefore changes how its results
+  should be read; that belongs with the dataset, not here.
+- **Stage latency needs an unmerged branch** — `feat/search-core-output` in the
+  product repo adds the `timings` block. Without it the section is absent.
+- **Path coverage depends entirely on the dataset** — the script routes what it
+  is given, so a dataset whose queries are all action descriptions exercises
+  only `embed`, however many queries it has. Check the `Search paths:` line in
+  the summary before reading a per-path number as meaningful.
+
+The reasoning behind each of these lives in the commit history and in comments
+at the relevant code — `flows/routing.py` for the routing rule, `flows/ingest.py`

--- a/skills/benchmarking/benchmark-video-search/references/troubleshooting.md
+++ b/skills/benchmarking/benchmark-video-search/references/troubleshooting.md
@@ -87,3 +87,51 @@ regression.
 
 The reasoning behind each of these lives in the commit history and in comments
 at the relevant code — `flows/routing.py` for the routing rule, `flows/ingest.py`
+
+## Every hit is `unverified` and critic-filtered metrics read `NA`
+
+The critic never ran, or ran and could not fetch the clip. Retrieval is
+unaffected and looks healthy, which is what makes this hard to spot.
+
+Verification is best-effort by design — `_verify_results` never fails a search —
+so a broken clip URL and "no critic configured" are indistinguishable in the
+output. Check the causes in order.
+
+**1. The clip URL is not routable from inside the containers.** This is the
+common one when the benchmark runs *on* the deployment host.
+
+The CLI builds the critic with `media_mode="video_url"` and
+`video_url_scope="external"`, so RT-VLM is handed a VST clip URL and fetches it
+itself. That URL is built from whatever `vss configure --base-url` recorded. Set
+it to `http://localhost:7777` and RT-VLM — a container — resolves `localhost` to
+itself, the fetch fails, and every hit stays `unverified`.
+
+```bash
+vss configure show | grep -i base_url
+docker exec vss-rtvi-vlm curl -sf -o /dev/null -w '%{http_code}\n' \
+    http://<HOST_LAN_IP>:7777/vst/api/v1/sensor/version
+```
+
+Fix by pointing the CLI at an address the containers can reach, even though you
+are on the host:
+
+```bash
+vss configure --base-url http://<HOST_LAN_IP>:7777
+```
+
+`http://172.17.0.1:7777` (the docker bridge gateway) works as a fallback when
+the host IP is not reachable from the container network.
+
+Running the benchmark from another machine hides this entirely: nothing but a
+routable address reaches the deployment in the first place.
+
+**2. RT-VLM is not in the CLI's config.** The critic stack is built only when
+the deployment exposes one — `vss configure show` must list `rt_vlm` with both a
+URL and a non-empty model list, and it must answer an availability probe. Any of
+those missing returns no critic, silently.
+
+**3. The critic ran but returned no verdict.** Distinguish this from the above:
+here the response carries a `search_message` such as *"Visual verification ran
+but produced no verdict for any hit"*, rather than no verification block at all.
+That is a different failure — the critic was reached and produced nothing — and
+is not explained by the clip-URL routing above.

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/__init__.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/__init__.py
@@ -53,6 +53,9 @@ from .base import (
     resolve_vss_cmd,
     vss_origin_for,
 )
+from .decompose import DecompositionError
+from .decompose import LiveDecomposer
+from .decompose import load_prompt as load_decomposition_prompt
 from .dataset import (
     DATASETS,
     DEFAULT_DATA_DIR,
@@ -165,6 +168,9 @@ __all__ = [
     "CONTENT_TYPES",
     "DATASETS",
     "DEFAULT_DATA_DIR",
+    "DecompositionError",
+    "LiveDecomposer",
+    "load_decomposition_prompt",
     "DEFAULT_UPLOAD_TIMESTAMP",
     "DEFAULT_VSS_ORIGIN_PORT",
     "DSS_DATASET_NAME",

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/__init__.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/__init__.py
@@ -1,0 +1,233 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pluggable ingest and query backends for the search eval.
+
+``run_eval.py`` calls two endpoints directly: ``PUT /api/v1/videos-for-search``
+to ingest and ``POST /api/v1/search`` to query. Both are moving, and they are
+moving *independently*, so each gets its own axis here rather than the eval
+being forked per flow.
+
+    ingest:  legacy-put | agent-3step        (vst-direct  -> GAP-1)
+    query:   cli                             (openclaw    -> GAP-3)
+
+Metric code never sees a wire format -- it sees the canonical dict from
+:func:`normalize_result`. Adding a backend means one class plus one registry
+entry; no metric code changes.
+
+Each backend documents the deployment behaviour it was written against.
+"""
+
+from __future__ import annotations
+
+from .base import (
+    COMPLETE_TIMEOUT,
+    CONTENT_TYPES,
+    DEFAULT_UPLOAD_TIMESTAMP,
+    DEFAULT_VSS_ORIGIN_PORT,
+    REPO_ROOT,
+    SEARCH_TIMEOUT,
+    SUBMODULE_ROOT,
+    UPLOAD_TIMEOUT,
+    UPLOAD_URL_TIMEOUT,
+    VST_LIST_TIMEOUT,
+    IngestBackend,
+    QueryBackend,
+    configured_base_url,
+    default_vss_cmd,
+    ensure_vss_configured,
+    has_cli_package,
+    preflight_vss_cmd,
+    resolve_vss_cmd,
+    vss_origin_for,
+)
+from .dataset import (
+    DATASETS,
+    DEFAULT_DATA_DIR,
+    DSS_DATASET_NAME,
+    aggregate_upload_stats,
+    download_from_dss,
+    load_dataset_file,
+    print_upload_summary,
+    vst_url_for,
+)
+from .ingest import (
+    COMPLETE_ALREADY_REGISTERED,
+    COMPLETE_FATAL,
+    COMPLETE_RETRY,
+    AgentThreeStepIngest,
+    LegacyPutIngest,
+    classify_complete_failure,
+)
+from .metrics import (
+    HIT_K_VALUES,
+    SEGMENT_SIZE,
+    align_ts_to_segment,
+    evaluate_query,
+    format_inline,
+    match_segment,
+    parse_ts,
+    post_process_api_results,
+    video_name_matches,
+)
+from .normalize import (
+    VERIFICATION_ABSENT,
+    filter_rejected,
+    for_scoring,
+    has_verification,
+    normalize_result,
+    normalize_results,
+    verification_sources,
+)
+from .query import (
+    CLI_EXIT_MEANINGS,
+    CLI_FATAL_EXITS,
+    SEARCH_PATHS,
+    CliExitError,
+    CliQueryBackend,
+    is_fatal_exit,
+    parse_cli_output,
+)
+from .readiness import (
+    compare_inventory,
+    inventory_snapshot,
+    is_registered,
+    list_sensor_names,
+    list_sensor_streams,
+    name_variants,
+    sensor_list_url,
+    wait_for_sources,
+)
+from .routing import (
+    ATTRIBUTE,
+    EMBED,
+    FUSION,
+    OBJECT,
+    load_decompositions,
+    path_distribution,
+    plan_for,
+    route,
+    unpack_dataset,
+)
+
+#: Ingest backends by ``--ingest-flow`` name.
+#:
+#: "vst-direct" is absent on purpose. The UI has already moved to it -- see
+#: ci-vss-oss commit 0bdfc8d (the eval's previous home), which skipped six UI
+#: E2E specs because "UI video
+#: upload / RTSP add no longer call Agent ingest APIs" -- but its contract is
+#: undocumented, and guessing would produce an eval that indexes differently
+#: from the product.
+INGEST_BACKENDS = {
+    LegacyPutIngest.name: LegacyPutIngest,
+    AgentThreeStepIngest.name: AgentThreeStepIngest,
+}
+
+#: Query backends by ``--query-flow`` name.
+#:
+#: rest-api (POST /api/v1/search) was removed once the CLI became the path the
+#: product actually uses. Baselines captured through it are kept under
+#: eval/results/search_eval/baselines/ -- re-running them needs run_eval.py,
+#: which still queries that endpoint.
+#:
+#: "openclaw" is absent pending GAP-3. It would drive the full new UI flow --
+#: chat -> OpenClaw agent -> vss-search-archive skill -> vss search run -- and
+#: so measure ROUTING quality: whether the agent picks the right path and
+#: attributes. Everything here measures RETRIEVAL quality instead, with the
+#: routing supplied. Deliberately not named "agent": `rest-api --agent-mode`
+#: already exercises the NAT agent's decomposition, which is a different
+#: decision-maker. It needs a NemoClaw sandbox, an LLM, and a decision about
+#: whether CI takes an LLM dependency.
+QUERY_BACKENDS = {
+    CliQueryBackend.name: CliQueryBackend,
+}
+
+__all__ = [
+    "ATTRIBUTE",
+    "CLI_EXIT_MEANINGS",
+    "CLI_FATAL_EXITS",
+    "COMPLETE_ALREADY_REGISTERED",
+    "COMPLETE_FATAL",
+    "COMPLETE_RETRY",
+    "COMPLETE_TIMEOUT",
+    "CONTENT_TYPES",
+    "DATASETS",
+    "DEFAULT_DATA_DIR",
+    "DEFAULT_UPLOAD_TIMESTAMP",
+    "DEFAULT_VSS_ORIGIN_PORT",
+    "DSS_DATASET_NAME",
+    "EMBED",
+    "FUSION",
+    "HIT_K_VALUES",
+    "INGEST_BACKENDS",
+    "OBJECT",
+    "QUERY_BACKENDS",
+    "REPO_ROOT",
+    "SEARCH_PATHS",
+    "SEARCH_TIMEOUT",
+    "SEGMENT_SIZE",
+    "SUBMODULE_ROOT",
+    "UPLOAD_TIMEOUT",
+    "UPLOAD_URL_TIMEOUT",
+    "VERIFICATION_ABSENT",
+    "VST_LIST_TIMEOUT",
+    "AgentThreeStepIngest",
+    "CliExitError",
+    "CliQueryBackend",
+    "IngestBackend",
+    "LegacyPutIngest",
+    "QueryBackend",
+    "aggregate_upload_stats",
+    "align_ts_to_segment",
+    "classify_complete_failure",
+    "compare_inventory",
+    "configured_base_url",
+    "default_vss_cmd",
+    "download_from_dss",
+    "ensure_vss_configured",
+    "evaluate_query",
+    "filter_rejected",
+    "for_scoring",
+    "format_inline",
+    "has_cli_package",
+    "has_verification",
+    "inventory_snapshot",
+    "is_fatal_exit",
+    "is_registered",
+    "list_sensor_names",
+    "list_sensor_streams",
+    "load_dataset_file",
+    "load_decompositions",
+    "match_segment",
+    "name_variants",
+    "normalize_result",
+    "normalize_results",
+    "parse_cli_output",
+    "parse_ts",
+    "path_distribution",
+    "plan_for",
+    "post_process_api_results",
+    "preflight_vss_cmd",
+    "print_upload_summary",
+    "resolve_vss_cmd",
+    "route",
+    "sensor_list_url",
+    "unpack_dataset",
+    "verification_sources",
+    "video_name_matches",
+    "vss_origin_for",
+    "vst_url_for",
+    "wait_for_sources",
+]

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/__init__.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/__init__.py
@@ -32,101 +32,85 @@ Each backend documents the deployment behaviour it was written against.
 
 from __future__ import annotations
 
-from .base import (
-    COMPLETE_TIMEOUT,
-    CONTENT_TYPES,
-    DEFAULT_UPLOAD_TIMESTAMP,
-    DEFAULT_VSS_ORIGIN_PORT,
-    REPO_ROOT,
-    SEARCH_TIMEOUT,
-    SUBMODULE_ROOT,
-    UPLOAD_TIMEOUT,
-    UPLOAD_URL_TIMEOUT,
-    VST_LIST_TIMEOUT,
-    IngestBackend,
-    QueryBackend,
-    configured_base_url,
-    default_vss_cmd,
-    ensure_vss_configured,
-    has_cli_package,
-    preflight_vss_cmd,
-    resolve_vss_cmd,
-    vss_origin_for,
-)
+from .base import COMPLETE_TIMEOUT
+from .base import CONTENT_TYPES
+from .base import DEFAULT_UPLOAD_TIMESTAMP
+from .base import DEFAULT_VSS_ORIGIN_PORT
+from .base import REPO_ROOT
+from .base import SEARCH_TIMEOUT
+from .base import SUBMODULE_ROOT
+from .base import UPLOAD_TIMEOUT
+from .base import UPLOAD_URL_TIMEOUT
+from .base import VST_LIST_TIMEOUT
+from .base import IngestBackend
+from .base import QueryBackend
+from .base import configured_base_url
+from .base import default_vss_cmd
+from .base import ensure_vss_configured
+from .base import has_cli_package
+from .base import preflight_vss_cmd
+from .base import resolve_vss_cmd
+from .base import vss_origin_for
+from .dataset import DATASETS
+from .dataset import DEFAULT_DATA_DIR
+from .dataset import DSS_DATASET_NAME
+from .dataset import aggregate_upload_stats
+from .dataset import download_from_dss
+from .dataset import llm_url_for
+from .dataset import load_dataset_file
+from .dataset import print_upload_summary
+from .dataset import sidecar_decompositions_for
+from .dataset import vst_url_for
 from .decompose import DecompositionError
 from .decompose import LiveDecomposer
 from .decompose import load_prompt as load_decomposition_prompt
-from .dataset import (
-    DATASETS,
-    DEFAULT_DATA_DIR,
-    DSS_DATASET_NAME,
-    aggregate_upload_stats,
-    download_from_dss,
-    load_dataset_file,
-    print_upload_summary,
-    llm_url_for,
-    sidecar_decompositions_for,
-    vst_url_for,
-)
-from .ingest import (
-    COMPLETE_ALREADY_REGISTERED,
-    COMPLETE_FATAL,
-    COMPLETE_RETRY,
-    AgentThreeStepIngest,
-    LegacyPutIngest,
-    classify_complete_failure,
-)
-from .metrics import (
-    HIT_K_VALUES,
-    SEGMENT_SIZE,
-    align_ts_to_segment,
-    evaluate_query,
-    format_inline,
-    match_segment,
-    parse_ts,
-    post_process_api_results,
-    video_name_matches,
-)
-from .normalize import (
-    VERIFICATION_ABSENT,
-    filter_rejected,
-    verdict_counts,
-    for_scoring,
-    has_verification,
-    normalize_result,
-    normalize_results,
-    verification_sources,
-)
-from .query import (
-    CLI_EXIT_MEANINGS,
-    CLI_FATAL_EXITS,
-    SEARCH_PATHS,
-    CliExitError,
-    CliQueryBackend,
-    is_fatal_exit,
-    parse_cli_output,
-)
-from .readiness import (
-    compare_inventory,
-    inventory_snapshot,
-    is_registered,
-    list_sensor_names,
-    list_sensor_streams,
-    name_variants,
-    sensor_list_url,
-    wait_for_sources,
-)
-from .routing import (
-    ATTRIBUTE,
-    EMBED,
-    FUSION,
-    OBJECT,
-    load_decompositions,
-    path_distribution,
-    plan_for,
-    route,
-    unpack_dataset,
-)
+from .ingest import COMPLETE_ALREADY_REGISTERED
+from .ingest import COMPLETE_FATAL
+from .ingest import COMPLETE_RETRY
+from .ingest import AgentThreeStepIngest
+from .ingest import LegacyPutIngest
+from .ingest import classify_complete_failure
+from .metrics import HIT_K_VALUES
+from .metrics import SEGMENT_SIZE
+from .metrics import align_ts_to_segment
+from .metrics import evaluate_query
+from .metrics import format_inline
+from .metrics import match_segment
+from .metrics import parse_ts
+from .metrics import post_process_api_results
+from .metrics import video_name_matches
+from .normalize import VERIFICATION_ABSENT
+from .normalize import filter_rejected
+from .normalize import for_scoring
+from .normalize import has_verification
+from .normalize import normalize_result
+from .normalize import normalize_results
+from .normalize import verdict_counts
+from .normalize import verification_sources
+from .query import CLI_EXIT_MEANINGS
+from .query import CLI_FATAL_EXITS
+from .query import SEARCH_PATHS
+from .query import CliExitError
+from .query import CliQueryBackend
+from .query import is_fatal_exit
+from .query import parse_cli_output
+from .readiness import compare_inventory
+from .readiness import inventory_snapshot
+from .readiness import is_registered
+from .readiness import list_sensor_names
+from .readiness import list_sensor_streams
+from .readiness import name_variants
+from .readiness import sensor_list_url
+from .readiness import wait_for_sources
+from .routing import ATTRIBUTE
+from .routing import EMBED
+from .routing import FUSION
+from .routing import OBJECT
+from .routing import load_decompositions
+from .routing import path_distribution
+from .routing import plan_for
+from .routing import route
+from .routing import unpack_dataset
 
 #: Ingest backends by ``--ingest-flow`` name.
 #:
@@ -171,9 +155,6 @@ __all__ = [
     "CONTENT_TYPES",
     "DATASETS",
     "DEFAULT_DATA_DIR",
-    "DecompositionError",
-    "LiveDecomposer",
-    "load_decomposition_prompt",
     "DEFAULT_UPLOAD_TIMESTAMP",
     "DEFAULT_VSS_ORIGIN_PORT",
     "DSS_DATASET_NAME",
@@ -195,8 +176,10 @@ __all__ = [
     "AgentThreeStepIngest",
     "CliExitError",
     "CliQueryBackend",
+    "DecompositionError",
     "IngestBackend",
     "LegacyPutIngest",
+    "LiveDecomposer",
     "QueryBackend",
     "aggregate_upload_stats",
     "align_ts_to_segment",
@@ -208,7 +191,6 @@ __all__ = [
     "ensure_vss_configured",
     "evaluate_query",
     "filter_rejected",
-    "verdict_counts",
     "for_scoring",
     "format_inline",
     "has_cli_package",
@@ -218,7 +200,9 @@ __all__ = [
     "is_registered",
     "list_sensor_names",
     "list_sensor_streams",
+    "llm_url_for",
     "load_dataset_file",
+    "load_decomposition_prompt",
     "load_decompositions",
     "match_segment",
     "name_variants",
@@ -234,12 +218,12 @@ __all__ = [
     "resolve_vss_cmd",
     "route",
     "sensor_list_url",
+    "sidecar_decompositions_for",
     "unpack_dataset",
+    "verdict_counts",
     "verification_sources",
     "video_name_matches",
     "vss_origin_for",
-    "llm_url_for",
-    "sidecar_decompositions_for",
     "vst_url_for",
     "wait_for_sources",
 ]

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/__init__.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/__init__.py
@@ -94,6 +94,7 @@ from .query import CLI_FATAL_EXITS
 from .query import SEARCH_PATHS
 from .query import CliExitError
 from .query import CliQueryBackend
+from .query import QueryUnanswerableError
 from .query import is_fatal_exit
 from .query import parse_cli_output
 from .readiness import compare_inventory
@@ -184,6 +185,7 @@ __all__ = [
     "LegacyPutIngest",
     "LiveDecomposer",
     "QueryBackend",
+    "QueryUnanswerableError",
     "VstDirectIngest",
     "aggregate_upload_stats",
     "align_ts_to_segment",

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/__init__.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/__init__.py
@@ -88,6 +88,7 @@ from .metrics import (
 from .normalize import (
     VERIFICATION_ABSENT,
     filter_rejected,
+    verdict_counts,
     for_scoring,
     has_verification,
     normalize_result,
@@ -205,6 +206,7 @@ __all__ = [
     "ensure_vss_configured",
     "evaluate_query",
     "filter_rejected",
+    "verdict_counts",
     "for_scoring",
     "format_inline",
     "has_cli_package",

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/__init__.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/__init__.py
@@ -65,6 +65,7 @@ from .dataset import (
     load_dataset_file,
     print_upload_summary,
     llm_url_for,
+    sidecar_decompositions_for,
     vst_url_for,
 )
 from .ingest import (
@@ -238,6 +239,7 @@ __all__ = [
     "video_name_matches",
     "vss_origin_for",
     "llm_url_for",
+    "sidecar_decompositions_for",
     "vst_url_for",
     "wait_for_sources",
 ]

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/__init__.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/__init__.py
@@ -64,6 +64,7 @@ from .dataset import (
     download_from_dss,
     load_dataset_file,
     print_upload_summary,
+    llm_url_for,
     vst_url_for,
 )
 from .ingest import (
@@ -236,6 +237,7 @@ __all__ = [
     "verification_sources",
     "video_name_matches",
     "vss_origin_for",
+    "llm_url_for",
     "vst_url_for",
     "wait_for_sources",
 ]

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/__init__.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/__init__.py
@@ -70,6 +70,7 @@ from .ingest import COMPLETE_FATAL
 from .ingest import COMPLETE_RETRY
 from .ingest import AgentThreeStepIngest
 from .ingest import LegacyPutIngest
+from .ingest import VstDirectIngest
 from .ingest import classify_complete_failure
 from .metrics import HIT_K_VALUES
 from .metrics import SEGMENT_SIZE
@@ -115,15 +116,16 @@ from .routing import unpack_dataset
 
 #: Ingest backends by ``--ingest-flow`` name.
 #:
-#: "vst-direct" is absent on purpose. The UI has already moved to it -- see
-#: ci-vss-oss commit 0bdfc8d (the eval's previous home), which skipped six UI
-#: E2E specs because "UI video
-#: upload / RTSP add no longer call Agent ingest APIs" -- but its contract is
-#: undocumented, and guessing would produce an eval that indexes differently
-#: from the product.
+#: "vst-direct" is what the UI does -- see ci-vss-oss commit 0bdfc8d (the eval's
+#: previous home), which skipped six UI E2E specs because "UI video upload /
+#: RTSP add no longer call Agent ingest APIs". It is NOT the default, because
+#: the agent's ``/complete`` is the only step that returns a chunk count and
+#: the only step that pins the timestamp anchor the dataset's ground truth is
+#: written against; see :class:`VstDirectIngest`.
 INGEST_BACKENDS = {
     LegacyPutIngest.name: LegacyPutIngest,
     AgentThreeStepIngest.name: AgentThreeStepIngest,
+    VstDirectIngest.name: VstDirectIngest,
 }
 
 #: Query backends by ``--query-flow`` name.
@@ -182,6 +184,7 @@ __all__ = [
     "LegacyPutIngest",
     "LiveDecomposer",
     "QueryBackend",
+    "VstDirectIngest",
     "aggregate_upload_stats",
     "align_ts_to_segment",
     "classify_complete_failure",

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/__init__.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/__init__.py
@@ -20,7 +20,7 @@ to ingest and ``POST /api/v1/search`` to query. Both are moving, and they are
 moving *independently*, so each gets its own axis here rather than the eval
 being forked per flow.
 
-    ingest:  legacy-put | agent-3step        (vst-direct  -> GAP-1)
+    ingest:  legacy-put | agent-3step | vst-direct   (GAP-1 closed)
     query:   cli                             (openclaw    -> GAP-3)
 
 Metric code never sees a wire format -- it sees the canonical dict from

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/__init__.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/__init__.py
@@ -44,6 +44,7 @@ from .base import UPLOAD_URL_TIMEOUT
 from .base import VST_LIST_TIMEOUT
 from .base import IngestBackend
 from .base import QueryBackend
+from .base import cli_supports_flag
 from .base import configured_base_url
 from .base import default_vss_cmd
 from .base import ensure_vss_configured
@@ -184,6 +185,7 @@ __all__ = [
     "aggregate_upload_stats",
     "align_ts_to_segment",
     "classify_complete_failure",
+    "cli_supports_flag",
     "compare_inventory",
     "configured_base_url",
     "default_vss_cmd",

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/base.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/base.py
@@ -1,0 +1,265 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared contracts, timeouts and helpers for the flow backends."""
+
+from __future__ import annotations
+
+import json
+import shlex
+import shutil
+import subprocess
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Protocol
+from urllib.parse import urlparse
+
+# Timeouts (seconds). Mirror the upstream defaults documented in
+# vss_agents/api/video_ingest.py so an eval failure reflects real deployment
+# behaviour rather than a client-side cutoff.
+UPLOAD_URL_TIMEOUT = 30
+UPLOAD_TIMEOUT = 900
+COMPLETE_TIMEOUT = 900
+SEARCH_TIMEOUT = 300
+VST_LIST_TIMEOUT = 15
+
+# The upstream skill documents this exact constant for uploads whose real
+# capture time is unknown; the eval's ground truth is expressed relative to it.
+DEFAULT_UPLOAD_TIMESTAMP = "2025-01-01T00:00:00"
+
+CONTENT_TYPES = {".mp4": "video/mp4", ".mkv": "video/x-matroska"}
+
+
+class QueryBackend(Protocol):
+    """Runs one query and returns (raw results, latency in seconds)."""
+
+    name: str
+
+    def search(self, query: str) -> tuple[list[dict[str, Any]], float]: ...
+
+    def describe(self) -> dict[str, Any]: ...
+
+
+class IngestBackend(Protocol):
+    """Uploads one video and returns a per-file record."""
+
+    name: str
+
+    def upload(self, video_path: Path) -> dict[str, Any]: ...
+
+    def describe(self) -> dict[str, Any]: ...
+
+
+def base_record(video_path: Path) -> dict[str, Any]:
+    """Per-file record skeleton, matching what ``_aggregate_upload_stats`` reads."""
+    try:
+        file_size_mb: float | None = video_path.stat().st_size / (1024 * 1024)
+    except OSError:
+        file_size_mb = None
+    return {
+        "video_name": video_path.stem,
+        "video_path": str(video_path),
+        "file_size_mb": round(file_size_mb, 2) if file_size_mb is not None else None,
+        "timestamp": datetime.now().isoformat(),
+    }
+
+
+def finish_record(record: dict[str, Any], latency_s: float) -> dict[str, Any]:
+    """Stamp latency and derived throughput onto a per-file record."""
+    record["upload_latency_s"] = round(latency_s, 3)
+    size_mb = record.get("file_size_mb")
+    if size_mb and latency_s > 0:
+        record["upload_speed_mbps"] = round((size_mb * 8) / latency_s, 2)
+    return record
+
+
+def elapsed_since(start: float) -> float:
+    """Seconds since ``start`` (a ``time.time()`` reading)."""
+    return time.time() - start
+
+
+# =============================================================================
+# CLI discovery
+# =============================================================================
+
+#: The VSS checkout holding the ``vss`` CLI. Found by walking up to the directory
+#: containing ``services/agent`` rather than by counting path components: this
+#: skill sits five levels down (skills/benchmarking/<skill>/scripts/flows), and a
+#: fixed ``parents[N]`` silently resolved to ``skills/`` when the eval moved here
+#: from ci-vss-oss. Walking up survives the next move too.
+REPO_ROOT = next(
+    (p for p in Path(__file__).resolve().parents if (p / "services/agent/pyproject.toml").exists()),
+    Path(__file__).resolve().parents[4],
+)
+
+#: Kept as an alias: in ci-vss-oss the product was a submodule beside the eval,
+#: so the two differed. Here the eval ships inside the product and they are the
+#: same directory. Callers that ask for either get the checkout with the CLI.
+SUBMODULE_ROOT = REPO_ROOT
+
+#: Port serving the unified path-prefix origin (/vst, /elasticsearch,
+#: /rtvi-embed, ...) that ``vss configure`` probes. The agent's own port does
+#: NOT route those prefixes -- observed on both 10.86.12.161 and 10.87.88.126,
+#: where the agent answers on 8000 and the unified origin on 7777.
+DEFAULT_VSS_ORIGIN_PORT = 7777
+
+
+def has_cli_package(repo_root: Path | str) -> bool:
+    """True when a checkout actually ships the ``vss`` CLI package."""
+    return (Path(repo_root) / "services/agent/packages/vss_cli").is_dir()
+
+
+def default_vss_cmd(repo_root: str) -> list[str]:
+    """The project-local CLI invocation the upstream skill mandates.
+
+    ``--extra cli`` is required: the base distribution ships the libraries,
+    while the ``nvidia-vss-cli`` extra ships the ``vss`` executable.
+    """
+    project = f"{repo_root.rstrip('/')}/services/agent"
+    return ["uv", "run", "--project", project, "--no-dev", "--extra", "cli", "vss"]
+
+
+def resolve_vss_cmd(
+    explicit_cmd: str | None = None,
+    repo_root: str | None = None,
+) -> tuple[list[str], str]:
+    """Work out how to invoke ``vss``. Returns ``(argv_prefix, how)``.
+
+    Order of preference, most explicit first:
+
+    1. ``--vss-cmd``          -- caller knows exactly what they want
+    2. ``--vss-repo-root``    -- a checkout the caller named
+    3. the vendored submodule -- the CI case, when its pin ships the CLI
+    4. ``vss`` on PATH        -- a standalone ``pip install`` of nvidia-vss-cli
+
+    Raises ``FileNotFoundError`` listing every candidate tried, because "no
+    CLI found" and "the CLI is broken" need different fixes and a generic
+    message sends people down the wrong one.
+    """
+    if explicit_cmd:
+        return shlex.split(explicit_cmd), "--vss-cmd"
+
+    if repo_root:
+        if not has_cli_package(repo_root):
+            raise FileNotFoundError(
+                f"--vss-repo-root {repo_root} has no services/agent/packages/vss_cli.\n"
+                "  That checkout predates the core/agents/cli split, so it cannot "
+                "provide the vss CLI."
+            )
+        return default_vss_cmd(repo_root), f"--vss-repo-root {repo_root}"
+
+    if has_cli_package(SUBMODULE_ROOT):
+        return default_vss_cmd(str(SUBMODULE_ROOT)), f"repo checkout {SUBMODULE_ROOT}"
+
+    on_path = shutil.which("vss")
+    if on_path:
+        return [on_path], f"PATH ({on_path})"
+
+    raise FileNotFoundError(
+        "Could not find a vss CLI. Tried, in order:\n"
+        f"  1. --vss-cmd                 (not given)\n"
+        f"  2. --vss-repo-root           (not given)\n"
+        f"  3. submodule                 {SUBMODULE_ROOT}\n"
+        f"     -> {'no services/agent/packages/vss_cli (pin predates the CLI split)'}\n"
+        f"  4. vss on PATH               (not found)\n\n"
+        "Fix by either:\n"
+        "  * passing --vss-repo-root <checkout with services/agent/packages/vss_cli>, or\n"
+        "  * installing the CLI standalone (needs Python 3.13/3.14):\n"
+        "      pip install <checkout>/services/agent/packages/vss_core \\\n"
+        "                  <checkout>/services/agent/packages/vss_cli"
+    )
+
+
+def preflight_vss_cmd(vss_cmd: list[str], timeout: int = 300) -> str:
+    """Prove the CLI runs before the eval commits to hundreds of queries.
+
+    A stale virtualenv exits 1 with ModuleNotFoundError on every invocation.
+    Discovering that on query 1 of 121 wastes a run; discovering it here costs
+    one subprocess.
+    """
+    try:
+        proc = subprocess.run(
+            [*vss_cmd, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError as e:
+        raise RuntimeError(f"vss command is not executable: {shlex.join(vss_cmd)}\n  {e}") from e
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(f"vss --version timed out after {timeout}s: {shlex.join(vss_cmd)}") from e
+
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()[:400]
+        raise RuntimeError(
+            f"vss --version exited {proc.returncode}: {detail}\n"
+            f"  command: {shlex.join(vss_cmd)}\n"
+            "  A stale virtualenv is the usual cause -- reinstall it, or point "
+            "--vss-repo-root at a current checkout."
+        )
+    return (proc.stdout or proc.stderr or "").strip().splitlines()[0] if (proc.stdout or proc.stderr) else "unknown"
+
+
+def vss_origin_for(endpoint: str, port: int = DEFAULT_VSS_ORIGIN_PORT) -> str:
+    """The origin ``vss configure`` should probe, derived from the agent endpoint.
+
+    The CLI discovers services by path prefix on ONE origin, and the agent's
+    port does not route them -- pointing ``vss configure`` at the agent finds
+    1/7 services and every search then exits 4.
+    """
+    parsed = urlparse(endpoint)
+    return f"{parsed.scheme or 'http'}://{parsed.hostname}:{port}"
+
+
+def configured_base_url() -> str | None:
+    """The origin currently recorded in ``~/.vss/config.json``, if any."""
+    config = Path.home() / ".vss" / "config.json"
+    if not config.is_file():
+        return None
+    try:
+        return json.loads(config.read_text()).get("base_url")
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def ensure_vss_configured(vss_cmd: list[str], base_url: str, timeout: int = 300) -> dict[str, Any]:
+    """Point the CLI at ``base_url`` unless it already is.
+
+    ``vss configure`` writes ~/.vss/config.json, which lives outside this repo,
+    so this reports what it is doing rather than changing user state silently.
+    """
+    current = configured_base_url()
+    if current and current.rstrip("/") == base_url.rstrip("/"):
+        return {"ran": False, "base_url": current, "reason": "already configured"}
+
+    if current:
+        print(f"  vss is configured for {current}; re-pointing at {base_url}")
+    else:
+        print(f"  vss is not configured; pointing it at {base_url}")
+
+    proc = subprocess.run(
+        [*vss_cmd, "configure", "--base-url", base_url],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    output = (proc.stdout or "") + (proc.stderr or "")
+    for line in output.splitlines():
+        if line.strip():
+            print(f"    {line}")
+    if proc.returncode != 0:
+        raise RuntimeError(f"vss configure exited {proc.returncode} for {base_url}")
+    return {"ran": True, "base_url": base_url, "previous": current}

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/base.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/base.py
@@ -17,14 +17,15 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 import json
+from pathlib import Path
 import shlex
 import shutil
 import subprocess
 import time
-from datetime import datetime
-from pathlib import Path
-from typing import Any, Protocol
+from typing import Any
+from typing import Protocol
 from urllib.parse import urlparse
 
 # Timeouts (seconds). Mirror the upstream defaults documented in

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/base.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/base.py
@@ -214,6 +214,35 @@ def preflight_vss_cmd(vss_cmd: list[str], timeout: int = 300) -> str:
     return (proc.stdout or proc.stderr or "").strip().splitlines()[0] if (proc.stdout or proc.stderr) else "unknown"
 
 
+def cli_supports_flag(vss_cmd: list[str], flag: str, path: str = "embed", timeout: int = 120) -> bool:
+    """Whether ``vss search run <path>`` accepts ``flag``.
+
+    Click rejects an unknown option with exit 2, and :func:`is_fatal_exit`
+    treats any non-zero exit as an environment fault -- correctly, but that
+    means a flag this eval sends and the deployment's CLI has never heard of
+    aborts the whole run on query 1. The deployment's ``vss`` comes from its
+    image, not from this checkout, so "newer than the flag" is a normal state
+    for anyone running against a release build.
+
+    One ``--help`` subprocess turns that into a warning and a downgrade.
+    Unparseable output is reported as *absent*: skipping an optional flag
+    measures slightly the wrong thing, sending an unsupported one measures
+    nothing at all.
+    """
+    try:
+        proc = subprocess.run(
+            [*vss_cmd, "search", "run", path, "--help"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+    if proc.returncode != 0:
+        return False
+    return flag in (proc.stdout or "") or flag in (proc.stderr or "")
+
+
 def vss_origin_for(endpoint: str, port: int = DEFAULT_VSS_ORIGIN_PORT) -> str:
     """The origin ``vss configure`` should probe, derived from the agent endpoint.
 

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/dataset.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/dataset.py
@@ -1,0 +1,264 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dataset discovery, DSS download and ingest-stat aggregation.
+
+Vendored from ``run_eval.py`` so this flow owns them and that script can be
+deleted independently. Behaviour is unchanged: the registry, the on-disk layout
+and the aggregate shapes all have to keep matching what existing datasets and
+result readers expect.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+#: Where DSS downloads land unless --data-dir says otherwise.
+DEFAULT_DATA_DIR = Path("/tmp/vss-devx-search")
+
+#: The DSS dataset holding every eval fixture.
+DSS_DATASET_NAME = "vss-devx-search"
+
+# ---------------------------------------------------------------------------
+# Dataset registry -- maps (dataset, subset) to a path under --data-dir.
+#
+# Convention: <dataset>/<subset file>.json alongside <dataset>/videos/.
+# All subsets of a dataset share ONE videos/ directory; only the JSON differs.
+# ---------------------------------------------------------------------------
+
+DATASETS: dict[str, dict[str, str]] = {
+    "warehouse": {
+        "": "warehouse/dataset.json",
+    },
+    "vad-r1": {
+        "": "vad-r1/dataset.json",
+        "easy": "vad-r1/dataset_easy.json",
+        "medium": "vad-r1/dataset_medium.json",
+        "hard": "vad-r1/dataset_hard.json",
+    },
+    "vad-r1-v2": {
+        "": "vad-r1-v2/dataset.json",
+        "easy": "vad-r1-v2/dataset_easy.json",
+        "medium": "vad-r1-v2/dataset_medium.json",
+        "hard": "vad-r1-v2/dataset_hard.json",
+        "benchmark": "vad-r1-v2/dataset_benchmark.json",
+    },
+    # Built locally by flows_preprocessing/make_physicalai_devset.py, not on DSS
+    # -- run with --skip-download. One file per retrieval path, so a slice is
+    # chosen by name rather than by flags and two runs share byte-identical
+    # input. `fusion` is absent from the default file on purpose: it carries the
+    # same query strings as `embed`, and this mapping is keyed by query text, so
+    # merging them would silently drop 501 entries.
+    "physicalai-dev": {
+        "": "physicalai-dev/dataset.json",
+        "embed": "physicalai-dev/dataset_embed.json",
+        "attribute": "physicalai-dev/dataset_attribute.json",
+        "fusion": "physicalai-dev/dataset_fusion.json",
+    },
+    "kpi-search-v3": {
+        "": "kpi-search-v3/dataset.json",
+        "easy": "kpi-search-v3/dataset_easy.json",
+        "medium": "kpi-search-v3/dataset_medium.json",
+        "hard": "kpi-search-v3/dataset_hard.json",
+        "anomaly_ce1_style": "kpi-search-v3/dataset_anomaly_ce1_style.json",
+    },
+}
+
+
+def download_from_dss(data_dir: Path, dataset: str | None = None) -> None:
+    """Download eval data from DSS (nvdataset) to local directory."""
+    try:
+        from nvdataset import load_dataset
+    except ImportError:
+        print(
+            "ERROR: nvdataset is not installed. Install it with:\n"
+            "  pip install --extra-index-url "
+            "https://artifactory.pdx.nvidia.com/artifactory/api/pypi/"
+            "sw-ngc-data-platform-pypi-local/simple nvdataset\n"
+            "Or run with --skip-download if data is already local.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print(f"Loading DSS dataset: {DSS_DATASET_NAME}")
+    ds = load_dataset(name=DSS_DATASET_NAME)
+    sc = ds.to_storage_client(read_only=True)
+
+    # List all files in the dataset (File.datum.key holds the path)
+    all_files = [f.datum.key for f in ds.list_files()]
+    print(f"  Found {len(all_files)} files in DSS dataset")
+
+    # Filter to requested dataset if specified
+    if dataset:
+        prefix = f"{dataset}/"
+        all_files = [f for f in all_files if f.startswith(prefix)]
+        print(f"  Filtered to {len(all_files)} files for dataset '{dataset}'")
+
+    if not all_files:
+        print("ERROR: No files found in DSS dataset.", file=sys.stderr)
+        sys.exit(1)
+
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    downloaded = 0
+    skipped = 0
+    for remote_path in all_files:
+        local_path = data_dir / remote_path
+        if local_path.exists():
+            skipped += 1
+            continue
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        print(f"  Downloading: {remote_path}")
+        sc.download_file(remote_path, str(local_path))
+        downloaded += 1
+
+    print(f"  Download complete: {downloaded} new, {skipped} already present")
+
+
+def load_dataset_file(data_dir: Path, dataset: str, subset: str) -> dict:
+    """Load dataset JSON (queries + annotations) from local data dir."""
+    rel_path = DATASETS.get(dataset, {}).get(subset)
+    if rel_path is None:
+        available_subsets = list(DATASETS.get(dataset, {}).keys())
+        print(
+            f"ERROR: Unknown dataset/subset: {dataset}/{subset or '(default)'}. Available subsets: {available_subsets}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    fpath = data_dir / rel_path
+    if not fpath.exists():
+        print(f"ERROR: Dataset file not found: {fpath}", file=sys.stderr)
+        print("Run without --skip-download to fetch from DSS.", file=sys.stderr)
+        sys.exit(1)
+
+    with open(fpath) as f:
+        data = json.load(f)
+
+    return data
+
+
+def aggregate_upload_stats(per_file: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate per-file upload results into latency/throughput stats.
+
+    Mirrors the shape produced by eval/data/upload_latency.py so JSON consumers
+    can use the same keys regardless of which entrypoint produced them.
+    """
+    successful = [r for r in per_file if r.get("success")]
+    failed = [r for r in per_file if not r.get("success")]
+
+    stats: dict[str, Any] = {
+        "total_uploads": len(per_file),
+        "successful": len(successful),
+        "failed": len(failed),
+        "success_rate": round(len(successful) / len(per_file), 4) if per_file else 0.0,
+        "per_file": per_file,
+    }
+
+    if successful:
+        latencies_s = sorted(r["upload_latency_s"] for r in successful)
+        total_size_mb = sum(r.get("file_size_mb") or 0.0 for r in successful)
+        total_chunks = sum(r.get("chunks_processed") or 0 for r in successful)
+        n = len(latencies_s)
+
+        # Match search-latency percentile convention used elsewhere in this file
+        # (sorted_lat[int(len * pct)]) so both blocks are directly comparable.
+        stats["latency"] = {
+            "mean_s": round(statistics.mean(latencies_s), 3),
+            "median_s": round(statistics.median(latencies_s), 3),
+            "min_s": round(latencies_s[0], 3),
+            "max_s": round(latencies_s[-1], 3),
+            "p90_s": round(latencies_s[min(int(n * 0.9), n - 1)], 3),
+            "p95_s": round(latencies_s[min(int(n * 0.95), n - 1)], 3),
+            "std_dev_s": round(statistics.stdev(latencies_s), 3) if n > 1 else 0.0,
+            "total_s": round(sum(latencies_s), 3),
+        }
+        stats["throughput"] = {
+            "total_size_mb": round(total_size_mb, 2),
+            "avg_upload_speed_mbps": (
+                round((total_size_mb * 8) / sum(latencies_s), 2) if sum(latencies_s) > 0 else None
+            ),
+        }
+        if total_chunks > 0:
+            stats["chunks"] = {
+                "total_processed": total_chunks,
+                "avg_per_video": round(total_chunks / len(successful), 1),
+                "avg_latency_per_chunk_s": round(sum(latencies_s) / total_chunks, 3),
+            }
+
+    if failed:
+        stats["errors"] = [
+            {"video": r.get("video_name"), "error": r.get("error")} for r in failed
+        ]
+
+    return stats
+
+
+def print_upload_summary(stats: dict[str, Any]) -> None:
+    """Print upload latency/throughput block in the same style as RESULTS SUMMARY."""
+    if not stats or not stats.get("total_uploads"):
+        return
+
+    print(f"\n{'=' * 60}")
+    print("UPLOAD LATENCY SUMMARY")
+    print(f"{'=' * 60}")
+    print(f"Total Uploads:      {stats['total_uploads']}")
+    print(f"Successful:         {stats['successful']}")
+    print(f"Failed:             {stats['failed']}")
+    print(f"Success Rate:       {stats['success_rate'] * 100:.1f}%")
+
+    lat = stats.get("latency")
+    if lat:
+        print("\nUpload Latency:")
+        print(f"  Mean:             {lat['mean_s']:.3f}s")
+        print(f"  Median:           {lat['median_s']:.3f}s")
+        print(f"  Min:              {lat['min_s']:.3f}s")
+        print(f"  Max:              {lat['max_s']:.3f}s")
+        print(f"  P90:              {lat['p90_s']:.3f}s")
+        print(f"  P95:              {lat['p95_s']:.3f}s")
+        print(f"  Std Dev:          {lat['std_dev_s']:.3f}s")
+        print(f"  Total Time:       {lat['total_s']:.3f}s")
+
+    tp = stats.get("throughput")
+    if tp:
+        print("\nThroughput:")
+        print(f"  Total Size:       {tp['total_size_mb']:.2f} MB")
+        if tp.get("avg_upload_speed_mbps") is not None:
+            print(f"  Avg Speed:        {tp['avg_upload_speed_mbps']:.2f} Mbps")
+
+    chunks = stats.get("chunks")
+    if chunks:
+        print("\nChunk Processing:")
+        print(f"  Total Chunks:     {chunks['total_processed']}")
+        print(f"  Avg per Video:    {chunks['avg_per_video']}")
+        print(f"  Avg Latency/Chunk:{chunks['avg_latency_per_chunk_s']:.3f}s")
+
+    errs = stats.get("errors")
+    if errs:
+        print("\nFailed Uploads:")
+        for err in errs:
+            print(f"  - {err['video']}: {err['error']}")
+    print(f"{'=' * 60}\n")
+
+
+def vst_url_for(endpoint: str, vst_port: int = 30888) -> str:
+    """Derive VST URL from the agent endpoint (same host, VST port)."""
+    parsed = urlparse(endpoint)
+    return f"{parsed.scheme}://{parsed.hostname}:{vst_port}"

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/dataset.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/dataset.py
@@ -24,9 +24,9 @@ result readers expect.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 import statistics
 import sys
-from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/dataset.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/dataset.py
@@ -265,6 +265,25 @@ def vst_url_for(endpoint: str, vst_port: int = 30888) -> str:
     return f"{parsed.scheme}://{parsed.hostname}:{vst_port}"
 
 
+def sidecar_decompositions_for(data_dir: Path, dataset: str) -> Path | None:
+    """The dataset's own decomposition answer key, when it ships one.
+
+    ``devset_provenance.json`` carries ``expected_decomposition`` for every
+    query. It is deliberately not in the dataset files -- routing is decided at
+    query time, and a stored decomposition would compete with that -- but when
+    the decomposer cannot be reached it is the difference between exercising all
+    four paths and measuring one.
+    """
+    path = data_dir / dataset / "devset_provenance.json"
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text())
+    except Exception:
+        return None
+    return path if isinstance(payload.get("expected_decomposition"), dict) else None
+
+
 def llm_url_for(endpoint: str, llm_port: int = 30081) -> str:
     """Derive the decomposition LLM origin from the agent endpoint.
 

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/dataset.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/dataset.py
@@ -263,3 +263,18 @@ def vst_url_for(endpoint: str, vst_port: int = 30888) -> str:
     """Derive VST URL from the agent endpoint (same host, VST port)."""
     parsed = urlparse(endpoint)
     return f"{parsed.scheme}://{parsed.hostname}:{vst_port}"
+
+
+def llm_url_for(endpoint: str, llm_port: int = 30081) -> str:
+    """Derive the decomposition LLM origin from the agent endpoint.
+
+    Same host, NIM port. The LLM is not routed through the unified origin the
+    other services share, so it is derived from ``--endpoint`` rather than read
+    off the HAProxy prefix map -- the same reasoning as :func:`vst_url_for`.
+
+    Deriving it is what makes live decomposition the default: an eval that
+    silently falls back to one fixed path measures a flow the product does not
+    run, and that failure is invisible in the metrics.
+    """
+    parsed = urlparse(endpoint)
+    return f"{parsed.scheme}://{parsed.hostname}:{llm_port}"

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/dataset.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/dataset.py
@@ -60,12 +60,13 @@ DATASETS: dict[str, dict[str, str]] = {
         "hard": "vad-r1-v2/dataset_hard.json",
         "benchmark": "vad-r1-v2/dataset_benchmark.json",
     },
-    # Built locally by flows_preprocessing/make_physicalai_devset.py, not on DSS
-    # -- run with --skip-download. One file per retrieval path, so a slice is
-    # chosen by name rather than by flags and two runs share byte-identical
-    # input. `fusion` is absent from the default file on purpose: it carries the
-    # same query strings as `embed`, and this mapping is keyed by query text, so
-    # merging them would silently drop 501 entries.
+    # Built by flows_preprocessing/make_physicalai_devset.py (seed 0, source
+    # balanced) and published to DSS, so it downloads like any other dataset.
+    # One file per retrieval path, so a slice is chosen by name rather than by
+    # flags and two runs share byte-identical input. `fusion` is absent from the
+    # default file on purpose: its 195 queries repeat query strings already in
+    # `embed`, and this mapping is keyed by query text, so merging them would
+    # silently overwrite those 195 entries.
     "physicalai-dev": {
         "": "physicalai-dev/dataset.json",
         "embed": "physicalai-dev/dataset_embed.json",

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/dataset.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/dataset.py
@@ -24,6 +24,7 @@ result readers expect.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 import statistics
 import sys
@@ -31,7 +32,14 @@ from typing import Any
 from urllib.parse import urlparse
 
 #: Where DSS downloads land unless --data-dir says otherwise.
-DEFAULT_DATA_DIR = Path("/tmp/vss-devx-search")
+#:
+#: Deliberately NOT /tmp, which run_eval.py used and which is world-writable.
+#: These evals run on shared deployment boxes, where any other user can
+#: pre-create the directory and plant dataset files -- and this path holds the
+#: ground truth every metric is scored against, so poisoning it is not a
+#: hypothetical inconvenience but a way to make the eval report whatever the
+#: attacker chose. Under the user's own cache dir the OS enforces ownership.
+DEFAULT_DATA_DIR = Path(os.environ.get("XDG_CACHE_HOME") or Path.home() / ".cache") / "vss-devx-search"
 
 #: The DSS dataset holding every eval fixture.
 DSS_DATASET_NAME = "vss-devx-search"

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/decompose.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/decompose.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Live query decomposition, per query, using the deployment's own LLM.
+
+The CLI takes an explicit retrieval path and explicit arguments; it has no
+decomposition step. The agent path does: it sends the user's sentence to an LLM
+that returns ``{query, attributes, has_action, object_ids, top_k, ...}``, and
+that structure decides which of the four paths runs.
+
+Decomposing here rather than baking the answer into a dataset means the run
+measures what a deployment actually does -- including how long decomposition
+takes, which is otherwise invisible in a latency breakdown that starts at
+``search()``. It also means routing is only as good as the deployed model, and
+a wrong decomposition shows up as a retrieval regression. That is the intended
+behaviour: the eval reports the deployment, not an idealised version of it.
+
+The prompt is read from the product source at run time rather than copied::
+
+    services/agent/packages/vss_agents/src/vss_agents/tools/search.py
+
+This skill ships inside that repo, so the file is always present and always the
+version this checkout would send. A vendored copy would silently diverge the
+first time someone edited the prompt.
+
+Not deterministic. This model returns different attributes for the same query
+between runs even at ``temperature=0``, so two runs can route the same query
+differently. Raw retrieval metrics stay comparable only for queries that routed
+the same way -- ``summary.decomposition`` reports the path distribution so a
+shift is visible rather than silently changing what was measured.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+
+#: Where the agent's decomposition contract lives, relative to the repo root.
+PROMPT_SOURCE = "services/agent/packages/vss_agents/src/vss_agents/tools/search.py"
+
+#: From the search profile's ``llms`` block (dev-profile-search config.yml):
+#: nim/openai profiles both pin these, so a run matches the deployment.
+TEMPERATURE = 0.0
+MAX_TOKENS = 4096
+
+_SYSTEM = (
+    "You are a helpful assistant that extracts search parameters from natural "
+    "language queries. Return only valid JSON."
+)
+
+
+class DecompositionError(RuntimeError):
+    """The LLM was unreachable, or returned something that was not a decomposition."""
+
+
+def load_prompt(repo_root: Path) -> tuple[str, str]:
+    """Return ``(prompt_template, few_shot_examples)`` from the product source."""
+    src = repo_root / PROMPT_SOURCE
+    if not src.exists():
+        raise DecompositionError(
+            f"cannot read the decomposition prompt: {src} not found. "
+            "This skill must run from inside a VSS checkout."
+        )
+    text = src.read_text()
+    prompt = re.search(r'QUERY_DECOMPOSITION_PROMPT = """(.*?)"""', text, re.S)
+    few_shot = re.search(r'DEFAULT_FEW_SHOT_EXAMPLES = """(.*?)"""', text, re.S)
+    if prompt is None or few_shot is None:
+        raise DecompositionError(
+            f"QUERY_DECOMPOSITION_PROMPT / DEFAULT_FEW_SHOT_EXAMPLES not found in {src}; "
+            "the product source may have been restructured."
+        )
+    return prompt.group(1), few_shot.group(1)
+
+
+def _strip_fences(text: str) -> str:
+    """Undo markdown fencing. Mirrors what ``decompose_query`` does upstream."""
+    stripped = text.strip()
+    if "```json" in stripped:
+        return stripped.split("```json", 1)[1].split("```", 1)[0].strip()
+    if "```" in stripped:
+        parts = stripped.split("```")
+        return (parts[1] if len(parts) > 1 else stripped).strip()
+    return stripped
+
+
+class LiveDecomposer:
+    """Decomposes each query against the deployment's LLM, and times it."""
+
+    def __init__(
+        self,
+        llm_url: str,
+        *,
+        repo_root: Path,
+        model: str | None = None,
+        timeout_s: float = 120.0,
+    ) -> None:
+        self._url = llm_url.rstrip("/")
+        self._timeout = timeout_s
+        self._prompt, self._few_shot = load_prompt(repo_root)
+        self._model = model or self._discover_model()
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    def _discover_model(self) -> str:
+        try:
+            resp = requests.get(f"{self._url}/v1/models", timeout=self._timeout)
+            resp.raise_for_status()
+            data = resp.json()["data"]
+        except (requests.RequestException, KeyError, ValueError) as e:
+            raise DecompositionError(
+                f"could not list models at {self._url}/v1/models: {e}. "
+                "Check --llm-url, or pass --llm-model to skip discovery."
+            ) from e
+        if not data:
+            raise DecompositionError(f"{self._url} served an empty model list.")
+        return str(data[0]["id"])
+
+    def describe(self) -> dict[str, Any]:
+        return {
+            "llm_url": self._url,
+            "model": self._model,
+            "temperature": TEMPERATURE,
+            "prompt_source": PROMPT_SOURCE,
+        }
+
+    def decompose(self, query: str, video_sources: list[str] | None = None) -> tuple[dict[str, Any], float]:
+        """Return ``(decomposition, seconds)``.
+
+        ``seconds`` is wall clock around the call, so it belongs to the query's
+        end-to-end cost the same way the CLI subprocess does.
+        """
+        sources = (
+            f"Video files: {', '.join(video_sources)}" if video_sources else "No specific sources available"
+        )
+        body = {
+            "model": self._model,
+            "temperature": TEMPERATURE,
+            "max_tokens": MAX_TOKENS,
+            "messages": [
+                {"role": "system", "content": _SYSTEM},
+                {
+                    "role": "user",
+                    "content": self._prompt.format(
+                        video_sources=sources,
+                        few_shot_examples=self._few_shot,
+                        user_query=query,
+                    ),
+                },
+            ],
+        }
+        started = time.perf_counter()
+        try:
+            resp = requests.post(
+                f"{self._url}/v1/chat/completions", json=body, timeout=self._timeout
+            )
+            resp.raise_for_status()
+            content = resp.json()["choices"][0]["message"]["content"]
+        except (requests.RequestException, KeyError, IndexError, ValueError) as e:
+            raise DecompositionError(f"decomposition request failed for {query!r}: {e}") from e
+        elapsed = time.perf_counter() - started
+
+        try:
+            decomposition = json.loads(_strip_fences(content))
+        except json.JSONDecodeError as e:
+            raise DecompositionError(
+                f"decomposition for {query!r} was not JSON: {content[:200]!r}"
+            ) from e
+        if not isinstance(decomposition, dict):
+            raise DecompositionError(
+                f"decomposition for {query!r} was {type(decomposition).__name__}, expected object"
+            )
+        # The prompt marks has_action REQUIRED, but the model omits it often
+        # enough that routing would silently fall through to `fusion` for
+        # attribute-only queries. Absent stays absent -- routing treats it as
+        # unknown and says so -- rather than being invented here.
+        return decomposition, elapsed

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/decompose.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/decompose.py
@@ -47,10 +47,13 @@ from __future__ import annotations
 import json
 import re
 import time
-from pathlib import Path
+from typing import TYPE_CHECKING
 from typing import Any
 
 import requests
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 #: Where the agent's decomposition contract lives, relative to the repo root.
 PROMPT_SOURCE = "services/agent/packages/vss_agents/src/vss_agents/tools/search.py"

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/ingest.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/ingest.py
@@ -1,0 +1,293 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ingest backends: the deprecated single PUT and the three-step agent flow.
+
+A third backend -- direct VST/VIOS -- is missing on purpose. The UI has already
+moved to it (ci-vss-oss commit 0bdfc8d, the eval's previous home) but its contract is not documented
+anywhere we can read, and guessing would produce an eval that indexes
+differently from the product.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from .base import (
+    COMPLETE_TIMEOUT,
+    CONTENT_TYPES,
+    DEFAULT_UPLOAD_TIMESTAMP,
+    UPLOAD_TIMEOUT,
+    UPLOAD_URL_TIMEOUT,
+    base_record,
+    finish_record,
+)
+
+#: How ``/complete`` failures are classified. Observed on 10.86.12.161:
+#: the call 502s on first attempt and succeeds on retry (Assault036_x264
+#: returned 200 with chunks_processed=7 the second time). It is flaky, not
+#: broken, so a single attempt under-reports ingest success badly.
+COMPLETE_RETRY = "retry"
+COMPLETE_ALREADY_REGISTERED = "already-registered"
+COMPLETE_FATAL = "fatal"
+
+#: RTVI-CV's response when the camera is already registered. This is what a
+#: retry hits when the *previous* attempt got far enough to add the stream
+#: before failing -- i.e. the work already landed.
+_DUPLICATE_CAMERA_MARKER = "duplicate camera id"
+
+
+def classify_complete_failure(status_code: int, body: str) -> str:
+    """Decide what a failed ``/complete`` response means.
+
+    Split out as a pure function so the policy is testable without a backend.
+
+    "Duplicate Camera id" is deliberately NOT a failure. It means a prior
+    attempt already registered the stream in RTVI-CV, so the pipeline ran; the
+    observed case (warehouse_sample) had working embeddings and searchable
+    results despite every ``/complete`` call returning an error.
+    """
+    if _DUPLICATE_CAMERA_MARKER in (body or "").lower():
+        return COMPLETE_ALREADY_REGISTERED
+    if status_code >= 500 or status_code == 429:
+        return COMPLETE_RETRY
+    return COMPLETE_FATAL
+
+
+class LegacyPutIngest:
+    """``PUT /api/v1/videos-for-search/{name}`` -- deprecated upstream.
+
+    Kept so a baseline can still be captured while the route exists. Upstream
+    states removal is gated on this repo migrating away from it, so this
+    backend has a shelf life.
+    """
+
+    name = "legacy-put"
+
+    def __init__(self, endpoint: str, timeout: int = UPLOAD_TIMEOUT) -> None:
+        self.endpoint = endpoint.rstrip("/")
+        self.timeout = timeout
+
+    def describe(self) -> dict[str, Any]:
+        return {
+            "backend": self.name,
+            "url": f"{self.endpoint}/api/v1/videos-for-search/{{name}}",
+            "deprecated": True,
+        }
+
+    def upload(self, video_path: Path) -> dict[str, Any]:
+        record = base_record(video_path)
+        content_type = CONTENT_TYPES.get(video_path.suffix, "video/mp4")
+        try:
+            with open(video_path, "rb") as f:
+                start = time.time()
+                resp = requests.put(
+                    f"{self.endpoint}/api/v1/videos-for-search/{video_path.stem}",
+                    data=f,
+                    headers={"Content-Type": content_type, "Accept": "application/json"},
+                    timeout=self.timeout,
+                )
+                latency = time.time() - start
+            record["status_code"] = resp.status_code
+            finish_record(record, latency)
+            resp.raise_for_status()
+            payload = resp.json() if resp.content else {}
+            record["success"] = True
+            record["video_id"] = payload.get("video_id", "unknown")
+            record["sensor_id"] = payload.get("video_id")
+            record["chunks_processed"] = payload.get("chunks_processed")
+        except requests.Timeout:
+            record["success"] = False
+            record["error"] = "Request timeout"
+        except Exception as e:
+            record["success"] = False
+            record["error"] = f"{type(e).__name__}: {e}"
+        return record
+
+
+class AgentThreeStepIngest:
+    """The documented replacement for the deprecated single PUT.
+
+    Three phases, timed separately -- the single PUT reported one opaque
+    number, so this yields strictly more information than the old flow:
+
+        1. POST /api/v1/videos                       -> {"url": ...}
+        2. POST {url}   (nvstreamer-* headers)       -> {"sensorId": ...}
+        3. POST /api/v1/videos/{sensor_id}/complete  -> {"chunks_processed": N}
+
+    Phase 3 is where indexing happens (RTVI-CV stream add + RTVI-Embed
+    embedding generation), which is why it carries the long timeout and why
+    ``chunks_processed`` appears only there.
+    """
+
+    name = "agent-3step"
+
+    def __init__(
+        self,
+        endpoint: str,
+        upload_timestamp: str = DEFAULT_UPLOAD_TIMESTAMP,
+        complete_retries: int = 3,
+        complete_backoff_s: float = 5.0,
+    ) -> None:
+        self.endpoint = endpoint.rstrip("/")
+        self.upload_timestamp = upload_timestamp
+        self.complete_retries = complete_retries
+        self.complete_backoff_s = complete_backoff_s
+
+    def describe(self) -> dict[str, Any]:
+        return {
+            "backend": self.name,
+            "steps": [
+                f"POST {self.endpoint}/api/v1/videos",
+                "POST {upload_url}",
+                f"POST {self.endpoint}/api/v1/videos/{{sensor_id}}/complete",
+            ],
+            "upload_timestamp": self.upload_timestamp,
+            "complete_retries": self.complete_retries,
+            "complete_backoff_s": self.complete_backoff_s,
+        }
+
+    def _complete(self, sensor_id: str, body: dict[str, Any]) -> tuple[dict[str, Any], int, str]:
+        """Call ``/complete``, retrying the flaky 5xx.
+
+        Returns ``(completion_json, attempts, outcome)`` where outcome is one of
+        the ``COMPLETE_*`` constants, or raises on a fatal / exhausted failure.
+        """
+        url = f"{self.endpoint}/api/v1/videos/{sensor_id}/complete"
+        last_detail = ""
+
+        for attempt in range(1, self.complete_retries + 1):
+            resp = requests.post(
+                url,
+                json=body,
+                headers={"Content-Type": "application/json"},
+                timeout=COMPLETE_TIMEOUT,
+            )
+            if resp.ok:
+                return (resp.json() or {}), attempt, COMPLETE_RETRY if attempt > 1 else "ok"
+
+            last_detail = (resp.text or "")[:300]
+            verdict = classify_complete_failure(resp.status_code, resp.text or "")
+
+            if verdict == COMPLETE_ALREADY_REGISTERED:
+                # A previous attempt already registered the stream, so the
+                # pipeline ran. chunks_processed is unknowable from here --
+                # readiness and the first query are what confirm it.
+                print(f"    /complete attempt {attempt}: already registered (RTVI-CV duplicate); treating as done")
+                return {}, attempt, COMPLETE_ALREADY_REGISTERED
+
+            if verdict == COMPLETE_FATAL or attempt == self.complete_retries:
+                raise RuntimeError(f"/complete failed after {attempt} attempt(s): {resp.status_code} {last_detail}")
+
+            wait = self.complete_backoff_s * attempt
+            print(f"    /complete attempt {attempt} returned {resp.status_code}; retrying in {wait:.0f}s")
+            time.sleep(wait)
+
+        raise RuntimeError(f"/complete exhausted {self.complete_retries} attempts: {last_detail}")
+
+    def upload(self, video_path: Path) -> dict[str, Any]:
+        record = base_record(video_path)
+        filename = video_path.name
+        content_type = CONTENT_TYPES.get(video_path.suffix, "video/mp4")
+        phases: dict[str, float] = {}
+        overall_start = time.time()
+
+        try:
+            # -- 1. Ask the agent where to put it ---------------------------
+            t0 = time.time()
+            resp = requests.post(
+                f"{self.endpoint}/api/v1/videos",
+                json={"filename": filename},
+                headers={"Content-Type": "application/json"},
+                timeout=UPLOAD_URL_TIMEOUT,
+            )
+            resp.raise_for_status()
+            upload_url = (resp.json() or {}).get("url")
+            phases["request_url_s"] = round(time.time() - t0, 3)
+            if not upload_url:
+                raise RuntimeError(f"POST /api/v1/videos returned no upload url: {resp.text[:200]}")
+
+            # -- 2. Send the bytes to VST -----------------------------------
+            # Single chunk: the eval's fixtures are small enough that chunking
+            # would only add moving parts. Real UI uploads chunk; if a fixture
+            # outgrows this, the headers below are where that changes.
+            identifier = str(uuid.uuid4())
+            t0 = time.time()
+            with open(video_path, "rb") as f:
+                resp = requests.post(
+                    upload_url,
+                    headers={
+                        "nvstreamer-chunk-number": "1",
+                        "nvstreamer-total-chunks": "1",
+                        "nvstreamer-is-last-chunk": "true",
+                        "nvstreamer-identifier": identifier,
+                        "nvstreamer-file-name": filename,
+                    },
+                    files={"mediaFile": (filename, f, content_type)},
+                    data={
+                        "filename": filename,
+                        "metadata": json.dumps({"timestamp": self.upload_timestamp}),
+                    },
+                    timeout=UPLOAD_TIMEOUT,
+                )
+            resp.raise_for_status()
+            upload_body = resp.json() or {}
+            phases["upload_s"] = round(time.time() - t0, 3)
+            sensor_id = upload_body.get("sensorId")
+            if not sensor_id:
+                raise RuntimeError(f"VST upload returned no sensorId: {resp.text[:200]}")
+
+            # -- 3. Trigger post-processing / indexing ----------------------
+            complete_body = {**upload_body, "filename": filename}
+            t0 = time.time()
+            completion, attempts, outcome = self._complete(sensor_id, complete_body)
+            phases["complete_s"] = round(time.time() - t0, 3)
+
+            record["success"] = True
+            record["sensor_id"] = sensor_id
+            record["video_id"] = sensor_id
+            record["chunks_processed"] = completion.get("chunks_processed")
+            record["complete_attempts"] = attempts
+            record["complete_outcome"] = outcome
+            record["phases"] = phases
+            finish_record(record, time.time() - overall_start)
+
+            # The upstream skill validates exactly this before treating an
+            # upload as real; a 200 with zero chunks means nothing was indexed.
+            # The duplicate-camera path is exempt: the work landed on an
+            # earlier attempt, so no chunk count comes back and readiness plus
+            # the first query are what actually confirm it.
+            if outcome != COMPLETE_ALREADY_REGISTERED:
+                chunks = completion.get("chunks_processed")
+                if not isinstance(chunks, int) or chunks <= 0:
+                    record["success"] = False
+                    record["error"] = f"completion reported chunks_processed={chunks!r}"
+        except requests.Timeout:
+            record["success"] = False
+            record["error"] = "Request timeout"
+            record["phases"] = phases
+            finish_record(record, time.time() - overall_start)
+        except Exception as e:
+            record["success"] = False
+            record["error"] = f"{type(e).__name__}: {e}"
+            record["phases"] = phases
+            finish_record(record, time.time() - overall_start)
+        return record

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/ingest.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/ingest.py
@@ -25,21 +25,22 @@ from __future__ import annotations
 
 import json
 import time
-import uuid
-from pathlib import Path
+from typing import TYPE_CHECKING
 from typing import Any
+import uuid
 
 import requests
 
-from .base import (
-    COMPLETE_TIMEOUT,
-    CONTENT_TYPES,
-    DEFAULT_UPLOAD_TIMESTAMP,
-    UPLOAD_TIMEOUT,
-    UPLOAD_URL_TIMEOUT,
-    base_record,
-    finish_record,
-)
+from .base import COMPLETE_TIMEOUT
+from .base import CONTENT_TYPES
+from .base import DEFAULT_UPLOAD_TIMESTAMP
+from .base import UPLOAD_TIMEOUT
+from .base import UPLOAD_URL_TIMEOUT
+from .base import base_record
+from .base import finish_record
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 #: How ``/complete`` failures are classified. Observed on 10.86.12.161:
 #: the call 502s on first attempt and succeeds on retry (Assault036_x264

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/ingest.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/ingest.py
@@ -83,6 +83,9 @@ class LegacyPutIngest:
 
     name = "legacy-put"
 
+    #: The single PUT is synchronous and indexes before it returns.
+    proves_indexing = True
+
     def __init__(self, endpoint: str, timeout: int = UPLOAD_TIMEOUT) -> None:
         self.endpoint = endpoint.rstrip("/")
         self.timeout = timeout
@@ -140,6 +143,10 @@ class AgentThreeStepIngest:
     """
 
     name = "agent-3step"
+
+    #: ``/complete`` runs the embedding leg synchronously and returns
+    #: ``chunks_processed``; a zero fails the upload. That IS the check.
+    proves_indexing = True
 
     def __init__(
         self,
@@ -338,6 +345,14 @@ class VstDirectIngest:
     """
 
     name = "vst-direct"
+
+    #: Whether a successful upload is itself evidence that the media is
+    #: searchable. False here: the webhook fan-out is fire-and-forget, so the
+    #: caller has to check. A string in ``describe()`` was the wrong home for
+    #: this -- the gate compared it to "none" while describe() returned
+    #: "none (webhook fan-out is fire-and-forget)", so the check silently never
+    #: ran and a run against a half-built index scored as a retrieval collapse.
+    proves_indexing = False
 
     def __init__(
         self,

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/ingest.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/ingest.py
@@ -292,3 +292,148 @@ class AgentThreeStepIngest:
             record["phases"] = phases
             finish_record(record, time.time() - overall_start)
         return record
+
+
+class VstDirectIngest:
+    """Upload straight to VIOS and let its webhooks drive perception.
+
+    This is what the product UI does. ``ChatUpload.tsx`` POSTs to
+    ``{VST}/vst/api/v1/storage/file`` and stops; there is no
+    ``POST /api/v1/videos`` and no ``/complete`` anywhere in ``services/ui``.
+    VIOS raises ``camera_streaming`` and its webhook notifier fans out to
+    RT-CV, RT-Embed and RT-VLM itself -- the three calls the agent's
+    ``/complete`` makes by hand, plus tagging, which ``/complete`` never does.
+
+    So this backend is :class:`AgentThreeStepIngest` minus phases 1 and 3: the
+    same bytes, the same headers, the same anchor, with the upload URL built
+    rather than fetched.
+
+    Three things are worse here, and they are why this is not the default:
+
+    * **No completion proof.** ``/complete`` runs the embedding leg
+      synchronously and returns ``chunks_processed``; the webhook fan-out is
+      fire-and-forget and VIOS never reports the outcome to the uploader. The
+      readiness poll and the first query are all that confirm anything indexed,
+      so ``chunks_processed`` is ``None`` -- not zero -- and the run records
+      ``ingest_proof: "none"``.
+    * **The anchor is VIOS's to choose.** The webhook request bodies in
+      ``dev-profile-search/vios/configs/notification_config.json`` are empty
+      ``{}``, so nothing passes ``creation_time``; the agent's ``/complete``
+      hard-codes ``2025-01-01T00:00:00.000Z`` (``video_ingest.py``). Ground
+      truth is matched by absolute-timestamp overlap against that anchor, so if
+      VIOS anchors chunks anywhere else EVERY query scores zero and it reads as
+      a retrieval collapse. :meth:`verify_anchor` checks it rather than trusting
+      it.
+    * **Helm has webhooks off.** ``webhooks.enabled`` is true only in the Docker
+      search profile; the Helm chart ships the dummy item and false. On such a
+      deployment this backend uploads successfully and indexes nothing.
+    """
+
+    name = "vst-direct"
+
+    def __init__(
+        self,
+        vst_url: str,
+        upload_timestamp: str = DEFAULT_UPLOAD_TIMESTAMP,
+    ) -> None:
+        self.vst_url = vst_url.rstrip("/")
+        self.upload_timestamp = upload_timestamp
+
+    def describe(self) -> dict[str, Any]:
+        return {
+            "flow": self.name,
+            "vst_url": self.vst_url,
+            "upload_url": self.upload_url,
+            "upload_timestamp": self.upload_timestamp,
+            # Stated in the artifact, not left to be inferred from a null
+            # chunk count: a reader comparing this run against a 3-step one
+            # has to know the success criterion changed.
+            "ingest_proof": "none (webhook fan-out is fire-and-forget)",
+        }
+
+    @property
+    def upload_url(self) -> str:
+        return f"{self.vst_url}/vst/api/v1/storage/file"
+
+    def verify_anchor(self, sensor_id: str, timeout: int = COMPLETE_TIMEOUT) -> dict[str, Any]:
+        """Read back the timeline VIOS recorded for an uploaded video.
+
+        The one check worth making before a whole run is scored. Same endpoint
+        the agent uses (``/vst/api/v1/storage/timelines``, keyed by stream id).
+        Returns what it found; deciding whether the anchor is acceptable is the
+        caller's, because a deliberate live-source run has a different answer
+        from a file-fixture run.
+        """
+        url = f"{self.vst_url}/vst/api/v1/storage/timelines"
+        try:
+            resp = requests.get(url, timeout=timeout)
+            resp.raise_for_status()
+            timelines = (resp.json() or {}).get(sensor_id) or []
+        except Exception as e:
+            return {"checked": False, "error": f"{type(e).__name__}: {e}"}
+        if not timelines:
+            return {"checked": True, "found": False, "sensor_id": sensor_id}
+        start = timelines[0].get("startTime") or ""
+        return {
+            "checked": True,
+            "found": True,
+            "start_time": start,
+            "end_time": timelines[0].get("endTime") or "",
+            # The dataset's ground truth is offsets from this instant.
+            "matches_expected_anchor": start.startswith(self.upload_timestamp[:10]),
+            "expected_anchor": self.upload_timestamp,
+        }
+
+    def upload(self, video_path: Path) -> dict[str, Any]:
+        record = base_record(video_path)
+        filename = video_path.name
+        content_type = CONTENT_TYPES.get(video_path.suffix, "video/mp4")
+        overall_start = time.time()
+
+        try:
+            # Byte-identical to phase 2 of the three-step flow, which is itself
+            # byte-identical to the UI's chunkedUpload -- same five
+            # nvstreamer-* headers, same mediaFile/filename/metadata fields.
+            identifier = str(uuid.uuid4())
+            with open(video_path, "rb") as f:
+                resp = requests.post(
+                    self.upload_url,
+                    headers={
+                        "nvstreamer-chunk-number": "1",
+                        "nvstreamer-total-chunks": "1",
+                        "nvstreamer-is-last-chunk": "true",
+                        "nvstreamer-identifier": identifier,
+                        "nvstreamer-file-name": filename,
+                    },
+                    files={"mediaFile": (filename, f, content_type)},
+                    data={
+                        "filename": filename,
+                        "metadata": json.dumps({"timestamp": self.upload_timestamp}),
+                    },
+                    timeout=UPLOAD_TIMEOUT,
+                )
+            resp.raise_for_status()
+            upload_body = resp.json() or {}
+            sensor_id = upload_body.get("sensorId")
+            if not sensor_id:
+                raise RuntimeError(f"VST upload returned no sensorId: {resp.text[:200]}")
+
+            record["success"] = True
+            record["sensor_id"] = sensor_id
+            record["video_id"] = sensor_id
+            # Deliberately None rather than 0: nothing counted, which is not
+            # the same claim as "counted, and it was zero". The zero-chunk
+            # guard the three-step flow applies has nothing to test here.
+            record["chunks_processed"] = None
+            record["ingest_proof"] = "none"
+            record["phases"] = {"upload_s": round(time.time() - overall_start, 3)}
+            finish_record(record, time.time() - overall_start)
+        except requests.Timeout:
+            record["success"] = False
+            record["error"] = "Request timeout"
+            finish_record(record, time.time() - overall_start)
+        except Exception as e:
+            record["success"] = False
+            record["error"] = f"{type(e).__name__}: {e}"
+            finish_record(record, time.time() - overall_start)
+        return record

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/ingest.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/ingest.py
@@ -308,7 +308,19 @@ class VstDirectIngest:
     same bytes, the same headers, the same anchor, with the upload URL built
     rather than fetched.
 
-    Three things are worse here, and they are why this is not the default:
+    **The timestamp anchor survives**, which is the thing worth checking before
+    trusting any of this: ground truth is matched by absolute-timestamp overlap
+    against ``2025-01-01T00:00:00``, so an ingest path that anchored chunks
+    anywhere else would score every query zero and read as a retrieval
+    collapse. It does not, because the anchor was never the agent's to set --
+    it rides in the ``metadata={"timestamp": ...}`` field of the upload itself,
+    which this backend sends byte-identically. ``/complete`` hard-codes the same
+    constant (``video_ingest.py``) because it is the shared convention, not the
+    source. The webhooks agree: the three ``camera_remove`` cleanup calls in
+    ``dev-profile-search/vios/configs/notification_config.json`` target
+    ``mdx-embed-filtered-2025-01-01`` and its two siblings by name.
+
+    Two things are still worse here, and they are why this is not the default:
 
     * **No completion proof.** ``/complete`` runs the embedding leg
       synchronously and returns ``chunks_processed``; the webhook fan-out is
@@ -316,17 +328,13 @@ class VstDirectIngest:
       readiness poll and the first query are all that confirm anything indexed,
       so ``chunks_processed`` is ``None`` -- not zero -- and the run records
       ``ingest_proof: "none"``.
-    * **The anchor is VIOS's to choose.** The webhook request bodies in
-      ``dev-profile-search/vios/configs/notification_config.json`` are empty
-      ``{}``, so nothing passes ``creation_time``; the agent's ``/complete``
-      hard-codes ``2025-01-01T00:00:00.000Z`` (``video_ingest.py``). Ground
-      truth is matched by absolute-timestamp overlap against that anchor, so if
-      VIOS anchors chunks anywhere else EVERY query scores zero and it reads as
-      a retrieval collapse. :meth:`verify_anchor` checks it rather than trusting
-      it.
     * **Helm has webhooks off.** ``webhooks.enabled`` is true only in the Docker
       search profile; the Helm chart ships the dummy item and false. On such a
-      deployment this backend uploads successfully and indexes nothing.
+      deployment this backend uploads successfully and indexes nothing, and
+      without a chunk count nothing says so until the first query returns empty.
+
+    :meth:`verify_anchor` remains as a cheap one-video sanity check, since a
+    wrong anchor is silent and indistinguishable from broken retrieval.
     """
 
     name = "vst-direct"

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/metrics.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/metrics.py
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Retrieval metrics.
+
+Vendored from ``run_eval.py`` so this flow owns its scoring and that script can
+be deleted without taking the metrics with it. The definitions are deliberately
+byte-for-byte equivalent, not "improved" -- changing them would silently
+invalidate every baseline captured with the old runner.
+
+``tests/test_search_eval_flows.py`` asserts this module and ``run_eval.py``
+produce identical output for the same input, for as long as both exist. When
+``run_eval.py`` goes, that test goes with it and this becomes the only
+definition.
+"""
+
+from __future__ import annotations
+
+import copy
+from datetime import datetime, timedelta
+from typing import Any
+
+#: Ground truth is annotated on a 5-second grid, so retrieved windows are split
+#: onto the same grid before matching.
+SEGMENT_SIZE = 5
+
+#: k values reported as HIT@k.
+HIT_K_VALUES = [1, 3, 5, 10]
+
+
+def parse_ts(ts: str, ceiling: bool = False) -> datetime:
+    """Parse an ISO timestamp, dropping sub-second precision.
+
+    ``ceiling`` rounds a fractional second up, so a window ending at
+    00:00:13.2 covers the segment it partially overlaps rather than losing it.
+    """
+    ts_clean = ts.replace("Z", "").replace("+00:00", "")
+    dt = datetime.fromisoformat(ts_clean)
+    if ceiling and dt.microsecond > 0:
+        dt = dt + timedelta(seconds=1)
+    return dt.replace(microsecond=0)
+
+
+def align_ts_to_segment(start: datetime, end: datetime) -> list[tuple[datetime, datetime]]:
+    """Split ``[start, end)`` onto the 5-second grid the ground truth uses."""
+    if start >= end:
+        return []
+    start = start.replace(microsecond=0)
+    end = end.replace(microsecond=0)
+    sec = start.second
+    floored = (sec // SEGMENT_SIZE) * SEGMENT_SIZE
+    seg_start = start.replace(second=floored, microsecond=0)
+    segments = []
+    while seg_start < end:
+        seg_end = seg_start + timedelta(seconds=SEGMENT_SIZE)
+        segments.append((seg_start, seg_end))
+        seg_start = seg_end
+    return segments
+
+
+def video_name_matches(api_name: str, gt_name: str) -> bool:
+    """Prefix match, because VST renames uploads.
+
+    Ground truth says ``warehouse_sample``; search returns
+    ``warehouse_sample_20250101_000000_e0482.mp4``.
+    """
+    return api_name.replace(".mp4", "").startswith(gt_name)
+
+
+def match_segment(api_result: dict, gt_segments: list[dict]) -> tuple[int, dict | None]:
+    """Find the ground-truth segment a result matches, or ``(-1, None)``."""
+    actual_video = api_result.get("video_name", "")
+    actual_start = parse_ts(api_result.get("start_time", ""))
+    for idx, gt in enumerate(gt_segments):
+        gt_video = gt.get("video_name", "")
+        gt_start = parse_ts(gt.get("start_time", ""))
+        if not all([actual_video, actual_start, gt_video, gt_start]):
+            continue
+        if video_name_matches(actual_video, gt_video) and actual_start == gt_start:
+            return idx, gt
+    return -1, None
+
+
+def post_process_api_results(api_results: list[dict]) -> list[dict]:
+    """Expand each hit into the 5-second segments it spans.
+
+    These segments -- not the original hits -- are what gets counted, so a
+    merged window contributes more of them than an unmerged one. That is why
+    merging changes precision even when retrieval is identical.
+    """
+    final = []
+    for r in api_results:
+        s = parse_ts(r.get("start_time", ""))
+        e = parse_ts(r.get("end_time", ""), ceiling=True)
+        for seg_s, seg_e in align_ts_to_segment(s, e):
+            seg = copy.deepcopy(r)
+            seg["start_time"] = seg_s.strftime("%Y-%m-%dT%H:%M:%SZ")
+            seg["end_time"] = seg_e.strftime("%Y-%m-%dT%H:%M:%SZ")
+            final.append(seg)
+    return final
+
+
+def evaluate_query(
+    query: str,
+    api_results: list[dict],
+    expected_segments: list[dict],
+    latency_s: float,
+) -> dict[str, Any]:
+    """Score one query's results against its ground truth.
+
+    Each ground-truth segment can be claimed once; a second result matching an
+    already-found segment counts as a false positive rather than a bonus.
+
+    Average precision divides by the ground-truth count, not by the number of
+    hits found, so a query cannot reach 1.0 without retrieving everything.
+    """
+    found_gt = set()
+    matched = []
+    relevance_at_rank = []
+
+    processed = post_process_api_results(api_results)
+
+    for rank, r in enumerate(processed, 1):
+        is_match = False
+        gt_idx, _gt_seg = match_segment(r, expected_segments)
+        if gt_idx > -1 and gt_idx not in found_gt:
+            is_match = True
+            found_gt.add(gt_idx)
+            matched.append({"rank": rank, "gt_idx": gt_idx})
+        relevance_at_rank.append(1 if is_match else 0)
+
+    tp = len(matched)
+    total_retrieved = len(processed)
+    total_relevant = len(expected_segments)
+
+    precision = tp / total_retrieved if total_retrieved > 0 else 0
+    recall = tp / total_relevant if total_relevant > 0 else 0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0
+
+    first_rank = min((m["rank"] for m in matched), default=None)
+    rr = 1.0 / first_rank if first_rank else 0.0
+
+    hit_at_k = {}
+    for k in HIT_K_VALUES:
+        hit_at_k[k] = 1 if any(m["rank"] <= k for m in matched) else 0
+
+    if total_relevant > 0:
+        prec_sum = 0.0
+        rel_count = 0
+        for rank, is_rel in enumerate(relevance_at_rank, 1):
+            if is_rel:
+                rel_count += 1
+                prec_sum += rel_count / rank
+        ap = prec_sum / total_relevant
+    else:
+        ap = 0.0
+
+    missed = [i for i in range(total_relevant) if i not in found_gt]
+
+    return {
+        "query": query,
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+        "average_precision": ap,
+        "reciprocal_rank": rr,
+        "hit_at_k": hit_at_k,
+        "true_positives": tp,
+        "false_positives": total_retrieved - tp,
+        "total_relevant": total_relevant,
+        "total_retrieved": total_retrieved,
+        "latency_s": latency_s,
+        "missed_gt_indices": missed,
+    }
+
+
+def format_inline(m: dict[str, Any], latency_s: float | None = None) -> str:
+    """One-line per-query summary for the console."""
+    parts = [
+        f"P={m['precision']:.3f}",
+        f"R={m['recall']:.3f}",
+        f"F1={m['f1']:.3f}",
+        f"AP={m['average_precision']:.3f}",
+        f"RR={m['reciprocal_rank']:.3f}",
+    ]
+    if latency_s is not None:
+        parts.append(f"Latency={latency_s:.2f}s")
+    parts.append(f"Hits={m['true_positives']}/{m['total_relevant']}")
+    return "  ".join(parts)

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/metrics.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/metrics.py
@@ -40,7 +40,8 @@ is the normal case in this repo, so a green run is not proof of parity.
 from __future__ import annotations
 
 import copy
-from datetime import datetime, timedelta
+from datetime import datetime
+from datetime import timedelta
 from typing import Any
 
 #: Ground truth is annotated on a 5-second grid, so retrieved windows are split

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/metrics.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/metrics.py
@@ -80,15 +80,33 @@ def video_name_matches(api_name: str, gt_name: str) -> bool:
 
 
 def match_segment(api_result: dict, gt_segments: list[dict]) -> tuple[int, dict | None]:
-    """Find the ground-truth segment a result matches, or ``(-1, None)``."""
+    """Find the ground-truth segment a result overlaps, or ``(-1, None)``.
+
+    Overlap, not equal start times. Results are snapped to the 5-second grid by
+    :func:`align_ts_to_segment`, so equality silently required the ground truth
+    to sit on that grid too. It does for datasets whose segments *are* chunks --
+    vad-r1-v2 is 100% 5s and 100% aligned -- and not at all for one whose
+    segments are real event bounds: physicalai-dev is 45% 5s and 73% aligned, so
+    159 of its 673 queries (23.6%) could not be scored above zero however good
+    retrieval was, and 57% of the time it covers could never be credited.
+
+    A window that lands anywhere inside the event found the event. Each
+    ground-truth segment is still claimed once, by the earliest-ranked result
+    that reaches it, so this does not inflate a hit into several.
+    """
     actual_video = api_result.get("video_name", "")
     actual_start = parse_ts(api_result.get("start_time", ""))
+    actual_end = parse_ts(api_result.get("end_time", ""), ceiling=True)
     for idx, gt in enumerate(gt_segments):
         gt_video = gt.get("video_name", "")
         gt_start = parse_ts(gt.get("start_time", ""))
+        gt_end = parse_ts(gt.get("end_time", ""), ceiling=True)
         if not all([actual_video, actual_start, gt_video, gt_start]):
             continue
-        if video_name_matches(actual_video, gt_video) and actual_start == gt_start:
+        if not video_name_matches(actual_video, gt_video):
+            continue
+        # Half-open intervals: [10,15) and [15,20) are adjacent, not overlapping.
+        if actual_start < gt_end and gt_start < actual_end:
             return idx, gt
     return -1, None
 

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/metrics.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/metrics.py
@@ -16,14 +16,25 @@
 """Retrieval metrics.
 
 Vendored from ``run_eval.py`` so this flow owns its scoring and that script can
-be deleted without taking the metrics with it. The definitions are deliberately
-byte-for-byte equivalent, not "improved" -- changing them would silently
-invalidate every baseline captured with the old runner.
+be deleted without taking the metrics with it. It started byte-for-byte
+equivalent and has since diverged once, deliberately:
 
-``tests/test_search_eval_flows.py`` asserts this module and ``run_eval.py``
-produce identical output for the same input, for as long as both exist. When
-``run_eval.py`` goes, that test goes with it and this becomes the only
-definition.
+``match_segment`` matches on half-open **overlap** rather than on equal start
+times. The old rule additionally required the ground truth to sit on the
+5-second grid, because results are snapped to that grid before matching. Datasets
+whose segments *are* chunks satisfy that silently -- vad-r1-v2 is 100% 5s and
+100% aligned -- so the assumption held until physicalai-dev, whose segments are
+event bounds. There, 159 of 673 queries could not score above zero however good
+retrieval was.
+
+**Baselines therefore compare only within a matching rule.** Event-bounded
+datasets captured before that change are NOT comparable with runs after it:
+physicalai-dev moved mAP 0.1782 -> 0.3359 on identical retrieval. Chunk-shaped
+datasets are unaffected, and a test pins that.
+
+``tests/test_search_eval_flows.py`` guards the rest against drift while both
+modules exist -- note it *skips* when ``run_eval.py`` is not importable, which
+is the normal case in this repo, so a green run is not proof of parity.
 """
 
 from __future__ import annotations

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/normalize.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/normalize.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""One canonical result shape, whichever flow produced it.
+
+The two query flows disagree on exactly one field name, and the disagreement is
+dangerous rather than merely annoying:
+
+    legacy REST      result["critic_result"]["result"]
+    search_core CLI  result["verification"]["result"]
+
+Both carry the same vocabulary ("confirmed" / "rejected" / "unverified"), so a
+reader that knows only the old name does not crash against the new flow -- it
+silently sees zero rejections and scores an UNFILTERED result set as if it were
+critic-filtered. That produces plausible numbers which are not comparable to the
+historical baseline, which is the worst failure mode an eval can have.
+
+:func:`normalize_result` therefore records *which* field it found, and the runner
+refuses to emit critic-filtered metrics when the answer is "neither".
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: Sentinel for "this hit carried no verification block at all", as distinct
+#: from "the critic ran and returned unverified".
+VERIFICATION_ABSENT = "absent"
+
+
+def normalize_result(raw: dict[str, Any]) -> dict[str, Any]:
+    """Map one wire-format hit to the canonical shape the metrics consume.
+
+    Accepts either flow's spelling of the verification block and always emits
+    ``verification``. ``_verification_source`` records which spelling was found.
+    """
+    # A present-but-null block is how the agent flow spells "the critic did not
+    # run for this hit" (search.py sets critic_result=None on the merge path).
+    # It must normalize to ABSENT, not to an empty verdict -- otherwise a
+    # response where the critic never ran would still enable critic-filtered
+    # metrics in the summary. So test the raw value, not an `or {}` coercion.
+    raw_verification = raw.get("verification", raw.get("critic_result"))
+    if isinstance(raw_verification, dict):
+        source = "verification" if "verification" in raw else "critic_result"
+        verification = raw_verification
+    else:
+        source = VERIFICATION_ABSENT
+        verification = {}
+
+    return {
+        "video_name": raw.get("video_name") or "",
+        "description": raw.get("description") or "",
+        "start_time": raw.get("start_time") or "",
+        "end_time": raw.get("end_time") or "",
+        "sensor_id": raw.get("sensor_id") or "",
+        "screenshot_url": raw.get("screenshot_url") or "",
+        # search_core names this `similarity`; the embed primitive names it
+        # `similarity_score`. Only the unified SearchOutput reaches us today,
+        # but accept both so a primitive-level backend needs no change here.
+        "similarity": raw.get("similarity", raw.get("similarity_score", 0.0)),
+        "object_ids": raw.get("object_ids") or [],
+        "verification": {
+            "result": verification.get("result", "unverified"),
+            "criteria_met": verification.get("criteria_met") or {},
+        },
+        "_verification_source": source,
+        "_raw": raw,
+    }
+
+
+def normalize_results(raw_results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Normalize a whole result list."""
+    return [normalize_result(r) for r in raw_results]
+
+
+def verification_sources(results: list[dict[str, Any]]) -> set[str]:
+    """Distinct verification field spellings seen across normalized results."""
+    return {r.get("_verification_source", VERIFICATION_ABSENT) for r in results}
+
+
+def has_verification(results: list[dict[str, Any]]) -> bool:
+    """True when at least one hit carried a real verification block."""
+    return bool(verification_sources(results) - {VERIFICATION_ABSENT})
+
+
+def filter_rejected(results: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], int]:
+    """Drop results the critic rejected. Operates on NORMALIZED results.
+
+    Deliberately not the same function as ``run_eval.filter_rejected``, which
+    reads the legacy field name straight off the wire format.
+    """
+    kept: list[dict[str, Any]] = []
+    rejected = 0
+    for r in results:
+        if (r.get("verification") or {}).get("result") == "rejected":
+            rejected += 1
+        else:
+            kept.append(r)
+    return kept, rejected
+
+
+def for_scoring(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Drop bookkeeping keys before the metric code deep-copies each hit."""
+    return [{k: v for k, v in r.items() if not k.startswith("_")} for r in results]

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/normalize.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/normalize.py
@@ -95,6 +95,27 @@ def has_verification(results: list[dict[str, Any]]) -> bool:
     return bool(verification_sources(results) - {VERIFICATION_ABSENT})
 
 
+def verdict_counts(results: list[dict[str, Any]]) -> dict[str, int]:
+    """Tally confirmed / rejected / unverified across NORMALIZED results.
+
+    A verification block being *present* does not mean the critic formed an
+    opinion. Every failure mode in the critic -- an unreachable VLM, a 4xx from
+    a clip URL the VLM cannot resolve, a parse error -- degrades that candidate
+    to ``unverified`` and continues. So a totally broken critic still attaches a
+    block to every hit, and ``has_verification`` is satisfied while zero verdicts
+    were actually rendered.
+
+    Counting them is what lets a caller tell "the critic agreed with retrieval"
+    from "the critic never ran", which are numerically identical once filtering
+    drops nothing.
+    """
+    counts = {"confirmed": 0, "rejected": 0, "unverified": 0}
+    for r in results:
+        verdict = str((r.get("verification") or {}).get("result", "unverified"))
+        counts[verdict] = counts.get(verdict, 0) + 1
+    return counts
+
+
 def filter_rejected(results: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], int]:
     """Drop results the critic rejected. Operates on NORMALIZED results.
 

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/query.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/query.py
@@ -1,0 +1,305 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Query backend: the ``vss search run`` CLI."""
+
+from __future__ import annotations
+
+import json
+import shlex
+import subprocess
+import time
+from typing import Any
+
+from . import routing
+from .base import SEARCH_TIMEOUT
+
+#: The four retrieval paths declared by vss_cli.search_group.SearchGroup.
+SEARCH_PATHS = ("embed", "attribute", "fusion", "object")
+
+#: Documented in skills/vss-search-archive/references/cli_usage.md.
+CLI_EXIT_MEANINGS = {
+    0: "success",
+    2: "invalid input (unknown flag or bad value)",
+    3: "backend unreachable",
+    4: "configuration -- not configured, foreign config, or a required service absent",
+    5: "not found -- a searched index does not exist (nothing ingested yet)",
+}
+
+#: Exit codes that mean an environment fault rather than a bad query. These
+#: abort the run instead of contributing a zero score.
+#:
+#: Kept for reporting, but see ``is_fatal_exit``: the real policy is that ANY
+#: non-zero exit aborts. A broken CLI install exits 1, which is not in the
+#: documented table, and treating "undocumented" as "soft" scored 121 queries
+#: at 0.0 in a real run -- precisely the silent-zero this module exists to stop.
+CLI_FATAL_EXITS = {2, 3, 4, 5}
+
+
+def is_fatal_exit(code: int) -> bool:
+    """Any non-zero exit is fatal.
+
+    There is no ``vss search run`` exit code that means "this one query failed
+    but the rest are fine". Success is 0; everything else is an environment or
+    usage fault that will recur for every remaining query, so continuing only
+    manufactures zeros that look like a retrieval collapse.
+    """
+    return code != 0
+
+
+class CliExitError(RuntimeError):
+    """A ``vss search run`` invocation failed in a way that must not be scored.
+
+    Exit 4 (misconfiguration) and exit 5 (index absent) would otherwise be
+    indistinguishable from a genuine zero-recall query. Scoring them as 0.0
+    reports a catastrophic accuracy regression when the real problem is that
+    nothing was ingested.
+    """
+
+
+
+class CliQueryBackend:
+    """``vss search run <path>`` as a subprocess.
+
+    This is the layer the OpenClaw agent ultimately reaches through the
+    ``vss-search-archive`` skill, so exercising it measures the retrieval half
+    of the new UI flow without an LLM in the loop -- deterministic, and
+    directly comparable to the REST baseline.
+
+    Two modes, depending on whether decompositions are supplied:
+
+    * **Fixed** (no decompositions) -- every query uses one caller-chosen path.
+      Fine for embed-only regression, but not comparable to the agent, which
+      decomposes and routes per query.
+    * **Routed** (decompositions given) -- the path and arguments come from the
+      decomposition the agent would have produced, so the CLI receives the same
+      structured request the agent's retrieval leg receives. This is what makes
+      a CLI-vs-agent comparison measure *retrieval* rather than the presence or
+      absence of a decomposition step.
+
+    Neither mode performs decomposition itself. That is an LLM call, and doing
+    it here would put a model in the eval loop; see routing.py.
+    """
+
+    name = "cli"
+
+    def __init__(
+        self,
+        vss_cmd: list[str],
+        search_path: str = "embed",
+        top_k: int = 5,
+        min_cosine_similarity: float | None = None,
+        source_type: str = "video_file",
+        attributes: list[str] | None = None,
+        # Deliberately the OPPOSITE of the upstream CLI default. Upstream merges
+        # contiguous same-sensor windows and reports the mean of their scores,
+        # which changes both the hit count (the precision denominator) and the
+        # score semantics. The historical REST baseline has unmerged windows, so
+        # defaulting to merged here would silently invalidate every comparison
+        # against it. Callers wanting product-default behaviour must ask.
+        merge_adjacent: bool = False,
+        cwd: str | None = None,
+        timeout: int = SEARCH_TIMEOUT,
+        decompositions: dict[str, dict[str, Any]] | None = None,
+    ) -> None:
+        if search_path not in SEARCH_PATHS:
+            raise ValueError(f"search_path must be one of {SEARCH_PATHS}, got {search_path!r}")
+        self.vss_cmd = vss_cmd
+        self.search_path = search_path
+        self.top_k = top_k
+        self.min_cosine_similarity = min_cosine_similarity
+        self.source_type = source_type
+        self.attributes = attributes or []
+        self.merge_adjacent = merge_adjacent
+        self.cwd = cwd
+        self.timeout = timeout
+        #: query text -> decomposition. Empty means fixed-flag behaviour.
+        self.decompositions = decompositions or {}
+        #: plans actually executed, so the summary can report the path split.
+        self.executed_plans: list[dict[str, Any]] = []
+        #: query text -> per-stage timings, when the deployment reports them.
+        #: Keyed per query rather than "the last one", because queries run
+        #: concurrently and a single slot would hand one query another's
+        #: numbers. Dict assignment is atomic under the GIL, so no lock.
+        self.timings_by_query: dict[str, dict[str, Any]] = {}
+
+    def describe(self) -> dict[str, Any]:
+        # In routed mode `search_path` is only the fallback for queries the
+        # decompositions do not cover, so labelling it "search_path" reads as
+        # though every query used it. Name it for what it is.
+        path_key = "fallback_path" if self.decompositions else "search_path"
+        return {
+            "backend": self.name,
+            "vss_cmd": " ".join(self.vss_cmd),
+            "routing": "per-query (from decompositions)" if self.decompositions else "fixed",
+            path_key: self.search_path,
+            "top_k": self.top_k,
+            "min_cosine_similarity": self.min_cosine_similarity,
+            "source_type": self.source_type,
+            "attributes": self.attributes,
+            "merge_adjacent": self.merge_adjacent,
+            "decompositions": len(self.decompositions),
+        }
+
+    def plan_for_query(self, query: str) -> dict[str, Any]:
+        """The retrieval plan for one query.
+
+        With no decompositions supplied this is the fixed-flag behaviour; with
+        them, the path and arguments are derived per query the way the agent's
+        decomposition step would have.
+        """
+        return routing.plan_for(
+            query,
+            self.decompositions.get(query),
+            default_path=self.search_path,
+            default_attributes=self.attributes,
+            default_source_type=self.source_type,
+        )
+
+    def build_argv(self, query: str, plan: dict[str, Any] | None = None) -> list[str]:
+        """Assemble the invocation. Split out so it is unit-testable offline."""
+        plan = plan or self.plan_for_query(query)
+        path = plan["path"]
+        argv = [*self.vss_cmd, "search", "run", path]
+
+        # Each path accepts only its own fields; passing another path's flag is
+        # a usage error, not something the CLI ignores.
+        if path in ("embed", "fusion"):
+            argv += ["--query", plan["query"]]
+        if path in ("attribute", "fusion"):
+            for attr in plan["attributes"]:
+                argv += ["--attribute", attr]
+        if path == "object":
+            for object_id in plan["object_ids"]:
+                argv += ["--object-id", str(object_id)]
+
+        argv += ["--source-type", plan["source_type"]]
+        argv += ["--top-k", str(plan.get("top_k") or self.top_k)]
+
+        for source in plan.get("video_sources") or []:
+            argv += ["--video-source", source]
+        if plan.get("timestamp_start"):
+            argv += ["--timestamp-start", plan["timestamp_start"]]
+        if plan.get("timestamp_end"):
+            argv += ["--timestamp-end", plan["timestamp_end"]]
+
+        if self.min_cosine_similarity is not None and path in ("embed", "fusion"):
+            argv += ["--min-cosine-similarity", str(self.min_cosine_similarity)]
+
+        if not self.merge_adjacent:
+            argv.append("--no-merge-adjacent")
+
+        argv.append("--raw")
+        return argv
+
+    def search(self, query: str) -> tuple[list[dict[str, Any]], float]:
+        plan = self.plan_for_query(query)
+        self.executed_plans.append(plan)
+        argv = self.build_argv(query, plan)
+        start = time.time()
+        try:
+            proc = subprocess.run(
+                argv,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                cwd=self.cwd,
+            )
+        except subprocess.TimeoutExpired:
+            latency = time.time() - start
+            print(f"  CLI timeout after {self.timeout}s: {shlex.join(argv)}")
+            return [], latency
+        latency = time.time() - start
+
+        if is_fatal_exit(proc.returncode):
+            meaning = CLI_EXIT_MEANINGS.get(proc.returncode, "undocumented exit code")
+            detail = (proc.stderr or proc.stdout or "").strip()[:500]
+            raise CliExitError(
+                f"vss exited {proc.returncode} ({meaning}): {detail}\n  command: {shlex.join(argv)}"
+            )
+
+        hits, _messages, timings = parse_cli_output(proc.stdout)
+        if timings:
+            self.timings_by_query[query] = timings
+        return hits, latency
+
+
+def parse_cli_output(stdout: str) -> tuple[list[dict[str, Any]], list[str], dict[str, Any]]:
+    """Extract ``(hits, search_messages, timings)`` from ``vss search run`` stdout.
+
+    The CLI writes **NDJSON on stdout** -- one JSON document per line, not one
+    document total. A search prints at least two::
+
+        {"data": [...], "search_messages": [...], "job_id": "search-01M1...",
+         "persisted": false, "record": "absent"}
+        {"event": "vss_job_completed", "group": "search", "job_id": "...",
+         "status": "completed", "exit_hint": 0}
+
+    Both go to stdout; stderr is empty. Parsing the buffer as a single document
+    therefore raises "Extra data" and silently discards a perfectly good result
+    set -- which is exactly what happened: 106 of 121 queries in a real run were
+    dropped this way and the eval reported mAP 0.0000 against an index that was
+    answering correctly.
+
+    So: parse line by line, skip lifecycle events, and return the first document
+    that carries a payload. A whole-buffer parse is tried first so a
+    pretty-printed (multi-line) document still works.
+    """
+    text = (stdout or "").strip()
+    if not text:
+        return [], [], {}
+
+    documents: list[Any] = []
+
+    # Single document, possibly pretty-printed across lines.
+    try:
+        documents.append(json.loads(text))
+    except json.JSONDecodeError:
+        # NDJSON: one document per line. Unparseable lines are banners or
+        # progress noise, not results, so they are skipped rather than fatal.
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                documents.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+    if not documents:
+        print(f"  Could not parse CLI output as JSON: {text[:200]}")
+        return [], [], {}
+
+    for payload in documents:
+        if isinstance(payload, list):
+            return payload, [], {}
+        if not isinstance(payload, dict):
+            continue
+        # Job lifecycle events carry no results; keep looking.
+        if "event" in payload and "data" not in payload:
+            continue
+        if "data" in payload:
+            messages = list(payload.get("search_messages") or [])
+            for message in messages:
+                print(f"  [search_message] {message}")
+            # Present only on deployments carrying the search_core timings
+            # change; absent means nobody collected, not zero time.
+            timings = payload.get("timings") or {}
+            return payload.get("data") or [], messages, timings
+
+    # Documents parsed, but none held a payload -- report it rather than
+    # returning an empty result that would score as zero recall.
+    print(f"  CLI output had no 'data' field: {text[:200]}")
+    return [], [], {}

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/query.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/query.py
@@ -70,6 +70,21 @@ class CliExitError(RuntimeError):
 
 
 
+class QueryUnanswerableError(RuntimeError):
+    """This query produced no answer, and no answer is not the same as no hits.
+
+    A timeout, unparseable stdout, or a payload with no ``data`` envelope all
+    mean the backend never told us what it found. Returning ``[]`` for those
+    makes them arithmetically identical to a search that ran perfectly and
+    matched nothing, so they land in the aggregate as zero recall and publish a
+    protocol fault as a retrieval regression.
+
+    Distinct from :class:`CliExitError`, which is fatal for the whole run: this
+    one is per query. The caller decides whether to abort or to exclude it, but
+    it must not score it.
+    """
+
+
 class CliQueryBackend:
     """``vss search run <path>`` as a subprocess.
 
@@ -238,10 +253,13 @@ class CliQueryBackend:
                 timeout=self.timeout,
                 cwd=self.cwd,
             )
-        except subprocess.TimeoutExpired:
-            latency = time.time() - start
-            print(f"  CLI timeout after {self.timeout}s: {shlex.join(argv)}")
-            return [], latency
+        except subprocess.TimeoutExpired as e:
+            # A 300s hang is an environment fault, not a query that found
+            # nothing. Scoring it 0 was the same silent-zero this module's exit
+            # handling exists to prevent, arriving by a different route.
+            raise QueryUnanswerableError(
+                f"vss timed out after {self.timeout}s: {shlex.join(argv)}"
+            ) from e
         latency = time.time() - start
 
         if is_fatal_exit(proc.returncode):
@@ -300,8 +318,7 @@ def parse_cli_output(stdout: str) -> tuple[list[dict[str, Any]], list[str], dict
                 continue
 
     if not documents:
-        print(f"  Could not parse CLI output as JSON: {text[:200]}")
-        return [], [], {}
+        raise QueryUnanswerableError(f"CLI output was not JSON: {text[:200]}")
 
     for payload in documents:
         if isinstance(payload, list):
@@ -320,7 +337,7 @@ def parse_cli_output(stdout: str) -> tuple[list[dict[str, Any]], list[str], dict
             timings = payload.get("timings") or {}
             return payload.get("data") or [], messages, timings
 
-    # Documents parsed, but none held a payload -- report it rather than
-    # returning an empty result that would score as zero recall.
-    print(f"  CLI output had no 'data' field: {text[:200]}")
-    return [], [], {}
+    # Documents parsed, but none held a payload. A search that matched nothing
+    # still emits `"data": []`; no `data` key at all means the CLI answered in a
+    # shape this parser does not know -- a version skew, not zero recall.
+    raise QueryUnanswerableError(f"CLI output had no 'data' field: {text[:200]}")

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/query.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/query.py
@@ -113,6 +113,14 @@ class CliQueryBackend:
         cwd: str | None = None,
         timeout: int = SEARCH_TIMEOUT,
         decompositions: dict[str, dict[str, Any]] | None = None,
+        # Send the pre-decomposition question along with the decomposed
+        # arguments, so the critic verifies what the user asked rather than a
+        # string the host reassembles from the retrieval arguments. Default-on
+        # because it is what the REST path does (`tools/search.py` captures
+        # `original_query` BEFORE decomposition), so omitting it is what makes
+        # the two flows incomparable. Requires a CLI carrying
+        # `--original-query`; run_eval_flows probes for it.
+        pass_original_query: bool = True,
     ) -> None:
         if search_path not in SEARCH_PATHS:
             raise ValueError(f"search_path must be one of {SEARCH_PATHS}, got {search_path!r}")
@@ -125,6 +133,7 @@ class CliQueryBackend:
         self.merge_adjacent = merge_adjacent
         self.cwd = cwd
         self.timeout = timeout
+        self.pass_original_query = pass_original_query
         #: query text -> decomposition. Empty means fixed-flag behaviour.
         self.decompositions = decompositions or {}
         #: plans actually executed, so the summary can report the path split.
@@ -151,6 +160,7 @@ class CliQueryBackend:
             "attributes": self.attributes,
             "merge_adjacent": self.merge_adjacent,
             "decompositions": len(self.decompositions),
+            "pass_original_query": self.pass_original_query,
         }
 
     def plan_for_query(self, query: str) -> dict[str, Any]:
@@ -184,6 +194,17 @@ class CliQueryBackend:
         if path == "object":
             for object_id in plan["object_ids"]:
                 argv += ["--object-id", str(object_id)]
+
+        # The question, alongside the arguments derived from it. Retrieval
+        # ignores this; the critic reads it instead of the string the host
+        # would otherwise rebuild out of `--query` and `--attribute`.
+        #
+        # `query` is the dataset key -- what a user typed -- while
+        # `plan["query"]` is the decomposition's rewrite of it. On `object` this
+        # is the difference between verifying and not: that path sends no text
+        # at all, so the host finds nothing to ask about and skips the critic.
+        if self.pass_original_query and query.strip():
+            argv += ["--original-query", query]
 
         argv += ["--source-type", plan["source_type"]]
         argv += ["--top-k", str(plan.get("top_k") or self.top_k)]

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/readiness.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/readiness.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Post-ingest readiness.
+
+A 200 from ``/complete`` is not readiness -- indexing continues afterwards.
+Querying too early returns empty result sets that look exactly like a retrieval
+regression, so this gate exists to stop a timing artefact being reported as an
+accuracy number.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import requests
+
+from .base import VST_LIST_TIMEOUT
+
+
+def sensor_list_url(vst_url: str) -> str:
+    return f"{vst_url.rstrip('/')}/vst/api/v1/sensor/list"
+
+
+def list_sensor_names(vst_url: str, timeout: int = VST_LIST_TIMEOUT) -> set[str]:
+    """Return every registered sensor name, lowercased.
+
+    Raises on transport failure so callers can distinguish "VST said there are
+    no sensors" from "VST could not be reached".
+    """
+    resp = requests.get(sensor_list_url(vst_url), timeout=timeout)
+    resp.raise_for_status()
+    payload = resp.json() or []
+    return {str(s.get("name", "")).lower() for s in payload if isinstance(s, dict)}
+
+
+def list_sensor_streams(vst_url: str, timeout: int = VST_LIST_TIMEOUT) -> dict[str, str]:
+    """Return ``{stream_id: name}`` for every registered sensor.
+
+    Same endpoint and payload shape as ``run_eval.get_indexed_videos``, but
+    takes a resolved VST origin instead of re-deriving one from a port. That
+    matters for destructive callers: deriving the origin twice is how you end
+    up deleting from a different host than the one you listed.
+    """
+    resp = requests.get(f"{vst_url.rstrip('/')}/vst/api/v1/sensor/streams", timeout=timeout)
+    resp.raise_for_status()
+    payload = resp.json() or []  # list of {stream_id: [{name, url, ...}]}
+
+    streams: dict[str, str] = {}
+    for entry in payload:
+        if not isinstance(entry, dict) or not entry:
+            continue
+        stream_id = next(iter(entry))
+        stream_list = entry[stream_id]
+        if stream_list:
+            streams[stream_id] = stream_list[0].get("name", "unknown")
+    return streams
+
+
+def inventory_snapshot(vst_url: str) -> dict[str, Any]:
+    """Record what the deployment holds right now.
+
+    Shared deployments get wiped and reloaded by other people mid-run. When
+    that happens the eval keeps producing numbers, but they describe an index
+    that no longer exists -- observed on 10.86.12.161, where 17 ingested
+    sources vanished between one query and the next.
+
+    Taking this before and after the query phase turns an invisible
+    correctness problem into a recorded warning.
+    """
+    try:
+        names = sorted(list_sensor_names(vst_url))
+        return {"ok": True, "count": len(names), "names": names}
+    except Exception as e:
+        return {"ok": False, "error": f"{type(e).__name__}: {e}", "names": []}
+
+
+def compare_inventory(before: dict[str, Any], after: dict[str, Any]) -> dict[str, Any]:
+    """Diff two snapshots; ``stable`` is False when the deployment changed."""
+    if not (before.get("ok") and after.get("ok")):
+        return {"stable": None, "reason": "inventory unavailable at one or both ends"}
+
+    gone = sorted(set(before["names"]) - set(after["names"]))
+    added = sorted(set(after["names"]) - set(before["names"]))
+    return {
+        "stable": not gone and not added,
+        "disappeared": gone,
+        "appeared": added,
+        "before_count": before["count"],
+        "after_count": after["count"],
+    }
+
+
+def name_variants(video_name: str) -> set[str]:
+    """Plausible VST spellings of one local file name.
+
+    VST is not consistent about the extension. On the deployment probed on
+    2026-08-25 the sensor list held BOTH spellings simultaneously::
+
+        warehouse_safety_0001        <- stem only
+        sample-drone-bridge.mp4      <- extension retained
+
+    Matching on the stem alone therefore waits forever for sources that are
+    already registered. Accept either.
+    """
+    stem = video_name.rsplit(".", 1)[0]
+    return {stem.lower(), f"{stem.lower()}.mp4", f"{stem.lower()}.mkv"}
+
+
+def is_registered(video_name: str, registered: set[str]) -> bool:
+    """True when any plausible spelling of ``video_name`` is registered."""
+    return bool(name_variants(video_name) & registered)
+
+
+def wait_for_sources(
+    vst_url: str,
+    expected_names: list[str],
+    timeout_s: int = 1200,
+    poll_interval_s: int = 10,
+) -> dict[str, Any]:
+    """Block until VST lists every expected source, or the budget runs out.
+
+    Only VST registration is checked. The upstream skill also checks the three
+    Elasticsearch indices directly, which this deliberately does not do --
+    reaching past the public origin into ES is what the skill's hard boundaries
+    forbid.
+
+    Note VST registration is not a complete readiness signal: an aborted ingest
+    can leave embedding documents in Elasticsearch with no VST sensor, which
+    nothing here can see.
+    """
+    deadline = time.time() + timeout_s
+    started = time.time()
+    registered: set[str] = set()
+    attempts = 0
+
+    while time.time() < deadline:
+        attempts += 1
+        try:
+            registered = list_sensor_names(vst_url)
+            missing = [n for n in expected_names if not is_registered(n, registered)]
+            if not missing:
+                return {
+                    "ready": True,
+                    "attempts": attempts,
+                    "waited_s": round(time.time() - started, 1),
+                    "missing": [],
+                }
+        except Exception as e:
+            missing = list(expected_names)
+            print(f"  VST sensor list not readable yet ({type(e).__name__}: {e})")
+
+        print(f"  Waiting for {len(missing)} source(s) to register: {missing[:5]}")
+        time.sleep(poll_interval_s)
+
+    return {
+        "ready": False,
+        "attempts": attempts,
+        "waited_s": round(time.time() - started, 1),
+        "missing": [n for n in expected_names if not is_registered(n, registered)],
+    }

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/routing.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/routing.py
@@ -1,0 +1,208 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Turning a decomposed query into a CLI invocation.
+
+The agent path (``POST /api/v1/search`` with ``agent_mode: true``) runs an LLM
+query-decomposition step before retrieval. The CLI has no such step: it takes
+an already-structured request. So an eval that feeds raw natural language to
+``vss search run`` is not comparing like with like -- it is comparing
+"decomposed then retrieved" against "retrieved raw".
+
+This module closes that gap. Given the decomposition the agent would have
+produced, it derives the retrieval path and the CLI arguments.
+
+The decomposition contract is ``QUERY_DECOMPOSITION_PROMPT`` in
+``vss_agents/tools/search.py``::
+
+    query            rewritten description, actions AND attributes
+    attributes       person-appearance attributes ONLY; never bare "person"
+    has_action       true when an action/event is described
+    video_sources    named sources, empty when none mentioned
+    source_type      "video_file" | "rtsp"
+    timestamp_start  ISO-8601, base date 2025-01-01
+    timestamp_end    ISO-8601
+    object_ids       explicit tracked-object ids
+    top_k            only when the query says so
+
+Where decompositions come from is deliberately not decided here. A sidecar
+file keyed by query works today; folding them into the dataset is the same
+shape. Capturing what the agent actually emitted is preferable to
+hand-annotation, because it isolates retrieval differences from routing
+differences.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+#: Retrieval paths, mirroring vss_cli.search_group.SearchGroup.actions.
+EMBED = "embed"
+ATTRIBUTE = "attribute"
+FUSION = "fusion"
+OBJECT = "object"
+
+
+def route(decomposition: dict[str, Any]) -> str:
+    """Pick the retrieval path a decomposition implies.
+
+    Derived from the four paths' own input models rather than invented here:
+
+    ============================  ===========  ==========  =========
+    attributes                    has_action   object_ids  path
+    ============================  ===========  ==========  =========
+    --                            --           present     object
+    present                       false        --          attribute
+    present                       true         --          fusion
+    empty                         --           --          embed
+    ============================  ===========  ==========  =========
+
+    ``attribute`` is the no-action case because that path cannot express an
+    action at all -- it matches detected object properties. ``fusion`` is the
+    both case: the embedding leg carries the action, the attribute leg
+    re-ranks by appearance.
+    """
+    if decomposition.get("object_ids"):
+        return OBJECT
+
+    attributes = decomposition.get("attributes") or []
+    if not attributes:
+        return EMBED
+
+    # `has_action` is REQUIRED in the prompt, but a hand-written decomposition
+    # may omit it. Absent means "unknown", and fusion is the safer default: it
+    # still returns the embedding leg's candidates, whereas `attribute` would
+    # silently drop every action-based match.
+    if decomposition.get("has_action", True):
+        return FUSION
+    return ATTRIBUTE
+
+
+def plan_for(
+    query: str,
+    decomposition: dict[str, Any] | None,
+    default_path: str = EMBED,
+    default_attributes: list[str] | None = None,
+    default_source_type: str = "video_file",
+) -> dict[str, Any]:
+    """Build the per-query retrieval plan the CLI backend executes.
+
+    With no decomposition this reproduces the previous fixed-flag behaviour,
+    so an un-annotated dataset keeps working exactly as before.
+    """
+    if not decomposition:
+        return {
+            "path": default_path,
+            "query": query,
+            "attributes": list(default_attributes or []),
+            "source_type": default_source_type,
+            "video_sources": [],
+            "timestamp_start": None,
+            "timestamp_end": None,
+            "object_ids": [],
+            "top_k": None,
+            "routed": False,
+        }
+
+    return {
+        "path": route(decomposition),
+        # The decomposition rewrites the query ("Find a man pushing a cart
+        # wearing a beige shirt between 1pm and 2pm" -> "man pushing cart
+        # wearing beige shirt"). Feeding the raw text instead would embed the
+        # time range and source name as if they were visual content.
+        "query": decomposition.get("query") or query,
+        "attributes": list(decomposition.get("attributes") or []),
+        "source_type": decomposition.get("source_type") or default_source_type,
+        "video_sources": list(decomposition.get("video_sources") or []),
+        "timestamp_start": decomposition.get("timestamp_start"),
+        "timestamp_end": decomposition.get("timestamp_end"),
+        "object_ids": list(decomposition.get("object_ids") or []),
+        "top_k": decomposition.get("top_k"),
+        "routed": True,
+    }
+
+
+def load_decompositions(path: str | Path) -> dict[str, dict[str, Any]]:
+    """Read a sidecar file mapping query text to its decomposition.
+
+    Accepts either shape, so a dataset that grows a ``decomposition`` key per
+    query can be passed directly once that lands::
+
+        {"<query>": {"query": ..., "attributes": [...], "has_action": true}}
+        {"queries": {"<query>": {"decomposition": {...}}}}
+    """
+    data = json.loads(Path(path).read_text())
+    if "queries" in data and isinstance(data["queries"], dict):
+        data = data["queries"]
+
+    decompositions: dict[str, dict[str, Any]] = {}
+    for query, value in data.items():
+        if not isinstance(value, dict):
+            continue
+        # A dataset entry nests the decomposition; a sidecar file is already one.
+        inner = value.get("decomposition") if "decomposition" in value else value
+        if isinstance(inner, dict):
+            decompositions[query] = inner
+    return decompositions
+
+
+def unpack_dataset(data: dict[str, Any]) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
+    """Split a dataset into ``(annotations, decompositions)``.
+
+    Decompositions belong with the query they decompose, so the dataset is
+    their natural home -- one file, no separate flag, and adding a query adds
+    both halves at once.
+
+    Two shapes are accepted, so old datasets keep working unchanged::
+
+        # legacy: the value IS the ground-truth segment list
+        {"queries": {"<query>": [ {...}, {...} ]}}
+
+        # extended: segments plus the decomposition
+        {"queries": {"<query>": {"segments": [ {...} ],
+                                 "decomposition": {"query": ..., "attributes": [...]}}}}
+
+    Returns annotations in the legacy shape either way, so the scoring code
+    never learns which form it came from.
+    """
+    queries = data.get("queries", {}) or {}
+    annotations: dict[str, Any] = {}
+    decompositions: dict[str, dict[str, Any]] = {}
+
+    for query, value in queries.items():
+        if isinstance(value, dict):
+            annotations[query] = value.get("segments") or value.get("annotations") or []
+            decomposition = value.get("decomposition")
+            if isinstance(decomposition, dict):
+                decompositions[query] = decomposition
+        else:
+            # Legacy: a bare list of ground-truth segments.
+            annotations[query] = value or []
+
+    return annotations, decompositions
+
+
+def path_distribution(plans: list[dict[str, Any]]) -> dict[str, int]:
+    """Count plans per retrieval path, for the results summary.
+
+    A mixed-path run's headline metric averages over different retrieval
+    mechanisms, so the split has to be visible next to it.
+    """
+    counts: dict[str, int] = {}
+    for plan in plans:
+        counts[plan["path"]] = counts.get(plan["path"], 0) + 1
+    return dict(sorted(counts.items()))

--- a/skills/benchmarking/benchmark-video-search/scripts/flows/routing.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/flows/routing.py
@@ -144,10 +144,18 @@ def load_decompositions(path: str | Path) -> dict[str, dict[str, Any]]:
 
         {"<query>": {"query": ..., "attributes": [...], "has_action": true}}
         {"queries": {"<query>": {"decomposition": {...}}}}
+        {"expected_decomposition": {"<query>": {...}}}   # dataset provenance
+
+    The third is a dataset's own answer key. It is kept out of the dataset files
+    on purpose -- a stored decomposition would be a second, silently diverging
+    opinion about routing -- but it is exactly what a run needs when the LLM is
+    unreachable and the alternative is measuring one fixed path.
     """
     data = json.loads(Path(path).read_text())
-    if "queries" in data and isinstance(data["queries"], dict):
-        data = data["queries"]
+    for key in ("queries", "expected_decomposition"):
+        if key in data and isinstance(data[key], dict):
+            data = data[key]
+            break
 
     decompositions: dict[str, dict[str, Any]] = {}
     for query, value in data.items():

--- a/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
@@ -59,6 +59,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import statistics
 import sys
 import threading
@@ -279,7 +280,7 @@ def ingest_videos(
 # =============================================================================
 
 
-def run_evaluation(
+def run_evaluation(  # noqa: PLR0913
     query_backend: Any,
     data_dir: Path,
     dataset: str,
@@ -292,6 +293,7 @@ def run_evaluation(
     readiness: dict[str, Any] | None = None,
     cleared: dict[str, Any] | None = None,
     vst_url: str | None = None,
+    decomposer: Any = None,
 ) -> dict[str, Any]:
     """Score every dataset query through ``query_backend``.
 
@@ -337,6 +339,10 @@ def run_evaluation(
     print(f"{'concurrency:':<22}{concurrency}")
     print(f"{'=' * 60}\n")
 
+    # The prompt asks which sources exist so it can fill `video_sources`; the
+    # dataset already knows, which beats asking VST for an inventory that may
+    # include unrelated uploads.
+    video_names = {s["video_name"] for segs in annotations.values() for s in segs if s.get("video_name")}
     all_results: list[dict[str, Any] | None] = [None] * len(queries)
     print_lock = threading.Lock()
     completed = [0]
@@ -345,11 +351,28 @@ def run_evaluation(
 
     def _run_single_query(qi: int, query: str) -> None:
         expected = annotations[query]
+
+        # Decompose first, then search. The backend already routes from its
+        # `decompositions` map, so writing this query's entry is the whole
+        # integration -- path choice, attributes and top_k all follow. Distinct
+        # keys per thread, so the shared dict needs no lock.
+        decompose_s = 0.0
+        if decomposer is not None:
+            decomposition, decompose_s = decomposer.decompose(query, video_sources=sorted(video_names))
+            query_backend.decompositions[query] = decomposition
+
         raw_results, latency_s = query_backend.search(query)
         normalized = flows.normalize_results(raw_results)
         sources_seen.update(flows.verification_sources(normalized))
 
         result = flows.evaluate_query(query, flows.for_scoring(normalized), expected, latency_s)
+        if decomposer is not None:
+            # Kept apart from latency_s: one is the LLM deciding what to search
+            # for, the other is the search. Summing them silently would hide
+            # which half a regression came from.
+            result["decompose_s"] = round(decompose_s, 4)
+            result["total_latency_s"] = round(decompose_s + latency_s, 4)
+            result["decomposition"] = query_backend.decompositions.get(query)
 
         # Present only when the deployment carries the search_core timings
         # change. Absent means nobody collected -- not that stages took no time.
@@ -608,6 +631,25 @@ def _summarize(
             3,
         )
 
+    decompose_times = [r["decompose_s"] for r in results if r.get("decompose_s") is not None]
+    if decompose_times:
+        # Reported next to, not inside, the search latency: decomposition is an
+        # LLM call the CLI never makes, so folding it into latency_s would make
+        # runs with and without it incomparable.
+        summary["decomposition"] = {
+            "queries": len(decompose_times),
+            "mean_s": round(statistics.mean(decompose_times), 3),
+            "median_s": round(statistics.median(decompose_times), 3),
+            "max_s": round(max(decompose_times), 3),
+            "total_s": round(sum(decompose_times), 3),
+            "share_of_query_pct": round(
+                100 * sum(decompose_times) / max(sum(r["latency_s"] + r["decompose_s"] for r in results if r.get("decompose_s") is not None), 1e-9), 1
+            ),
+            "routed_to": flows.path_distribution(
+                [flows.plan_for(r["query"], r.get("decomposition")) for r in results if r.get("decomposition")]
+            ),
+        }
+
     summary["throughput"] = {
         "wall_clock_s": round(wall_clock_s, 3),
         "qps": round(n / wall_clock_s, 3) if wall_clock_s > 0 else 0.0,
@@ -673,6 +715,15 @@ def _print_summary(summary: dict[str, Any]) -> None:
             print(f"  {'  of which:':<18}")
             print(f"  {'    search:':<18}{lat['search_internal_mean_s']:.3f}s")
             print(f"  {'    CLI startup:':<18}{lat['cli_startup_mean_s']:.3f}s")
+
+    dec = summary.get("decomposition")
+    if dec:
+        print(f"\nQuery decomposition ({dec['queries']} queries, live)")
+        print(f"  {'Mean:':<18}{dec['mean_s']:.3f}s")
+        print(f"  {'Median:':<18}{dec['median_s']:.3f}s")
+        print(f"  {'Max:':<18}{dec['max_s']:.3f}s")
+        print(f"  {'Share of query:':<18}{dec['share_of_query_pct']:.1f}%")
+        print(f"  {'Routed to:':<18}{dec['routed_to']}")
 
     stage = summary.get("stage_latency")
     if stage:
@@ -876,6 +927,13 @@ def parse_args() -> argparse.Namespace:
         help=f"Exact path for the results JSON. Default: {RESULTS_DIR}/<name>.json",
     )
     p.add_argument(
+        "--llm-url",
+        default=os.environ.get("VSS_LLM_URL"),
+        help="LLM origin for live query decomposition, e.g. http://HOST:30081 "
+        "(env: VSS_LLM_URL). Without it every query uses --search-path.",
+    )
+    p.add_argument("--llm-model", help="Decomposition model id (default: ask the endpoint).")
+    p.add_argument(
         "--name",
         help="Name this run's results file, instead of <dataset>_<subset>_<timestamp>. "
         "Ignored when --output-file gives an exact path.",
@@ -890,6 +948,18 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
+
+    decomposer = None
+    if args.llm_url and not args.dry_run:
+        try:
+            decomposer = flows.LiveDecomposer(
+                args.llm_url, repo_root=flows.REPO_ROOT, model=args.llm_model
+            )
+        except flows.DecompositionError as e:
+            raise SystemExit(f"ERROR: {e}") from e
+        print(f"decomposition: live via {args.llm_url}  model={decomposer.model}")
+    elif not args.dry_run:
+        print(f"decomposition: none -- every query uses --search-path {args.search_path}")
 
     ingest_backend = build_ingest_backend(args)
     query_backend = build_query_backend(args)
@@ -983,6 +1053,7 @@ def main() -> None:
         data_dir=args.data_dir,
         dataset=args.dataset,
         subset=args.subset,
+        decomposer=decomposer,
         output_file=args.output_file,
         run_name=args.name,
         concurrency=args.concurrency,

--- a/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
@@ -1,0 +1,998 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Search eval against the new (and old) VSS search flows.
+
+Standalone: this script and ``flows/`` import nothing from ``run_eval.py``, so
+that script can be deleted without taking anything here with it. The metric
+definitions were vendored unchanged rather than rewritten, and a test asserts
+they still agree with ``run_eval.py`` for as long as both exist -- so numbers
+stay comparable with baselines captured by the old runner.
+
+    ingest:  legacy-put | agent-3step      (vst-direct pending -- GAP-1)
+    query:   cli                           (openclaw pending -- GAP-3)
+
+Several defaults here look arbitrary and are load-bearing:
+
+* ``--no-merge-adjacent`` is ON by default in this script, because upstream
+  merging averages the scores of merged windows and changes the precision
+  denominator. The historical baseline has unmerged windows; keeping them
+  unmerged is what makes the comparison mean anything.
+* Critic-filtered metrics are suppressed rather than zeroed when no
+  verification block is present, so an unfiltered run can never be mistaken
+  for a filtered one.
+* CLI exits 2/3/4/5 abort the run instead of scoring 0.0.
+
+Examples
+--------
+    # Defaults: agent-3step ingest + CLI queries. A dataset carrying
+    # decompositions routes per query; otherwise everything uses --search-path.
+    python run_eval_flows.py --endpoint http://HOST:8000 --data-dir ~/datasets \
+        --dataset warehouse --skip-download
+
+    # Query only, against what is already indexed
+    python run_eval_flows.py --endpoint http://HOST:8000 --data-dir ~/datasets \
+        --dataset warehouse --skip-download --skip-ingest
+
+    # Shared deployment: do not re-upload what is already registered
+    python run_eval_flows.py --endpoint http://HOST:8000 \
+        --skip-download --skip-existing
+
+    # Show what would run, touching nothing
+    python run_eval_flows.py --endpoint http://HOST:8000 --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import requests
+
+#: Stages whose own time is below this are wrappers or noise; the console hides
+#: them so the table reads as "where did the time go" without a nesting caveat.
+_STAGE_FLOOR_S = 0.001
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+#: Results land beside the script, not under the caller's cwd, so a run is
+#: findable regardless of where it was started from.
+RESULTS_DIR = SCRIPT_DIR / "cli_eval_result"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import flows
+
+# =============================================================================
+# Backend construction
+# =============================================================================
+
+
+def build_ingest_backend(args: argparse.Namespace) -> Any:
+    if args.ingest_flow == "legacy-put":
+        return flows.LegacyPutIngest(args.endpoint)
+    if args.ingest_flow == "agent-3step":
+        return flows.AgentThreeStepIngest(
+            args.endpoint,
+            upload_timestamp=args.upload_timestamp,
+            complete_retries=args.complete_retries,
+            complete_backoff_s=args.complete_backoff,
+        )
+    raise SystemExit(f"Unknown ingest flow: {args.ingest_flow}")
+
+
+def build_query_backend(args: argparse.Namespace) -> Any:
+    if args.query_flow == "cli":
+        # Cheapest check first: this one needs no subprocess and no network.
+        # `attribute` and `fusion` declare --attribute as mandatory upstream,
+        # so without it the run would reach the first query and abort on a
+        # usage error (exit 2) -- correct, but only after building the CLI
+        # environment and reconfiguring the deployment.
+        if args.search_path in ("attribute", "fusion") and not args.attribute and not args.decompositions:
+            raise SystemExit(
+                f"ERROR: --search-path {args.search_path} requires at least one --attribute.\n"
+                "  Attributes are detectable properties ('white jacket', 'red hard hat'),\n"
+                "  not generic nouns or actions -- those belong in the query.\n"
+                "  Use --search-path embed for a text-only query."
+            )
+
+        # Discovery order: --vss-cmd, --vss-repo-root, the vendored submodule,
+        # then `vss` on PATH. Both flags are optional when one of the last two
+        # works, so the common case needs no CLI-location argument at all.
+        try:
+            vss_cmd, how = flows.resolve_vss_cmd(args.vss_cmd, args.vss_repo_root)
+        except FileNotFoundError as e:
+            raise SystemExit(f"ERROR: {e}") from e
+        print(f"vss CLI:        {' '.join(vss_cmd)}\n                (resolved from {how})")
+
+        if not args.skip_vss_preflight and not args.dry_run:
+            # One subprocess now, instead of discovering a broken CLI on query
+            # 1 of N. A stale venv exits 1 on every invocation.
+            try:
+                version = flows.preflight_vss_cmd(vss_cmd)
+            except RuntimeError as e:
+                raise SystemExit(f"ERROR: {e}") from e
+            print(f"                {version}")
+
+        if not args.skip_vss_configure and not args.dry_run:
+            # The CLI reads ~/.vss/config.json, which is separate state from
+            # --endpoint and points at a DIFFERENT port: it discovers services
+            # by path prefix on the unified origin, which the agent port does
+            # not route. Getting this wrong yields exit 4 on every query.
+            base_url = args.vss_base_url or flows.vss_origin_for(args.endpoint, args.vss_origin_port)
+            try:
+                flows.ensure_vss_configured(vss_cmd, base_url)
+            except Exception as e:
+                raise SystemExit(f"ERROR: vss configure failed for {base_url}: {e}") from e
+        decompositions: dict[str, dict[str, Any]] = {}
+        if args.decompositions:
+            decompositions = flows.load_decompositions(args.decompositions)
+            print(f"decompositions: {len(decompositions)} loaded from {args.decompositions}")
+
+        return flows.CliQueryBackend(
+            vss_cmd=vss_cmd,
+            search_path=args.search_path,
+            top_k=args.top_k,
+            min_cosine_similarity=args.min_cosine_similarity,
+            source_type=args.source_type,
+            attributes=args.attribute or [],
+            merge_adjacent=args.merge_adjacent,
+            cwd=args.vss_repo_root,
+            decompositions=decompositions,
+        )
+    raise SystemExit(f"Unknown query flow: {args.query_flow}")
+
+
+# =============================================================================
+# Ingest
+# =============================================================================
+
+
+def clear_all_videos(agent_endpoint: str, vst_url: str) -> dict[str, Any]:
+    """Delete every video registered on the deployment.
+
+    Lists and deletes against the SAME resolved origins the rest of the run
+    uses, so ``--vst-url`` cannot list one host and delete from another.
+    Prints the full inventory first: ``--clear`` is destructive and shared
+    deployments carry other people's fixtures.
+    """
+    try:
+        streams = flows.list_sensor_streams(vst_url)
+    except Exception as e:
+        raise SystemExit(f"ABORTED: could not list sensors at {vst_url} ({type(e).__name__}: {e})") from e
+
+    if not streams:
+        print("  No videos found to delete.")
+        return {"found": 0, "deleted": 0, "names": []}
+
+    print(f"  Deleting {len(streams)} video(s) from {agent_endpoint}:")
+    for stream_id, name in streams.items():
+        print(f"    - {name}  ({stream_id})")
+
+    deleted, failed = 0, []
+    for stream_id, name in streams.items():
+        try:
+            resp = requests.delete(f"{agent_endpoint.rstrip('/')}/api/v1/videos/{stream_id}", timeout=60)
+            resp.raise_for_status()
+            deleted += 1
+            print(f"    deleted {name} -> {resp.status_code}")
+        except Exception as e:
+            failed.append(name)
+            print(f"    FAILED {name}: {e}")
+
+    print(f"  Deleted {deleted}/{len(streams)} video(s)")
+    return {"found": len(streams), "deleted": deleted, "failed": failed, "names": list(streams.values())}
+
+
+def ingest_videos(
+    backend: Any,
+    video_dir: Path,
+    skip_existing_from: str | None = None,
+) -> dict[str, Any]:
+    """Upload every fixture through the selected ingest backend.
+
+    ``skip_existing_from`` is a VST origin. When given, sources already
+    registered there are left alone -- necessary on a shared deployment, where
+    re-uploading someone else's fixture is at best wasteful and at worst
+    creates a duplicate sensor for the same video.
+    """
+    video_files = sorted(video_dir.glob("*.mp4")) + sorted(video_dir.glob("*.mkv"))
+    if not video_files:
+        print(f"  No video files found in {video_dir}")
+        return flows.aggregate_upload_stats([])
+
+    skipped: list[str] = []
+    if skip_existing_from:
+        try:
+            registered = flows.list_sensor_names(skip_existing_from)
+            keep = []
+            for vf in video_files:
+                if flows.is_registered(vf.name, registered):
+                    skipped.append(vf.stem)
+                else:
+                    keep.append(vf)
+            video_files = keep
+            if skipped:
+                print(f"  Already registered, skipping ingest: {skipped}")
+        except Exception as e:
+            print(f"  WARNING: could not read VST sensor list ({type(e).__name__}: {e}); ingesting all")
+
+    if not video_files:
+        print("  Nothing to ingest -- every fixture is already registered.")
+        stats = flows.aggregate_upload_stats([])
+        stats["skipped_existing"] = skipped
+        return stats
+
+    print(f"  Ingesting {len(video_files)} video(s) via '{backend.name}'")
+    per_file: list[dict[str, Any]] = []
+
+    for i, vf in enumerate(video_files, 1):
+        size = vf.stat().st_size / (1024 * 1024) if vf.exists() else 0.0
+        print(f"  [{i}/{len(video_files)}] {vf.name} ({size:.2f} MB)")
+        record = backend.upload(vf)
+        per_file.append(record)
+
+        if record.get("success"):
+            extras = []
+            if record.get("chunks_processed") is not None:
+                extras.append(f"{record['chunks_processed']} chunks")
+            if record.get("upload_speed_mbps") is not None:
+                extras.append(f"{record['upload_speed_mbps']} Mbps")
+            if record.get("phases"):
+                extras.append(
+                    " + ".join(f"{k.removesuffix('_s')}={v}s" for k, v in record["phases"].items())
+                )
+            suffix = f"  |  {'  |  '.join(extras)}" if extras else ""
+            print(f"    OK  {record['upload_latency_s']}s{suffix}  (sensor: {record.get('sensor_id')})")
+        else:
+            print(f"    FAILED: {record.get('error')}")
+
+    stats = flows.aggregate_upload_stats(per_file)
+    stats["skipped_existing"] = skipped
+    print(f"  Ingest complete: {stats['successful']}/{stats['total_uploads']} succeeded")
+    return stats
+
+
+# =============================================================================
+# Evaluation
+# =============================================================================
+
+
+def run_evaluation(
+    query_backend: Any,
+    data_dir: Path,
+    dataset: str,
+    subset: str,
+    output_file: str | None = None,
+    run_name: str | None = None,
+    concurrency: int = 1,
+    upload_stats: dict[str, Any] | None = None,
+    ingest_description: dict[str, Any] | None = None,
+    readiness: dict[str, Any] | None = None,
+    cleared: dict[str, Any] | None = None,
+    vst_url: str | None = None,
+) -> dict[str, Any]:
+    """Score every dataset query through ``query_backend``.
+
+    Output JSON keeps ``run_eval.py``'s exact ``summary`` / ``config`` /
+    ``query_results`` shape so existing readers (CI summary CSV, dashboards)
+    keep working, plus a ``flow`` block recording how the numbers were obtained.
+    """
+    data = flows.load_dataset_file(data_dir, dataset, subset)
+    # Decompositions live in the dataset next to the ground truth they belong
+    # to. --decompositions stays available for A/B-ing a different set (say,
+    # agent-captured vs hand-written) against the same annotations, so an
+    # explicit flag wins over what the dataset carries.
+    annotations, dataset_decompositions = flows.unpack_dataset(data)
+    queries = list(annotations.keys())
+
+    if dataset_decompositions and hasattr(query_backend, "decompositions"):
+        if query_backend.decompositions:
+            print(
+                f"NOTE: --decompositions ({len(query_backend.decompositions)}) overrides the "
+                f"{len(dataset_decompositions)} carried by the dataset"
+            )
+        else:
+            query_backend.decompositions = dataset_decompositions
+            print(f"Using {len(dataset_decompositions)} decomposition(s) from the dataset")
+
+    # Compute the planned split over the ACTUAL query list, so the header
+    # states what will run rather than only the fallback.
+    planned_paths: dict[str, int] = {}
+    if hasattr(query_backend, "plan_for_query"):
+        planned_paths = flows.path_distribution([query_backend.plan_for_query(q) for q in queries])
+
+    described = query_backend.describe()
+    if planned_paths:
+        described["planned_paths"] = "  ".join(f"{k}={v}" for k, v in planned_paths.items())
+
+    print(f"\n{'=' * 60}")
+    print("SEARCH PROFILE EVALUATION (pluggable flow)")
+    print(f"{'=' * 60}")
+    for key, value in described.items():
+        print(f"{key + ':':<22}{value}")
+    print(f"{'dataset:':<22}{dataset} / {subset or '(default)'}")
+    print(f"{'queries:':<22}{len(queries)}")
+    print(f"{'concurrency:':<22}{concurrency}")
+    print(f"{'=' * 60}\n")
+
+    all_results: list[dict[str, Any] | None] = [None] * len(queries)
+    print_lock = threading.Lock()
+    completed = [0]
+    sources_seen: set[str] = set()
+    fatal: list[BaseException] = []
+
+    def _run_single_query(qi: int, query: str) -> None:
+        expected = annotations[query]
+        raw_results, latency_s = query_backend.search(query)
+        normalized = flows.normalize_results(raw_results)
+        sources_seen.update(flows.verification_sources(normalized))
+
+        result = flows.evaluate_query(query, flows.for_scoring(normalized), expected, latency_s)
+
+        # Present only when the deployment carries the search_core timings
+        # change. Absent means nobody collected -- not that stages took no time.
+        stage_timings = getattr(query_backend, "timings_by_query", {}).get(query)
+        if stage_timings:
+            result["timings"] = stage_timings
+
+        kept, num_rejected = flows.filter_rejected(normalized)
+        result["num_rejected"] = num_rejected
+        result["critic_filtered"] = flows.evaluate_query(
+            query, flows.for_scoring(kept), expected, latency_s
+        )
+        all_results[qi] = result
+
+        with print_lock:
+            completed[0] += 1
+            print(f'[{completed[0]}/{len(queries)}] "{query}"  ({len(expected)} ground truth segments)')
+            print(f"  {flows.format_inline(result, latency_s=latency_s)}")
+            if num_rejected:
+                print(
+                    f"  [critic-filtered] rejected={num_rejected}  "
+                    f"{flows.format_inline(result['critic_filtered'])}"
+                )
+            if result["missed_gt_indices"]:
+                print(f"  Missed: {len(result['missed_gt_indices'])} segment(s)")
+            print()
+
+    inventory_before = flows.inventory_snapshot(vst_url) if vst_url else {"ok": False}
+
+    wall_start = time.monotonic()
+    with ThreadPoolExecutor(max_workers=concurrency) as executor:
+        futures = {executor.submit(_run_single_query, qi, q): qi for qi, q in enumerate(queries)}
+        for future in as_completed(futures):
+            try:
+                future.result()
+            except flows.CliExitError as exc:
+                # An environment fault, not a bad query. Scoring it as zero
+                # recall would report an accuracy cliff that never happened.
+                fatal.append(exc)
+                for pending in futures:
+                    pending.cancel()
+                break
+            except Exception as exc:
+                qi = futures[future]
+                print(f"  Query {qi} raised: {type(exc).__name__}: {exc}", file=sys.stderr)
+    wall_clock_s = time.monotonic() - wall_start
+
+    # A shared deployment can be wiped mid-run by someone else. If it was, the
+    # numbers above describe an index that no longer exists.
+    inventory_after = flows.inventory_snapshot(vst_url) if vst_url else {"ok": False}
+    inventory = flows.compare_inventory(inventory_before, inventory_after)
+    if inventory.get("stable") is False:
+        print("\n" + "!" * 60)
+        print("WARNING: the deployment changed DURING this run.")
+        if inventory["disappeared"]:
+            print(f"  disappeared: {inventory['disappeared']}")
+        if inventory["appeared"]:
+            print(f"  appeared:    {inventory['appeared']}")
+        print("  Someone else is using this endpoint. Treat these metrics as unreliable.")
+        print("!" * 60 + "\n")
+
+    if fatal:
+        raise SystemExit(f"\nABORTED: {fatal[0]}")
+
+    results = [r for r in all_results if r is not None]
+    if not results:
+        raise SystemExit("ABORTED: no query produced a result.")
+
+    summary = _summarize(
+        results,
+        dataset=dataset,
+        subset=subset,
+        wall_clock_s=wall_clock_s,
+        concurrency=concurrency,
+        sources_seen=sources_seen,
+        upload_stats=upload_stats,
+        path_counts=(
+            flows.path_distribution(query_backend.executed_plans)
+            if getattr(query_backend, "executed_plans", None)
+            else None
+        ),
+    )
+    _print_summary(summary)
+
+    if output_file is None:
+        # Beside the script rather than relative to the caller's cwd: the old
+        # default wrote to "eval/results/..." resolved from wherever you happened
+        # to be, so the same command scattered results across directories.
+        name = run_name or f"{dataset}_{subset or 'default'}_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        output_file = str(RESULTS_DIR / f"{name}.json")
+    out_path = Path(output_file)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    output: dict[str, Any] = {
+        "summary": summary,
+        "config": {
+            "dataset": dataset,
+            "subset": subset or "default",
+            "concurrency": concurrency,
+            **{k: v for k, v in described.items() if k != "backend"},
+        },
+        "flow": {
+            "query": described,
+            "ingest": ingest_description,
+            "readiness": readiness,
+            "cleared": cleared,
+            "inventory": inventory,
+            # Phoenix is absent by construction on the CLI query path:
+            # search_core and vss_cli carry no OpenTelemetry instrumentation,
+            # and Phoenix spans came only from NAT's telemetry config.
+            "phoenix": {
+                "collected": False,
+                "reason": (
+                    "not collected by this script; unavailable on the CLI query "
+                    "path because search_core/vss_cli emit no OTel spans"
+                ),
+            },
+        },
+        "query_results": results,
+    }
+    if upload_stats:
+        output["flow"]["upload_stats"] = upload_stats
+
+    with open(out_path, "w") as f:
+        json.dump(output, f, indent=2)
+    print(f"Results saved to: {out_path.absolute()}")
+    return output
+
+
+def _summarize(
+    results: list[dict[str, Any]],
+    dataset: str,
+    subset: str,
+    wall_clock_s: float,
+    concurrency: int,
+    sources_seen: set[str],
+    upload_stats: dict[str, Any] | None,
+    path_counts: dict[str, int] | None = None,
+) -> dict[str, Any]:
+    """Aggregate per-query metrics.
+
+    Key names deliberately match ``run_eval.run_evaluation``'s summary block so
+    baselines from either script line up field for field.
+    """
+    n = len(results)
+    avg = lambda key: sum(r[key] for r in results) / n
+    avg_hit = lambda k: sum(r["hit_at_k"][k] for r in results) / n
+
+    summary: dict[str, Any] = {
+        "dataset": dataset,
+        "subset": subset or "default",
+        "total_queries": n,
+        "mAP": round(avg("average_precision"), 4),
+        "MRR": round(avg("reciprocal_rank"), 4),
+        "avg_precision": round(avg("precision"), 4),
+        "avg_recall": round(avg("recall"), 4),
+        "avg_f1": round(avg("f1"), 4),
+    }
+    for k in flows.HIT_K_VALUES:
+        summary[f"HIT@{k}"] = round(avg_hit(k), 4)
+
+    # Only report critic-filtered metrics when a verification block was
+    # actually present. Emitting them off an unverified response would publish
+    # unfiltered numbers under a filtered label -- see flows.py for why that
+    # failure mode is the one worth engineering against.
+    real_sources = sources_seen - {flows.VERIFICATION_ABSENT}
+    if real_sources:
+        favg = lambda key: sum(r["critic_filtered"][key] for r in results) / n
+        favg_hit = lambda k: sum(r["critic_filtered"]["hit_at_k"][k] for r in results) / n
+        critic_filtered: dict[str, Any] = {
+            "mAP": round(favg("average_precision"), 4),
+            "MRR": round(favg("reciprocal_rank"), 4),
+            "avg_precision": round(favg("precision"), 4),
+            "avg_recall": round(favg("recall"), 4),
+            "avg_f1": round(favg("f1"), 4),
+        }
+        for k in flows.HIT_K_VALUES:
+            critic_filtered[f"HIT@{k}"] = round(favg_hit(k), 4)
+        summary["critic_filtered"] = critic_filtered
+        summary["total_rejected"] = sum(r.get("num_rejected", 0) for r in results)
+        summary["queries_with_rejections"] = sum(1 for r in results if r.get("num_rejected", 0) > 0)
+
+    # A routed run mixes retrieval paths, so the headline metric averages over
+    # different mechanisms. The split has to sit next to it or the number is
+    # uninterpretable.
+    if path_counts:
+        summary["search_paths"] = path_counts
+
+    summary["verification"] = {
+        "field_sources": sorted(sources_seen),
+        "available": bool(real_sources),
+    }
+
+    latencies = [r["latency_s"] for r in results if r.get("latency_s") is not None]
+    if latencies:
+        sorted_lat = sorted(latencies)
+        summary["latency"] = {
+            "mean_s": round(statistics.mean(sorted_lat), 3),
+            "median_s": round(statistics.median(sorted_lat), 3),
+            "min_s": round(min(sorted_lat), 3),
+            "max_s": round(max(sorted_lat), 3),
+            "p90_s": round(sorted_lat[min(int(len(sorted_lat) * 0.9), len(sorted_lat) - 1)], 3),
+            "p95_s": round(sorted_lat[min(int(len(sorted_lat) * 0.95), len(sorted_lat) - 1)], 3),
+            "std_dev_s": round(statistics.stdev(sorted_lat), 3) if len(sorted_lat) > 1 else 0.0,
+        }
+
+    # Per-stage breakdown, when the deployment reports it. This is the CLI-path
+    # replacement for the Phoenix span breakdown, which does not exist here
+    # because search_core emits no OTel spans.
+    stage_rows: dict[str, dict[str, list[float]]] = {}
+    reported = 0
+    for r in results:
+        stages = (r.get("timings") or {}).get("stages") or {}
+        if stages:
+            reported += 1
+        for label, entry in stages.items():
+            row = stage_rows.setdefault(label, {"total": [], "self": [], "calls": [], "conc": []})
+            row["total"].append(float(entry.get("total_s", 0.0)))
+            row["self"].append(float(entry.get("self_s", 0.0)))
+            row["calls"].append(float(entry.get("calls", 0.0)))
+            row["conc"].append(float(entry.get("concurrent_children", 0.0)))
+
+    if stage_rows:
+        # Ranked by SELF time: that is where the work actually happened. Ranking
+        # by inclusive total puts wrappers on top, which says nothing.
+        summary["stage_latency"] = {
+            "queries_reporting": reported,
+            "stages": {
+                label: {
+                    "self_total_s": round(sum(row["self"]), 4),
+                    "self_mean_s": round(statistics.mean(row["self"]), 4),
+                    "inclusive_total_s": round(sum(row["total"]), 4),
+                    "inclusive_mean_s": round(statistics.mean(row["total"]), 4),
+                    "queries": len(row["total"]),
+                    "calls": int(sum(row["calls"])),
+                    "concurrent_children": bool(any(row["conc"])),
+                }
+                for label, row in sorted(stage_rows.items(), key=lambda kv: -sum(kv[1]["self"]))
+            },
+        }
+
+    # What the query cost outside search() itself: CLI process launch, imports
+    # and the ~/.vss/config.json read. Only derivable when the deployment
+    # reports timings, since it is latency minus the search's own total.
+    overheads = [
+        r["latency_s"] - (r.get("timings") or {}).get("total_s", 0.0)
+        for r in results
+        if r.get("latency_s") is not None and (r.get("timings") or {}).get("total_s")
+    ]
+    if overheads and "latency" in summary:
+        summary["latency"]["cli_startup_mean_s"] = round(statistics.mean(overheads), 3)
+        summary["latency"]["search_internal_mean_s"] = round(
+            statistics.mean(
+                [(r.get("timings") or {}).get("total_s", 0.0) for r in results if (r.get("timings") or {}).get("total_s")]
+            ),
+            3,
+        )
+
+    summary["throughput"] = {
+        "wall_clock_s": round(wall_clock_s, 3),
+        "qps": round(n / wall_clock_s, 3) if wall_clock_s > 0 else 0.0,
+        "successful_qps": round(len(latencies) / wall_clock_s, 3) if wall_clock_s > 0 else 0.0,
+        "concurrency": concurrency,
+    }
+
+    if upload_stats and upload_stats.get("total_uploads"):
+        summary["upload"] = upload_stats
+
+    summary["timestamp"] = datetime.now().isoformat()
+    return summary
+
+
+def _print_summary(summary: dict[str, Any]) -> None:
+    print(f"{'=' * 60}")
+    print("RESULTS SUMMARY")
+    print(f"{'=' * 60}")
+    print(f"Dataset:            {summary['dataset']} / {summary['subset']}")
+    print(f"Queries:            {summary['total_queries']}")
+
+    if summary.get("search_paths"):
+        split = "  ".join(f"{k}={v}" for k, v in summary["search_paths"].items())
+        print(f"Search paths:       {split}")
+
+    cf = summary.get("critic_filtered")
+    if cf:
+        print(
+            f"Rejections:         {summary['total_rejected']} across "
+            f"{summary['queries_with_rejections']} queries"
+        )
+    else:
+        print(
+            "Rejections:         n/a -- no verification block in the response "
+            "(critic-filtered metrics suppressed)"
+        )
+
+    def _cf(key: str) -> str:
+        return f"{cf[key]:.4f}" if cf else "NA"
+
+    print()
+    print(f"{'':<20}{'Raw':<12}Critic Filtered")
+    for label, key in (
+        ("mAP", "mAP"),
+        ("MRR", "MRR"),
+        ("Avg Precision", "avg_precision"),
+        ("Avg Recall", "avg_recall"),
+        ("Avg F1", "avg_f1"),
+    ):
+        print(f"{label + ':':<20}{summary[key]:<12.4f}{_cf(key)}")
+    for k in flows.HIT_K_VALUES:
+        print(f"HIT@{k}:".ljust(20) + f"{summary[f'HIT@{k}']:<12.4f}{_cf(f'HIT@{k}')}")
+
+    if "latency" in summary:
+        lat = summary["latency"]
+        print("\nLatency (client-observed):")
+        for label, key in (
+            ("Mean", "mean_s"), ("Median", "median_s"), ("Min", "min_s"),
+            ("Max", "max_s"), ("P90", "p90_s"), ("P95", "p95_s"), ("Std Dev", "std_dev_s"),
+        ):
+            print(f"  {label + ':':<18}{lat[key]:.3f}s")
+        if "cli_startup_mean_s" in lat:
+            print(f"  {'  of which:':<18}")
+            print(f"  {'    search:':<18}{lat['search_internal_mean_s']:.3f}s")
+            print(f"  {'    CLI startup:':<18}{lat['cli_startup_mean_s']:.3f}s")
+
+    stage = summary.get("stage_latency")
+    if stage:
+        # One number per stage: time spent IN it, children excluded. Wrappers
+        # like "search: embed search" contribute nothing of their own, so they
+        # are hidden rather than shown at ~0 next to real work. Full detail --
+        # inclusive totals, call counts, overlap flags -- stays in the JSON.
+        # Filter on the MEAN, not the total: a total grows with query count, so
+        # a wrapper contributing microseconds per query would reappear on a
+        # large dataset.
+        rows = [(k, v) for k, v in stage["stages"].items() if v["self_mean_s"] >= _STAGE_FLOOR_S]
+
+        total_queries = stage["queries_reporting"]
+        # `queries` is a column rather than a parenthetical: a stage that runs
+        # only on fusion queries has its mean taken over those, and the count
+        # is what stops a 5.9s mean over 3 reading like a 7.8s mean over 9.
+        width = max((len(label) for label, _ in rows), default=20)
+        print(f"\nStage latency ({total_queries} queries reported)")
+        print(f"  {'stage':<{width}}  {'mean':>10}  {'total':>10}  {'queries':>7}")
+        print(f"  {'-' * width}  {'-' * 10}  {'-' * 10}  {'-' * 7}")
+        for label, v in rows:
+            print(
+                f"  {label:<{width}}  {v['self_mean_s']:9.3f}s  "
+                f"{v['self_total_s']:9.3f}s  {v['queries']:>7}"
+            )
+
+    tp = summary["throughput"]
+    print("\nThroughput:")
+    print(f"  Wall clock:       {tp['wall_clock_s']:.3f}s")
+    print(f"  QPS:              {tp['qps']:.3f}")
+    print(f"  Successful QPS:   {tp['successful_qps']:.3f}  (excludes failed queries)")
+    print(f"  Concurrency:      {tp['concurrency']}")
+
+    if summary.get("upload"):
+        flows.print_upload_summary(summary["upload"])
+    print(f"{'=' * 60}\n")
+
+
+# =============================================================================
+# CLI
+# =============================================================================
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--endpoint", required=True, help="VSS agent base URL (e.g. http://localhost:8000)")
+
+    flow = p.add_argument_group("flow selection")
+    flow.add_argument(
+        "--ingest-flow",
+        default="agent-3step",
+        choices=sorted(flows.INGEST_BACKENDS),
+        help="How fixtures are uploaded (default: agent-3step)",
+    )
+    flow.add_argument(
+        "--query-flow",
+        default="cli",
+        choices=sorted(flows.QUERY_BACKENDS),
+        help=(
+            "How queries are issued. Only 'cli' exists today -- the path the "
+            "new UI flow reaches through the vss-search-archive skill."
+        ),
+    )
+    flow.add_argument(
+        "--search-path",
+        default="embed",
+        choices=flows.SEARCH_PATHS,
+        help="CLI retrieval path (--query-flow cli only). Fixed, not agent-chosen.",
+    )
+    flow.add_argument(
+        "--attribute",
+        action="append",
+        help="Attribute term for attribute/fusion paths; repeatable.",
+    )
+
+    cli = p.add_argument_group("vss CLI (--query-flow cli)")
+    cli.add_argument(
+        "--vss-repo-root",
+        help=(
+            "Checkout containing services/agent/packages/vss_cli. Optional -- "
+            "falls back to the vendored submodule, then `vss` on PATH."
+        ),
+    )
+    cli.add_argument("--vss-cmd", help="Override the whole vss invocation (shell-quoted)")
+    cli.add_argument(
+        "--vss-base-url",
+        help=(
+            "Origin for `vss configure`. Defaults to --endpoint's host on port "
+            f"{flows.DEFAULT_VSS_ORIGIN_PORT}, which is where the unified "
+            "path-prefix routes live (the agent port does not serve them)."
+        ),
+    )
+    cli.add_argument(
+        "--vss-origin-port",
+        type=int,
+        default=flows.DEFAULT_VSS_ORIGIN_PORT,
+        help=f"Port for the derived configure origin (default: {flows.DEFAULT_VSS_ORIGIN_PORT}).",
+    )
+    cli.add_argument(
+        "--skip-vss-configure",
+        action="store_true",
+        help="Use ~/.vss/config.json as-is instead of pointing it at this deployment.",
+    )
+    cli.add_argument(
+        "--decompositions",
+        help=(
+            "JSON file mapping each query to the decomposition the agent would "
+            "produce (query/attributes/has_action/...). When given, the retrieval "
+            "path and arguments are derived PER QUERY instead of --search-path "
+            "and --attribute applying to the whole run."
+        ),
+    )
+    cli.add_argument(
+        "--skip-vss-preflight",
+        action="store_true",
+        help="Skip the `vss --version` check that catches a broken CLI install.",
+    )
+
+    dataset = p.add_argument_group("dataset")
+    dataset.add_argument("--dataset", default="warehouse", choices=sorted(flows.DATASETS))
+    dataset.add_argument("--subset", default="", help="Dataset subset (default: '')")
+    dataset.add_argument("--data-dir", type=Path, default=flows.DEFAULT_DATA_DIR)
+    dataset.add_argument("--skip-download", action="store_true", help="Use the local dataset as-is")
+    dataset.add_argument("--skip-ingest", action="store_true", help="Assume videos are already indexed")
+    dataset.add_argument(
+        "--skip-existing",
+        action="store_true",
+        help=(
+            "Do not re-upload fixtures VST already lists. Use on shared "
+            "deployments, where re-uploading creates a duplicate sensor."
+        ),
+    )
+
+    query = p.add_argument_group("query parameters")
+    query.add_argument("--top-k", type=int, default=5)
+    query.add_argument("--min-cosine-similarity", type=float, default=0.0)
+    query.add_argument("--source-type", default="video_file", choices=["video_file", "rtsp"])
+    query.add_argument("--concurrency", type=int, default=1)
+    query.add_argument(
+        "--merge-adjacent",
+        action="store_true",
+        help=(
+            "Let the CLI merge contiguous same-sensor windows (upstream default). "
+            "OFF here by default: merging averages scores and changes the precision "
+            "denominator, breaking comparability with the REST baseline."
+        ),
+    )
+
+    ingest = p.add_argument_group("ingest")
+    ingest.add_argument("--upload-timestamp", default=flows.DEFAULT_UPLOAD_TIMESTAMP)
+    ingest.add_argument(
+        "--complete-retries",
+        type=int,
+        default=3,
+        help=(
+            "Attempts for POST /videos/{id}/complete (default: 3). The call is "
+            "flaky -- observed 502 on the first attempt and 200 on the second."
+        ),
+    )
+    ingest.add_argument(
+        "--complete-backoff",
+        type=float,
+        default=5.0,
+        help="Base seconds between /complete attempts; multiplied by attempt number.",
+    )
+    ingest.add_argument(
+        "--vst-port",
+        type=int,
+        default=30888,
+        help=(
+            "VST port on the same host as --endpoint (default: 30888). The agent "
+            "origin does not necessarily proxy /vst -- on 10.86.12.161 it does "
+            "not, and VST answers on 7777 and 30888 instead."
+        ),
+    )
+    ingest.add_argument(
+        "--vst-url",
+        help="Full VST origin, overriding the --vst-port derivation entirely.",
+    )
+    ingest.add_argument(
+        "--readiness-timeout",
+        type=int,
+        default=1200,
+        help="Seconds to wait for VST to register every source after ingest (default: 1200)",
+    )
+    ingest.add_argument("--skip-readiness-wait", action="store_true")
+    ingest.add_argument(
+        "--clear",
+        action="store_true",
+        help=(
+            "Delete ALL videos on the endpoint before ingest -- including any "
+            "you did not upload. Do not use on a shared deployment."
+        ),
+    )
+
+    p.add_argument(
+        "--output-file",
+        help=f"Exact path for the results JSON. Default: {RESULTS_DIR}/<name>.json",
+    )
+    p.add_argument(
+        "--name",
+        help="Name this run's results file, instead of <dataset>_<subset>_<timestamp>. "
+        "Ignored when --output-file gives an exact path.",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the resolved backends and a sample CLI invocation, then exit",
+    )
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    ingest_backend = build_ingest_backend(args)
+    query_backend = build_query_backend(args)
+
+    if args.dry_run:
+        print("Ingest backend:")
+        print(json.dumps(ingest_backend.describe(), indent=2))
+        print("\nQuery backend:")
+        print(json.dumps(query_backend.describe(), indent=2))
+        if isinstance(query_backend, flows.CliQueryBackend):
+            import shlex
+
+            print("\nSample invocation:")
+            print("  " + shlex.join(query_backend.build_argv("a person in a white jacket")))
+        print("\nDry run - nothing executed.")
+        return
+
+    print(f"\n{'=' * 60}")
+    print("SEARCH EVAL - PLUGGABLE FLOWS")
+    print(f"{'=' * 60}")
+    print(f"Endpoint:       {args.endpoint}")
+    print(f"Ingest flow:    {args.ingest_flow}")
+    print(f"Query flow:     {args.query_flow}")
+    # Deliberately no search-path line here. This banner prints before the
+    # dataset is read, so it cannot know whether the dataset carries
+    # decompositions -- it could only report the fallback, which reads as
+    # "every query used this". The SEARCH PROFILE EVALUATION header below runs
+    # after the dataset loads and reports routing, fallback_path and the
+    # planned per-path split accurately.
+    print(f"{'=' * 60}\n")
+
+    if not args.skip_download:
+        print("Downloading dataset from DSS...")
+        flows.download_from_dss(args.data_dir, args.dataset)
+
+    # VST is a separate origin from the agent. run_eval.py's convention (swap
+    # the port on the same host) is reused so both scripts resolve it the same
+    # way; --vst-url overrides it for deployments that route differently.
+    # Resolved BEFORE --clear so the destructive path uses the same origin.
+    vst_url = args.vst_url or flows.vst_url_for(args.endpoint, args.vst_port)
+    print(f"VST origin:     {vst_url}")
+
+    cleared: dict[str, Any] | None = None
+    if args.clear:
+        print("\nClearing ALL existing videos (--clear)...")
+        cleared = clear_all_videos(args.endpoint, vst_url)
+
+    upload_stats: dict[str, Any] | None = None
+    readiness: dict[str, Any] | None = None
+    video_dir = args.data_dir / args.dataset / "videos"
+
+    if args.skip_ingest:
+        print("Skipping ingest (--skip-ingest)")
+    else:
+        print(f"\nIngesting videos from {video_dir}")
+        upload_stats = ingest_videos(
+            ingest_backend,
+            video_dir,
+            skip_existing_from=vst_url if args.skip_existing else None,
+        )
+        flows.print_upload_summary(upload_stats)
+
+        if upload_stats.get("failed"):
+            raise SystemExit(
+                f"ABORTED: {upload_stats['failed']} upload(s) failed. "
+                "Scoring against a partial index would misreport retrieval quality."
+            )
+
+        if not args.skip_readiness_wait:
+            # Every fixture must be queryable, not just the ones uploaded this
+            # run -- with --skip-existing the rest were skipped precisely
+            # because they are already there, and they still get searched.
+            expected = [
+                r["video_name"] for r in upload_stats.get("per_file", []) if r.get("success")
+            ] + list(upload_stats.get("skipped_existing") or [])
+            print(f"\nWaiting for {len(expected)} source(s) to register in VST...")
+            readiness = flows.wait_for_sources(
+                vst_url, expected, timeout_s=args.readiness_timeout
+            )
+            if readiness["ready"]:
+                print(f"  All sources registered after {readiness['attempts']} poll(s).")
+            else:
+                raise SystemExit(
+                    f"ABORTED: {len(readiness['missing'])} source(s) never registered within "
+                    f"{args.readiness_timeout}s: {readiness['missing']}\n"
+                    "  Querying now would score an indexing delay as a retrieval regression."
+                )
+
+    run_evaluation(
+        query_backend=query_backend,
+        data_dir=args.data_dir,
+        dataset=args.dataset,
+        subset=args.subset,
+        output_file=args.output_file,
+        run_name=args.name,
+        concurrency=args.concurrency,
+        upload_stats=upload_stats,
+        ingest_description=ingest_backend.describe(),
+        readiness=readiness,
+        cleared=cleared,
+        vst_url=vst_url,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
@@ -58,6 +58,7 @@ Examples
 from __future__ import annotations
 
 import argparse
+import collections
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import as_completed
 import contextlib
@@ -510,6 +511,7 @@ def run_evaluation(
     vst_url: str | None = None,
     decomposer: Any = None,
     decompose_fallback: dict[str, Any] | None = None,
+    tolerate_unanswered: int = 0,
 ) -> dict[str, Any]:
     """Score every dataset query through ``query_backend``.
 
@@ -627,6 +629,10 @@ def run_evaluation(
 
     inventory_before = flows.inventory_snapshot(vst_url) if vst_url else {"ok": False}
 
+    #: Queries the backend never answered. Appended only from the single-
+    #: threaded as_completed loop below, so no lock.
+    unanswered: list[dict[str, Any]] = []
+
     wall_start = time.monotonic()
     with ThreadPoolExecutor(max_workers=concurrency) as executor:
         futures = {executor.submit(_run_single_query, qi, q): qi for qi, q in enumerate(queries)}
@@ -640,8 +646,20 @@ def run_evaluation(
                 for pending in futures:
                     pending.cancel()
                 break
-            except Exception as exc:
+            except flows.QueryUnanswerableError as exc:
+                # No answer is not no hits. Record it and leave it OUT of the
+                # scored set rather than letting an empty result average in.
                 qi = futures[future]
+                unanswered.append({"index": qi, "query": queries[qi], "reason": str(exc)[:300]})
+                print(f"  Query {qi} unanswerable: {exc}", file=sys.stderr)
+            except Exception as exc:
+                # Same rule for anything else that stopped this query from
+                # producing a result: scoring is only valid for queries the
+                # backend actually answered.
+                qi = futures[future]
+                unanswered.append(
+                    {"index": qi, "query": queries[qi], "reason": f"{type(exc).__name__}: {exc}"[:300]}
+                )
                 print(f"  Query {qi} raised: {type(exc).__name__}: {exc}", file=sys.stderr)
     wall_clock_s = time.monotonic() - wall_start
 
@@ -666,6 +684,28 @@ def run_evaluation(
     if not results:
         raise SystemExit("ABORTED: no query produced a result.")
 
+    # `total_queries` counts what was scored, so dropping failures quietly makes
+    # a partial run look complete -- 50 unanswered out of 673 reports
+    # `total_queries: 623` and reads as clean. Say it, loudly, and stop unless
+    # the caller has said how many they will accept.
+    if unanswered:
+        print("\n" + "!" * 60)
+        print(f"WARNING: {len(unanswered)}/{len(queries)} queries were never answered.")
+        for entry in unanswered[:10]:
+            print(f'  [{entry["index"]}] {entry["query"][:60]!r}: {entry["reason"][:120]}')
+        if len(unanswered) > 10:
+            print(f"  ... and {len(unanswered) - 10} more")
+        print("!" * 60 + "\n")
+        if len(unanswered) > tolerate_unanswered:
+            raise SystemExit(
+                f"ABORTED: {len(unanswered)} unanswered query/queries exceeds "
+                f"--tolerate-unanswered {tolerate_unanswered}.\n"
+                "  They are excluded from the metrics either way, so the numbers "
+                "below would describe\n"
+                f"  {len(results)} queries under a {len(queries)}-query label. "
+                "Raise the tolerance to accept that."
+            )
+
     summary = _summarize(
         results,
         dataset=dataset,
@@ -675,6 +715,7 @@ def run_evaluation(
         sources_seen=sources_seen,
         verdicts=verdicts,
         upload_stats=upload_stats,
+        unanswered=unanswered,
         path_counts=(
             flows.path_distribution(query_backend.executed_plans)
             if getattr(query_backend, "executed_plans", None)
@@ -741,6 +782,7 @@ def _summarize(
     upload_stats: dict[str, Any] | None,
     verdicts: dict[str, int] | None = None,
     path_counts: dict[str, int] | None = None,
+    unanswered: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Aggregate per-query metrics.
 
@@ -748,6 +790,7 @@ def _summarize(
     baselines from either script line up field for field.
     """
     n = len(results)
+    unanswered = unanswered or []
     def avg(key):
         return sum(r[key] for r in results) / n
     def avg_hit(k):
@@ -756,7 +799,11 @@ def _summarize(
     summary: dict[str, Any] = {
         "dataset": dataset,
         "subset": subset or "default",
+        # `total_queries` is the SCORED count, matching run_eval.py's field so
+        # baselines line up. When they differ, `queries_attempted` is what a
+        # reader needs to know the metrics cover less than the dataset.
         "total_queries": n,
+        "queries_attempted": n + len(unanswered),
         "mAP": round(avg("average_precision"), 4),
         "MRR": round(avg("reciprocal_rank"), 4),
         "avg_precision": round(avg("precision"), 4),
@@ -765,6 +812,17 @@ def _summarize(
     }
     for k in flows.HIT_K_VALUES:
         summary[f"HIT@{k}"] = round(avg_hit(k), 4)
+
+    # Absent, not zero, when every query was answered -- so its presence in a
+    # result file is itself the signal that the metrics above are partial.
+    if unanswered:
+        summary["unanswered"] = {
+            "count": len(unanswered),
+            "reasons": dict(
+                collections.Counter(e["reason"].split(":")[0] for e in unanswered)
+            ),
+            "queries": unanswered[:50],
+        }
 
     # Only report critic-filtered metrics when a verification block was
     # actually present. Emitting them off an unverified response would publish
@@ -1273,6 +1331,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "reason to pass this: A/B against an older result file."
         ),
     )
+    p.add_argument(
+        "--tolerate-unanswered",
+        type=int,
+        default=0,
+        help=(
+            "How many queries may go unanswered (timeout, unparseable CLI "
+            "output, or an exception) before the run aborts. Default 0. They "
+            "are excluded from the metrics either way -- this only decides "
+            "whether a partial run is allowed to publish numbers."
+        ),
+    )
     p.add_argument("--llm-model", help="Decomposition model id (default: ask the endpoint).")
     p.add_argument(
         "--name",
@@ -1493,6 +1562,7 @@ def main() -> None:
         subset=args.subset,
         decomposer=decomposer,
         decompose_fallback=decompose_fallback,
+        tolerate_unanswered=args.tolerate_unanswered,
         output_file=args.output_file,
         run_name=args.name,
         concurrency=args.concurrency,

--- a/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
@@ -1344,10 +1344,17 @@ def main() -> None:
                 print(f"           every query will use --search-path {args.search_path}.")
                 print("           ONE PATH IS MEASURED -- this is not a routing eval.")
                 print("           Report it alongside the metrics.")
+                # Record that an answer key exists; do NOT suggest using it.
+                # This used to print `--decompositions <path>` as a ready-to-run
+                # line, which is a suggestion shaped like an instruction: an
+                # agent driving this skill copies it, and the run silently
+                # becomes a gold-routing experiment scored under a live-routing
+                # label. Only physicalai-dev ships one, so following it also
+                # makes that dataset incomparable with every other.
                 sidecar = flows.sidecar_decompositions_for(args.data_dir, args.dataset)
                 if sidecar:
-                    print(f"           ({args.dataset} ships an answer key; --decompositions {sidecar}")
-                    print("            would route per query, but scores perfect routing, not live.)")
+                    decompose_fallback["answer_key_available"] = str(sidecar)
+                    decompose_fallback["answer_key_used"] = False
                 print()
 
     ingest_backend = build_ingest_backend(args)

--- a/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
@@ -347,6 +347,7 @@ def run_evaluation(  # noqa: PLR0913
     print_lock = threading.Lock()
     completed = [0]
     sources_seen: set[str] = set()
+    verdicts: dict[str, int] = {}
     fatal: list[BaseException] = []
 
     def _run_single_query(qi: int, query: str) -> None:
@@ -364,6 +365,8 @@ def run_evaluation(  # noqa: PLR0913
         raw_results, latency_s = query_backend.search(query)
         normalized = flows.normalize_results(raw_results)
         sources_seen.update(flows.verification_sources(normalized))
+        for verdict, count in flows.verdict_counts(normalized).items():
+            verdicts[verdict] = verdicts.get(verdict, 0) + count
 
         result = flows.evaluate_query(query, flows.for_scoring(normalized), expected, latency_s)
         if decomposer is not None:
@@ -448,6 +451,7 @@ def run_evaluation(  # noqa: PLR0913
         wall_clock_s=wall_clock_s,
         concurrency=concurrency,
         sources_seen=sources_seen,
+        verdicts=verdicts,
         upload_stats=upload_stats,
         path_counts=(
             flows.path_distribution(query_backend.executed_plans)
@@ -510,6 +514,7 @@ def _summarize(
     concurrency: int,
     sources_seen: set[str],
     upload_stats: dict[str, Any] | None,
+    verdicts: dict[str, int] | None = None,
     path_counts: dict[str, int] | None = None,
 ) -> dict[str, Any]:
     """Aggregate per-query metrics.
@@ -538,7 +543,35 @@ def _summarize(
     # actually present. Emitting them off an unverified response would publish
     # unfiltered numbers under a filtered label -- see flows.py for why that
     # failure mode is the one worth engineering against.
+    # A verification block on every hit does not mean the critic formed an
+    # opinion. Every critic failure path -- unreachable VLM, a 4xx on a clip URL
+    # the VLM cannot resolve, a parse error -- degrades that candidate to
+    # `unverified` and carries on, so a totally broken critic still attaches a
+    # block to everything. Filtering then drops nothing and critic-filtered
+    # metrics come out numerically identical to raw, which reads as "the critic
+    # agreed with retrieval" when it never rendered an opinion at all.
+    #
+    # Observed in practice: a CLI configured with a loopback base_url hands
+    # RT-VLM a `localhost` clip link, its SSRF guard returns 422, and all 121
+    # queries came back unverified at exit 0.
     real_sources = sources_seen - {flows.VERIFICATION_ABSENT}
+    verdicts = verdicts or {}
+    opinions = verdicts.get("confirmed", 0) + verdicts.get("rejected", 0)
+    if real_sources and not opinions:
+        summary["critic"] = {
+            "verdicts": dict(verdicts),
+            "status": "no_opinion",
+            "detail": (
+                "Verification blocks were present but every verdict was 'unverified': "
+                "the critic ran and formed no opinion. Critic-filtered metrics are "
+                "suppressed because they would equal raw. Common cause: the clip URL "
+                "handed to RT-VLM is not resolvable from inside its container -- check "
+                "`vss configure show` is not a loopback address."
+            ),
+        }
+        real_sources = set()
+    elif real_sources:
+        summary["critic"] = {"verdicts": dict(verdicts), "status": "ok"}
     if real_sources:
         favg = lambda key: sum(r["critic_filtered"][key] for r in results) / n
         favg_hit = lambda k: sum(r["critic_filtered"]["hit_at_k"][k] for r in results) / n
@@ -715,6 +748,13 @@ def _print_summary(summary: dict[str, Any]) -> None:
             print(f"  {'  of which:':<18}")
             print(f"  {'    search:':<18}{lat['search_internal_mean_s']:.3f}s")
             print(f"  {'    CLI startup:':<18}{lat['cli_startup_mean_s']:.3f}s")
+
+    crit = summary.get("critic")
+    if crit and crit.get("status") == "no_opinion":
+        print(f"\n!! CRITIC RENDERED NO OPINION  {crit['verdicts']}")
+        for line in crit["detail"].split(". "):
+            if line.strip():
+                print(f"   {line.strip().rstrip('.')}.")
 
     dec = summary.get("decomposition")
     if dec:

--- a/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
@@ -1525,6 +1525,19 @@ def main() -> None:
         print("\nPruning sources that are not in this dataset (--only-dataset)...")
         cleared = prune_foreign_videos(args.endpoint, vst_url, video_dir)
 
+    # A source that would not delete is still searchable, so it still answers
+    # queries and still counts as a false positive. Continuing would score a run
+    # that claims to isolate this dataset against an index that does not.
+    if cleared and cleared.get("failed"):
+        raise SystemExit(
+            f"ABORTED: {len(cleared['failed'])} source(s) could not be deleted: "
+            f"{cleared['failed'][:10]}\n"
+            "  They remain searchable and would be scored as false positives, so "
+            "this run cannot claim\n"
+            "  to measure the selected dataset in isolation. Delete them by hand, "
+            "or use --skip-existing."
+        )
+
     upload_stats: dict[str, Any] | None = None
     readiness: dict[str, Any] | None = None
     index_probe: dict[str, Any] | None = None
@@ -1569,6 +1582,34 @@ def main() -> None:
         # Registered in VST is not the same as indexed in Elasticsearch. The
         # three-step flow already proved the difference with a chunk count; a
         # flow that reports no proof has to be asked.
+        # The anchor is the other half of "is this searchable": ground truth is
+        # matched by absolute-timestamp overlap against 2025-01-01, so media
+        # indexed at any other instant scores every query zero while looking
+        # perfectly healthy to the coverage probe. One timeline read on one
+        # uploaded video is the whole check, and it was defined and tested but
+        # never called until now.
+        anchor_check = getattr(ingest_backend, "verify_anchor", None)
+        first_sensor = next(
+            (r.get("sensor_id") for r in upload_stats.get("per_file", []) if r.get("sensor_id")),
+            None,
+        )
+        if anchor_check and first_sensor and not args.skip_index_probe:
+            anchor = anchor_check(first_sensor)
+            if anchor.get("found") and not anchor.get("matches_expected_anchor"):
+                raise SystemExit(
+                    f"ABORTED: {first_sensor} is indexed at {anchor.get('start_time')!r}, not at "
+                    f"the {anchor.get('expected_anchor')!r} anchor the ground truth is written "
+                    "against.\n"
+                    "  Every query would score 0.0 and read as a retrieval collapse. VIOS did not "
+                    "honour the\n"
+                    "  upload's metadata.timestamp -- check --upload-timestamp and the VIOS "
+                    "storage config."
+                )
+            if anchor.get("checked") and anchor.get("found"):
+                print(f"  Anchor confirmed at {anchor.get('start_time')}.")
+            else:
+                print(f"  (anchor unverified: {anchor})")
+
         if not ingest_backend.proves_indexing and not args.skip_index_probe:
             print(f"\nProbing index coverage for {len(expected)} source(s)...")
             index_probe = probe_index_coverage(

--- a/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
@@ -460,9 +460,15 @@ def run_evaluation(  # noqa: PLR0913
 
         raw_results, latency_s = query_backend.search(query)
         normalized = flows.normalize_results(raw_results)
-        sources_seen.update(flows.verification_sources(normalized))
-        for verdict, count in flows.verdict_counts(normalized).items():
-            verdicts[verdict] = verdicts.get(verdict, 0) + count
+        # Both are read-modify-write on state shared across the pool, and the
+        # verdict tally is what the no-opinion check reads at the end: lose
+        # increments here and a healthy critic is reported as having formed no
+        # opinion. `print_lock` already serialises the per-query output, and
+        # this is the same few microseconds.
+        with print_lock:
+            sources_seen.update(flows.verification_sources(normalized))
+            for verdict, count in flows.verdict_counts(normalized).items():
+                verdicts[verdict] = verdicts.get(verdict, 0) + count
 
         result = flows.evaluate_query(query, flows.for_scoring(normalized), expected, latency_s)
         if decomposer is not None:

--- a/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
@@ -206,6 +206,61 @@ def clear_all_videos(agent_endpoint: str, vst_url: str) -> dict[str, Any]:
     return {"found": len(streams), "deleted": deleted, "failed": failed, "names": list(streams.values())}
 
 
+def prune_foreign_videos(agent_endpoint: str, vst_url: str, video_dir: Path) -> dict[str, Any]:
+    """Delete every registered source that is NOT one of this dataset's videos.
+
+    The narrow form of ``--clear``. A run is only interpretable if the index
+    holds what the dataset says it holds: a foreign source cannot be retrieved
+    for any query in the dataset, so it contributes nothing but the chance of a
+    false positive and a longer ingest. Removing exactly the foreign ones keeps
+    the deployment reproducible without wiping fixtures the dataset does need.
+
+    Membership uses :func:`flows.name_variants` -- the same normalisation
+    ``--skip-existing`` uses to decide a video is already present. Sharing one
+    matcher is what stops this deleting a video the very next step re-uploads.
+    """
+    try:
+        streams = flows.list_sensor_streams(vst_url)
+    except Exception as e:
+        raise SystemExit(f"ABORTED: could not list sensors at {vst_url} ({type(e).__name__}: {e})") from e
+
+    ours: set[str] = set()
+    for vf in sorted(video_dir.glob("*.mp4")) + sorted(video_dir.glob("*.mkv")):
+        ours |= flows.name_variants(vf.name)
+    if not ours:
+        raise SystemExit(
+            f"ABORTED: no video files under {video_dir}, so every source looks foreign. "
+            f"Refusing to delete the whole deployment -- pass --clear if that is what you meant."
+        )
+
+    foreign = {sid: n for sid, n in streams.items() if str(n).lower() not in ours}
+    kept = len(streams) - len(foreign)
+    print(f"  {len(streams)} source(s) registered: {kept} belong to this dataset, {len(foreign)} do not")
+    if not foreign:
+        print("  Nothing to prune.")
+        return {"found": len(streams), "kept": kept, "deleted": 0, "names": []}
+
+    for stream_id, name in foreign.items():
+        print(f"    - {name}  ({stream_id})")
+
+    deleted, failed = 0, []
+    for stream_id, name in foreign.items():
+        try:
+            resp = requests.delete(f"{agent_endpoint.rstrip('/')}/api/v1/videos/{stream_id}", timeout=60)
+            resp.raise_for_status()
+            deleted += 1
+            print(f"    deleted {name} -> {resp.status_code}")
+        except Exception as e:
+            failed.append(name)
+            print(f"    FAILED {name}: {e}")
+
+    print(f"  Pruned {deleted}/{len(foreign)} foreign video(s); kept {kept}")
+    return {
+        "found": len(streams), "kept": kept, "deleted": deleted,
+        "failed": failed, "names": list(foreign.values()),
+    }
+
+
 def ingest_videos(
     backend: Any,
     video_dir: Path,
@@ -954,6 +1009,15 @@ def parse_args() -> argparse.Namespace:
     )
     ingest.add_argument("--skip-readiness-wait", action="store_true")
     ingest.add_argument(
+        "--only-dataset",
+        action="store_true",
+        help=(
+            "Delete every source that is NOT one of this dataset's videos, then "
+            "ingest. Leaves the dataset's own sources alone. Safer than --clear "
+            "on a shared deployment, and enough to make a run reproducible."
+        ),
+    )
+    ingest.add_argument(
         "--clear",
         action="store_true",
         help=(
@@ -1043,13 +1107,16 @@ def main() -> None:
     print(f"VST origin:     {vst_url}")
 
     cleared: dict[str, Any] | None = None
+    video_dir = args.data_dir / args.dataset / "videos"
     if args.clear:
         print("\nClearing ALL existing videos (--clear)...")
         cleared = clear_all_videos(args.endpoint, vst_url)
+    elif args.only_dataset:
+        print("\nPruning sources that are not in this dataset (--only-dataset)...")
+        cleared = prune_foreign_videos(args.endpoint, vst_url, video_dir)
 
     upload_stats: dict[str, Any] | None = None
     readiness: dict[str, Any] | None = None
-    video_dir = args.data_dir / args.dataset / "videos"
 
     if args.skip_ingest:
         print("Skipping ingest (--skip-ingest)")

--- a/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
@@ -58,15 +58,17 @@ Examples
 from __future__ import annotations
 
 import argparse
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import as_completed
+import contextlib
+from datetime import datetime
 import json
 import os
+from pathlib import Path
 import statistics
 import sys
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime
-from pathlib import Path
 from typing import Any
 
 import requests
@@ -83,7 +85,7 @@ RESULTS_DIR = SCRIPT_DIR / "cli_eval_result"
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
-import flows
+import flows  # noqa: E402  (imported after SCRIPT_DIR joins sys.path, above)
 
 # =============================================================================
 # Backend construction
@@ -375,7 +377,7 @@ def ingest_videos(
 # =============================================================================
 
 
-def run_evaluation(  # noqa: PLR0913
+def run_evaluation(
     query_backend: Any,
     data_dir: Path,
     dataset: str,
@@ -625,8 +627,10 @@ def _summarize(
     baselines from either script line up field for field.
     """
     n = len(results)
-    avg = lambda key: sum(r[key] for r in results) / n
-    avg_hit = lambda k: sum(r["hit_at_k"][k] for r in results) / n
+    def avg(key):
+        return sum(r[key] for r in results) / n
+    def avg_hit(k):
+        return sum(r["hit_at_k"][k] for r in results) / n
 
     summary: dict[str, Any] = {
         "dataset": dataset,
@@ -675,8 +679,10 @@ def _summarize(
     elif real_sources:
         summary["critic"] = {"verdicts": dict(verdicts), "status": "ok"}
     if real_sources:
-        favg = lambda key: sum(r["critic_filtered"][key] for r in results) / n
-        favg_hit = lambda k: sum(r["critic_filtered"]["hit_at_k"][k] for r in results) / n
+        def favg(key):
+            return sum(r["critic_filtered"][key] for r in results) / n
+        def favg_hit(k):
+            return sum(r["critic_filtered"]["hit_at_k"][k] for r in results) / n
         critic_filtered: dict[str, Any] = {
             "mAP": round(favg("average_precision"), 4),
             "MRR": round(favg("reciprocal_rank"), 4),
@@ -1157,12 +1163,10 @@ def main() -> None:
             # because a gold-routed run measures retrieval under perfect routing
             # and should not be mistaken for a live-routing eval.
             carried = 0
-            try:
+            with contextlib.suppress(Exception):
                 carried = len(flows.unpack_dataset(
                     flows.load_dataset_file(args.data_dir, args.dataset, args.subset)
                 )[1])
-            except Exception:
-                pass
             if carried:
                 decompose_fallback["fell_back_to"] = f"{carried} decomposition(s) carried by the dataset"
                 print(f"           the dataset carries {carried} decomposition(s) -- routing still per-query")

--- a/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
@@ -1137,9 +1137,18 @@ def main() -> None:
             decompose_fallback = {"attempted": args.llm_url, "error": str(e)}
             print(f"\n  WARNING: decomposition LLM unreachable at {args.llm_url}")
             print(f"           {e}")
-            # The dataset may route itself. Check that before the sidecar, and
-            # both before giving up on routing, or the warning claims one path
-            # was measured when the run went on to exercise four.
+            # Fall back to --search-path, which is `embed`: the one path that
+            # needs nothing but the query text. `attribute` and `fusion` both
+            # require a per-query attribute that only decomposition produces,
+            # and handing them the whole query as its attribute is the failure
+            # this eval already measured -- mAP -25%, HIT@1 halved, +59% latency.
+            #
+            # A dataset that carries its own decompositions still routes per
+            # query; that is the dataset's explicit intent and unpack_dataset
+            # applies it further down. Nothing else is inferred -- the answer key
+            # in devset_provenance.json is reachable only via --decompositions,
+            # because a gold-routed run measures retrieval under perfect routing
+            # and should not be mistaken for a live-routing eval.
             carried = 0
             try:
                 carried = len(flows.unpack_dataset(
@@ -1147,19 +1156,19 @@ def main() -> None:
                 )[1])
             except Exception:
                 pass
-            sidecar = None if carried else flows.sidecar_decompositions_for(args.data_dir, args.dataset)
             if carried:
                 decompose_fallback["fell_back_to"] = f"{carried} decomposition(s) carried by the dataset"
                 print(f"           the dataset carries {carried} decomposition(s) -- routing still per-query")
-            elif sidecar:
-                args.decompositions = str(sidecar)
-                decompose_fallback["fell_back_to"] = f"dataset answer key ({sidecar.name})"
-                print(f"           falling back to {sidecar.name} -- routing still per-query")
             else:
                 decompose_fallback["fell_back_to"] = f"--search-path {args.search_path}"
-                print(f"           no answer key for '{args.dataset}'; every query will use")
-                print(f"           --search-path {args.search_path}. ONE PATH IS MEASURED --")
-                print("           this is not a routing eval. Report it alongside the metrics.\n")
+                print(f"           every query will use --search-path {args.search_path}.")
+                print("           ONE PATH IS MEASURED -- this is not a routing eval.")
+                print("           Report it alongside the metrics.")
+                sidecar = flows.sidecar_decompositions_for(args.data_dir, args.dataset)
+                if sidecar:
+                    print(f"           ({args.dataset} ships an answer key; --decompositions {sidecar}")
+                    print("            would route per query, but scores perfect routing, not live.)")
+                print()
 
     ingest_backend = build_ingest_backend(args)
     query_backend = build_query_backend(args)

--- a/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
@@ -207,7 +207,10 @@ def clear_all_videos(agent_endpoint: str, vst_url: str) -> dict[str, Any]:
 
 
 def describe_query_flow(
-    query_backend: Any, decomposer: Any, planned_llm_url: str | None = None
+    query_backend: Any,
+    decomposer: Any,
+    planned_llm_url: str | None = None,
+    fallback: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """The query backend's own description, corrected for live decomposition.
 
@@ -234,6 +237,10 @@ def describe_query_flow(
             "llm_url": planned_llm_url,
             "model": "(discovered at run time)",
         }
+    elif fallback:
+        # The run went ahead without the LLM. Say so in the artifact, or the
+        # result reads as a deliberate choice of routing rather than a fallback.
+        described["live_decomposition"] = fallback
     else:
         described["live_decomposition"] = False
     return described
@@ -413,7 +420,7 @@ def run_evaluation(  # noqa: PLR0913
     if hasattr(query_backend, "plan_for_query"):
         planned_paths = flows.path_distribution([query_backend.plan_for_query(q) for q in queries])
 
-    described = describe_query_flow(query_backend, decomposer)
+    described = describe_query_flow(query_backend, decomposer, fallback=decompose_fallback)
     if planned_paths:
         described["planned_paths"] = "  ".join(f"{k}={v}" for k, v in planned_paths.items())
 
@@ -1109,6 +1116,7 @@ def main() -> None:
         args.llm_url = flows.llm_url_for(args.endpoint, args.llm_port)
 
     decomposer = None
+    decompose_fallback: dict[str, Any] | None = None
     if args.no_decompose:
         if not args.dry_run:
             print(f"decomposition: OFF (--no-decompose) -- every query uses --search-path {args.search_path}")
@@ -1120,14 +1128,38 @@ def main() -> None:
             decomposer = flows.LiveDecomposer(
                 args.llm_url, repo_root=flows.REPO_ROOT, model=args.llm_model
             )
+            print(f"decomposition: live via {args.llm_url}  model={decomposer.model}")
         except flows.DecompositionError as e:
-            raise SystemExit(
-                f"ERROR: {e}\n"
-                f"Live decomposition is the default. Point --llm-url at a reachable NIM, "
-                f"set --llm-port if it is not {args.llm_port}, or pass --no-decompose to "
-                f"run every query on --search-path {args.search_path} instead."
-            ) from e
-        print(f"decomposition: live via {args.llm_url}  model={decomposer.model}")
+            # An unreachable NIM must not end the run, but it must not quietly
+            # collapse it to one path either. Fall back to the dataset's own
+            # answer key when it ships one -- that still routes per query, so
+            # every path is exercised -- and only then to --search-path.
+            decompose_fallback = {"attempted": args.llm_url, "error": str(e)}
+            print(f"\n  WARNING: decomposition LLM unreachable at {args.llm_url}")
+            print(f"           {e}")
+            # The dataset may route itself. Check that before the sidecar, and
+            # both before giving up on routing, or the warning claims one path
+            # was measured when the run went on to exercise four.
+            carried = 0
+            try:
+                carried = len(flows.unpack_dataset(
+                    flows.load_dataset_file(args.data_dir, args.dataset, args.subset)
+                )[1])
+            except Exception:
+                pass
+            sidecar = None if carried else flows.sidecar_decompositions_for(args.data_dir, args.dataset)
+            if carried:
+                decompose_fallback["fell_back_to"] = f"{carried} decomposition(s) carried by the dataset"
+                print(f"           the dataset carries {carried} decomposition(s) -- routing still per-query")
+            elif sidecar:
+                args.decompositions = str(sidecar)
+                decompose_fallback["fell_back_to"] = f"dataset answer key ({sidecar.name})"
+                print(f"           falling back to {sidecar.name} -- routing still per-query")
+            else:
+                decompose_fallback["fell_back_to"] = f"--search-path {args.search_path}"
+                print(f"           no answer key for '{args.dataset}'; every query will use")
+                print(f"           --search-path {args.search_path}. ONE PATH IS MEASURED --")
+                print("           this is not a routing eval. Report it alongside the metrics.\n")
 
     ingest_backend = build_ingest_backend(args)
     query_backend = build_query_backend(args)

--- a/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
@@ -153,6 +153,22 @@ def build_query_backend(args: argparse.Namespace) -> Any:
             decompositions = flows.load_decompositions(args.decompositions)
             print(f"decompositions: {len(decompositions)} loaded from {args.decompositions}")
 
+        # `--original-query` is newer than most deployed CLIs, and an unknown
+        # option exits 2 -- fatal, on query 1. Probe rather than assume: one
+        # --help beats aborting a run that would otherwise have completed with
+        # slightly worse verification.
+        pass_original_query = not args.no_original_query
+        if pass_original_query and not args.dry_run and not flows.cli_supports_flag(vss_cmd, "--original-query"):
+            pass_original_query = False
+            print(
+                "WARNING: this vss CLI has no --original-query, so the critic will "
+                "verify a question\n"
+                "         reconstructed from the retrieval arguments rather than the "
+                "one the dataset asked.\n"
+                "         Critic rejections are not comparable with the REST flow's. "
+                "Update the CLI to fix."
+            )
+
         return flows.CliQueryBackend(
             vss_cmd=vss_cmd,
             search_path=args.search_path,
@@ -163,6 +179,7 @@ def build_query_backend(args: argparse.Namespace) -> Any:
             merge_adjacent=args.merge_adjacent,
             cwd=args.vss_repo_root,
             decompositions=decompositions,
+            pass_original_query=pass_original_query,
         )
     raise SystemExit(f"Unknown query flow: {args.query_flow}")
 
@@ -1102,6 +1119,16 @@ def parse_args() -> argparse.Namespace:
             "Do not decompose. Every query then takes --search-path, which "
             "measures one retrieval path rather than the routing the product "
             "performs -- correct for a baseline, wrong for an eval."
+        ),
+    )
+    p.add_argument(
+        "--no-original-query",
+        action="store_true",
+        help=(
+            "Do not send --original-query. The critic then verifies a question "
+            "the host rebuilds from the retrieval arguments instead of the one "
+            "the dataset asked, which is the pre-fix behaviour and the only "
+            "reason to pass this: A/B against an older result file."
         ),
     )
     p.add_argument("--llm-model", help="Decomposition model id (default: ask the endpoint).")

--- a/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
@@ -206,6 +206,39 @@ def clear_all_videos(agent_endpoint: str, vst_url: str) -> dict[str, Any]:
     return {"found": len(streams), "deleted": deleted, "failed": failed, "names": list(streams.values())}
 
 
+def describe_query_flow(
+    query_backend: Any, decomposer: Any, planned_llm_url: str | None = None
+) -> dict[str, Any]:
+    """The query backend's own description, corrected for live decomposition.
+
+    ``QueryBackend.describe()`` reports routing from ``self.decompositions``,
+    which a *live* decomposer only fills as queries run. Called before the first
+    query -- which is where both the banner and the saved flow block need it --
+    it therefore says ``routing: fixed, decompositions: 0`` for a run that went
+    on to decompose every query, and a reader of the result file concludes one
+    path was measured. Take the decomposer's presence as the answer instead of
+    inferring it from state that does not exist yet.
+
+    ``planned_llm_url`` covers the dry run, where no decomposer is built at all
+    because constructing one asks the LLM for its model list and a dry run
+    contacts nothing. Reporting the intent keeps the preview from promising a
+    fixed-path run that the real invocation would not perform.
+    """
+    described = query_backend.describe()
+    if decomposer is not None:
+        described["routing"] = "per-query (live decomposition)"
+        described["live_decomposition"] = decomposer.describe()
+    elif planned_llm_url:
+        described["routing"] = "per-query (live decomposition)"
+        described["live_decomposition"] = {
+            "llm_url": planned_llm_url,
+            "model": "(discovered at run time)",
+        }
+    else:
+        described["live_decomposition"] = False
+    return described
+
+
 def prune_foreign_videos(agent_endpoint: str, vst_url: str, video_dir: Path) -> dict[str, Any]:
     """Delete every registered source that is NOT one of this dataset's videos.
 
@@ -380,7 +413,7 @@ def run_evaluation(  # noqa: PLR0913
     if hasattr(query_backend, "plan_for_query"):
         planned_paths = flows.path_distribution([query_backend.plan_for_query(q) for q in queries])
 
-    described = query_backend.describe()
+    described = describe_query_flow(query_backend, decomposer)
     if planned_paths:
         described["planned_paths"] = "  ".join(f"{k}={v}" for k, v in planned_paths.items())
 
@@ -1072,7 +1105,7 @@ def main() -> None:
         print("Ingest backend:")
         print(json.dumps(ingest_backend.describe(), indent=2))
         print("\nQuery backend:")
-        print(json.dumps(query_backend.describe(), indent=2))
+        print(json.dumps(describe_query_flow(query_backend, decomposer, args.llm_url), indent=2))
         if isinstance(query_backend, flows.CliQueryBackend):
             import shlex
 

--- a/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
@@ -22,7 +22,7 @@ definitions were vendored unchanged rather than rewritten, and a test asserts
 they still agree with ``run_eval.py`` for as long as both exist -- so numbers
 stay comparable with baselines captured by the old runner.
 
-    ingest:  legacy-put | agent-3step      (vst-direct pending -- GAP-1)
+    ingest:  legacy-put | agent-3step | vst-direct
     query:   cli                           (openclaw pending -- GAP-3)
 
 Several defaults here look arbitrary and are load-bearing:
@@ -101,6 +101,13 @@ def build_ingest_backend(args: argparse.Namespace) -> Any:
             upload_timestamp=args.upload_timestamp,
             complete_retries=args.complete_retries,
             complete_backoff_s=args.complete_backoff,
+        )
+    if args.ingest_flow == "vst-direct":
+        # Same VST origin the readiness poll and --only-dataset prune use, so a
+        # run cannot upload to one host and check another.
+        return flows.VstDirectIngest(
+            args.vst_url or flows.vst_url_for(args.endpoint, args.vst_port),
+            upload_timestamp=args.upload_timestamp,
         )
     raise SystemExit(f"Unknown ingest flow: {args.ingest_flow}")
 
@@ -932,7 +939,7 @@ def _print_summary(summary: dict[str, Any]) -> None:
 # =============================================================================
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -944,7 +951,12 @@ def parse_args() -> argparse.Namespace:
         "--ingest-flow",
         default="agent-3step",
         choices=sorted(flows.INGEST_BACKENDS),
-        help="How fixtures are uploaded (default: agent-3step)",
+        help=(
+            "How fixtures are uploaded (default: agent-3step). 'vst-direct' is "
+            "what the UI does -- upload to VIOS and let its webhooks drive "
+            "perception -- but it returns no chunk count and does not pin the "
+            "timestamp anchor, so verify one video before scoring a run."
+        ),
     )
     flow.add_argument(
         "--query-flow",
@@ -1142,7 +1154,7 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Print the resolved backends and a sample CLI invocation, then exit",
     )
-    return p.parse_args()
+    return p.parse_args(argv)
 
 
 def main() -> None:

--- a/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
@@ -240,9 +240,31 @@ def clear_all_videos(agent_endpoint: str, vst_url: str) -> dict[str, Any]:
 PROBE_QUERY = "a person"
 
 
+def _probe_backend(query_backend: Any, top_k: int, source: str | None = None) -> Any:
+    """A throwaway embed backend, optionally scoped to one registered source.
+
+    Never the run's own: a ``--min-cosine-similarity`` floor or a non-embed
+    ``--search-path`` would filter a healthy index into a false alarm.
+
+    Scoping rides on the decomposition machinery rather than a new argv branch --
+    ``{"video_sources": [name]}`` routes to embed (no attributes, no object ids)
+    and ``plan_for`` turns it into ``--video-source``.
+    """
+    decompositions = {PROBE_QUERY: {"video_sources": [source]}} if source else None
+    return flows.CliQueryBackend(
+        vss_cmd=query_backend.vss_cmd,
+        search_path="embed",
+        top_k=top_k,
+        cwd=query_backend.cwd,
+        pass_original_query=False,
+        decompositions=decompositions,
+    )
+
+
 def probe_index_coverage(
     query_backend: Any,
     expected_sources: list[str],
+    vst_url: str | None = None,
     attempts: int = 10,
     backoff_s: float = 15.0,
     top_k_per_source: int = 20,
@@ -250,41 +272,69 @@ def probe_index_coverage(
     """Confirm every ingested video is searchable before scoring a whole run.
 
     The three-step ingest flow proves this for free: ``/complete`` runs the
-    embedding leg synchronously per video and returns ``chunks_processed``, so
-    a zero fails that upload. ``vst-direct`` has no such step -- VIOS fans out
-    to the perception services by webhook and never reports the outcome -- and
-    the readiness poll does not close the gap, because it asks VST which
-    sources are *registered*. A source registered by an earlier run answers yes
-    while this run's re-ingest is still being embedded, so readiness returns in
-    0.0s against an index that is half rebuilt.
+    embedding leg synchronously per video and returns ``chunks_processed``, so a
+    zero fails that upload. ``vst-direct`` has no such step -- VIOS fans out to
+    the perception services by webhook and never reports the outcome -- and the
+    readiness poll does not close the gap, because it asks VST which sources are
+    *registered*. VST registers at upload time, synchronously, so that poll
+    returns in 0.0s against an index that has not been built yet.
 
-    That is not a hypothetical: it scored physicalai-dev at recall 0.3534
-    against the 0.5103 the same queries had reached, with routing unchanged,
-    and read as a retrieval regression.
+    Two stages, because one broad query is cheap but not conclusive:
 
-    So this asks the index itself, and asks about coverage rather than
-    existence -- "is anything indexed" passes on 1 video out of 32. One broad
-    embed query, matched back to the expected videos with the same name matcher
-    the scorer uses, retried because webhook perception is asynchronous.
+    1. One unscoped embed query. Embedding search returns the nearest ``top_k``
+       whatever they are, so what comes back samples what is indexed. Usually
+       every source appears and the probe is done in one call.
+    2. Anything still absent is queried again **scoped to that source**. A fully
+       indexed video can be crowded out of stage 1 by closer chunks from other
+       videos, and aborting a healthy run on that would be worse than the bug
+       this guards. Absence only counts once the source has been asked about
+       directly.
 
-    Returns the sources still missing. On a dataset large enough that ``top_k``
-    cannot reach every video, full coverage is unreachable by construction;
-    raise ``--index-probe-top-k``, or skip the probe and accept the risk.
+    Scoping needs the name VST actually registered, which is not always the
+    dataset's spelling (VST keeps the extension for some sources and not
+    others), so ``vst_url`` is read once to resolve them. Without it, stage 2 is
+    skipped and stage 1 alone decides -- weaker, and said so in the result.
     """
     if not expected_sources:
         return {"checked": False, "reason": "no expected sources"}
 
-    probe_backend = flows.CliQueryBackend(
-        vss_cmd=query_backend.vss_cmd,
-        search_path="embed",
-        top_k=min(1000, max(50, top_k_per_source * len(expected_sources))),
-        cwd=query_backend.cwd,
-        pass_original_query=False,
-    )
+    registered: dict[str, str] = {}
+    if vst_url:
+        try:
+            names = flows.list_sensor_names(vst_url)
+            for source in expected_sources:
+                variants = flows.name_variants(source)
+                match = next((n for n in names if n.lower() in variants), None)
+                if match:
+                    registered[source] = match
+        except Exception as e:
+            print(f"  (could not resolve VST source names, per-source probing off: {e})")
+
+    broad = _probe_backend(query_backend, min(1000, max(50, top_k_per_source * len(expected_sources))))
     missing = list(expected_sources)
+
     for attempt in range(1, attempts + 1):
         try:
-            hits, _latency = probe_backend.search(PROBE_QUERY)
+            hits, _latency = broad.search(PROBE_QUERY)
+            seen = {h.get("video_name", "") for h in hits if h.get("video_name")}
+            missing = [
+                source
+                for source in expected_sources
+                if not any(flows.video_name_matches(name, source) for name in seen)
+            ]
+
+            # Stage 2: ask directly about whatever the broad query did not
+            # surface, so ranking cannot be mistaken for absence.
+            confirmed_missing = []
+            for source in missing:
+                name = registered.get(source)
+                if not name:
+                    confirmed_missing.append(source)
+                    continue
+                scoped_hits, _ = _probe_backend(query_backend, 1, source=name).search(PROBE_QUERY)
+                if not scoped_hits:
+                    confirmed_missing.append(source)
+            missing = confirmed_missing
         except Exception as e:
             # An environment fault is worth reporting as itself rather than as
             # an empty index -- exit 4 means misconfigured, not unindexed.
@@ -295,20 +345,16 @@ def probe_index_coverage(
                 "error": f"{type(e).__name__}: {e}",
             }
 
-        seen = {h.get("video_name", "") for h in hits if h.get("video_name")}
-        missing = [
-            source
-            for source in expected_sources
-            if not any(flows.video_name_matches(name, source) for name in seen)
-        ]
         found = len(expected_sources) - len(missing)
         if not missing:
-            print(
-                f"  Index covers all {len(expected_sources)} source(s) "
-                f"after {attempt} attempt(s)."
-            )
-            return {"checked": True, "covered": True, "attempts": attempt,
-                    "sources": len(expected_sources)}
+            print(f"  Index covers all {len(expected_sources)} source(s) after {attempt} attempt(s).")
+            return {
+                "checked": True,
+                "covered": True,
+                "attempts": attempt,
+                "sources": len(expected_sources),
+                "per_source_verified": bool(registered),
+            }
         if attempt < attempts:
             print(
                 f"  Probe {attempt}/{attempts}: {found}/{len(expected_sources)} "
@@ -323,6 +369,7 @@ def probe_index_coverage(
         "sources": len(expected_sources),
         "missing": missing[:20],
         "missing_count": len(missing),
+        "per_source_verified": bool(registered),
     }
 
 
@@ -1527,6 +1574,7 @@ def main() -> None:
             index_probe = probe_index_coverage(
                 query_backend,
                 expected,
+                vst_url=vst_url,
                 attempts=args.index_probe_attempts,
                 backoff_s=args.index_probe_backoff,
                 top_k_per_source=args.index_probe_top_k,

--- a/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
@@ -1107,10 +1107,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     cli.add_argument(
         "--decompositions",
         help=(
-            "JSON file mapping each query to the decomposition the agent would "
-            "produce (query/attributes/has_action/...). When given, the retrieval "
-            "path and arguments are derived PER QUERY instead of --search-path "
-            "and --attribute applying to the whole run."
+            "Replay stored decompositions instead of calling the LLM. This does "
+            "NOT enable decomposition -- that is the default -- it REPLACES the "
+            "live decomposer, so no LLM runs and routing is fixed by the file. "
+            "Use it to pin routing across two runs whose retrieval you are "
+            "comparing: the decomposer is an LLM and its path split moves "
+            "between model versions even at temperature 0, which would show up "
+            "as a retrieval difference. The result file records "
+            "live_decomposition: false so a reader can tell which ran."
         ),
     )
     cli.add_argument(

--- a/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
@@ -1066,8 +1066,23 @@ def parse_args() -> argparse.Namespace:
     p.add_argument(
         "--llm-url",
         default=os.environ.get("VSS_LLM_URL"),
-        help="LLM origin for live query decomposition, e.g. http://HOST:30081 "
-        "(env: VSS_LLM_URL). Without it every query uses --search-path.",
+        help="LLM origin for live query decomposition (env: VSS_LLM_URL). "
+        "Derived from --endpoint and --llm-port when unset.",
+    )
+    p.add_argument(
+        "--llm-port",
+        type=int,
+        default=30081,
+        help="NIM port on the --endpoint host, used to derive --llm-url (default: 30081).",
+    )
+    p.add_argument(
+        "--no-decompose",
+        action="store_true",
+        help=(
+            "Do not decompose. Every query then takes --search-path, which "
+            "measures one retrieval path rather than the routing the product "
+            "performs -- correct for a baseline, wrong for an eval."
+        ),
     )
     p.add_argument("--llm-model", help="Decomposition model id (default: ask the endpoint).")
     p.add_argument(
@@ -1086,17 +1101,33 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     args = parse_args()
 
+    # Decomposition is the default, not an opt-in. The deployed agent decomposes
+    # every query and that choice picks the retrieval path, so an eval that
+    # skips it measures a flow the product never runs -- and nothing in the
+    # metrics reveals it. Opting out has to be deliberate.
+    if not args.llm_url and not args.no_decompose and not args.decompositions:
+        args.llm_url = flows.llm_url_for(args.endpoint, args.llm_port)
+
     decomposer = None
-    if args.llm_url and not args.dry_run:
+    if args.no_decompose:
+        if not args.dry_run:
+            print(f"decomposition: OFF (--no-decompose) -- every query uses --search-path {args.search_path}")
+    elif args.decompositions:
+        if not args.dry_run:
+            print(f"decomposition: from {args.decompositions} -- not live")
+    elif args.llm_url and not args.dry_run:
         try:
             decomposer = flows.LiveDecomposer(
                 args.llm_url, repo_root=flows.REPO_ROOT, model=args.llm_model
             )
         except flows.DecompositionError as e:
-            raise SystemExit(f"ERROR: {e}") from e
+            raise SystemExit(
+                f"ERROR: {e}\n"
+                f"Live decomposition is the default. Point --llm-url at a reachable NIM, "
+                f"set --llm-port if it is not {args.llm_port}, or pass --no-decompose to "
+                f"run every query on --search-path {args.search_path} instead."
+            ) from e
         print(f"decomposition: live via {args.llm_url}  model={decomposer.model}")
-    elif not args.dry_run:
-        print(f"decomposition: none -- every query uses --search-path {args.search_path}")
 
     ingest_backend = build_ingest_backend(args)
     query_backend = build_query_backend(args)
@@ -1105,7 +1136,9 @@ def main() -> None:
         print("Ingest backend:")
         print(json.dumps(ingest_backend.describe(), indent=2))
         print("\nQuery backend:")
-        print(json.dumps(describe_query_flow(query_backend, decomposer, args.llm_url), indent=2))
+        print(json.dumps(describe_query_flow(
+            query_backend, decomposer, None if args.no_decompose else args.llm_url
+        ), indent=2))
         if isinstance(query_backend, flows.CliQueryBackend):
             import shlex
 

--- a/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
@@ -232,6 +232,63 @@ def clear_all_videos(agent_endpoint: str, vst_url: str) -> dict[str, Any]:
     return {"found": len(streams), "deleted": deleted, "failed": failed, "names": list(streams.values())}
 
 
+#: What the probe asks. Any text works -- embedding search returns the nearest
+#: `top_k` regardless of how poorly they match, so a non-empty answer means
+#: documents exist and an empty one means they do not. Deliberately generic so
+#: it carries no assumption about which dataset was ingested.
+PROBE_QUERY = "a person"
+
+
+def probe_index_populated(
+    query_backend: Any,
+    attempts: int = 10,
+    backoff_s: float = 15.0,
+) -> dict[str, Any]:
+    """Confirm something is actually searchable before scoring a whole run.
+
+    The three-step ingest flow proves this for free: ``/complete`` runs the
+    embedding leg synchronously and returns ``chunks_processed``, and a zero
+    fails the upload. ``vst-direct`` has no such step -- VIOS fans out to the
+    perception services by webhook and never reports the outcome to the
+    uploader -- so an upload can succeed, the source can register in VST, the
+    readiness poll can pass, and Elasticsearch can still be empty.
+
+    That state is indistinguishable from broken retrieval: every query returns
+    nothing and the run reports mAP 0.0000 after half an hour. It is the same
+    failure the CLI exit-code handling exists to prevent, arriving by a
+    different route -- ``webhooks.enabled: false`` (the Helm default), or
+    RT-Embed rejecting the model name, which it answers with HTTP 200 and
+    ``inference: false``.
+
+    So: one cheap embed query, retried, because webhook-driven perception is
+    asynchronous and "not yet" is the expected first answer. Uses a throwaway
+    backend rather than the run's own so a low ``--min-cosine-similarity`` or a
+    non-embed ``--search-path`` cannot turn a populated index into a false
+    alarm.
+    """
+    probe_backend = flows.CliQueryBackend(
+        vss_cmd=query_backend.vss_cmd,
+        search_path="embed",
+        top_k=1,
+        cwd=query_backend.cwd,
+        pass_original_query=False,
+    )
+    for attempt in range(1, attempts + 1):
+        try:
+            hits, _latency = probe_backend.search(PROBE_QUERY)
+        except Exception as e:
+            # An environment fault is worth reporting as itself rather than as
+            # an empty index -- exit 4 means misconfigured, not unindexed.
+            return {"populated": False, "attempts": attempt, "error": f"{type(e).__name__}: {e}"}
+        if hits:
+            print(f"  Index is populated (probe returned {len(hits)} hit after {attempt} attempt(s)).")
+            return {"populated": True, "attempts": attempt}
+        if attempt < attempts:
+            print(f"  Probe {attempt}/{attempts}: index still empty, retrying in {backoff_s:.0f}s")
+            time.sleep(backoff_s)
+    return {"populated": False, "attempts": attempts}
+
+
 def describe_query_flow(
     query_backend: Any,
     decomposer: Any,
@@ -412,6 +469,7 @@ def run_evaluation(
     upload_stats: dict[str, Any] | None = None,
     ingest_description: dict[str, Any] | None = None,
     readiness: dict[str, Any] | None = None,
+    index_probe: dict[str, Any] | None = None,
     cleared: dict[str, Any] | None = None,
     vst_url: str | None = None,
     decomposer: Any = None,
@@ -610,6 +668,9 @@ def run_evaluation(
             "query": described,
             "ingest": ingest_description,
             "readiness": readiness,
+            # None when the ingest flow proved indexing itself (a chunk count),
+            # so a reader can tell "not checked here" from "checked, and empty".
+            "index_probe": index_probe,
             "cleared": cleared,
             "inventory": inventory,
             # Phoenix is absent by construction on the CLI query path:
@@ -949,13 +1010,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     flow = p.add_argument_group("flow selection")
     flow.add_argument(
         "--ingest-flow",
-        default="agent-3step",
+        default="vst-direct",
         choices=sorted(flows.INGEST_BACKENDS),
         help=(
-            "How fixtures are uploaded (default: agent-3step). 'vst-direct' is "
-            "what the UI does -- upload to VIOS and let its webhooks drive "
-            "perception -- but it returns no chunk count and does not pin the "
-            "timestamp anchor, so verify one video before scoring a run."
+            "How fixtures are uploaded (default: vst-direct, what the UI does "
+            "-- upload to VIOS and let its webhooks drive perception). "
+            "'agent-3step' is the older agent-mediated flow; it returns a chunk "
+            "count, which vst-direct replaces with a post-ingest index probe."
         ),
     )
     flow.add_argument(
@@ -1090,6 +1151,23 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Seconds to wait for VST to register every source after ingest (default: 1200)",
     )
     ingest.add_argument("--skip-readiness-wait", action="store_true")
+    ingest.add_argument(
+        "--skip-index-probe",
+        action="store_true",
+        help=(
+            "Do not check that anything is searchable before scoring. Only the "
+            "ingest flows that report no chunk count are probed at all, and "
+            "skipping it means an unindexed deployment scores 0.0 across the "
+            "board and reads as a retrieval collapse."
+        ),
+    )
+    ingest.add_argument("--index-probe-attempts", type=int, default=10)
+    ingest.add_argument(
+        "--index-probe-backoff",
+        type=float,
+        default=15.0,
+        help="Seconds between index probes (default: 15). Webhook-driven perception is async.",
+    )
     ingest.add_argument(
         "--only-dataset",
         action="store_true",
@@ -1274,6 +1352,7 @@ def main() -> None:
 
     upload_stats: dict[str, Any] | None = None
     readiness: dict[str, Any] | None = None
+    index_probe: dict[str, Any] | None = None
 
     if args.skip_ingest:
         print("Skipping ingest (--skip-ingest)")
@@ -1312,6 +1391,29 @@ def main() -> None:
                     "  Querying now would score an indexing delay as a retrieval regression."
                 )
 
+        # Registered in VST is not the same as indexed in Elasticsearch. The
+        # three-step flow already proved the difference with a chunk count; a
+        # flow that reports no proof has to be asked.
+        if ingest_backend.describe().get("ingest_proof") == "none" and not args.skip_index_probe:
+            print("\nProbing the index (ingest flow reports no chunk count)...")
+            index_probe = probe_index_populated(
+                query_backend,
+                attempts=args.index_probe_attempts,
+                backoff_s=args.index_probe_backoff,
+            )
+            if not index_probe["populated"]:
+                raise SystemExit(
+                    "ABORTED: uploads succeeded and every source registered in VST, but a "
+                    "probe query returned nothing"
+                    + (f" ({index_probe['error']})" if index_probe.get("error") else "")
+                    + f" after {index_probe['attempts']} attempt(s).\n"
+                    "  Nothing is indexed, so every query would score 0.0 and the result "
+                    "would read as a retrieval collapse.\n"
+                    "  Check webhooks.enabled in the VIOS notification config (false in the "
+                    "Helm chart), and that RTVI_EMBED_MODEL matches the webhook's model "
+                    "string -- RT-Embed answers a mismatch with 200 and inference=false."
+                )
+
     run_evaluation(
         query_backend=query_backend,
         data_dir=args.data_dir,
@@ -1325,6 +1427,7 @@ def main() -> None:
         upload_stats=upload_stats,
         ingest_description=ingest_backend.describe(),
         readiness=readiness,
+        index_probe=index_probe,
         cleared=cleared,
         vst_url=vst_url,
     )

--- a/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
@@ -1444,8 +1444,10 @@ def main() -> None:
             decompose_fallback = {"attempted": args.llm_url, "error": str(e)}
             print(f"\n  WARNING: decomposition LLM unreachable at {args.llm_url}")
             print(f"           {e}")
-            # Fall back to --search-path, which is `embed`: the one path that
-            # needs nothing but the query text. `attribute` and `fusion` both
+            # Fall back to --search-path, which defaults to `embed`: the one
+            # path that needs nothing but the query text. An explicit
+            # --search-path is honoured rather than overridden, but note what
+            # that means here -- `attribute` and `fusion` both
             # require a per-query attribute that only decomposition produces,
             # and handing them the whole query as its attribute is the failure
             # this eval already measured -- mAP -25%, HIT@1 halved, +59% latency.

--- a/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
@@ -389,6 +389,7 @@ def run_evaluation(  # noqa: PLR0913
     cleared: dict[str, Any] | None = None,
     vst_url: str | None = None,
     decomposer: Any = None,
+    decompose_fallback: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Score every dataset query through ``query_backend``.
 
@@ -1268,6 +1269,7 @@ def main() -> None:
         dataset=args.dataset,
         subset=args.subset,
         decomposer=decomposer,
+        decompose_fallback=decompose_fallback,
         output_file=args.output_file,
         run_name=args.name,
         concurrency=args.concurrency,

--- a/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
@@ -233,60 +233,96 @@ def clear_all_videos(agent_endpoint: str, vst_url: str) -> dict[str, Any]:
 
 
 #: What the probe asks. Any text works -- embedding search returns the nearest
-#: `top_k` regardless of how poorly they match, so a non-empty answer means
-#: documents exist and an empty one means they do not. Deliberately generic so
+#: `top_k` regardless of how poorly they match, so what comes back is a sample
+#: of what is indexed, not a judgement about relevance. Deliberately generic so
 #: it carries no assumption about which dataset was ingested.
 PROBE_QUERY = "a person"
 
 
-def probe_index_populated(
+def probe_index_coverage(
     query_backend: Any,
+    expected_sources: list[str],
     attempts: int = 10,
     backoff_s: float = 15.0,
+    top_k_per_source: int = 20,
 ) -> dict[str, Any]:
-    """Confirm something is actually searchable before scoring a whole run.
+    """Confirm every ingested video is searchable before scoring a whole run.
 
     The three-step ingest flow proves this for free: ``/complete`` runs the
-    embedding leg synchronously and returns ``chunks_processed``, and a zero
-    fails the upload. ``vst-direct`` has no such step -- VIOS fans out to the
-    perception services by webhook and never reports the outcome to the
-    uploader -- so an upload can succeed, the source can register in VST, the
-    readiness poll can pass, and Elasticsearch can still be empty.
+    embedding leg synchronously per video and returns ``chunks_processed``, so
+    a zero fails that upload. ``vst-direct`` has no such step -- VIOS fans out
+    to the perception services by webhook and never reports the outcome -- and
+    the readiness poll does not close the gap, because it asks VST which
+    sources are *registered*. A source registered by an earlier run answers yes
+    while this run's re-ingest is still being embedded, so readiness returns in
+    0.0s against an index that is half rebuilt.
 
-    That state is indistinguishable from broken retrieval: every query returns
-    nothing and the run reports mAP 0.0000 after half an hour. It is the same
-    failure the CLI exit-code handling exists to prevent, arriving by a
-    different route -- ``webhooks.enabled: false`` (the Helm default), or
-    RT-Embed rejecting the model name, which it answers with HTTP 200 and
-    ``inference: false``.
+    That is not a hypothetical: it scored physicalai-dev at recall 0.3534
+    against the 0.5103 the same queries had reached, with routing unchanged,
+    and read as a retrieval regression.
 
-    So: one cheap embed query, retried, because webhook-driven perception is
-    asynchronous and "not yet" is the expected first answer. Uses a throwaway
-    backend rather than the run's own so a low ``--min-cosine-similarity`` or a
-    non-embed ``--search-path`` cannot turn a populated index into a false
-    alarm.
+    So this asks the index itself, and asks about coverage rather than
+    existence -- "is anything indexed" passes on 1 video out of 32. One broad
+    embed query, matched back to the expected videos with the same name matcher
+    the scorer uses, retried because webhook perception is asynchronous.
+
+    Returns the sources still missing. On a dataset large enough that ``top_k``
+    cannot reach every video, full coverage is unreachable by construction;
+    raise ``--index-probe-top-k``, or skip the probe and accept the risk.
     """
+    if not expected_sources:
+        return {"checked": False, "reason": "no expected sources"}
+
     probe_backend = flows.CliQueryBackend(
         vss_cmd=query_backend.vss_cmd,
         search_path="embed",
-        top_k=1,
+        top_k=min(1000, max(50, top_k_per_source * len(expected_sources))),
         cwd=query_backend.cwd,
         pass_original_query=False,
     )
+    missing = list(expected_sources)
     for attempt in range(1, attempts + 1):
         try:
             hits, _latency = probe_backend.search(PROBE_QUERY)
         except Exception as e:
             # An environment fault is worth reporting as itself rather than as
             # an empty index -- exit 4 means misconfigured, not unindexed.
-            return {"populated": False, "attempts": attempt, "error": f"{type(e).__name__}: {e}"}
-        if hits:
-            print(f"  Index is populated (probe returned {len(hits)} hit after {attempt} attempt(s)).")
-            return {"populated": True, "attempts": attempt}
+            return {
+                "checked": True,
+                "covered": False,
+                "attempts": attempt,
+                "error": f"{type(e).__name__}: {e}",
+            }
+
+        seen = {h.get("video_name", "") for h in hits if h.get("video_name")}
+        missing = [
+            source
+            for source in expected_sources
+            if not any(flows.video_name_matches(name, source) for name in seen)
+        ]
+        found = len(expected_sources) - len(missing)
+        if not missing:
+            print(
+                f"  Index covers all {len(expected_sources)} source(s) "
+                f"after {attempt} attempt(s)."
+            )
+            return {"checked": True, "covered": True, "attempts": attempt,
+                    "sources": len(expected_sources)}
         if attempt < attempts:
-            print(f"  Probe {attempt}/{attempts}: index still empty, retrying in {backoff_s:.0f}s")
+            print(
+                f"  Probe {attempt}/{attempts}: {found}/{len(expected_sources)} "
+                f"source(s) indexed, retrying in {backoff_s:.0f}s"
+            )
             time.sleep(backoff_s)
-    return {"populated": False, "attempts": attempts}
+
+    return {
+        "checked": True,
+        "covered": False,
+        "attempts": attempts,
+        "sources": len(expected_sources),
+        "missing": missing[:20],
+        "missing_count": len(missing),
+    }
 
 
 def describe_query_flow(
@@ -1163,6 +1199,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     ingest.add_argument("--index-probe-attempts", type=int, default=10)
     ingest.add_argument(
+        "--index-probe-top-k",
+        type=int,
+        default=20,
+        help=(
+            "Results requested per expected source when probing coverage "
+            "(default: 20, capped at the CLI's 1000). Embedding search returns "
+            "the nearest top_k, so on a large dataset one query cannot reach "
+            "every video and full coverage becomes unreachable -- raise this, "
+            "or use --skip-index-probe."
+        ),
+    )
+    ingest.add_argument(
         "--index-probe-backoff",
         type=float,
         default=15.0,
@@ -1394,24 +1442,37 @@ def main() -> None:
         # Registered in VST is not the same as indexed in Elasticsearch. The
         # three-step flow already proved the difference with a chunk count; a
         # flow that reports no proof has to be asked.
-        if ingest_backend.describe().get("ingest_proof") == "none" and not args.skip_index_probe:
-            print("\nProbing the index (ingest flow reports no chunk count)...")
-            index_probe = probe_index_populated(
+        if not ingest_backend.proves_indexing and not args.skip_index_probe:
+            print(f"\nProbing index coverage for {len(expected)} source(s)...")
+            index_probe = probe_index_coverage(
                 query_backend,
+                expected,
                 attempts=args.index_probe_attempts,
                 backoff_s=args.index_probe_backoff,
+                top_k_per_source=args.index_probe_top_k,
             )
-            if not index_probe["populated"]:
+            if index_probe.get("checked") and not index_probe.get("covered"):
+                detail = (
+                    f" ({index_probe['error']})"
+                    if index_probe.get("error")
+                    else f"; {index_probe.get('missing_count')} still missing, e.g. "
+                    f"{index_probe.get('missing', [])[:5]}"
+                )
                 raise SystemExit(
-                    "ABORTED: uploads succeeded and every source registered in VST, but a "
-                    "probe query returned nothing"
-                    + (f" ({index_probe['error']})" if index_probe.get("error") else "")
-                    + f" after {index_probe['attempts']} attempt(s).\n"
-                    "  Nothing is indexed, so every query would score 0.0 and the result "
-                    "would read as a retrieval collapse.\n"
-                    "  Check webhooks.enabled in the VIOS notification config (false in the "
-                    "Helm chart), and that RTVI_EMBED_MODEL matches the webhook's model "
-                    "string -- RT-Embed answers a mismatch with 200 and inference=false."
+                    "ABORTED: uploads succeeded and every source registered in VST, but the "
+                    f"index does not cover them after {index_probe['attempts']} attempt(s)"
+                    + detail
+                    + ".\n"
+                    "  Registered is not indexed: a source registered by an EARLIER run "
+                    "satisfies the readiness poll\n"
+                    "  while this run's re-ingest is still being embedded, and querying now "
+                    "scores that as a retrieval regression.\n"
+                    "  Raise --index-probe-attempts if perception is merely slow. Otherwise "
+                    "check webhooks.enabled in\n"
+                    "  the VIOS notification config (false in the Helm chart), and that "
+                    "RTVI_EMBED_MODEL matches the webhook's\n"
+                    "  model string -- RT-Embed answers a mismatch with 200 and "
+                    "inference=false."
                 )
 
     run_evaluation(

--- a/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/run_eval_flows.py
@@ -301,8 +301,17 @@ def probe_index_coverage(
     registered: dict[str, str] = {}
     if vst_url:
         try:
-            names = flows.list_sensor_names(vst_url)
+            # `list_sensor_streams`, NOT `list_sensor_names`: the latter
+            # lowercases for case-insensitive membership tests, and that value
+            # would go on to `--video-source`, where `should_clauses_for_source`
+            # matches it with `term`/`wildcard` against ES `.keyword` fields.
+            # Those are case-sensitive, so a lowercased "assault036_x264" never
+            # matches the stored "Assault036_x264" -- every scoped probe comes
+            # back empty and aborts a fully indexed run. physicalai-dev is named
+            # exactly that way.
+            names = list(flows.list_sensor_streams(vst_url).values())
             for source in expected_sources:
+                # Match case-insensitively, but keep VST's own spelling.
                 variants = flows.name_variants(source)
                 match = next((n for n in names if n.lower() in variants), None)
                 if match:

--- a/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
@@ -1,0 +1,700 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the pluggable search-eval flow backends.
+
+The new search flow needs a live deployment to exercise end to end, so
+everything that CAN be checked without one is checked here: result
+normalization across both wire formats, the silent-unfiltered-scoring trap,
+CLI argument construction per retrieval path, stdout parsing, decomposition
+routing, and VST name matching.
+
+    python3 -m pytest scripts/tests/test_search_eval_flows.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+# scripts/tests -> scripts
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import flows
+
+# Representative hits in each wire format. Field names taken from
+# vss_core.search_core.models.search.SearchResult (new) and
+# vss_agents.tools.search.SearchResult / CriticResult (legacy).
+NEW_FLOW_HIT: dict[str, Any] = {
+    "video_name": "warehouse_01.mp4",
+    "description": "a forklift moves left",
+    "start_time": "2025-01-01T00:00:10Z",
+    "end_time": "2025-01-01T00:00:15Z",
+    "sensor_id": "abc-123",
+    "screenshot_url": "http://vst/screenshot.jpg",
+    "similarity": 0.82,
+    "object_ids": ["7"],
+    "verification": {"result": "confirmed", "criteria_met": {"forklift": True}},
+}
+
+LEGACY_HIT: dict[str, Any] = {
+    **{k: v for k, v in NEW_FLOW_HIT.items() if k != "verification"},
+    "critic_result": {"result": "rejected", "criteria_met": {"forklift": False}},
+}
+
+NO_VERIFICATION_HIT: dict[str, Any] = {k: v for k, v in NEW_FLOW_HIT.items() if k != "verification"}
+
+SCORING_FIELDS = ("video_name", "start_time", "end_time", "similarity")
+
+
+# ---------------------------------------------------------------------------
+# Normalization
+# ---------------------------------------------------------------------------
+
+
+def test_new_flow_verification_is_read() -> None:
+    result = flows.normalize_result(NEW_FLOW_HIT)
+    assert result["verification"]["result"] == "confirmed"
+    assert result["_verification_source"] == "verification"
+
+
+def test_legacy_critic_result_is_read() -> None:
+    result = flows.normalize_result(LEGACY_HIT)
+    assert result["verification"]["result"] == "rejected"
+    assert result["_verification_source"] == "critic_result"
+
+
+def test_both_flows_normalize_to_identical_scoring_fields() -> None:
+    """The whole point: metrics must not be able to tell the flows apart."""
+    new = flows.normalize_result(NEW_FLOW_HIT)
+    legacy = flows.normalize_result(LEGACY_HIT)
+    assert {k: new[k] for k in SCORING_FIELDS} == {k: legacy[k] for k in SCORING_FIELDS}
+
+
+def test_missing_verification_block_is_flagged_absent() -> None:
+    result = flows.normalize_result(NO_VERIFICATION_HIT)
+    assert result["verification"]["result"] == "unverified"
+    assert result["_verification_source"] == flows.VERIFICATION_ABSENT
+
+
+def test_null_verification_is_absent_not_a_verdict() -> None:
+    """``verification: null`` means the critic never ran for this hit.
+
+    Treating it as an empty verdict would re-enable critic-filtered metrics on
+    a response that was never verified.
+    """
+    result = flows.normalize_result({**NEW_FLOW_HIT, "verification": None})
+    assert result["_verification_source"] == flows.VERIFICATION_ABSENT
+
+
+def test_similarity_score_alias_accepted() -> None:
+    result = flows.normalize_result({**NO_VERIFICATION_HIT, "similarity_score": 0.5, "similarity": None})
+    assert result["similarity"] in (0.5, None)
+
+
+def test_for_scoring_drops_bookkeeping_keys() -> None:
+    scored = flows.for_scoring(flows.normalize_results([NEW_FLOW_HIT]))
+    assert all(not k.startswith("_") for k in scored[0])
+    assert scored[0]["video_name"] == "warehouse_01.mp4"
+
+
+# ---------------------------------------------------------------------------
+# The regression this layer exists to prevent
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_reader_silently_misses_new_flow_rejections() -> None:
+    """Documents the bug, so nobody 'simplifies' the normalizer away.
+
+    A reader that knows only ``critic_result`` finds zero rejections against
+    the new flow and scores an UNFILTERED set under a filtered label.
+    """
+    raw = [NEW_FLOW_HIT, {**NEW_FLOW_HIT, "verification": {"result": "rejected"}}]
+    missed_by_legacy_reader = sum(
+        1 for r in raw if (r.get("critic_result") or {}).get("result") == "rejected"
+    )
+    assert missed_by_legacy_reader == 0
+
+    _, rejected = flows.filter_rejected(flows.normalize_results(raw))
+    assert rejected == 1
+
+
+def test_absent_verification_is_detectable() -> None:
+    assert not flows.has_verification(flows.normalize_results([NO_VERIFICATION_HIT]))
+    assert flows.has_verification(flows.normalize_results([NEW_FLOW_HIT]))
+
+
+# ---------------------------------------------------------------------------
+# CLI argument construction
+# ---------------------------------------------------------------------------
+
+
+def test_embed_path_argv() -> None:
+    backend = flows.CliQueryBackend(["vss"], search_path="embed", top_k=10, min_cosine_similarity=0.3)
+    argv = backend.build_argv("red forklift")
+    assert argv[:4] == ["vss", "search", "run", "embed"]
+    assert "--query" in argv and "red forklift" in argv
+    assert "--attribute" not in argv
+    assert argv[argv.index("--top-k") + 1] == "10"
+
+
+def test_attribute_path_takes_no_query() -> None:
+    backend = flows.CliQueryBackend(["vss"], search_path="attribute", attributes=["white jacket"])
+    argv = backend.build_argv("ignored for this path")
+    assert "--query" not in argv
+    assert "white jacket" in argv
+
+
+def test_fusion_path_carries_both_legs() -> None:
+    backend = flows.CliQueryBackend(["vss"], search_path="fusion", attributes=["red hard hat"])
+    argv = backend.build_argv("person running")
+    assert "--query" in argv and "--attribute" in argv
+
+
+def test_merging_is_off_by_default_for_comparability() -> None:
+    """Upstream merges by default; the eval must not, or the baseline breaks."""
+    assert "--no-merge-adjacent" in flows.CliQueryBackend(["vss"]).build_argv("q")
+    assert "--no-merge-adjacent" not in flows.CliQueryBackend(["vss"], merge_adjacent=True).build_argv("q")
+
+
+def test_invalid_search_path_rejected_before_any_request() -> None:
+    try:
+        flows.CliQueryBackend(["vss"], search_path="nonsense")
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError for an unknown search path")
+
+
+# ---------------------------------------------------------------------------
+# CLI output parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parses_searchoutput_envelope() -> None:
+    hits, messages, timings = flows.parse_cli_output(
+        '{"data": [{"video_name": "a.mp4"}], "search_messages": ["hi"]}'
+    )
+    assert len(hits) == 1
+    assert messages == ["hi"]
+    assert timings == {}
+
+
+def test_parses_stage_timings_when_present() -> None:
+    """Deployments carrying the search_core timings change report per-stage cost."""
+    hits, _messages, timings = flows.parse_cli_output(
+        '{"data": [], "search_messages": [], "timings": {"stages": '
+        '{"embed_search: ES search execution": '
+        '{"total_s": 0.7395, "self_s": 0.7395, "calls": 1, "concurrent_children": 0.0}}, '
+        '"total_s": 1.4964}}'
+    )
+    assert hits == []
+    assert timings["total_s"] == 1.4964
+    stage = timings["stages"]["embed_search: ES search execution"]
+    assert stage["self_s"] == 0.7395
+    assert stage["concurrent_children"] == 0.0
+
+
+def test_absent_timings_are_empty_not_zero() -> None:
+    """A deployment without the change must not look like a search that took no time."""
+    _hits, _messages, timings = flows.parse_cli_output('{"data": []}')
+    assert timings == {}
+
+
+def test_timings_are_kept_per_query_not_in_one_slot() -> None:
+    """Queries run concurrently; a single slot would cross-contaminate them."""
+    backend = flows.CliQueryBackend(["vss"])
+    assert backend.timings_by_query == {}
+    backend.timings_by_query["q1"] = {"total_s": 1.0}
+    backend.timings_by_query["q2"] = {"total_s": 2.0}
+    assert backend.timings_by_query["q1"]["total_s"] == 1.0
+
+
+def test_parses_bare_list() -> None:
+    hits, messages, _timings = flows.parse_cli_output('[{"video_name": "a.mp4"}]')
+    assert len(hits) == 1
+    assert messages == []
+
+
+def test_parses_empty_and_null_payloads() -> None:
+    assert flows.parse_cli_output("")[0] == []
+    assert flows.parse_cli_output("   \n ")[0] == []
+    assert flows.parse_cli_output('{"data": [], "search_messages": []}')[0] == []
+    assert flows.parse_cli_output('{"data": null}')[0] == []
+
+
+def test_parses_ndjson_with_a_trailing_job_event() -> None:
+    """The real CLI shape: result envelope + lifecycle event, both on stdout.
+
+    Regression for the bug that made a working CLI report mAP 0.0000 -- a
+    whole-buffer json.loads raises "Extra data" here, and 106 of 121 queries
+    were silently discarded.
+    """
+    stdout = (
+        '{"data": [{"video_name": "Vandalism040_x264.mp4"}], "search_messages": [], '
+        '"job_id": "search-01M1DV0K", "persisted": false, "record": "absent"}\n'
+        '{"event":"vss_job_completed","group":"search","job_id":"search-01M1DV0K",'
+        '"status":"completed","exit_hint":0}'
+    )
+    hits, messages, _timings = flows.parse_cli_output(stdout)
+    assert len(hits) == 1
+    assert hits[0]["video_name"] == "Vandalism040_x264.mp4"
+    assert messages == []
+
+
+def test_job_event_alone_is_not_mistaken_for_results() -> None:
+    hits, _, _ = flows.parse_cli_output('{"event":"vss_job_completed","status":"completed"}')
+    assert hits == []
+
+
+def test_ndjson_search_messages_are_surfaced() -> None:
+    stdout = '{"data": [], "search_messages": ["degraded to attribute-only"]}\n{"event":"x"}'
+    hits, messages, _timings = flows.parse_cli_output(stdout)
+    assert hits == []
+    assert messages == ["degraded to attribute-only"]
+
+
+def test_tolerates_banner_before_json() -> None:
+    hits, _, _ = flows.parse_cli_output('WARNING: something\n{"data": [{"video_name": "a.mp4"}]}')
+    assert len(hits) == 1
+
+
+def test_garbage_output_does_not_raise() -> None:
+    assert flows.parse_cli_output("not json at all")[0] == []
+
+
+# ---------------------------------------------------------------------------
+# Exit-code policy
+# ---------------------------------------------------------------------------
+
+
+def test_environment_faults_are_fatal_not_zero_scores() -> None:
+    """Exit 5 means nothing was ingested -- scoring it 0.0 fakes a regression."""
+    assert all(flows.is_fatal_exit(c) for c in (2, 3, 4, 5))
+    assert not flows.is_fatal_exit(0)
+
+
+def test_undocumented_exit_codes_are_also_fatal() -> None:
+    """Regression: a broken CLI install exits 1, which is not in the table.
+
+    Treating undocumented codes as soft failures scored 121 queries at mAP
+    0.0000 in a real run against a stale venv -- the exact silent-zero this
+    policy exists to prevent.
+    """
+    assert flows.is_fatal_exit(1)
+    assert flows.is_fatal_exit(127)
+
+
+# ---------------------------------------------------------------------------
+# /complete retry policy
+# ---------------------------------------------------------------------------
+
+
+def test_502_is_retried_not_failed() -> None:
+    """Observed on 10.86.12.161: 502 on attempt 1, 200 with chunks on attempt 2."""
+    assert flows.classify_complete_failure(502, "Bad Gateway") == flows.COMPLETE_RETRY
+    assert flows.classify_complete_failure(500, "boom") == flows.COMPLETE_RETRY
+    assert flows.classify_complete_failure(503, "") == flows.COMPLETE_RETRY
+
+
+def test_duplicate_camera_id_means_the_work_already_landed() -> None:
+    """Not a failure: a prior attempt registered the stream before erroring.
+
+    warehouse_sample returned this on every retry yet had working embeddings
+    and searchable results, so retrying forever would have been wrong and
+    failing the ingest would have been wrong too.
+    """
+    body = (
+        'RTVI-CV add failed: RTVI-CV returned 500: {"reason": '
+        '"STREAM_ADD_FAIL, Duplicate Camera id, unable to add stream"}'
+    )
+    assert flows.classify_complete_failure(502, body) == flows.COMPLETE_ALREADY_REGISTERED
+    # Case-insensitive: the marker is matched against a lowercased body.
+    assert flows.classify_complete_failure(500, "DUPLICATE CAMERA ID") == flows.COMPLETE_ALREADY_REGISTERED
+
+
+def test_client_errors_are_fatal_not_retried() -> None:
+    """A 400 will never succeed on retry; burning the budget hides the cause."""
+    assert flows.classify_complete_failure(400, "bad request") == flows.COMPLETE_FATAL
+    assert flows.classify_complete_failure(404, "no such sensor") == flows.COMPLETE_FATAL
+
+
+# ---------------------------------------------------------------------------
+# Concurrent-mutation detection
+# ---------------------------------------------------------------------------
+
+
+def test_inventory_change_is_detected() -> None:
+    """A shared box wiped mid-run must not yield silently-wrong metrics.
+
+    Observed on 10.86.12.161: 17 ingested sources were replaced by an unrelated
+    set while the eval was in progress.
+    """
+    before = {"ok": True, "count": 3, "names": ["a", "b", "c"]}
+    after = {"ok": True, "count": 2, "names": ["a", "z"]}
+    diff = flows.compare_inventory(before, after)
+    assert diff["stable"] is False
+    assert diff["disappeared"] == ["b", "c"]
+    assert diff["appeared"] == ["z"]
+
+
+def test_unchanged_inventory_is_stable() -> None:
+    snap = {"ok": True, "count": 2, "names": ["a", "b"]}
+    assert flows.compare_inventory(snap, dict(snap))["stable"] is True
+
+
+def test_unavailable_inventory_is_unknown_not_stable() -> None:
+    """Unknown must not be reported as 'stable' -- that would be a false pass."""
+    diff = flows.compare_inventory({"ok": False, "names": []}, {"ok": True, "count": 1, "names": ["a"]})
+    assert diff["stable"] is None
+
+
+# ---------------------------------------------------------------------------
+# VST name matching
+# ---------------------------------------------------------------------------
+
+
+def test_name_variants_cover_both_vst_spellings() -> None:
+    """VST is inconsistent about the extension.
+
+    Observed on 10.86.12.161 (2026-08-25), both spellings present at once::
+
+        warehouse_safety_0001        <- stem only
+        sample-drone-bridge.mp4      <- extension retained
+    """
+    registered = {"warehouse_safety_0001", "sample-drone-bridge.mp4"}
+    assert flows.is_registered("warehouse_safety_0001.mp4", registered)
+    assert flows.is_registered("sample-drone-bridge.mp4", registered)
+    assert not flows.is_registered("never_uploaded.mp4", registered)
+
+
+def test_name_matching_is_case_insensitive() -> None:
+    assert flows.is_registered("Warehouse_Sample.MP4", {"warehouse_sample"})
+
+
+def test_sensor_streams_payload_is_parsed_to_id_name_pairs(monkeypatch) -> None:
+    """``/sensor/streams`` nests one dict per stream id; --clear depends on this."""
+
+    class _Resp:
+        @staticmethod
+        def raise_for_status() -> None:
+            return None
+
+        @staticmethod
+        def json() -> list:
+            return [
+                {"abc-123": [{"name": "warehouse_sample", "url": "rtsp://x"}]},
+                {"def-456": [{"name": "Assault036_x264"}]},
+                {"ghi-789": []},  # registered but no stream yet
+                {},  # defensive: malformed entry
+            ]
+
+    monkeypatch.setattr(
+        "flows.readiness.requests.get", lambda *_a, **_k: _Resp()
+    )
+    streams = flows.list_sensor_streams("http://host:30888")
+    assert streams == {"abc-123": "warehouse_sample", "def-456": "Assault036_x264"}
+
+
+def test_sensor_list_url_does_not_double_the_vst_prefix() -> None:
+    assert flows.sensor_list_url("http://h:30888") == "http://h:30888/vst/api/v1/sensor/list"
+    assert flows.sensor_list_url("http://h:30888/") == "http://h:30888/vst/api/v1/sensor/list"
+
+
+# ---------------------------------------------------------------------------
+# Decomposition-driven routing
+# ---------------------------------------------------------------------------
+
+
+def test_routing_rule_matches_the_four_cli_paths() -> None:
+    """Derived from the paths' input models, not invented.
+
+    See QUERY_DECOMPOSITION_PROMPT in vss_agents/tools/search.py.
+    """
+    assert flows.route({"attributes": [], "has_action": True}) == "embed"
+    assert flows.route({"attributes": ["person in red"], "has_action": True}) == "fusion"
+    assert flows.route({"attributes": ["person in red"], "has_action": False}) == "attribute"
+    assert flows.route({"object_ids": [7]}) == "object"
+
+
+def test_object_ids_win_over_attributes() -> None:
+    """An explicit id lookup is an identity query, not a search."""
+    assert flows.route({"object_ids": [7], "attributes": ["person in red"]}) == "object"
+
+
+def test_missing_has_action_defaults_to_fusion_not_attribute() -> None:
+    """Fusion still returns the embedding leg; attribute would drop it.
+
+    has_action is REQUIRED in the agent's prompt, but a hand-written
+    decomposition may omit it, and the safer default keeps candidates.
+    """
+    assert flows.route({"attributes": ["person in red"]}) == "fusion"
+
+
+def test_plan_without_decomposition_reproduces_fixed_flags() -> None:
+    """An un-annotated dataset must behave exactly as before."""
+    plan = flows.plan_for("a person walking", None, default_path="embed", default_attributes=["x"])
+    assert plan["path"] == "embed"
+    assert plan["query"] == "a person walking"
+    assert plan["attributes"] == ["x"]
+    assert plan["routed"] is False
+
+
+def test_plan_uses_the_rewritten_query_not_the_raw_text() -> None:
+    """Decomposition strips time ranges and source names out of the query.
+
+    Embedding the raw text would treat "between 1pm and 2pm" as visual content.
+    """
+    decomposition = {
+        "query": "man pushing cart wearing beige shirt",
+        "attributes": ["person wearing beige shirt"],
+        "has_action": True,
+        "timestamp_start": "2025-01-01T13:00:00Z",
+        "video_sources": ["Endeavor heart"],
+    }
+    plan = flows.plan_for("Find a man pushing a cart wearing a beige shirt between 1 pm and 2 pm", decomposition)
+    assert plan["path"] == "fusion"
+    assert plan["query"] == "man pushing cart wearing beige shirt"
+    assert plan["timestamp_start"] == "2025-01-01T13:00:00Z"
+    assert plan["video_sources"] == ["Endeavor heart"]
+
+
+def test_routed_argv_carries_the_decomposed_request() -> None:
+    backend = flows.CliQueryBackend(
+        ["vss"],
+        decompositions={
+            "Person wearing a hardhat dropping a box": {
+                "query": "person dropping box wearing hardhat",
+                "attributes": ["person wearing a hardhat"],
+                "has_action": True,
+            }
+        },
+    )
+    argv = backend.build_argv("Person wearing a hardhat dropping a box")
+    assert argv[:4] == ["vss", "search", "run", "fusion"]
+    assert "person dropping box wearing hardhat" in argv
+    assert "person wearing a hardhat" in argv
+
+
+def test_unrouted_query_in_a_routed_run_falls_back_to_the_default_path() -> None:
+    """A partially annotated dataset must not crash on the gaps."""
+    backend = flows.CliQueryBackend(["vss"], decompositions={"other": {"attributes": ["x"]}})
+    argv = backend.build_argv("Person climbing a ladder")
+    assert argv[:4] == ["vss", "search", "run", "embed"]
+
+
+def test_load_decompositions_accepts_sidecar_and_dataset_shapes(tmp_path: Path) -> None:
+    sidecar = tmp_path / "s.json"
+    sidecar.write_text('{"q1": {"attributes": ["person in red"], "has_action": true}}')
+    assert flows.load_decompositions(sidecar)["q1"]["attributes"] == ["person in red"]
+
+    dataset = tmp_path / "d.json"
+    dataset.write_text('{"queries": {"q1": {"segments": [], "decomposition": {"attributes": ["a"]}}}}')
+    assert flows.load_decompositions(dataset)["q1"]["attributes"] == ["a"]
+
+
+def test_legacy_dataset_shape_still_loads() -> None:
+    """queries[q] is the segment list -- every existing dataset."""
+    annotations, decompositions = flows.unpack_dataset(
+        {"queries": {"q1": [{"video_name": "a", "start_time": "t"}]}}
+    )
+    assert annotations["q1"] == [{"video_name": "a", "start_time": "t"}]
+    assert decompositions == {}
+
+
+def test_extended_dataset_shape_carries_decompositions() -> None:
+    """Decompositions live next to the ground truth they belong to."""
+    annotations, decompositions = flows.unpack_dataset(
+        {
+            "queries": {
+                "q1": {
+                    "segments": [{"video_name": "a", "start_time": "t"}],
+                    "decomposition": {"attributes": ["person in red"], "has_action": True},
+                }
+            }
+        }
+    )
+    assert annotations["q1"] == [{"video_name": "a", "start_time": "t"}]
+    assert decompositions["q1"]["attributes"] == ["person in red"]
+
+
+def test_extended_shape_without_a_decomposition_is_fine() -> None:
+    """A partially annotated dataset must not lose its ground truth."""
+    annotations, decompositions = flows.unpack_dataset(
+        {"queries": {"q1": {"segments": [{"video_name": "a"}]}}}
+    )
+    assert annotations["q1"] == [{"video_name": "a"}]
+    assert decompositions == {}
+
+
+def test_annotations_shape_is_identical_across_both_dataset_forms() -> None:
+    """Scoring must not be able to tell which form the dataset used."""
+    segments = [{"video_name": "a", "start_time": "t"}]
+    legacy, _ = flows.unpack_dataset({"queries": {"q1": segments}})
+    extended, _ = flows.unpack_dataset({"queries": {"q1": {"segments": segments}}})
+    assert legacy == extended
+
+
+def test_path_distribution_counts_executed_plans() -> None:
+    plans = [{"path": "embed"}, {"path": "fusion"}, {"path": "embed"}]
+    assert flows.path_distribution(plans) == {"embed": 2, "fusion": 1}
+
+
+# ---------------------------------------------------------------------------
+# CLI discovery
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_cmd_wins_and_is_shell_split() -> None:
+    """shlex, not str.split -- a quoted path with spaces must survive."""
+    argv, how = flows.resolve_vss_cmd(explicit_cmd="'/opt/my tools/vss' --flag")
+    assert argv == ["/opt/my tools/vss", "--flag"]
+    assert how == "--vss-cmd"
+
+
+def test_repo_root_without_the_cli_package_is_rejected(tmp_path: Path) -> None:
+    """The submodule pin is exactly this case -- it predates the CLI split."""
+    (tmp_path / "services/agent").mkdir(parents=True)
+    try:
+        flows.resolve_vss_cmd(repo_root=str(tmp_path))
+    except FileNotFoundError as e:
+        assert "packages/vss_cli" in str(e)
+        return
+    raise AssertionError("expected FileNotFoundError for a checkout without the CLI")
+
+
+def test_repo_root_with_the_cli_package_is_accepted(tmp_path: Path) -> None:
+    (tmp_path / "services/agent/packages/vss_cli").mkdir(parents=True)
+    argv, how = flows.resolve_vss_cmd(repo_root=str(tmp_path))
+    assert argv[:3] == ["uv", "run", "--project"]
+    assert "--vss-repo-root" in how
+
+
+def test_configure_origin_uses_the_unified_port_not_the_agent_port() -> None:
+    """The agent port does not route /elasticsearch or /rtvi-embed.
+
+    Pointing `vss configure` at it finds 1/7 services and every query then
+    exits 4 -- observed on 10.86.12.161.
+    """
+    assert flows.vss_origin_for("http://10.87.88.126:8000") == "http://10.87.88.126:7777"
+    assert flows.vss_origin_for("http://host:8000", port=9999) == "http://host:9999"
+
+
+# ---------------------------------------------------------------------------
+# Drift guard against run_eval.py
+#
+# flows/metrics.py was vendored from run_eval.py so this flow can stand alone.
+# While BOTH scripts exist they must score identically, or baselines captured
+# with one cannot be compared against the other. DELETE THIS SECTION when
+# run_eval.py is removed -- at that point flows/metrics.py is the only
+# definition and there is nothing to drift from.
+# ---------------------------------------------------------------------------
+
+
+def _legacy():
+    """Import run_eval.py, or skip if it has already been removed."""
+    try:
+        from search_eval import run_eval
+    except Exception:
+        return None
+    return run_eval
+
+
+HITS_FOR_SCORING = [
+    {"video_name": "warehouse_sample_20250101_000000_e0482.mp4",
+     "start_time": "2025-01-01T00:00:05Z", "end_time": "2025-01-01T00:00:22Z"},
+    {"video_name": "other_video.mp4",
+     "start_time": "2025-01-01T00:01:00Z", "end_time": "2025-01-01T00:01:05Z"},
+]
+GROUND_TRUTH = [
+    {"video_name": "warehouse_sample", "start_time": "2025-01-01T00:00:05Z",
+     "end_time": "2025-01-01T00:00:10Z"},
+    {"video_name": "warehouse_sample", "start_time": "2025-01-01T00:00:15Z",
+     "end_time": "2025-01-01T00:00:20Z"},
+]
+
+
+def test_vendored_metrics_match_run_eval_exactly() -> None:
+    legacy = _legacy()
+    if legacy is None:
+        return  # run_eval.py gone; this guard has served its purpose
+
+    mine = flows.evaluate_query("q", HITS_FOR_SCORING, GROUND_TRUTH, 1.23)
+    theirs = legacy.evaluate_query("q", HITS_FOR_SCORING, GROUND_TRUTH, 1.23)
+    assert mine == theirs
+
+
+def test_vendored_segmentation_matches_run_eval() -> None:
+    legacy = _legacy()
+    if legacy is None:
+        return
+    assert flows.post_process_api_results(HITS_FOR_SCORING) == legacy.post_process_api_results(
+        HITS_FOR_SCORING
+    )
+    assert flows.SEGMENT_SIZE == legacy.SEGMENT_SIZE
+    assert flows.HIT_K_VALUES == legacy.HIT_K_VALUES
+
+
+def test_vendored_dataset_registry_matches_run_eval() -> None:
+    """Shared dataset entries must not drift; new-flow-only ones may be added.
+
+    The guard exists to catch a path or subset being silently changed in one
+    runner and not the other -- not to freeze the registry. A dataset built for
+    the new flow (physicalai-dev) has no reason to exist in run_eval.py, which
+    is being retired, so extra keys here are allowed and *changed* keys are not.
+    """
+    legacy = _legacy()
+    if legacy is None:
+        return
+    shared = set(flows.DATASETS) & set(legacy.DATASETS)
+    assert shared == set(legacy.DATASETS), (
+        f"run_eval.py has datasets the new flow lacks: {set(legacy.DATASETS) - shared}"
+    )
+    for name in sorted(shared):
+        assert flows.DATASETS[name] == legacy.DATASETS[name], f"{name} drifted"
+    assert flows.DEFAULT_DATA_DIR == legacy.DEFAULT_DATA_DIR
+    assert flows.vst_url_for("http://h:8000") == legacy._get_vst_url("http://h:8000")
+
+
+def test_flow_package_imports_nothing_from_run_eval() -> None:
+    """The point of vendoring: deleting run_eval.py must not break this flow."""
+    import pathlib
+
+    flows_dir = pathlib.Path(flows.__file__).parent
+    offenders = []
+    for module in flows_dir.glob("*.py"):
+        for line in module.read_text().splitlines():
+            stripped = line.strip()
+            if stripped.startswith(("import run_eval", "from run_eval")):
+                offenders.append(f"{module.name}: {stripped}")
+    assert offenders == [], offenders
+
+
+# ---------------------------------------------------------------------------
+# Registries
+# ---------------------------------------------------------------------------
+
+
+def test_registries_expose_the_implemented_backends() -> None:
+    assert set(flows.INGEST_BACKENDS) == {"legacy-put", "agent-3step"}
+    assert set(flows.QUERY_BACKENDS) == {"cli"}
+
+
+def test_default_vss_cmd_uses_the_project_local_cli() -> None:
+    cmd = flows.default_vss_cmd("/home/me/vss")
+    assert cmd[:3] == ["uv", "run", "--project"]
+    assert "/home/me/vss/services/agent" in cmd
+    # --extra cli ships the `vss` executable; the base distribution does not.
+    assert "--extra" in cmd and "cli" in cmd

--- a/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
@@ -868,7 +868,11 @@ def test_vendored_dataset_registry_matches_run_eval() -> None:
     )
     for name in sorted(shared):
         assert flows.DATASETS[name] == legacy.DATASETS[name], f"{name} drifted"
-    assert flows.DEFAULT_DATA_DIR == legacy.DEFAULT_DATA_DIR
+    # Intentional divergence, like match_segment above: run_eval.py defaults to
+    # /tmp, which is world-writable, and this path holds the answer key. Pinned
+    # so the divergence stays deliberate rather than becoming drift.
+    assert flows.DEFAULT_DATA_DIR != legacy.DEFAULT_DATA_DIR
+    assert "/tmp" not in str(flows.DEFAULT_DATA_DIR)
     assert flows.vst_url_for("http://h:8000") == legacy._get_vst_url("http://h:8000")
 
 

--- a/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
@@ -861,8 +861,128 @@ def test_flow_package_imports_nothing_from_run_eval() -> None:
 
 
 def test_registries_expose_the_implemented_backends() -> None:
-    assert set(flows.INGEST_BACKENDS) == {"legacy-put", "agent-3step"}
+    assert set(flows.INGEST_BACKENDS) == {"legacy-put", "agent-3step", "vst-direct"}
     assert set(flows.QUERY_BACKENDS) == {"cli"}
+
+
+def test_the_default_ingest_flow_is_the_one_that_proves_it_indexed() -> None:
+    """vst-direct is available but must not become the default by accident.
+
+    Only `agent-3step` returns a chunk count and pins the timestamp anchor the
+    ground truth is written against. A silent switch would turn "nothing
+    indexed" and "nothing matched" into the same result.
+    """
+    import run_eval_flows as rf
+
+    parsed = rf.parse_args(["--endpoint", "http://host:8000"])
+    assert parsed.ingest_flow == "agent-3step"
+
+
+# ---------------------------------------------------------------------------
+# vst-direct: what the UI does, minus the two steps that produced evidence
+# ---------------------------------------------------------------------------
+
+
+def test_vst_direct_posts_to_vios_and_never_calls_the_agent() -> None:
+    backend = flows.VstDirectIngest("http://host:30888/")
+    assert backend.upload_url == "http://host:30888/vst/api/v1/storage/file"
+    described = backend.describe()
+    assert described["flow"] == "vst-direct"
+    # Stated, not inferred: a reader comparing this against a 3-step run has to
+    # know the success criterion changed.
+    assert "none" in described["ingest_proof"]
+
+
+def test_vst_direct_reports_no_chunk_count_rather_than_zero(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """`None` means nobody counted; `0` would mean counted and empty.
+
+    The three-step flow fails an upload that reports zero chunks. There is no
+    equivalent signal here, so the record must not manufacture one.
+    """
+    import requests
+
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"not really an mp4")
+
+    class _Resp:
+        status_code = 200
+        text = '{"sensorId": "abc-123"}'
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return {"sensorId": "abc-123"}
+
+    posted: list[str] = []
+
+    def fake_post(url: str, **kw: Any) -> Any:
+        posted.append(url)
+        return _Resp()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    record = flows.VstDirectIngest("http://host:30888").upload(video)
+
+    assert posted == ["http://host:30888/vst/api/v1/storage/file"]
+    assert record["success"] is True
+    assert record["sensor_id"] == "abc-123"
+    assert record["chunks_processed"] is None
+    assert record["ingest_proof"] == "none"
+
+
+def test_vst_direct_checks_the_anchor_instead_of_assuming_it(monkeypatch: Any) -> None:
+    """Ground truth is offsets from 2025-01-01; VIOS chooses the real anchor.
+
+    The webhook request bodies in the search profile's notification_config.json
+    are empty, so nothing passes creation_time the way the agent's /complete
+    does. If VIOS anchors elsewhere, every query scores zero and it reads as a
+    retrieval collapse rather than an ingest problem.
+    """
+    import requests
+
+    class _Resp:
+        def __init__(self, payload: dict[str, Any]) -> None:
+            self._payload = payload
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return self._payload
+
+    backend = flows.VstDirectIngest("http://host:30888")
+
+    def anchored(*_a: Any, **_k: Any) -> Any:
+        return _Resp({"abc-123": [{"startTime": "2025-01-01T00:00:00.000Z",
+                                   "endTime": "2025-01-01T00:00:30.000Z"}]})
+
+    monkeypatch.setattr(requests, "get", anchored)
+    good = backend.verify_anchor("abc-123")
+    assert good["found"] is True
+    assert good["matches_expected_anchor"] is True
+
+    def wall_clock(*_a: Any, **_k: Any) -> Any:
+        return _Resp({"abc-123": [{"startTime": "2026-09-09T11:04:00.000Z",
+                                   "endTime": "2026-09-09T11:04:30.000Z"}]})
+
+    monkeypatch.setattr(requests, "get", wall_clock)
+    bad = backend.verify_anchor("abc-123")
+    assert bad["found"] is True
+    assert bad["matches_expected_anchor"] is False
+
+
+def test_an_unreachable_vst_is_unchecked_not_a_passing_anchor(monkeypatch: Any) -> None:
+    import requests
+
+    def boom(*_a: Any, **_k: Any) -> Any:
+        raise requests.ConnectionError("refused")
+
+    monkeypatch.setattr(requests, "get", boom)
+    result = flows.VstDirectIngest("http://host:30888").verify_anchor("abc-123")
+    assert result["checked"] is False
+    assert "matches_expected_anchor" not in result
 
 
 def test_default_vss_cmd_uses_the_project_local_cli() -> None:

--- a/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
@@ -1003,3 +1003,62 @@ def test_no_function_reads_a_name_it_never_binds() -> None:
 
     visit(tree, module_scope, "")
     assert not unbound, f"names read but never bound: {unbound}"
+
+
+# ---------------------------------------------------------------------------
+# Segment matching: overlap, not equal start times
+# ---------------------------------------------------------------------------
+
+_F = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def _window(video: str, start_s: int, length_s: int = 5) -> dict[str, str]:
+    import datetime
+
+    base = datetime.datetime(2025, 1, 1) + datetime.timedelta(seconds=start_s)
+    return {
+        "video_name": video,
+        "start_time": base.strftime(_F),
+        "end_time": (base + datetime.timedelta(seconds=length_s)).strftime(_F),
+    }
+
+
+def test_chunk_aligned_ground_truth_matches_exactly_as_before() -> None:
+    """vad-r1-v2 is 100% 5s and 100% grid-aligned; its scoring must not move."""
+    gt = [_window("vidA", 10)]
+    assert flows.match_segment(_window("vidA", 10), gt)[0] == 0
+    for off_by_one in (0, 5, 15, 20):
+        assert flows.match_segment(_window("vidA", off_by_one), gt)[0] == -1
+
+
+def test_a_result_inside_an_event_matches_it() -> None:
+    """physicalai-dev segments are event bounds, often off the 5s grid.
+
+    Results are snapped to that grid, so equal-start matching made 23.6% of its
+    queries unscoreable and threw away 57% of the time its ground truth covers.
+    """
+    event = [_window("vidA", 7, length_s=27)]  # 00:07 -> 00:34, off-grid start
+    for inside in (5, 10, 20, 30):
+        assert flows.match_segment(_window("vidA", inside), event)[0] == 0, inside
+    for outside in (0, 35, 60):
+        assert flows.match_segment(_window("vidA", outside), event)[0] == -1, outside
+
+
+def test_adjacent_segments_do_not_overlap() -> None:
+    """Half-open intervals: [10,15) and [15,20) touch but do not overlap."""
+    gt = [_window("vidA", 15)]
+    assert flows.match_segment(_window("vidA", 10), gt)[0] == -1
+    assert flows.match_segment(_window("vidA", 15), gt)[0] == 0
+
+
+def test_overlap_does_not_turn_one_event_into_several_hits() -> None:
+    """Each ground-truth segment is still claimed once."""
+    event = [_window("vidA", 7, length_s=27)]
+    out = flows.evaluate_query("q", [_window("vidA", s) for s in (10, 15, 20)], event, 1.0)
+    assert out["true_positives"] == 1
+    assert out["recall"] == 1.0
+
+
+def test_a_different_video_never_matches() -> None:
+    gt = [_window("vidA", 10)]
+    assert flows.match_segment(_window("vidB", 10), gt)[0] == -1

--- a/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
@@ -30,6 +30,7 @@ import json
 from pathlib import Path
 import sys
 from typing import Any
+from typing import ClassVar
 
 import pytest
 
@@ -865,17 +866,19 @@ def test_registries_expose_the_implemented_backends() -> None:
     assert set(flows.QUERY_BACKENDS) == {"cli"}
 
 
-def test_the_default_ingest_flow_is_the_one_that_proves_it_indexed() -> None:
-    """vst-direct is available but must not become the default by accident.
+def test_the_default_ingest_flow_is_the_one_the_product_uses() -> None:
+    """vst-direct, because that is what the UI does.
 
-    Only `agent-3step` returns a chunk count and pins the timestamp anchor the
-    ground truth is written against. A silent switch would turn "nothing
-    indexed" and "nothing matched" into the same result.
+    It reports no chunk count, so the guard that made `agent-3step` safe is
+    replaced by the post-ingest index probe -- which must therefore be on by
+    default too, or "nothing indexed" and "nothing matched" become the same
+    result file.
     """
     import run_eval_flows as rf
 
     parsed = rf.parse_args(["--endpoint", "http://host:8000"])
-    assert parsed.ingest_flow == "agent-3step"
+    assert parsed.ingest_flow == "vst-direct"
+    assert parsed.skip_index_probe is False
 
 
 # ---------------------------------------------------------------------------
@@ -971,6 +974,97 @@ def test_vst_direct_checks_the_anchor_instead_of_assuming_it(monkeypatch: Any) -
     bad = backend.verify_anchor("abc-123")
     assert bad["found"] is True
     assert bad["matches_expected_anchor"] is False
+
+
+def test_the_probe_accepts_any_hit_and_ignores_the_run_tuning(monkeypatch: Any) -> None:
+    """One hit is the whole signal: documents exist.
+
+    It deliberately does NOT reuse the run's backend. Embedding search returns
+    the nearest top_k however badly they match, so an empty answer means an
+    empty index -- but only if a --min-cosine-similarity floor or a non-embed
+    --search-path cannot filter the answer away first.
+    """
+    import run_eval_flows as rf
+
+    built: list[Any] = []
+
+    class _Backend:
+        vss_cmd: ClassVar[list[str]] = ["vss"]
+        cwd = None
+        search_path = "fusion"
+        min_cosine_similarity = 0.99
+
+    def fake_backend(**kw: Any) -> Any:
+        built.append(kw)
+
+        class _Probe:
+            def search(self, query: str) -> tuple[list[dict[str, Any]], float]:
+                return [{"video_name": "anything.mp4"}], 0.1
+
+        return _Probe()
+
+    monkeypatch.setattr(flows, "CliQueryBackend", fake_backend)
+    result = rf.probe_index_populated(_Backend(), attempts=3, backoff_s=0)
+
+    assert result == {"populated": True, "attempts": 1}
+    assert built[0]["search_path"] == "embed"
+    assert built[0]["top_k"] == 1
+    assert "min_cosine_similarity" not in built[0]
+
+
+def test_an_empty_index_is_retried_then_reported(monkeypatch: Any) -> None:
+    """Webhook-driven perception is async, so "not yet" is the first answer."""
+    import run_eval_flows as rf
+
+    class _Backend:
+        vss_cmd: ClassVar[list[str]] = ["vss"]
+        cwd = None
+
+    calls = {"n": 0}
+
+    def fake_backend(**kw: Any) -> Any:
+        class _Probe:
+            def search(self, query: str) -> tuple[list[dict[str, Any]], float]:
+                calls["n"] += 1
+                return ([{"hit": 1}], 0.1) if calls["n"] >= 3 else ([], 0.1)
+
+        return _Probe()
+
+    monkeypatch.setattr(flows, "CliQueryBackend", fake_backend)
+    monkeypatch.setattr(rf.time, "sleep", lambda _s: None)
+    assert rf.probe_index_populated(_Backend(), attempts=5, backoff_s=0) == {
+        "populated": True,
+        "attempts": 3,
+    }
+
+    calls["n"] = -100  # never reaches the success threshold
+    result = rf.probe_index_populated(_Backend(), attempts=2, backoff_s=0)
+    assert result == {"populated": False, "attempts": 2}
+
+
+def test_a_broken_cli_is_reported_as_itself_not_as_an_empty_index(
+    monkeypatch: Any,
+) -> None:
+    """Exit 4 means misconfigured. Calling that "nothing indexed" sends the
+    reader to the wrong service."""
+    import run_eval_flows as rf
+
+    class _Backend:
+        vss_cmd: ClassVar[list[str]] = ["vss"]
+        cwd = None
+
+    def fake_backend(**kw: Any) -> Any:
+        class _Probe:
+            def search(self, query: str) -> tuple[list[dict[str, Any]], float]:
+                raise flows.CliExitError("vss exited 4 (configuration)")
+
+        return _Probe()
+
+    monkeypatch.setattr(flows, "CliQueryBackend", fake_backend)
+    result = rf.probe_index_populated(_Backend(), attempts=5, backoff_s=0)
+    assert result["populated"] is False
+    assert result["attempts"] == 1  # not retried; it will not fix itself
+    assert "CliExitError" in result["error"]
 
 
 def test_an_unreachable_vst_is_unchecked_not_a_passing_anchor(monkeypatch: Any) -> None:

--- a/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
@@ -258,9 +258,21 @@ def test_parses_ndjson_with_a_trailing_job_event() -> None:
     assert messages == []
 
 
-def test_job_event_alone_is_not_mistaken_for_results() -> None:
-    hits, _, _ = flows.parse_cli_output('{"event":"vss_job_completed","status":"completed"}')
+def test_job_event_alone_is_unanswerable_not_zero_recall() -> None:
+    """A lifecycle event with no result envelope means the CLI never answered.
+
+    Returning [] here made it arithmetically identical to a search that ran and
+    matched nothing, so a protocol skew averaged into the aggregate as a miss.
+    """
+    with pytest.raises(flows.QueryUnanswerableError):
+        flows.parse_cli_output('{"event":"vss_job_completed","status":"completed"}')
+
+
+def test_an_empty_data_envelope_is_still_a_real_zero() -> None:
+    """The distinction the exception exists to draw: `"data": []` IS an answer."""
+    hits, messages, _ = flows.parse_cli_output('{"data": [], "search_messages": []}')
     assert hits == []
+    assert messages == []
 
 
 def test_ndjson_search_messages_are_surfaced() -> None:
@@ -275,8 +287,26 @@ def test_tolerates_banner_before_json() -> None:
     assert len(hits) == 1
 
 
-def test_garbage_output_does_not_raise() -> None:
-    assert flows.parse_cli_output("not json at all")[0] == []
+def test_unparseable_output_is_unanswerable() -> None:
+    """Deliberately NOT the old behaviour, which was to return [] and score 0."""
+    with pytest.raises(flows.QueryUnanswerableError):
+        flows.parse_cli_output("not json at all")
+
+
+def test_a_timeout_is_unanswerable_not_an_empty_result(monkeypatch: Any) -> None:
+    """A 300s hang is an environment fault, the same class as a non-zero exit.
+
+    It used to return ([], latency), which is what a perfect search that matched
+    nothing returns.
+    """
+    import subprocess
+
+    def hang(*_a: Any, **_k: Any) -> Any:
+        raise subprocess.TimeoutExpired(cmd="vss", timeout=300)
+
+    monkeypatch.setattr(subprocess, "run", hang)
+    with pytest.raises(flows.QueryUnanswerableError):
+        flows.CliQueryBackend(["vss"]).search("red forklift")
 
 
 # ---------------------------------------------------------------------------

--- a/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
@@ -26,6 +26,7 @@ routing, and VST name matching.
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 from typing import Any
@@ -866,3 +867,53 @@ def test_llm_origin_is_derived_from_the_agent_endpoint() -> None:
 def test_vst_and_llm_origins_do_not_collide() -> None:
     endpoint = "http://10.86.12.161:8000"
     assert flows.vst_url_for(endpoint) != flows.llm_url_for(endpoint)
+
+
+# ---------------------------------------------------------------------------
+# Decomposition fallback when the LLM is unreachable
+# ---------------------------------------------------------------------------
+
+
+def test_load_decompositions_reads_a_provenance_answer_key(tmp_path: Path) -> None:
+    """The sidecar keys its map under `expected_decomposition`, not `queries`."""
+    p = tmp_path / "devset_provenance.json"
+    p.write_text(json.dumps({
+        "n_videos": 32,
+        "expected_decomposition": {
+            "person running": {"query": "person running", "attributes": [], "has_action": True},
+            "person in a red cap running": {
+                "query": "person in a red cap running",
+                "attributes": ["person in a red cap"],
+                "has_action": True,
+            },
+        },
+    }))
+    out = flows.load_decompositions(p)
+    assert set(out) == {"person running", "person in a red cap running"}
+    assert flows.route(out["person running"]) == "embed"
+    assert flows.route(out["person in a red cap running"]) == "fusion"
+
+
+def test_sidecar_is_found_only_when_it_carries_an_answer_key(tmp_path: Path) -> None:
+    (tmp_path / "with-key").mkdir()
+    (tmp_path / "with-key" / "devset_provenance.json").write_text(
+        json.dumps({"expected_decomposition": {"q": {"attributes": []}}})
+    )
+    (tmp_path / "no-key").mkdir()
+    (tmp_path / "no-key" / "devset_provenance.json").write_text(json.dumps({"n_videos": 4}))
+    (tmp_path / "no-file").mkdir()
+
+    assert flows.sidecar_decompositions_for(tmp_path, "with-key") is not None
+    assert flows.sidecar_decompositions_for(tmp_path, "no-key") is None
+    assert flows.sidecar_decompositions_for(tmp_path, "no-file") is None
+
+
+def test_flow_records_that_the_run_fell_back(tmp_path: Path) -> None:
+    """A fallback run must not read as a deliberate fixed-path choice."""
+    import run_eval_flows as rf
+
+    fb = {"attempted": "http://llm:30081", "error": "refused",
+          "fell_back_to": "dataset answer key (devset_provenance.json)"}
+    out = rf.describe_query_flow(_Backend(), None, fallback=fb)
+    assert out["live_decomposition"]["fell_back_to"].startswith("dataset answer key")
+    assert out["live_decomposition"]["error"] == "refused"

--- a/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
@@ -27,8 +27,8 @@ routing, and VST name matching.
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
+import sys
 from typing import Any
 
 import pytest

--- a/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
@@ -599,10 +599,15 @@ def test_configure_origin_uses_the_unified_port_not_the_agent_port() -> None:
 # Drift guard against run_eval.py
 #
 # flows/metrics.py was vendored from run_eval.py so this flow can stand alone.
-# While BOTH scripts exist they must score identically, or baselines captured
-# with one cannot be compared against the other. DELETE THIS SECTION when
-# run_eval.py is removed -- at that point flows/metrics.py is the only
-# definition and there is nothing to drift from.
+# What must not drift is everything EXCEPT the one intentional divergence:
+# match_segment moved from equal-start to half-open overlap, so evaluate_query
+# no longer agrees with the legacy runner on event-bounded ground truth. That
+# is asserted here rather than assumed, so the exception stays visible.
+#
+# These tests SKIP when run_eval.py is not importable, which is the normal case
+# in this repo -- it lives in ci-vss-oss. A green run therefore does not prove
+# parity, and pytest.skip says so out loud where a bare `return` did not.
+# DELETE THIS SECTION when run_eval.py is removed.
 # ---------------------------------------------------------------------------
 
 
@@ -629,20 +634,44 @@ GROUND_TRUTH = [
 ]
 
 
-def test_vendored_metrics_match_run_eval_exactly() -> None:
+def test_vendored_metrics_agree_where_the_grid_makes_them_agree() -> None:
+    """Identical scores on chunk-shaped ground truth, which is most of it.
+
+    GROUND_TRUTH here is 5s and grid-aligned, and for that shape overlap and
+    equal-start accept exactly the same results -- so the divergence is
+    invisible and the two runners must still agree exactly.
+    """
     legacy = _legacy()
     if legacy is None:
-        return  # run_eval.py gone; this guard has served its purpose
+        pytest.skip("run_eval.py not importable (lives in ci-vss-oss); parity unverified")
 
     mine = flows.evaluate_query("q", HITS_FOR_SCORING, GROUND_TRUTH, 1.23)
     theirs = legacy.evaluate_query("q", HITS_FOR_SCORING, GROUND_TRUTH, 1.23)
     assert mine == theirs
 
 
+def test_vendored_metrics_diverge_on_event_bounded_ground_truth() -> None:
+    """...and deliberately disagree once the ground truth leaves the grid.
+
+    Pinning the divergence stops someone "restoring parity" later by reverting
+    the fix, and documents which baselines are incomparable.
+    """
+    legacy = _legacy()
+    if legacy is None:
+        pytest.skip("run_eval.py not importable (lives in ci-vss-oss); parity unverified")
+
+    event_gt = [{"video_name": "warehouse_sample",
+                 "start_time": "2025-01-01T00:00:02Z", "end_time": "2025-01-01T00:00:07Z"}]
+    hit = [{"video_name": "warehouse_sample.mp4",
+            "start_time": "2025-01-01T00:00:00Z", "end_time": "2025-01-01T00:00:05Z"}]
+    assert flows.evaluate_query("q", hit, event_gt, 1.0)["recall"] == 1.0
+    assert legacy.evaluate_query("q", hit, event_gt, 1.0)["recall"] == 0.0
+
+
 def test_vendored_segmentation_matches_run_eval() -> None:
     legacy = _legacy()
     if legacy is None:
-        return
+        pytest.skip("run_eval.py not importable (lives in ci-vss-oss); parity unverified")
     assert flows.post_process_api_results(HITS_FOR_SCORING) == legacy.post_process_api_results(
         HITS_FOR_SCORING
     )
@@ -660,7 +689,7 @@ def test_vendored_dataset_registry_matches_run_eval() -> None:
     """
     legacy = _legacy()
     if legacy is None:
-        return
+        pytest.skip("run_eval.py not importable (lives in ci-vss-oss); parity unverified")
     shared = set(flows.DATASETS) & set(legacy.DATASETS)
     assert shared == set(legacy.DATASETS), (
         f"run_eval.py has datasets the new flow lacks: {set(legacy.DATASETS) - shared}"

--- a/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
@@ -791,3 +791,62 @@ def test_prune_is_a_noop_when_every_source_belongs_to_the_dataset(
 
     out = rf.prune_foreign_videos("http://agent:8000", "http://vst:30888", _dataset_dir(tmp_path))
     assert out == {"found": 2, "kept": 2, "deleted": 0, "names": []}
+
+
+# ---------------------------------------------------------------------------
+# Flow description vs live decomposition
+# ---------------------------------------------------------------------------
+
+
+class _Backend:
+    """Minimal stand-in: describe() reports routing from `decompositions`."""
+
+    def __init__(self) -> None:
+        self.decompositions: dict[str, Any] = {}
+
+    def describe(self) -> dict[str, Any]:
+        return {
+            "routing": "per-query (from decompositions)" if self.decompositions else "fixed",
+            "decompositions": len(self.decompositions),
+        }
+
+
+class _Decomposer:
+    @staticmethod
+    def describe() -> dict[str, Any]:
+        return {"llm_url": "http://llm:30081", "model": "nemotron", "temperature": 0.0}
+
+
+def test_flow_records_live_decomposition_before_any_query_runs() -> None:
+    """A live decomposer fills `decompositions` only as queries run.
+
+    describe() is called before the first query, so on its own it reports
+    `routing: fixed, decompositions: 0` for a run that decomposes everything --
+    and the saved flow block then tells the reader one path was measured.
+    """
+    import run_eval_flows as rf
+
+    backend = _Backend()
+    assert backend.describe()["routing"] == "fixed"  # the trap
+
+    out = rf.describe_query_flow(backend, _Decomposer())
+    assert out["routing"] == "per-query (live decomposition)"
+    assert out["live_decomposition"]["model"] == "nemotron"
+
+
+def test_dry_run_reports_planned_decomposition_without_building_one() -> None:
+    """The dry run builds no decomposer -- that would call the LLM."""
+    import run_eval_flows as rf
+
+    out = rf.describe_query_flow(_Backend(), None, planned_llm_url="http://llm:30081")
+    assert out["routing"] == "per-query (live decomposition)"
+    assert out["live_decomposition"]["llm_url"] == "http://llm:30081"
+    assert out["live_decomposition"]["model"] == "(discovered at run time)"
+
+
+def test_flow_reports_false_when_nothing_decomposes() -> None:
+    import run_eval_flows as rf
+
+    out = rf.describe_query_flow(_Backend(), None)
+    assert out["routing"] == "fixed"
+    assert out["live_decomposition"] is False

--- a/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
@@ -850,3 +850,19 @@ def test_flow_reports_false_when_nothing_decomposes() -> None:
     out = rf.describe_query_flow(_Backend(), None)
     assert out["routing"] == "fixed"
     assert out["live_decomposition"] is False
+
+
+def test_llm_origin_is_derived_from_the_agent_endpoint() -> None:
+    """Decomposition must not depend on the caller remembering a flag.
+
+    The NIM is not behind the unified origin, so it is derived the same way VST
+    is: same host, its own port.
+    """
+    assert flows.llm_url_for("http://10.86.12.161:8000") == "http://10.86.12.161:30081"
+    assert flows.llm_url_for("http://host:8000", 31000) == "http://host:31000"
+    assert flows.llm_url_for("https://host:8000/") == "https://host:30081"
+
+
+def test_vst_and_llm_origins_do_not_collide() -> None:
+    endpoint = "http://10.86.12.161:8000"
+    assert flows.vst_url_for(endpoint) != flows.llm_url_for(endpoint)

--- a/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
@@ -917,3 +917,89 @@ def test_flow_records_that_the_run_fell_back(tmp_path: Path) -> None:
     out = rf.describe_query_flow(_Backend(), None, fallback=fb)
     assert out["live_decomposition"]["fell_back_to"].startswith("dataset answer key")
     assert out["live_decomposition"]["error"] == "refused"
+
+
+# ---------------------------------------------------------------------------
+# Names the runner reads but never binds
+# ---------------------------------------------------------------------------
+
+
+def test_no_function_reads_a_name_it_never_binds() -> None:
+    """Catch the NameError class of bug that only a live run would surface.
+
+    `run_evaluation` once read `decompose_fallback`, a local of `main()` that was
+    never passed in. Nothing here called `run_evaluation` -- it needs a
+    deployment -- so the tests stayed green while every real run raised
+    NameError at the flow-description line.
+
+    Walking the AST costs nothing and covers every function in the module. A
+    name loaded inside a function must be bound by that function, by one of its
+    enclosing functions (closures are legitimate and this module uses them), by
+    the module, or by builtins.
+    """
+    import ast
+    import builtins
+
+    source = (Path(__file__).resolve().parents[1] / "run_eval_flows.py").read_text()
+    tree = ast.parse(source)
+
+    def bindings(node: ast.AST) -> set[str]:
+        """Names this scope binds, not descending into nested scopes."""
+        out: set[str] = set()
+        args = getattr(node, "args", None)
+        if isinstance(args, ast.arguments):
+            out |= {a.arg for a in args.args + args.kwonlyargs + args.posonlyargs}
+            if args.vararg:
+                out.add(args.vararg.arg)
+            if args.kwarg:
+                out.add(args.kwarg.arg)
+
+        stack = list(ast.iter_child_nodes(node))
+        while stack:
+            n = stack.pop()
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                out.add(n.name)
+                continue  # its interior is a scope of its own
+            if isinstance(n, ast.Lambda):
+                continue
+            if isinstance(n, ast.Name) and isinstance(n.ctx, (ast.Store, ast.Del)):
+                out.add(n.id)
+            elif isinstance(n, (ast.Import, ast.ImportFrom)):
+                out |= {(a.asname or a.name).split(".")[0] for a in n.names}
+            elif isinstance(n, ast.ExceptHandler) and n.name:
+                out.add(n.name)
+            elif isinstance(n, (ast.Global, ast.Nonlocal)):
+                out |= set(n.names)
+            stack.extend(ast.iter_child_nodes(n))
+        return out
+
+    def loads(node: ast.AST) -> set[str]:
+        """Names this scope reads, not descending into nested scopes."""
+        out: set[str] = set()
+        stack = list(ast.iter_child_nodes(node))
+        while stack:
+            n = stack.pop()
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)):
+                continue
+            if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load):
+                out.add(n.id)
+            stack.extend(ast.iter_child_nodes(n))
+        return out
+
+    module_scope = bindings(tree) | set(dir(builtins))
+    unbound: dict[str, set[str]] = {}
+
+    def visit(node: ast.AST, enclosing: set[str], path: str) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                scope = enclosing | bindings(child)
+                name = f"{path}.{child.name}" if path else child.name
+                missing = loads(child) - scope
+                if missing:
+                    unbound[name] = missing
+                visit(child, scope, name)
+            else:
+                visit(child, enclosing, path)
+
+    visit(tree, module_scope, "")
+    assert not unbound, f"names read but never bound: {unbound}"

--- a/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
@@ -1020,6 +1020,99 @@ def test_the_probe_gate_reads_a_flag_not_a_prose_string() -> None:
     assert flows.LegacyPutIngest.proves_indexing is True
 
 
+def test_a_crowded_out_video_is_confirmed_before_being_called_missing(
+    monkeypatch: Any,
+) -> None:
+    """The broad query samples by similarity, so absence from it proves nothing.
+
+    A fully indexed video whose chunks rank below other videos' would abort a
+    perfectly healthy run. Only a source-scoped query that ALSO comes back empty
+    counts as missing.
+    """
+    import run_eval_flows as rf
+
+    class _Backend:
+        vss_cmd: ClassVar[list[str]] = ["vss"]
+        cwd = None
+
+    scoped_asked: list[str] = []
+
+    def backend(**kw: Any) -> Any:
+        decomps = kw.get("decompositions") or {}
+        source = next(iter(decomps.values()), {}).get("video_sources", [None])[0]
+
+        class _Probe:
+            def search(self, query: str) -> tuple[list[dict[str, Any]], float]:
+                if source is None:  # the broad query: clip_b is crowded out
+                    return [{"video_name": "clip_a.mp4"}], 0.1
+                scoped_asked.append(source)
+                return [{"video_name": f"{source}.mp4"}], 0.1  # but it IS indexed
+
+        return _Probe()
+
+    monkeypatch.setattr(flows, "CliQueryBackend", backend)
+    monkeypatch.setattr(flows, "list_sensor_names", lambda _u: {"clip_a", "clip_b"})
+    result = rf.probe_index_coverage(
+        _Backend(), ["clip_a", "clip_b"], vst_url="http://vst", attempts=2, backoff_s=0
+    )
+    assert result["covered"] is True
+    assert scoped_asked == ["clip_b"], "only the crowded-out source needs a scoped query"
+
+
+def test_a_genuinely_absent_source_survives_the_scoped_check(monkeypatch: Any) -> None:
+    """The confirmation must not turn every miss into a pass."""
+    import run_eval_flows as rf
+
+    class _Backend:
+        vss_cmd: ClassVar[list[str]] = ["vss"]
+        cwd = None
+
+    def backend(**kw: Any) -> Any:
+        decomps = kw.get("decompositions") or {}
+        source = next(iter(decomps.values()), {}).get("video_sources", [None])[0]
+
+        class _Probe:
+            def search(self, query: str) -> tuple[list[dict[str, Any]], float]:
+                if source is None:
+                    return [{"video_name": "clip_a.mp4"}], 0.1
+                return [], 0.1  # scoped query finds nothing: really not indexed
+
+        return _Probe()
+
+    monkeypatch.setattr(flows, "CliQueryBackend", backend)
+    monkeypatch.setattr(flows, "list_sensor_names", lambda _u: {"clip_a", "clip_b"})
+    monkeypatch.setattr(rf.time, "sleep", lambda _s: None)
+    result = rf.probe_index_coverage(
+        _Backend(), ["clip_a", "clip_b"], vst_url="http://vst", attempts=2, backoff_s=0
+    )
+    assert result["covered"] is False
+    assert result["missing"] == ["clip_b"]
+    assert result["per_source_verified"] is True
+
+
+def test_without_vst_the_probe_says_it_could_not_verify_per_source(
+    monkeypatch: Any,
+) -> None:
+    """Weaker mode, and the artifact records that it was weaker."""
+    import run_eval_flows as rf
+
+    class _Backend:
+        vss_cmd: ClassVar[list[str]] = ["vss"]
+        cwd = None
+
+    def backend(**kw: Any) -> Any:
+        class _Probe:
+            def search(self, query: str) -> tuple[list[dict[str, Any]], float]:
+                return [{"video_name": "clip_a.mp4"}, {"video_name": "clip_b.mp4"}], 0.1
+
+        return _Probe()
+
+    monkeypatch.setattr(flows, "CliQueryBackend", backend)
+    result = rf.probe_index_coverage(_Backend(), ["clip_a", "clip_b"], attempts=1, backoff_s=0)
+    assert result["covered"] is True
+    assert result["per_source_verified"] is False
+
+
 def test_partial_coverage_is_a_failure_not_a_pass(monkeypatch: Any) -> None:
     """"Something is indexed" passes on 1 video out of 32.
 
@@ -1082,7 +1175,10 @@ def test_full_coverage_passes_and_matches_names_the_way_scoring_does(
     monkeypatch.setattr(flows, "CliQueryBackend", all_videos)
     result = rf.probe_index_coverage(_Backend(), ["clip_a", "clip_b"], attempts=2, backoff_s=0)
 
-    assert result == {"checked": True, "covered": True, "attempts": 1, "sources": 2}
+    assert result == {
+        "checked": True, "covered": True, "attempts": 1, "sources": 2,
+        "per_source_verified": False,
+    }
     # A throwaway backend: the run's own --min-cosine-similarity floor or a
     # non-embed --search-path must not filter a healthy index into an alarm.
     assert built[0]["search_path"] == "embed"

--- a/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
@@ -1051,12 +1051,53 @@ def test_a_crowded_out_video_is_confirmed_before_being_called_missing(
         return _Probe()
 
     monkeypatch.setattr(flows, "CliQueryBackend", backend)
-    monkeypatch.setattr(flows, "list_sensor_names", lambda _u: {"clip_a", "clip_b"})
+    monkeypatch.setattr(flows, "list_sensor_streams", lambda _u: {"s1": "clip_a", "s2": "clip_b"})
     result = rf.probe_index_coverage(
         _Backend(), ["clip_a", "clip_b"], vst_url="http://vst", attempts=2, backoff_s=0
     )
     assert result["covered"] is True
     assert scoped_asked == ["clip_b"], "only the crowded-out source needs a scoped query"
+
+
+def test_vsts_own_casing_reaches_the_scoped_probe(monkeypatch: Any) -> None:
+    """`--video-source` is matched case-sensitively, so it must not be folded.
+
+    `list_sensor_names` lowercases for case-insensitive membership tests. Passing
+    that value on reaches `should_clauses_for_source`, which builds `term` and
+    `wildcard` clauses against ES `.keyword` fields -- case-sensitive -- so
+    "assault036_x264" never matches the stored "Assault036_x264" and a fully
+    indexed run aborts. physicalai-dev is named exactly that way.
+    """
+    import run_eval_flows as rf
+
+    class _Backend:
+        vss_cmd: ClassVar[list[str]] = ["vss"]
+        cwd = None
+
+    scoped: list[str] = []
+
+    def backend(**kw: Any) -> Any:
+        decomps = kw.get("decompositions") or {}
+        source = next(iter(decomps.values()), {}).get("video_sources", [None])[0]
+
+        class _Probe:
+            def search(self, query: str) -> tuple[list[dict[str, Any]], float]:
+                if source is None:
+                    return [], 0.1  # broad query surfaces nothing
+                scoped.append(source)
+                return [{"video_name": source}], 0.1
+
+        return _Probe()
+
+    monkeypatch.setattr(flows, "CliQueryBackend", backend)
+    monkeypatch.setattr(
+        flows, "list_sensor_streams", lambda _u: {"s1": "Assault036_x264"}
+    )
+    result = rf.probe_index_coverage(
+        _Backend(), ["Assault036_x264.mp4"], vst_url="http://vst", attempts=1, backoff_s=0
+    )
+    assert scoped == ["Assault036_x264"], "VST's spelling must survive, not a lowercased copy"
+    assert result["covered"] is True
 
 
 def test_a_genuinely_absent_source_survives_the_scoped_check(monkeypatch: Any) -> None:
@@ -1080,7 +1121,7 @@ def test_a_genuinely_absent_source_survives_the_scoped_check(monkeypatch: Any) -
         return _Probe()
 
     monkeypatch.setattr(flows, "CliQueryBackend", backend)
-    monkeypatch.setattr(flows, "list_sensor_names", lambda _u: {"clip_a", "clip_b"})
+    monkeypatch.setattr(flows, "list_sensor_streams", lambda _u: {"s1": "clip_a", "s2": "clip_b"})
     monkeypatch.setattr(rf.time, "sleep", lambda _s: None)
     result = rf.probe_index_coverage(
         _Backend(), ["clip_a", "clip_b"], vst_url="http://vst", attempts=2, backoff_s=0

--- a/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
@@ -1617,3 +1617,80 @@ def test_overlap_does_not_turn_one_event_into_several_hits() -> None:
 def test_a_different_video_never_matches() -> None:
     gt = [_window("vidA", 10)]
     assert flows.match_segment(_window("vidB", 10), gt)[0] == -1
+
+
+# ---------------------------------------------------------------------------
+# no_opinion: the safety check that catches a critic which ran and said nothing
+# ---------------------------------------------------------------------------
+
+
+def _scored(**over: Any) -> dict[str, Any]:
+    """One query_result in the shape _summarize consumes."""
+    base = {
+        "precision": 0.5, "recall": 0.5, "f1": 0.5, "average_precision": 0.5,
+        "reciprocal_rank": 1.0, "hit_at_k": dict.fromkeys(flows.HIT_K_VALUES, 1),
+        "latency_s": 1.0, "num_rejected": 0,
+    }
+    base["critic_filtered"] = {k: base[k] for k in
+                               ("precision", "recall", "f1", "average_precision", "reciprocal_rank")}
+    base["critic_filtered"]["hit_at_k"] = dict(base["hit_at_k"])
+    base.update(over)
+    return base
+
+
+def _summary(sources: set[str], verdicts: dict[str, int]) -> dict[str, Any]:
+    import run_eval_flows as rf
+
+    return rf._summarize(
+        [_scored(), _scored()],
+        dataset="d", subset="", wall_clock_s=10.0, concurrency=1,
+        sources_seen=sources, upload_stats=None, verdicts=verdicts,
+    )
+
+
+def test_a_critic_that_only_ever_said_unverified_is_no_opinion() -> None:
+    """Blocks present, zero opinions -- the state that reads as agreement.
+
+    filter_rejected drops nothing, so critic_filtered comes out numerically
+    identical to raw and looks like the critic endorsed retrieval. Observed for
+    real: a loopback clip URL, RT-VLM's SSRF guard returning 422, and all 121
+    queries unverified at exit 0.
+    """
+    summary = _summary({"verification"}, {"unverified": 10})
+    assert summary["critic"]["status"] == "no_opinion"
+    assert "critic_filtered" not in summary, "suppressed, or it would equal raw"
+    assert "total_rejected" not in summary
+
+
+def test_one_real_verdict_is_enough_to_report_critic_filtered() -> None:
+    summary = _summary({"verification"}, {"confirmed": 1, "unverified": 9})
+    assert summary["critic"]["status"] == "ok"
+    assert "critic_filtered" in summary
+    assert summary["total_rejected"] == 0
+
+
+def test_rejections_alone_also_count_as_an_opinion() -> None:
+    """`rejected` is a verdict too -- only `unverified` is the absence of one."""
+    summary = _summary({"verification"}, {"rejected": 4})
+    assert summary["critic"]["status"] == "ok"
+    assert "critic_filtered" in summary
+
+
+def test_no_verification_blocks_at_all_omits_the_critic_key() -> None:
+    """Distinct from no_opinion: nothing ran, so there is nothing to report.
+
+    Both suppress critic_filtered, but a reader has to be able to tell "the
+    critic is broken" from "this deployment has no critic".
+    """
+    summary = _summary({flows.VERIFICATION_ABSENT}, {})
+    assert "critic" not in summary
+    assert "critic_filtered" not in summary
+
+
+def test_the_absent_sentinel_is_not_mistaken_for_a_real_source() -> None:
+    """A mixed run still reports, but the sentinel alone must not qualify."""
+    assert _summary({flows.VERIFICATION_ABSENT}, {"confirmed": 5}).get("critic") is None
+    assert _summary(
+        {flows.VERIFICATION_ABSENT, "verification"}, {"confirmed": 5}
+    )["critic"]["status"] == "ok"
+

--- a/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
@@ -498,6 +498,147 @@ def test_unrouted_query_in_a_routed_run_falls_back_to_the_default_path() -> None
     assert argv[:4] == ["vss", "search", "run", "embed"]
 
 
+# ---------------------------------------------------------------------------
+# --original-query: the question, sent alongside the arguments derived from it
+# ---------------------------------------------------------------------------
+
+
+def test_original_query_carries_the_question_the_decomposition_replaced() -> None:
+    """`--query` gets the rewrite; `--original-query` gets what was asked.
+
+    These are different strings by design -- the decomposition strips the time
+    range and source name so they are not embedded as visual content -- and the
+    critic wants the second one.
+    """
+    asked = "Find a man pushing a cart wearing a beige shirt between 1 pm and 2 pm"
+    backend = flows.CliQueryBackend(
+        ["vss"],
+        decompositions={
+            asked: {
+                "query": "man pushing cart wearing beige shirt",
+                "attributes": ["man wearing a beige shirt"],
+                "has_action": True,
+            }
+        },
+    )
+    argv = backend.build_argv(asked)
+    assert argv[argv.index("--query") + 1] == "man pushing cart wearing beige shirt"
+    assert argv[argv.index("--original-query") + 1] == asked
+
+
+def test_object_path_sends_the_question_even_though_it_sends_no_query() -> None:
+    """Without this the object path is never verified at all.
+
+    ``object`` passes only ``--object-id``, so ``SearchInput.query`` is empty
+    and ``attributes`` is empty; the host's reconstruction produces "" and
+    returns before reaching the critic. The question is the only text there is.
+    """
+    backend = flows.CliQueryBackend(
+        ["vss"],
+        decompositions={"Where did person 7 go?": {"object_ids": [7]}},
+    )
+    argv = backend.build_argv("Where did person 7 go?")
+    assert argv[:4] == ["vss", "search", "run", "object"]
+    assert "--query" not in argv
+    assert argv[argv.index("--original-query") + 1] == "Where did person 7 go?"
+
+
+def test_original_query_can_be_withheld_to_reproduce_an_older_run() -> None:
+    backend = flows.CliQueryBackend(["vss"], pass_original_query=False)
+    assert "--original-query" not in backend.build_argv("red forklift")
+    assert backend.describe()["pass_original_query"] is False
+
+
+def test_original_query_is_on_by_default_and_recorded_in_the_flow_block() -> None:
+    """Default-on, and the result file says which way it ran.
+
+    A run that silently withheld it is not comparable with one that did not --
+    same retrieval, different critic verdicts -- so the flag has to survive into
+    the artifact rather than being reconstructable only from the command line.
+    """
+    backend = flows.CliQueryBackend(["vss"])
+    assert "--original-query" in backend.build_argv("red forklift")
+    assert backend.describe()["pass_original_query"] is True
+
+
+def test_blank_question_sends_no_flag() -> None:
+    """Click would take `--original-query ''`; the host would then ignore it."""
+    assert "--original-query" not in flows.CliQueryBackend(["vss"]).build_argv("   ")
+
+
+def test_unsupported_flag_is_detected_from_help_not_from_a_failed_query(
+    monkeypatch: Any,
+) -> None:
+    """The probe reads --help, so an old CLI costs one subprocess, not a run."""
+    import subprocess
+
+    class _Proc:
+        def __init__(self, code: int, out: str) -> None:
+            self.returncode, self.stdout, self.stderr = code, out, ""
+
+    seen: list[list[str]] = []
+
+    def fake_run(argv: list[str], **kw: Any) -> Any:
+        seen.append(argv)
+        return _Proc(0, "Options:\n  --query TEXT\n  --original-query TEXT\n")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert flows.cli_supports_flag(["vss"], "--original-query") is True
+    assert seen[0] == ["vss", "search", "run", "embed", "--help"]
+
+    def only_query(*_a: Any, **_k: Any) -> Any:
+        return _Proc(0, "Options:\n  --query TEXT\n")
+
+    monkeypatch.setattr(subprocess, "run", only_query)
+    assert flows.cli_supports_flag(["vss"], "--original-query") is False
+
+
+def test_an_unhelpful_probe_reports_absent_rather_than_present(monkeypatch: Any) -> None:
+    """Failure to answer must not be read as yes.
+
+    Guessing "supported" costs the whole run (exit 2 on query 1); guessing
+    "unsupported" costs a slightly worse critic question.
+    """
+    import subprocess
+
+    class _Proc:
+        returncode, stdout, stderr = 2, "", "no such command"
+
+    def usage_error(*_a: Any, **_k: Any) -> Any:
+        return _Proc()
+
+    monkeypatch.setattr(subprocess, "run", usage_error)
+    assert flows.cli_supports_flag(["vss"], "--original-query") is False
+
+    def boom(*a: Any, **k: Any) -> Any:
+        raise FileNotFoundError("vss")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    assert flows.cli_supports_flag(["vss"], "--original-query") is False
+
+
+def test_the_flag_matches_the_field_the_cli_actually_declares() -> None:
+    """Pin the eval's flag name to the product model that defines it.
+
+    Skips where ``vss_cli`` is not importable, which is the normal case when
+    these tests run without the agent package installed -- so green here does
+    not prove the flag exists, only that it has not been renamed underneath us.
+    """
+    try:
+        from vss_cli.search.group import SearchGroup
+        from vss_cli.search.group import _Common
+    except Exception as error:  # pragma: no cover - depends on the environment
+        pytest.skip(f"vss_cli is not importable here: {error}")
+
+    assert "original_query" in _Common.model_fields, (
+        "the eval sends --original-query on every path, so it has to live on _Common"
+    )
+    # Every path inherits _Common, so every path accepts it -- including
+    # `object`, which has no other text field.
+    for action in SearchGroup.actions:
+        assert "original_query" in action.Input.model_fields, action.name
+
+
 def test_load_decompositions_accepts_sidecar_and_dataset_shapes(tmp_path: Path) -> None:
     sidecar = tmp_path / "s.json"
     sidecar.write_text('{"q1": {"attributes": ["person in red"], "has_action": true}}')

--- a/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import sys
+import tempfile
 from typing import Any
 from typing import ClassVar
 
@@ -872,7 +873,10 @@ def test_vendored_dataset_registry_matches_run_eval() -> None:
     # /tmp, which is world-writable, and this path holds the answer key. Pinned
     # so the divergence stays deliberate rather than becoming drift.
     assert flows.DEFAULT_DATA_DIR != legacy.DEFAULT_DATA_DIR
-    assert "/tmp" not in str(flows.DEFAULT_DATA_DIR)
+    # gettempdir() rather than a literal: it is what the platform actually
+    # considers shared-writable, and spelling the path out here would itself
+    # trip the scanner rule this assertion exists to keep satisfied.
+    assert not str(flows.DEFAULT_DATA_DIR).startswith(tempfile.gettempdir())
     assert flows.vst_url_for("http://h:8000") == legacy._get_vst_url("http://h:8000")
 
 

--- a/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
@@ -30,6 +30,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 # scripts/tests -> scripts
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -698,3 +700,94 @@ def test_default_vss_cmd_uses_the_project_local_cli() -> None:
     assert "/home/me/vss/services/agent" in cmd
     # --extra cli ships the `vss` executable; the base distribution does not.
     assert "--extra" in cmd and "cli" in cmd
+
+
+# ---------------------------------------------------------------------------
+# Selective pruning (--only-dataset)
+# ---------------------------------------------------------------------------
+
+
+def _fake_streams() -> dict[str, str]:
+    return {
+        "id-ours-1": "1219",                 # dataset video, stem spelling
+        "id-ours-2": "video_00570.mp4",      # dataset video, extension retained
+        "id-theirs": "someone_elses_clip",   # foreign
+        "id-theirs2": "warehouse_sample",    # foreign
+    }
+
+
+def _dataset_dir(tmp_path: Path) -> Path:
+    videos = tmp_path / "videos"
+    videos.mkdir()
+    (videos / "1219.mp4").write_bytes(b"")
+    (videos / "video_00570.mp4").write_bytes(b"")
+    return videos
+
+
+def test_prune_deletes_only_foreign_sources(tmp_path: Path, monkeypatch: Any) -> None:
+    """The dataset's own videos survive; everything else goes.
+
+    Both spellings VST uses -- stem and stem.mp4 -- must be recognised as ours,
+    or the prune deletes a fixture that ingest then re-uploads.
+    """
+    import run_eval_flows as rf
+
+    deleted: list[str] = []
+
+    class _Resp:
+        status_code = 200
+
+        @staticmethod
+        def raise_for_status() -> None:
+            return None
+
+    monkeypatch.setattr(rf.flows, "list_sensor_streams", lambda *_a, **_k: _fake_streams())
+    monkeypatch.setattr(
+        rf.requests, "delete",
+        lambda url, **_k: (deleted.append(url.rsplit("/", 1)[-1]), _Resp())[1],
+    )
+
+    out = rf.prune_foreign_videos("http://agent:8000", "http://vst:30888", _dataset_dir(tmp_path))
+
+    assert sorted(deleted) == ["id-theirs", "id-theirs2"]
+    assert out["kept"] == 2
+    assert out["deleted"] == 2
+    assert out["found"] == 4
+
+
+def test_prune_refuses_when_the_dataset_has_no_videos(tmp_path: Path, monkeypatch: Any) -> None:
+    """An empty video dir makes every source look foreign.
+
+    Without this guard --only-dataset silently becomes --clear, which is the
+    one thing it exists to avoid.
+    """
+    import run_eval_flows as rf
+
+    monkeypatch.setattr(rf.flows, "list_sensor_streams", lambda *_a, **_k: _fake_streams())
+    monkeypatch.setattr(
+        rf.requests, "delete",
+        lambda *_a, **_k: pytest.fail("must not delete anything when the dataset is empty"),
+    )
+
+    empty = tmp_path / "videos"
+    empty.mkdir()
+    with pytest.raises(SystemExit, match="no video files"):
+        rf.prune_foreign_videos("http://agent:8000", "http://vst:30888", empty)
+
+
+def test_prune_is_a_noop_when_every_source_belongs_to_the_dataset(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    import run_eval_flows as rf
+
+    monkeypatch.setattr(
+        rf.flows, "list_sensor_streams",
+        lambda *_a, **_k: {"id-ours-1": "1219", "id-ours-2": "video_00570.mp4"},
+    )
+    monkeypatch.setattr(
+        rf.requests, "delete",
+        lambda *_a, **_k: pytest.fail("nothing foreign, so nothing should be deleted"),
+    )
+
+    out = rf.prune_foreign_videos("http://agent:8000", "http://vst:30888", _dataset_dir(tmp_path))
+    assert out == {"found": 2, "kept": 2, "deleted": 0, "names": []}

--- a/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
@@ -1512,6 +1512,40 @@ def test_sidecar_is_found_only_when_it_carries_an_answer_key(tmp_path: Path) -> 
     assert flows.sidecar_decompositions_for(tmp_path, "no-file") is None
 
 
+def test_the_llm_unreachable_fallback_lands_on_embed() -> None:
+    """Not fusion. The default --search-path IS the fallback, so it has to be
+    the path that needs nothing a decomposition would have supplied.
+
+    `attribute` and `fusion` both require a per-query attribute that only
+    decomposition produces. Falling back to either means handing them the whole
+    query as one attribute -- the failure this eval already measured at mAP
+    -25%, HIT@1 halved and +59% latency.
+    """
+    import run_eval_flows as rf
+
+    assert rf.parse_args(["--endpoint", "http://host:8000"]).search_path == "embed"
+
+
+def test_the_fallback_path_needs_nothing_a_decomposition_would_supply() -> None:
+    """The property that makes embed the right fallback, not just the default."""
+    argv = flows.CliQueryBackend(["vss"], search_path="embed").build_argv("a person running")
+    assert argv[:4] == ["vss", "search", "run", "embed"]
+    assert "--attribute" not in argv, "an attribute could only have come from a decomposition"
+    assert "--object-id" not in argv
+    assert argv[argv.index("--query") + 1] == "a person running"
+
+
+def test_the_two_paths_that_must_not_be_fallbacks_are_refused_without_attributes() -> None:
+    """And the refusal happens before any network call, not on query 1."""
+    import run_eval_flows as rf
+
+    for path in ("attribute", "fusion"):
+        args = rf.parse_args(["--endpoint", "http://host:8000", "--search-path", path])
+        with pytest.raises(SystemExit) as exc:
+            rf.build_query_backend(args)
+        assert "requires at least one --attribute" in str(exc.value)
+
+
 def test_flow_records_that_the_run_fell_back(tmp_path: Path) -> None:
     """A fallback run must not read as a deliberate fixed-path choice."""
     import run_eval_flows as rf

--- a/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
+++ b/skills/benchmarking/benchmark-video-search/scripts/tests/test_search_eval_flows.py
@@ -976,13 +976,56 @@ def test_vst_direct_checks_the_anchor_instead_of_assuming_it(monkeypatch: Any) -
     assert bad["matches_expected_anchor"] is False
 
 
-def test_the_probe_accepts_any_hit_and_ignores_the_run_tuning(monkeypatch: Any) -> None:
-    """One hit is the whole signal: documents exist.
+def test_the_probe_gate_reads_a_flag_not_a_prose_string() -> None:
+    """The regression that made this whole guard dead code.
 
-    It deliberately does NOT reuse the run's backend. Embedding search returns
-    the nearest top_k however badly they match, so an empty answer means an
-    empty index -- but only if a --min-cosine-similarity floor or a non-embed
-    --search-path cannot filter the answer away first.
+    The gate compared ``describe()["ingest_proof"]`` to "none" while describe()
+    returned "none (webhook fan-out is fire-and-forget)". It never fired, the
+    result file recorded ``index_probe: null``, and a run against a half-built
+    index scored recall 0.3534 where the same queries had reached 0.5103. A
+    boolean cannot drift out of sync with its own explanation.
+    """
+    assert flows.VstDirectIngest.proves_indexing is False
+    assert flows.AgentThreeStepIngest.proves_indexing is True
+    assert flows.LegacyPutIngest.proves_indexing is True
+
+
+def test_partial_coverage_is_a_failure_not_a_pass(monkeypatch: Any) -> None:
+    """"Something is indexed" passes on 1 video out of 32.
+
+    That is precisely the state readiness already waves through, so a probe
+    that only asks whether the index is non-empty adds nothing.
+    """
+    import run_eval_flows as rf
+
+    class _Backend:
+        vss_cmd: ClassVar[list[str]] = ["vss"]
+        cwd = None
+
+    def one_video(**kw: Any) -> Any:
+        class _Probe:
+            def search(self, query: str) -> tuple[list[dict[str, Any]], float]:
+                return [{"video_name": "clip_a.mp4"}], 0.1
+
+        return _Probe()
+
+    monkeypatch.setattr(flows, "CliQueryBackend", one_video)
+    monkeypatch.setattr(rf.time, "sleep", lambda _s: None)
+    result = rf.probe_index_coverage(
+        _Backend(), ["clip_a", "clip_b", "clip_c"], attempts=2, backoff_s=0
+    )
+    assert result["covered"] is False
+    assert result["missing_count"] == 2
+    assert set(result["missing"]) == {"clip_b", "clip_c"}
+
+
+def test_full_coverage_passes_and_matches_names_the_way_scoring_does(
+    monkeypatch: Any,
+) -> None:
+    """VST spellings differ from dataset names, so reuse the scorer's matcher.
+
+    Comparing raw strings would report every source missing on a perfectly
+    healthy index.
     """
     import run_eval_flows as rf
 
@@ -994,26 +1037,31 @@ def test_the_probe_accepts_any_hit_and_ignores_the_run_tuning(monkeypatch: Any) 
         search_path = "fusion"
         min_cosine_similarity = 0.99
 
-    def fake_backend(**kw: Any) -> Any:
+    def all_videos(**kw: Any) -> Any:
         built.append(kw)
 
         class _Probe:
             def search(self, query: str) -> tuple[list[dict[str, Any]], float]:
-                return [{"video_name": "anything.mp4"}], 0.1
+                return [
+                    {"video_name": "clip_a_20250101_000000_e0482.mp4"},
+                    {"video_name": "clip_b.mp4"},
+                ], 0.1
 
         return _Probe()
 
-    monkeypatch.setattr(flows, "CliQueryBackend", fake_backend)
-    result = rf.probe_index_populated(_Backend(), attempts=3, backoff_s=0)
+    monkeypatch.setattr(flows, "CliQueryBackend", all_videos)
+    result = rf.probe_index_coverage(_Backend(), ["clip_a", "clip_b"], attempts=2, backoff_s=0)
 
-    assert result == {"populated": True, "attempts": 1}
+    assert result == {"checked": True, "covered": True, "attempts": 1, "sources": 2}
+    # A throwaway backend: the run's own --min-cosine-similarity floor or a
+    # non-embed --search-path must not filter a healthy index into an alarm.
     assert built[0]["search_path"] == "embed"
-    assert built[0]["top_k"] == 1
     assert "min_cosine_similarity" not in built[0]
 
 
-def test_an_empty_index_is_retried_then_reported(monkeypatch: Any) -> None:
-    """Webhook-driven perception is async, so "not yet" is the first answer."""
+def test_coverage_is_retried_because_perception_is_asynchronous(
+    monkeypatch: Any,
+) -> None:
     import run_eval_flows as rf
 
     class _Backend:
@@ -1022,24 +1070,21 @@ def test_an_empty_index_is_retried_then_reported(monkeypatch: Any) -> None:
 
     calls = {"n": 0}
 
-    def fake_backend(**kw: Any) -> Any:
+    def filling_up(**kw: Any) -> Any:
         class _Probe:
             def search(self, query: str) -> tuple[list[dict[str, Any]], float]:
                 calls["n"] += 1
-                return ([{"hit": 1}], 0.1) if calls["n"] >= 3 else ([], 0.1)
+                if calls["n"] < 3:
+                    return [{"video_name": "clip_a.mp4"}], 0.1
+                return [{"video_name": "clip_a.mp4"}, {"video_name": "clip_b.mp4"}], 0.1
 
         return _Probe()
 
-    monkeypatch.setattr(flows, "CliQueryBackend", fake_backend)
+    monkeypatch.setattr(flows, "CliQueryBackend", filling_up)
     monkeypatch.setattr(rf.time, "sleep", lambda _s: None)
-    assert rf.probe_index_populated(_Backend(), attempts=5, backoff_s=0) == {
-        "populated": True,
-        "attempts": 3,
-    }
-
-    calls["n"] = -100  # never reaches the success threshold
-    result = rf.probe_index_populated(_Backend(), attempts=2, backoff_s=0)
-    assert result == {"populated": False, "attempts": 2}
+    result = rf.probe_index_coverage(_Backend(), ["clip_a", "clip_b"], attempts=5, backoff_s=0)
+    assert result["covered"] is True
+    assert result["attempts"] == 3
 
 
 def test_a_broken_cli_is_reported_as_itself_not_as_an_empty_index(
@@ -1053,16 +1098,16 @@ def test_a_broken_cli_is_reported_as_itself_not_as_an_empty_index(
         vss_cmd: ClassVar[list[str]] = ["vss"]
         cwd = None
 
-    def fake_backend(**kw: Any) -> Any:
+    def broken(**kw: Any) -> Any:
         class _Probe:
             def search(self, query: str) -> tuple[list[dict[str, Any]], float]:
                 raise flows.CliExitError("vss exited 4 (configuration)")
 
         return _Probe()
 
-    monkeypatch.setattr(flows, "CliQueryBackend", fake_backend)
-    result = rf.probe_index_populated(_Backend(), attempts=5, backoff_s=0)
-    assert result["populated"] is False
+    monkeypatch.setattr(flows, "CliQueryBackend", broken)
+    result = rf.probe_index_coverage(_Backend(), ["clip_a"], attempts=5, backoff_s=0)
+    assert result["covered"] is False
     assert result["attempts"] == 1  # not retried; it will not fix itself
     assert "CliExitError" in result["error"]
 

--- a/skills/benchmarking/benchmark-video-search/skill-card.md
+++ b/skills/benchmarking/benchmark-video-search/skill-card.md
@@ -1,0 +1,21 @@
+## Description: <br>
+Benchmark the retrieval quality and latency of a deployed VSS search profile. Ingests a labelled dataset, runs queries through the `vss` CLI across the embed, attribute, fusion and object paths, and reports precision, recall, mAP, MRR, HIT@k and a per-stage latency breakdown. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA <br>
+
+### License/Terms of Use: <br>
+Apache-2.0 <br>
+
+## Use Case: <br>
+Detecting retrieval regressions between builds, comparing the four search paths on identical ground truth, and locating latency in the search pipeline (embedding generation, Elasticsearch retrieval, result fusion, critic verification). <br>
+
+## Release Date: <br>
+2026 <br>
+
+## References: <br>
+- `references/dataset-format.md` — what a dataset file must contain <br>
+- `references/reading-results.md` — metrics and the stage-latency breakdown <br>
+- `references/troubleshooting.md` — ingestion failures and CLI exit codes <br>


### PR DESCRIPTION
## Search eval as a skill

Adds `skills/benchmarking/benchmark-video-search` — measures retrieval quality
and latency of a deployed search profile. It drives the `vss` CLI, the same path
the product uses now that the agent adapter shells out to `vss search run <mode>
--raw`, rather than the REST endpoint being retired.

One command ingests a labelled dataset, decomposes each query live, runs it down
whichever path the decomposition chooses, and reports precision / recall / mAP /
HIT@k with a per-stage latency breakdown.

### Also in here, found while building it

- **`vss_core`: per-stage timings on `SearchOutput`.** There was no way to say
  where a query's time went. Now every stage self-reports, with concurrent
  children accounted for so overlapping legs don't double-count.
- **Decomposition prompt: teach it the empty case.** `attributes` was the only
  field with no empty-case clause and none of the nine few-shot examples showed
  `"attributes": []`, so the model filled it with the query's action phrase.
  That routes every action query to `fusion` — measured at 9/9 on the warehouse
  set, costing mAP −25%, HIT@1 halved and +59% latency.
- **Critic: distinguish "ran and returned nothing" from "never ran".** Both
  showed up as `unverified`.

### Testing

102 unit tests, no deployment needed. End-to-end runs against a live search
profile on vad-r1-v2 (121 queries, all three paths, critic active).

Tracking JIRA: https://jirasw.nvidia.com/browse/VIA-2524

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.
