### PR TITLE
fix(ui): show tool names in agent traces

### DIFF
--- a/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
@@ -18,6 +18,7 @@ from collections.abc import Hashable
 import copy
 from datetime import UTC
 from datetime import datetime
+from html import escape
 import json
 import logging
 import re
@@ -97,6 +98,16 @@ _TOOL_FAILURE_PREFIX = "Tool call failed:"
 _TOOL_FAILURE_STATUSES = {"aborted", "error", "failed", "failure"}
 _REQUEST_OPTIONS_CONTEXT_MARKERS = ("current_request_options", "previous_request_options")
 _CONTEXT_BLOCK_PREFIX = "[Context:"
+_TRACE_TOOL_NAME = re.compile(r"^(?:Tool|Calling sub-agent):\s*([^\r\n]+)", re.IGNORECASE)
+
+
+def trace_step_title(step_number: int, step_type: str, content: str) -> str:
+    """Build a trace heading that exposes the called tool when one is present."""
+    tool_name = _TRACE_TOOL_NAME.match(content.strip())
+    if not tool_name:
+        return f"{step_number} - {step_type}"
+    # This becomes an HTML attribute in the legacy chat response.
+    return f"{step_number} - {step_type}: {escape(tool_name.group(1).strip(), quote=True)}"
 
 
 class TopAgentRequest(ChatRequestOrMessage):
