### PR TITLE
Enhanced blueprint-deploy and cleanup scripts for improved functionality

### DIFF
--- a/deploy/docker/scripts/blueprint-deploy.sh
+++ b/deploy/docker/scripts/blueprint-deploy.sh
@@ -1549,7 +1549,7 @@ function run_data_log_cleanup() {
 }
 
 function state_down() {
-  local _deploy_dir_names _deploy_dir_name _deploy_dir _source_env _overrides_env _generated_env
+  local _deploy_dir_names _deploy_dir_name _deploy_dir _source_env _overrides_env _generated_env _deploy_rel
 
   _deploy_dir_names=('industry-profiles/warehouse-operations')
 
@@ -1565,6 +1565,7 @@ function state_down() {
     done
   fi
   _compose_project_name="${_compose_project_name:-vss}"
+  _deploy_rel="industry-profiles/warehouse-operations"
 
   echo "[INFO] Cleaning up generated.env files from warehouse..."
   for _deploy_dir_name in "${_deploy_dir_names[@]}"; do
@@ -1581,9 +1582,17 @@ function state_down() {
 
   echo "[INFO] Bringing down docker compose project '${_compose_project_name}' (with volumes)..."
   if [[ "${dry_run}" == "true" ]]; then
-    echo "[DRY-RUN] docker compose -p ${_compose_project_name} down -v --remove-orphans"
+    echo "[DRY-RUN] cd ${deployment_directory} && docker compose -p ${_compose_project_name} -f compose.yml --env-file containers.env --env-file ${_deploy_rel}/.env --env-file ${_deploy_rel}/overrides.env down -v --remove-orphans"
   else
-    docker compose -p "${_compose_project_name}" down -v --remove-orphans
+    (
+      cd "${deployment_directory}" && docker compose \
+        -p "${_compose_project_name}" \
+        -f compose.yml \
+        --env-file containers.env \
+        --env-file "${_deploy_rel}/.env" \
+        --env-file "${_deploy_rel}/overrides.env" \
+        down -v --remove-orphans
+    )
   fi
 
   echo "[INFO] Removing dangling docker volumes..."
@@ -1598,8 +1607,17 @@ function state_down() {
     fi
   fi
 
-  echo "[INFO] Cleaning VSS_DATA_DIR data_log (kafka, elastic, redis, vst, nvstreamer, vss_video_analytics_api, etc.)..."
-  run_data_log_cleanup
+  echo "[INFO] Cleaning VSS_DATA_DIR data_log with cleanup_all_datalog.sh..."
+  if [[ "${dry_run}" == "true" ]]; then
+    echo "[DRY-RUN] VSS_DATA_DIR=${data_directory} VSS_APPS_DIR=${deployment_directory} bash scripts/cleanup_all_datalog.sh -e ${_deploy_rel}/overrides.env"
+  else
+    (
+      cd "${deployment_directory}" && \
+        VSS_DATA_DIR="${data_directory}" \
+        VSS_APPS_DIR="${deployment_directory}" \
+        bash scripts/cleanup_all_datalog.sh -e "${_deploy_rel}/overrides.env"
+    )
+  fi
 
   echo "[INFO] State down completed"
 }

--- a/deploy/docker/scripts/cleanup_all_datalog.sh
+++ b/deploy/docker/scripts/cleanup_all_datalog.sh
@@ -22,6 +22,12 @@ delete_backup_files="true"
 revert_from_oldest_backup="true"
 env_file="${script_dir}/../.env"
 
+# CI containers run as root but intentionally do not install sudo. Keep the
+# existing command sites usable in both CI and interactive host deployments.
+if ! command -v sudo >/dev/null 2>&1 && [[ "$(id -u)" -eq 0 ]]; then
+  sudo() { "$@"; }
+fi
+
 function usage() {
   echo "Usage: ${script_name} (-h|--help)"
   echo "   or: ${script_name} [options]"

--- a/services/analytics/video-analytics-api/test/integration-test/README.md
+++ b/services/analytics/video-analytics-api/test/integration-test/README.md
@@ -71,7 +71,7 @@ Generated in `docker_compose/infra/.env` by `generate_env.sh`:
 
 Exported by `scripts/run_integration_tests.sh` so the controller suites know which
 deployment profile they run against — the stack loads the warehouse 2D dump, so they
-default to that profile and profile-gated cases (such as the VLM verified alert types
+default to that profile and profile-gated cases (such as the VLM verification-coverage
 check on `/incidents`) run. Set them beforehand to exercise a different profile:
 
 - `COMPOSE_PROFILE` – `bp_wh_2d`


### PR DESCRIPTION
- Added a new variable `_deploy_rel` in the `state_down` function to streamline environment file handling.
- Updated the `docker compose` command to include specific environment files for better configuration management during the down process.
- Modified the data log cleanup process to utilize `cleanup_all_datalog.sh` with appropriate environment variables, improving clarity and functionality.
- Added a check for `sudo` command availability in `cleanup_all_datalog.sh` to ensure compatibility in CI environments.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
