### PR TITLE
fix(search): address post-merge TODOs (rtvi-vlm auth, tagging validation, top-percent-filter)

### DIFF
--- a/services/agent/packages/vss_core/src/vss_core/search_core/primitives/_search_helpers.py
+++ b/services/agent/packages/vss_core/src/vss_core/search_core/primitives/_search_helpers.py
@@ -529,6 +529,10 @@ async def execute_core_search(
         # The merge-adjacent headroom doubled ``top_k`` above, but tag mode never
         # runs that merge, so slicing with the doubled value would return up to
         # 2x the requested limit (e.g. top_k=2 returns 4). Cap with the original.
+        # Apply the top-percent filter the embed/attribute path applies after
+        # retrieval; tag mode returns before that common post-processing, so
+        # `--top-percent-filter` would otherwise be a no-op for tag.
+        search_results = _fusion.apply_top_percent_filter(search_results, getattr(config, "top_percent_filter", None))
         yield SearchOutput(data=search_results[:original_top_k], search_messages=search_messages)
         return
 
@@ -651,6 +655,7 @@ async def execute_core_search(
             weights={"tag": config.w_tag, "embed": config.w_embed, "attribute": config.w_attribute},
             rrf_k=config.rrf_k,
         )
+        search_results = _fusion.apply_top_percent_filter(search_results, getattr(config, "top_percent_filter", None))
         if getattr(config, "merge_adjacent", True):
             search_results = _fusion.merge_consecutive_results(search_results)
         yield SearchOutput(data=search_results[:original_top_k], search_messages=search_messages)

--- a/services/agent/packages/vss_core/tests/unit_test/lib/search_core/test_search.py
+++ b/services/agent/packages/vss_core/tests/unit_test/lib/search_core/test_search.py
@@ -933,3 +933,90 @@ class TestTagOnlyDeploymentAndFusionWeights:
                 tag_search=tag,
                 config=_config(fusion_method="weighted_rrf", w_tag=0, w_embed=0, w_attribute=1),
             )
+
+    @pytest.mark.asyncio
+    async def test_tag_mode_applies_top_percent_filter(self) -> None:
+        # The tag-only early return must apply `apply_top_percent_filter` like
+        # the embed/attribute path; otherwise `--top-percent-filter` is a no-op for tag.
+        # tag similarity == lexical_score, so a 0.5 threshold keeps >= 0.5*max.
+        tag = _FakeTag(
+            TagSearchOutput(
+                results=[
+                    TagSearchResultItem(
+                        video_name="keep",
+                        sensor_id="camT",
+                        start_time="2025-01-01T00:00:00Z",
+                        end_time="2025-01-01T00:00:05Z",
+                        lexical_score=1.0,
+                        tags=["red"],
+                    ),
+                    TagSearchResultItem(
+                        video_name="drop",
+                        sensor_id="camT",
+                        start_time="2025-01-01T00:10:00Z",
+                        end_time="2025-01-01T00:10:05Z",
+                        lexical_score=0.1,
+                        tags=["red"],
+                    ),
+                ]
+            )
+        )
+        out = await _run(
+            SearchInput(query="red", source_type="video_file", top_k=2, search_mode="tag"),
+            embed_search=_FakeEmbed([_embed_output([])]),
+            tag_search=tag,
+            config=_config(top_percent_filter=0.5),
+        )
+        assert [r.video_name for r in out.data] == ["keep"]
+
+    @pytest.mark.asyncio
+    async def test_fusion_applies_top_percent_filter(self) -> None:
+        # The fusion early return must apply `apply_top_percent_filter` before
+        # merging/slicing; otherwise `--top-percent-filter` is a no-op for fusion.
+        # Four same-sensor, non-overlapping embed hits with rrf_k=1 (rrf weights
+        # are 1.0) produce fused scores 1/(1+rank) = 0.5/0.333/0.25/0.2;
+        # a 0.5 threshold (>= 0.25) drops the 4th (e4).
+        embed = _FakeEmbed(
+            [
+                _embed_output(
+                    [
+                        _embed_item(
+                            video_name="e1",
+                            sensor_id="camE",
+                            similarity=1.0,
+                            start="2025-01-01T00:00:00Z",
+                            end="2025-01-01T00:00:05Z",
+                        ),
+                        _embed_item(
+                            video_name="e2",
+                            sensor_id="camE",
+                            similarity=0.8,
+                            start="2025-01-01T00:10:00Z",
+                            end="2025-01-01T00:10:05Z",
+                        ),
+                        _embed_item(
+                            video_name="e3",
+                            sensor_id="camE",
+                            similarity=0.6,
+                            start="2025-01-01T00:20:00Z",
+                            end="2025-01-01T00:20:05Z",
+                        ),
+                        _embed_item(
+                            video_name="e4",
+                            sensor_id="camE",
+                            similarity=0.4,
+                            start="2025-01-01T00:30:00Z",
+                            end="2025-01-01T00:30:05Z",
+                        ),
+                    ]
+                )
+            ]
+        )
+        out = await _run(
+            SearchInput(query="red", source_type="video_file", top_k=4, search_mode="fusion"),
+            embed_search=embed,
+            tag_search=_FakeTag(),
+            config=_config(fusion_method="rrf", rrf_k=1, top_percent_filter=0.5),
+        )
+        assert {r.video_name for r in out.data} == {"e1", "e2", "e3"}
+        assert "e4" not in {r.video_name for r in out.data}