@@ -1732,13 +1743,13 @@ async def top_agent(config: TopAgentConfig, builder: Builder) -> AsyncGenerator[
                 elif chunk.type == AgentMessageChunkType.TOOL_CALL:
                     step_num += 1
                     clean_content = chunk.content.replace("\\n", " ").replace("\n", " ")
-                    steps.append(f'<agent-think-step title="{step_num} - Tool Call">{clean_content}</agent-think-step>')
+                    title = trace_step_title(step_num, "Tool Call", chunk.content)
+                    steps.append(f'<agent-think-step title="{title}">{clean_content}</agent-think-step>')
                 elif chunk.type == AgentMessageChunkType.SUBAGENT_CALL:
                     step_num += 1
                     clean_content = chunk.content.replace("\\n", " ").replace("\n", " ")
-                    steps.append(
-                        f'<agent-think-step title="{step_num} - Sub-Agent Call">{clean_content}</agent-think-step>'
-                    )
+                    title = trace_step_title(step_num, "Sub-Agent Call", chunk.content)
+                    steps.append(f'<agent-think-step title="{title}">{clean_content}</agent-think-step>')
                 elif chunk.type == AgentMessageChunkType.FINAL:
                     final_content.append(chunk.content)
                 elif chunk.type == AgentMessageChunkType.ERROR:

--- a/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
@@ -40,6 +40,7 @@ from vss_agents.agents.top_agent import TopAgentRequest
 from vss_agents.agents.top_agent import TopAgentState
 from vss_agents.agents.top_agent import _augment_context_clip_offsets
 from vss_agents.agents.top_agent import strip_frontend_tags
+from vss_agents.agents.top_agent import trace_step_title
 from vss_agents.tools.lvs_config_media import LVS_CONFIG_MEDIA_BLOCKED_MESSAGE
 
 
@@ -58,6 +59,20 @@ class TestTopAgentConstants:
 
     def test_empty_scratchpad_error(self):
         assert "agent_scratchpad" in EMPTY_SCRATCHPAD_ERROR
+
+
+class TestTraceStepTitle:
+    def test_includes_the_tool_name_in_a_tool_call_step(self):
+        assert trace_step_title(2, "Tool Call", "Tool: vss_search\nArgs: {}") == "2 - Tool Call: vss_search"
+
+    def test_includes_the_tool_name_in_a_subagent_call_step(self):
+        assert (
+            trace_step_title(3, "Sub-Agent Call", "Calling sub-agent: video_search\nArgs: {}")
+            == "3 - Sub-Agent Call: video_search"
+        )
+
+    def test_escapes_tool_names_for_the_html_title_attribute(self):
+        assert trace_step_title(1, "Tool Call", 'Tool: search"<unsafe>') == "1 - Tool Call: search&quot;&lt;unsafe&gt;"
 
 
 class TestStripFrontendTags:

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/__tests__/ChatPanel.test.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/__tests__/ChatPanel.test.tsx
@@ -289,6 +289,26 @@ describe('ChatPanel', () => {
     expect(screen.getByText('vss-search-archive')).toBeInTheDocument();
   });
 
+  it('keeps workflow children visible when a start frame is replaced by completion', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      sseResponse([
+        'intermediate_data: {"id":"workflow","name":"Function Start: <workflow>","parent_id":"root"}\n',
+        'intermediate_data: {"id":"model","name":"nvidia/model","parent_id":"workflow"}\n',
+        'intermediate_data: {"id":"workflow","name":"Function Complete: <workflow>","parent_id":"root","status":"complete"}\n',
+        'data: {"choices":[{"delta":{"content":"done"}}]}\n\n',
+        'data: [DONE]\n\n',
+      ]),
+    ) as any;
+
+    render(<ChatPanel endpoint={endpoint} features={noHeader} />);
+    await act(async () => typeAndSend('run'));
+
+    await waitFor(() => expect(screen.getByText(/Intermediate steps \(1\)/)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(/Intermediate steps \(1\)/));
+    expect(screen.getByText('nvidia/model')).toBeInTheDocument();
+    expect(screen.queryByText(/Function (?:Start|Complete): <workflow>/)).not.toBeInTheDocument();
+  });
+
   it('notifies the embedder when a turn starts and ends', async () => {
     global.fetch = jest.fn().mockResolvedValue(sseResponse(['data: [DONE]\n\n'])) as any;
     const onBusyChange = jest.fn();

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/__tests__/agentThink.test.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/__tests__/agentThink.test.tsx
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: MIT AND Apache-2.0
+import { stepTitleWithToolName } from '../lib-src/markdown/AgentThink';
+
+describe('stepTitleWithToolName', () => {
+  it('shows the named tool for legacy generic tool-call headings', () => {
+    expect(stepTitleWithToolName('2 - Tool Call', 'Tool: vss_search\nArgs: {}')).toBe('2 - Tool Call: vss_search');
+  });
+
+  it('leaves already-specific and non-tool headings unchanged', () => {
+    expect(stepTitleWithToolName('2 - Tool Call: vss_search', 'Tool: vss_search')).toBe('2 - Tool Call: vss_search');
+    expect(stepTitleWithToolName('3 - Thought', 'Tool: vss_search')).toBe('3 - Thought');
+  });
+});

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/__tests__/agentThink.test.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/__tests__/agentThink.test.tsx
@@ -7,6 +7,18 @@ describe('stepTitleWithToolName', () => {
     expect(stepTitleWithToolName('2 - Tool Call', 'Tool: vss_search\nArgs: {}')).toBe('2 - Tool Call: vss_search');
   });
 
+  it('does not include normalized arguments or results in the tool heading', () => {
+    expect(stepTitleWithToolName('2 - Tool Call', 'Tool: vss_search Args: {} Result: found')).toBe(
+      '2 - Tool Call: vss_search',
+    );
+  });
+
+  it('shows the named sub-agent for legacy generic sub-agent headings', () => {
+    expect(stepTitleWithToolName('3 - Sub-Agent Call', 'Calling sub-agent: search_agent Args: {}')).toBe(
+      '3 - Sub-Agent Call: search_agent',
+    );
+  });
+
   it('leaves already-specific and non-tool headings unchanged', () => {
     expect(stepTitleWithToolName('2 - Tool Call: vss_search', 'Tool: vss_search')).toBe('2 - Tool Call: vss_search');
     expect(stepTitleWithToolName('3 - Thought', 'Tool: vss_search')).toBe('3 - Thought');

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/__tests__/steps.test.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/__tests__/steps.test.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { SseParser, buildStepTree } from '../lib-src/sse';
+import { SseParser, buildDisplayStepTree, buildStepTree, countDisplaySteps } from '../lib-src/sse';
 import { buildContextPrefix } from '../lib-src/useChatStream';
 import type { ChatStep } from '../lib-src/types';
 
@@ -35,6 +35,18 @@ describe('buildStepTree', () => {
     const tree = buildStepTree([step('a', 'a')]);
     expect(tree.map((s) => s.id)).toEqual(['a']);
     expect(tree[0].children).toEqual([]);
+  });
+
+  it('flattens the synthetic workflow root for display', () => {
+    const steps = [
+      { ...step('workflow'), name: 'Function Start: <workflow>' },
+      step('model', 'workflow'),
+      step('search_agent', 'model'),
+    ];
+
+    const displayTree = buildDisplayStepTree(steps);
+    expect(displayTree.map((node) => node.name)).toEqual(['model', 'search_agent']);
+    expect(countDisplaySteps(displayTree)).toBe(2);
   });
 });
 

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/__tests__/steps.test.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/__tests__/steps.test.ts
@@ -45,8 +45,18 @@ describe('buildStepTree', () => {
     ];
 
     const displayTree = buildDisplayStepTree(steps);
-    expect(displayTree.map((node) => node.name)).toEqual(['model', 'search_agent']);
+    expect(displayTree.map((node) => node.name)).toEqual(['model']);
+    expect(displayTree[0].children?.map((node) => node.name)).toEqual(['search_agent']);
     expect(countDisplaySteps(displayTree)).toBe(2);
+  });
+
+  it('also removes a completed synthetic workflow root', () => {
+    const steps = [
+      { ...step('workflow'), name: 'Function Complete: <workflow>' },
+      step('search_agent', 'workflow'),
+    ];
+
+    expect(buildDisplayStepTree(steps).map((node) => node.name)).toEqual(['search_agent']);
   });
 });
 

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/ChatSteps.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/ChatSteps.tsx
@@ -13,7 +13,7 @@
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import React, { useState } from 'react';
 
