### PR TITLE
fix(rt-vlm): suppress Qwen3-VL reasoning output

### DIFF
--- a/services/rtvi/rt-vlm/src/models/vllm_compatible/vllm_compatible_model.py
+++ b/services/rtvi/rt-vlm/src/models/vllm_compatible/vllm_compatible_model.py
@@ -4092,12 +4092,30 @@ class VllmCompatible(BaseVlmModel):
         self._inflight_req_ids.append(request_id)
 
         previous_text = ""
+        enforce_answer_boundary = (
+            self._model_architecture in _QWEN3VL_ARCHS
+            and not config.enable_reasoning
+            and bool(config.ignore_eos)
+        )
+        answer_boundary_seen = False
         try:
             async for output_item in self._llm.generate(
                 llm_inputs, sampling_params=vllm_sampling_params, request_id=request_id
             ):
                 if output_item.outputs:
+                    if answer_boundary_seen:
+                        # Keep consuming the fixed-work generation, but never expose
+                        # tokens produced after the logical answer boundary.
+                        continue
                     current_text = output_item.outputs[0].text
+                    if enforce_answer_boundary:
+                        token_ids = tuple(getattr(output_item.outputs[0], "token_ids", ()))
+                        boundary_ids = self._qwen3vl_answer_boundary_token_ids()
+                        answer_boundary_seen = any(
+                            token_id in boundary_ids for token_id in token_ids
+                        )
+                        if answer_boundary_seen:
+                            current_text = self._truncate_qwen3vl_non_reasoning_output(output_item)
                     delta = current_text[len(previous_text) :]
                     if delta:
                         previous_text = current_text

--- a/services/rtvi/rt-vlm/src/models/vllm_compatible/vllm_compatible_model.py
+++ b/services/rtvi/rt-vlm/src/models/vllm_compatible/vllm_compatible_model.py
@@ -1750,6 +1750,69 @@ class VllmCompatible(BaseVlmModel):
             return {"enable_thinking": bool(config.enable_reasoning)}
         return {}
 
+    def _apply_chat_template(self, messages: list[dict], config: VlmGenerationConfig) -> str:
+        """Apply the model template with a Qwen3-VL non-reasoning fallback."""
+        template_messages = messages
+        suppress_qwen_reasoning = (
+            self._model_architecture in _QWEN3VL_ARCHS and not config.enable_reasoning
+        )
+        if suppress_qwen_reasoning:
+            template_messages = copy.deepcopy(messages)
+            for message in reversed(template_messages):
+                if message.get("role") != "user":
+                    continue
+                content = message.get("content")
+                if isinstance(content, str):
+                    message["content"] = f"{content} /no_think"
+                elif isinstance(content, list):
+                    for item in reversed(content):
+                        if isinstance(item, dict) and item.get("type") == "text":
+                            item["text"] = f"{item.get('text', '')} /no_think"
+                            break
+                break
+
+        prompt = self._processor.apply_chat_template(
+            template_messages,
+            tokenize=False,
+            add_generation_prompt=True,
+            **self._get_apply_chat_template_kwargs(config),
+        )
+        if suppress_qwen_reasoning and not prompt.rstrip().endswith("</think>"):
+            prompt += "<think>\n\n</think>\n\n"
+        return prompt
+
+    def _apply_reasoning_suppression_sampling_params(
+        self, sampling_kwargs: dict, config: VlmGenerationConfig
+    ) -> None:
+        """Block reasoning tags without changing fixed-work generation length."""
+        if self._model_architecture in _QWEN3VL_ARCHS and not config.enable_reasoning:
+            sampling_kwargs["bad_words"] = ["<think>", "</think>"]
+
+    def _qwen3vl_answer_boundary_token_ids(self) -> set[int]:
+        tokenizer = self._processor.tokenizer
+        boundary_ids = set()
+        eos_token_ids = getattr(tokenizer, "eos_token_id", None)
+        if isinstance(eos_token_ids, int):
+            boundary_ids.add(eos_token_ids)
+        elif eos_token_ids is not None:
+            boundary_ids.update(int(token_id) for token_id in eos_token_ids)
+
+        im_end_id = tokenizer.convert_tokens_to_ids("<|im_end|>")
+        if isinstance(im_end_id, int) and im_end_id != getattr(tokenizer, "unk_token_id", None):
+            boundary_ids.add(im_end_id)
+        return boundary_ids
+
+    def _truncate_qwen3vl_non_reasoning_output(self, output) -> str:
+        generated = output.outputs[0]
+        token_ids = list(getattr(generated, "token_ids", ()))
+        boundary_ids = self._qwen3vl_answer_boundary_token_ids()
+        for index, token_id in enumerate(token_ids):
+            if token_id in boundary_ids:
+                return self._processor.tokenizer.decode(
+                    token_ids[:index], skip_special_tokens=True
+                ).rstrip()
+        return generated.text
+
     def _remove_orphan_think_tags(self, text: str, reasoning_description: str) -> tuple:
         # Handle orphan </think> (no opening <think> — start token was cut off or never generated).
         # Everything before </think> is reasoning; everything after is the actual answer.