--- a/skills/operations/vss-manage-video-io-storage/references/provision-vios-source.md
+++ b/skills/operations/vss-manage-video-io-storage/references/provision-vios-source.md
@@ -216,11 +216,34 @@ POST http://localhost:<rt-vlm-port>/v1/streams/add    # RTSP: feed the VIOS live
 # prompt.
 #   Upload (VOD): one finite call, then delete the temporary asset —
 TAG_PROMPT='Analyze only this video interval. Return JSON only with exactly two fields: "tags", an array of concise visible concepts, actions, objects, and events; and "description", one concise factual sentence. Do not infer facts that are not visible.'
-curl -s -X POST "http://localhost:<rt-vlm-port>/v1/generate_captions" \
+#   Capture the HTTP status and body; fail on >=400. Require at least one
+#   chunk in the response (the VOD body is a JSON object whose
+#   `chunk_responses` array carries the per-chunk tag output) — a 2xx with zero chunks
+#   can never yield tag hits, so it is a provisioning failure, not a silent
+#   success. Release the temporary RT-VLM file asset afterwards either way.
+tag_body=$(mktemp)
+if tag_code=$(curl -sS -o "$tag_body" -w '%{http_code}' \
+  -X POST "http://localhost:<rt-vlm-port>/v1/generate_captions" \
   -H "Content-Type: application/json" \
   --data-binary @- <<EOF
 {"id":"<sensorId>","model":"<resolved-vlm-model>","url":"<vios-storage-url>","creation_time":"<upload-anchor>","prompt":$(printf '%s' "$TAG_PROMPT" | jq -Rs .),"response_format":{"type":"json_object"},"temperature":0,"chunk_duration":5,"stream":false}
 EOF
+); then :; else
+  echo "rt-vlm tagging request failed (curl exit $?)" >&2
+  curl -s -X DELETE "http://localhost:<rt-vlm-port>/v1/files/<sensorId>" >/dev/null 2>&1 || true
+  rm -f "$tag_body"; exit 1
+fi
+case "$tag_code" in 2*|3*) : ;; *)
+  echo "rt-vlm tagging failed (http ${tag_code:-unknown})" >&2
+  curl -s -X DELETE "http://localhost:<rt-vlm-port>/v1/files/<sensorId>" >/dev/null 2>&1 || true
+  rm -f "$tag_body"; exit 1
+;; esac
+if ! jq -e '((.chunk_responses // .chunks // .data // []) | length) > 0' "$tag_body" >/dev/null 2>&1; then
+  echo "rt-vlm tagging produced no chunks (http ${tag_code}); cannot yield tag hits" >&2
+  curl -s -X DELETE "http://localhost:<rt-vlm-port>/v1/files/<sensorId>" >/dev/null 2>&1 || true
+  rm -f "$tag_body"; exit 1
+fi
+rm -f "$tag_body"
 #   then release the temporary RT-VLM file asset:
 curl -s -X DELETE "http://localhost:<rt-vlm-port>/v1/files/<sensorId>"
 #   Live (RTSP): register, then confirm admission (HTTP 200) and intentionally close