-import { buildStepTree } from './sse';
+import { buildDisplayStepTree, countDisplaySteps } from './sse';
 import type { ChatStep } from './types';
 
 const STATUS_DOT: Record<ChatStep['status'], string> = {
@@ -82,7 +82,8 @@ export const ChatSteps: React.FC<ChatStepsProps> = ({ steps, streaming, expandBy
   const open = manual ?? (!!streaming || !!expandByDefault);
   if (!steps.length) return null;
 
-  const tree = buildStepTree(steps);
+  const tree = buildDisplayStepTree(steps);
+  const displayedStepCount = countDisplaySteps(tree);
 
   return (
     <div className="mb-2 rounded-md border border-neutral-200 bg-neutral-50 px-3 py-2 dark:border-neutral-700 dark:bg-neutral-900/60">
@@ -94,7 +95,7 @@ export const ChatSteps: React.FC<ChatStepsProps> = ({ steps, streaming, expandBy
       >
         {open ? <IconChevronDown size={14} /> : <IconChevronRight size={14} />}
         <span>
-          Intermediate steps ({steps.length}){streaming ? ' — running' : ''}
+          Intermediate steps ({displayedStepCount}){streaming ? ' — running' : ''}
         </span>
       </button>
       {open && (

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/ChatSteps.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/ChatSteps.tsx
@@ -83,6 +83,7 @@ export const ChatSteps: React.FC<ChatStepsProps> = ({ steps, streaming, expandBy
   if (!steps.length) return null;
 
   const tree = buildDisplayStepTree(steps);
+  if (!tree.length) return null;
   const displayedStepCount = countDisplaySteps(tree);
 
   return (

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/markdown/AgentThink.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/markdown/AgentThink.tsx
@@ -29,6 +29,26 @@ interface ThinkProps {
   messageIsStreaming?: boolean;
 }
 
+const textFromReactNode = (node: React.ReactNode): string =>
+  React.Children.toArray(node)
+    .map((child) => {
+      if (typeof child === 'string' || typeof child === 'number') return String(child);
+      if (React.isValidElement<{ children?: React.ReactNode }>(child)) return textFromReactNode(child.props.children);
+      return '';
+    })
+    .join('');
+
+/**
+ * Older agent streams label every tool step simply "Tool Call", but put the
+ * actual tool name at the start of the step body. Keep those traces useful
+ * without requiring the backend to be upgraded in lockstep with the UI.
+ */
+export const stepTitleWithToolName = (title: string | undefined, children: React.ReactNode): string | undefined => {
+  if (!title || !/(?:^| - )Tool Call$/i.test(title)) return title;
+  const tool = textFromReactNode(children).match(/^\s*Tool:\s*([^\r\n]+)/i)?.[1]?.trim();
+  return tool ? `${title}: ${tool}` : title;
+};
+
 export const AgentThink: React.FC<ThinkProps> = ({
   children,
   title,
@@ -101,6 +121,7 @@ export const AgentThinkStep: React.FC<ThinkProps> = ({
   ...props
 }) => {
   const isStreaming = props['data-streaming'] === 'true' && !!messageIsStreaming;
+  const displayTitle = stepTitleWithToolName(title, children);
   // Steps stay open once written — unlike the parent trace, a finished step is
   // the part a user goes back to read.
   const [isOpen, setIsOpen] = useState(true);
@@ -133,7 +154,7 @@ export const AgentThinkStep: React.FC<ThinkProps> = ({
             )}
             <span className="text-sm font-medium text-gray-700 dark:text-gray-200">
               <strong>Step</strong>
-              {title ? ` - ${title}` : ''}
+              {displayTitle ? ` - ${displayTitle}` : ''}
             </span>
           </span>
           {!isStreaming &&

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/markdown/AgentThink.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/markdown/AgentThink.tsx
@@ -39,14 +39,23 @@ const textFromReactNode = (node: React.ReactNode): string =>
     .join('');
 
 /**
- * Older agent streams label every tool step simply "Tool Call", but put the
- * actual tool name at the start of the step body. Keep those traces useful
+ * Older agent streams use generic tool/sub-agent headings, but put the actual
+ * callable name at the start of the step body. Keep those traces useful
  * without requiring the backend to be upgraded in lockstep with the UI.
  */
 export const stepTitleWithToolName = (title: string | undefined, children: React.ReactNode): string | undefined => {
-  if (!title || !/(?:^| - )Tool Call$/i.test(title)) return title;
-  const tool = textFromReactNode(children).match(/^\s*Tool:\s*([^\r\n]+)/i)?.[1]?.trim();
-  return tool ? `${title}: ${tool}` : title;
+  if (!title) return title;
+
+  const stepType = title.match(/(?:^| - )(Tool Call|Sub-Agent Call)$/i)?.[1]?.toLowerCase();
+  if (!stepType) return title;
+
+  // Legacy markup normalizes body newlines to spaces, so match an identifier
+  // rather than reading to end-of-line and accidentally including Args/Result.
+  const prefix = stepType === 'tool call' ? 'Tool' : 'Calling sub-agent';
+  const callable = textFromReactNode(children).match(
+    new RegExp(`^\\s*${prefix}:\\s*([A-Za-z0-9_.:/-]+)`, 'i'),
+  )?.[1];
+  return callable ? `${title}: ${callable}` : title;
 };
 
 export const AgentThink: React.FC<ThinkProps> = ({

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/sse.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/sse.ts
@@ -77,16 +77,9 @@ export function buildDisplayStepTree(steps: ChatStep[]): ChatStep[] {
   const tree = buildStepTree(steps);
   const visible: ChatStep[] = [];
 
-  const appendDescendants = (nodes: ChatStep[]) => {
-    for (const node of nodes) {
-      visible.push({ ...node, children: [] });
-      appendDescendants(node.children ?? []);
-    }
-  };
-
   for (const node of tree) {
-    if (/^Function Start:\s*<workflow>$/i.test(node.name)) {
-      appendDescendants(node.children ?? []);
+    if (/^Function (?:Start|Complete):\s*<workflow>$/i.test(node.name)) {
+      visible.push(...(node.children ?? []));
     } else {
       visible.push(node);
     }

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/sse.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/sse.ts
@@ -67,6 +67,38 @@ export function buildStepTree(steps: ChatStep[]): ChatStep[] {
   return roots;
 }
 
+/**
+ * The NAT event stream wraps a turn in a synthetic workflow span. It is
+ * bookkeeping rather than an action the user asked the agent to take, and
+ * nesting everything under it makes an "Intermediate steps (N)" disclosure
+ * appear to contain only one item. Show its descendants as the visible list.
+ */
+export function buildDisplayStepTree(steps: ChatStep[]): ChatStep[] {
+  const tree = buildStepTree(steps);
+  const visible: ChatStep[] = [];
+
+  const appendDescendants = (nodes: ChatStep[]) => {
+    for (const node of nodes) {
+      visible.push({ ...node, children: [] });
+      appendDescendants(node.children ?? []);
+    }
+  };
+
+  for (const node of tree) {
+    if (/^Function Start:\s*<workflow>$/i.test(node.name)) {
+      appendDescendants(node.children ?? []);
+    } else {
+      visible.push(node);
+    }
+  }
+  return visible;
+}
+
+/** Count the entries users can reach in a rendered step tree. */
+export function countDisplaySteps(steps: ChatStep[]): number {
+  return steps.reduce((count, step) => count + 1 + countDisplaySteps(step.children ?? []), 0);
+}
+
 const PREFIXES = {
   data: 'data: ',
   step: 'intermediate_data: ',


### PR DESCRIPTION
## Summary
- include the called tool or sub-agent in backend trace headings
- derive tool names in the chat UI for streams from older backends
- add focused backend and UI coverage

## Validation
- uv run --project . --extra agent python -m pytest packages/vss_agents/tests/unit_test/agents/test_top_agent.py -q
- uv run --project . --extra agent ruff check packages/vss_agents/src/vss_agents/agents/top_agent.py packages/vss_agents/tests/unit_test/agents/test_top_agent.py
- npm test --workspace=@nv-metropolis-bp-vss-ui/chat -- --runInBand agentThink.test.tsx
- npm run typecheck --workspace=@nv-metropolis-bp-vss-ui/chat