@@ -1779,6 +1842,7 @@ class VllmCompatible(BaseVlmModel):
         chunk=None,
         ignore_eos=False,
         preserve_reasoning_tags=False,
+        enable_reasoning=True,
     ):
         with TimeMeasure("VLLM postprocess"):
             original_output = output
@@ -1803,12 +1867,18 @@ class VllmCompatible(BaseVlmModel):
                 ]
 
             generated_text = output[0].outputs[0].text
+            if (
+                self._model_architecture in _QWEN3VL_ARCHS
+                and not enable_reasoning
+                and ignore_eos
+            ):
+                generated_text = self._truncate_qwen3vl_non_reasoning_output(output[0])
             logger.debug("VLLM raw text output: %s", generated_text)
             if not generated_text:
                 logger.warning("Empty response from model")
                 return [VlmModelOutput(output="", input_tokens=0, output_tokens=0)]
 
-            if preserve_reasoning_tags:
+            if preserve_reasoning_tags and enable_reasoning:
                 final_response = generated_text.strip() if not ignore_eos else generated_text
                 reasoning_description = ""
             else:
@@ -1829,6 +1899,8 @@ class VllmCompatible(BaseVlmModel):
                     cleaned_text, reasoning_description = self._remove_orphan_think_tags(
                         cleaned_text, reasoning_description
                     )
+                if not enable_reasoning:
+                    reasoning_description = ""
                 logger.debug("VLLM reasoning description: %s", reasoning_description)
                 # Step 4: Remove <answer>, </answer>, <summary>, and </summary> tags, but keep their content
                 for tag in ["<answer>", "</answer>", "<summary>", "</summary>"]:
@@ -2285,6 +2357,7 @@ class VllmCompatible(BaseVlmModel):
         chunk=None,
         preserve_reasoning_tags=False,
         stream_id: Optional[str] = None,
+        generation_config: Optional[VlmGenerationConfig] = None,
     ):
         try:
             return await self._process_async_vllm(
@@ -2294,6 +2367,7 @@ class VllmCompatible(BaseVlmModel):
                 request_id,
                 chunk,
                 preserve_reasoning_tags,
+                generation_config,
             )
         finally:
             self._release_live_request(stream_id, request_id)
@@ -2306,6 +2380,7 @@ class VllmCompatible(BaseVlmModel):
         request_id,
         chunk=None,
         preserve_reasoning_tags=False,
+        generation_config: Optional[VlmGenerationConfig] = None,
     ):
         use_tensor_ipc = getattr(self, "_use_cuda_mm_tensor_ipc", False)
         if CPU_COPY_OTHER_THREAD:
@@ -2473,6 +2548,7 @@ class VllmCompatible(BaseVlmModel):
                 else False
             ),
             preserve_reasoning_tags,
+            generation_config.enable_reasoning if generation_config is not None else True,
         )
 
     @staticmethod
@@ -3690,12 +3766,7 @@ class VllmCompatible(BaseVlmModel):
         # default non-reasoning unless the request explicitly enables reasoning.
         apply_chat_template_kwargs = self._get_apply_chat_template_kwargs(config)
 