--- a/skills/vss-build-vision-ai/references/services/ingress.md
+++ b/skills/vss-build-vision-ai/references/services/ingress.md
@@ -65,8 +65,14 @@ backend rule**; tagging needs no new backend rule. For a build that resolves the
 `generate_captions` tagging leg can be driven from any host that reaches the origin,
 not only the deploy host's loopback. This is a conscious tradeoff: it
 re-exposes RT-VLM's SSE-generation and stream/file-mutation endpoints through
-HAProxy, so the origin's host-allowlist is the only boundary — front RT-VLM only
-when the build needs remote-driven tagging, and never on an unauthenticated origin.
+HAProxy, and the origin's host-allowlist is **not** a credential — any caller
+that can reach the origin can invoke inference and stream/file mutation. Do
+**not** copy `/rtvi-vlm` into the curated ingress unless an explicit
+authentication gate fronts the route; the default is loopback-only (the
+tagging leg is driven from the deploy host's loopback). A build that needs
+remote-driven tagging from other hosts must add an authentication gate
+(e.g. an authenticated reverse proxy or mTLS) before fronting `/rtvi-vlm`
+on the public origin.
 A side effect is that `vss configure` then records `rt_vlm` present, which
 activates the search CLI's fail-open critic (retrieval is unaffected). A build
 that uses RT-VLM only for Critic verification (no tagging leg) keeps it


### PR DESCRIPTION
## Summary

Addresses the three **TODO (non-blocking)** review comments left at merge time on PR #1785 (feat(search): add RT-VLM tag ingestion and BM25 tag search).

## Changes

1. **`ingress.md` — `/rtvi-vlm` auth gate (TODO 1).** The route's host-allowlist is not a credential, so any caller that can reach the origin can invoke RT-VLM inference and stream/file mutation. Made the requirement actionable: do **not** copy `/rtvi-vlm` into the curated ingress unless an explicit authentication gate fronts the route; the default is loopback-only, and a build that needs remote-driven tagging must add an auth gate (e.g. authenticated reverse proxy or mTLS) before fronting it publicly.

2. **`provision-vios-source.md` — finite tagging call validation (TODO 2).** The VOD `generate_captions` call neither failed on HTTP 4xx/5xx nor validated the response body, so a 2xx with zero/malformed chunks was still followed by asset deletion and reported as a provisioned upload that could never yield tag hits. Now captures the HTTP status and body, fails on >=400, requires at least one chunk in the response (the VOD body's `chunks`/`data` array), then releases the temporary RT-VLM file asset — on failure, cleans up the asset and exits non-zero. The `curl` is wrapped in `if/else` so a connection failure (non-zero curl exit) is handled under `set -e` instead of leaking the temp file.

3. **`_search_helpers.py` — `--top-percent-filter` on tag/fusion (TODO 3).** The tag-only and fusion early returns bypassed the common `apply_top_percent_filter()` call, so `vss search run tag|fusion --top-percent-filter ...` returned the same set as without the flag. Now applies the filter on both early-return paths (fusion: after `fuse_ranked_union`, before merge; tag: before the `top_k` slice), matching the embed/attribute path's ordering. Added action-level regression tests for both the tag and fusion paths (`test_tag_mode_applies_top_percent_filter`, `test_fusion_applies_top_percent_filter`).

## Verification

- 1370 tests pass; mypy clean (62 files); ruff check + format clean.
- DCO sign-off on the commit; pre-commit hooks passed (TruffleHog, ruff, SPDX, DCO).

## Related Issue
VIA-2753

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally.
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.