-        prompt = self._processor.apply_chat_template(
-            messages,
-            tokenize=False,
-            add_generation_prompt=True,
-            **apply_chat_template_kwargs,
-        )
+        prompt = self._apply_chat_template(messages, config)
 
         # NemotronH_Nano_VL_V2/Omni_Reasoning_V3 chat template stringifies multimodal content
         # dicts rather than inserting placeholder tokens. Detect this and rebuild with explicit
@@ -3823,6 +3894,7 @@ class VllmCompatible(BaseVlmModel):
         from vllm import SamplingParams
 
         sp_kwargs = _build_vllm_sampling_kwargs(config)
+        self._apply_reasoning_suppression_sampling_params(sp_kwargs, config)
         vllm_sampling_params = SamplingParams(**sp_kwargs)
         _set_cosmos_no_repeat_ngram_size(vllm_sampling_params, self._vlm_model_type)
 
@@ -3856,9 +3928,10 @@ class VllmCompatible(BaseVlmModel):
                     vllm_sampling_params,
                     video_frames_times,
                     request_id,
-                    chunks[0],
-                    config.preserve_reasoning_tags,
-                    stream_id,
+                    chunk=chunks[0],
+                    preserve_reasoning_tags=config.preserve_reasoning_tags,
+                    stream_id=stream_id,
+                    generation_config=config,
                 ),
                 self._event_loop,
             )
@@ -3902,12 +3975,7 @@ class VllmCompatible(BaseVlmModel):
         """Text-only generation using the vLLM engine (no multimodal data)."""
         config = generation_config or VlmGenerationConfig()
 
-        prompt = self._processor.apply_chat_template(
-            messages,
-            tokenize=False,
-            add_generation_prompt=True,
-            **self._get_apply_chat_template_kwargs(config),
-        )
+        prompt = self._apply_chat_template(messages, config)
         prompt_token_ids = self._processor.tokenizer.encode(prompt, add_special_tokens=False)
 
         llm_inputs = {"prompt_token_ids": prompt_token_ids}
@@ -3915,6 +3983,7 @@ class VllmCompatible(BaseVlmModel):
         from vllm import SamplingParams
 
         sp_kwargs = _build_vllm_sampling_kwargs(config)
+        self._apply_reasoning_suppression_sampling_params(sp_kwargs, config)
         vllm_sampling_params = SamplingParams(**sp_kwargs)
         request_id = str(uuid.uuid4())
         self._inflight_req_ids.append(request_id)
@@ -4009,12 +4078,7 @@ class VllmCompatible(BaseVlmModel):
         """Async generator yielding text deltas for token-level streaming."""
         config = generation_config or VlmGenerationConfig()
 
-        prompt = self._processor.apply_chat_template(
-            messages,
-            tokenize=False,
-            add_generation_prompt=True,
-            **self._get_apply_chat_template_kwargs(config),
-        )
+        prompt = self._apply_chat_template(messages, config)
         prompt_token_ids = self._processor.tokenizer.encode(prompt, add_special_tokens=False)
 
         llm_inputs = {"prompt_token_ids": prompt_token_ids}
@@ -4022,6 +4086,7 @@ class VllmCompatible(BaseVlmModel):
         from vllm import SamplingParams
 
         sp_kwargs = _build_vllm_sampling_kwargs(config)
+        self._apply_reasoning_suppression_sampling_params(sp_kwargs, config)
         vllm_sampling_params = SamplingParams(**sp_kwargs)
         request_id = str(uuid.uuid4())
         self._inflight_req_ids.append(request_id)

--- a/services/rtvi/rt-vlm/tests/model/vllm_compatible/test_input_error_handling.py
+++ b/services/rtvi/rt-vlm/tests/model/vllm_compatible/test_input_error_handling.py
@@ -74,9 +74,39 @@ class _QwenTokenizer:
         assert token_ids == [10, 11]
         return '{"visual_sentinel":"ALPHA"}'
 
+    def encode(self, _prompt, add_special_tokens=False):
+        assert add_special_tokens is False
+        return [1, 2]
+
 
 class _QwenProcessor:
     tokenizer = _QwenTokenizer()
+
+    def apply_chat_template(self, *_args, **_kwargs):
+        return "<|im_start|>assistant\n"
+
+
+class _QwenStreamingLLM:
+    async def generate(self, *_args, **_kwargs):
+        yield SimpleNamespace(
+            outputs=[SimpleNamespace(text='{"visual_sent', token_ids=[10])]
+        )
+        yield SimpleNamespace(
+            outputs=[
+                SimpleNamespace(
+                    text='{"visual_sentinel":"ALPHA"}<|im_end|>',
+                    token_ids=[10, 11, 99],
+                )
+            ]
+        )
+        yield SimpleNamespace(
+            outputs=[
+                SimpleNamespace(
+                    text='{"visual_sentinel":"ALPHA"}<|im_end|>reasoning leak',
+                    token_ids=[10, 11, 99, 20],
+                )
+            ]
+        )
 
 
 class _RequestQueue:
@@ -264,6 +294,32 @@ def test_qwen3vl_non_reasoning_truncates_backend_output_at_first_answer_boundary
     assert result[0].output == '{"visual_sentinel":"ALPHA"}'
     assert result[0].reasoning_description == ""
     assert result[0].output_tokens == 5
+
+
+def test_qwen3vl_non_reasoning_stream_hides_post_boundary_output(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm",
+        SimpleNamespace(SamplingParams=_FakeSamplingParams),
+    )
+    model = VllmCompatible.__new__(VllmCompatible)
+    model._model_architecture = "Qwen3VLForConditionalGeneration"
+    model._processor = _QwenProcessor()
+    model._llm = _QwenStreamingLLM()
+    model._inflight_req_ids = []
+
+    async def collect():
+        config = VlmGenerationConfig(enable_reasoning=False, ignore_eos=True)
+        return [
+            delta
+            async for delta in model.generate_text_only_stream(
+                [{"role": "user", "content": "Describe"}],
+                config,
+            )
+        ]
+
+    assert "".join(asyncio.run(collect())) == '{"visual_sentinel":"ALPHA"}'
+    assert model._inflight_req_ids == []
 
 
 @pytest.mark.parametrize(

--- a/services/rtvi/rt-vlm/tests/model/vllm_compatible/test_input_error_handling.py
+++ b/services/rtvi/rt-vlm/tests/model/vllm_compatible/test_input_error_handling.py
@@ -55,6 +55,30 @@ class _RecordingLLM:
         yield SimpleNamespace()
 
 
+class _ChatTemplateIgnoringReasoning:
+    def apply_chat_template(self, *args, **kwargs):
+        self.messages = args[0]
+        return "<|im_start|>assistant\n"
+
+
+class _QwenTokenizer:
+    eos_token_id = 99
+    unk_token_id = 0
+
+    def convert_tokens_to_ids(self, token):
+        assert token == "<|im_end|>"
+        return 99
+
+    def decode(self, token_ids, skip_special_tokens=True):
+        assert skip_special_tokens is True
+        assert token_ids == [10, 11]
+        return '{"visual_sentinel":"ALPHA"}'
+
+
+class _QwenProcessor:
+    tokenizer = _QwenTokenizer()
+
+
 class _RequestQueue:
     def __init__(self):
         self.request_id = "req-1"
@@ -175,6 +199,71 @@ def test_reasoning_chat_template_disables_thinking_by_default(architecture):
     assert model._get_apply_chat_template_kwargs(VlmGenerationConfig(enable_reasoning=True)) == {
         "enable_thinking": True
     }
+
+
+def test_qwen3vl_non_reasoning_fallback_closes_empty_think_block():
+    model = VllmCompatible.__new__(VllmCompatible)
+    model._model_architecture = "Qwen3VLForConditionalGeneration"
+    model._processor = _ChatTemplateIgnoringReasoning()
+    config = VlmGenerationConfig(enable_reasoning=False)
+    messages = [{"role": "user", "content": [{"type": "text", "text": "Describe"}]}]
+
+    prompt = model._apply_chat_template(messages, config)
+
+    assert prompt.endswith("<think>\n\n</think>\n\n")
+    assert model._processor.messages[0]["content"][0]["text"] == "Describe /no_think"
+    assert messages[0]["content"][0]["text"] == "Describe"
+
+
+def test_qwen3vl_reasoning_prompt_is_not_modified():
+    model = VllmCompatible.__new__(VllmCompatible)
+    model._model_architecture = "Qwen3VLForConditionalGeneration"
+    model._processor = _ChatTemplateIgnoringReasoning()
+    config = VlmGenerationConfig(enable_reasoning=True)
+
+    assert model._apply_chat_template([], config) == "<|im_start|>assistant\n"
+
+
+def test_qwen3vl_non_reasoning_keeps_fixed_work_generation_with_ignore_eos():
+    model = VllmCompatible.__new__(VllmCompatible)
+    model._model_architecture = "Qwen3VLForConditionalGeneration"
+    config = VlmGenerationConfig(enable_reasoning=False, ignore_eos=True)
+    sampling_kwargs = vllm_compatible_model._build_vllm_sampling_kwargs(config)
+
+    model._apply_reasoning_suppression_sampling_params(sampling_kwargs, config)
+
+    assert sampling_kwargs["ignore_eos"] is True
+    assert sampling_kwargs["bad_words"] == ["<think>", "</think>"]
+    assert "stop_token_ids" not in sampling_kwargs
+
+
+def test_qwen3vl_non_reasoning_truncates_backend_output_at_first_answer_boundary():
+    model = VllmCompatible.__new__(VllmCompatible)
+    model._model_architecture = "Qwen3VLForConditionalGeneration"
+    model._processor = _QwenProcessor()
+    model._inflight_req_ids = []
+    model._vlm_model_type = "cosmos-reason3"
+    output = SimpleNamespace(
+        prompt_token_ids=[1, 2],
+        outputs=[
+            SimpleNamespace(
+                text='{"visual_sentinel":"ALPHA"}\nStep-by-step analysis',
+                token_ids=[10, 11, 99, 20, 21],
+            )
+        ],
+    )
+
+    result = model._postprocess_vllm(
+        [output],
+        [],
+        ignore_eos=True,
+        preserve_reasoning_tags=False,
+        enable_reasoning=False,
+    )
+
+    assert result[0].output == '{"visual_sentinel":"ALPHA"}'
+    assert result[0].reasoning_description == ""
+    assert result[0].output_tokens == 5
 
 
 @pytest.mark.parametrize(
@@ -1225,7 +1314,7 @@ def test_generate_can_send_multi_frame_chunk_as_multi_image_input(monkeypatch):
     assert future.result() == ["ok"]
     content = processor.messages[-1]["content"]
     assert [item["type"] for item in content] == ["text", "image", "image", "image"]
-    assert content[0]["text"] == "Describe the time-lapsed video."
+    assert content[0]["text"] == "Describe the time-lapsed video. /no_think"
     assert [item["image"] for item in content[1:]] == [
         "frame_000000.jpg",
         "frame_000001.jpg",


### PR DESCRIPTION
## Summary

- suppress Qwen3-VL reasoning when `enable_reasoning=false`, including templates that ignore `enable_thinking`
- retain `ignore_eos=true` for fixed-work generation while enforcing an EOS/`<|im_end|>` answer boundary on returned text
- apply the same non-reasoning contract to video, text-only, and streaming generation
- add regression coverage for prompt construction, sampling parameters, answer truncation, and reasoning leakage

Fixes NVBug 6605402.

## Validation

- 119 focused vLLM-compatible unit tests passed
- validated on RTX PRO 4500 with the GHCR `nightly-20260917` RTVI-VLM image
- same 20-stream, 100-token reproduction completed with 0 `NoneType.get` failures, 0 incomplete-reasoning warnings, and 0 fatal invalidators
- frozen four-video sentinel contract passed with exact structural parity, correct request/frame ordering, and zero reasoning leakage
- changed Python files pass Python 3.12 compilation and `git diff --check`

Performance note: the 20-stream run exceeded the harness p95 latency target (13.51 s vs 10 s); this is orthogonal to the two correctness signatures addressed here.