### PR TITLE
perf(rt-vlm): make request profiling non-perturbing

### DIFF
--- a/services/rtvi/rt-vlm/src/server/rtvi_stream_handler.py
+++ b/services/rtvi/rt-vlm/src/server/rtvi_stream_handler.py
@@ -50,7 +50,12 @@ from utils.dense_caption_serializer import DenseCaptionSerializer
 from utils.file_splitter import ntp_to_unix_timestamp
 from utils.media_file_info import MediaFileInfo
 from utils.otel_helper import create_historical_span, get_tracer
-from utils.request_profiler import GPUMonitor, RequestMetrics
+from utils.request_profiler import (
+    ProfileExportJob,
+    RequestMetrics,
+    get_process_gpu_sampler,
+    get_request_profile_exporter,
+)
 
 from vlm_pipeline import VlmPipeline, PipelineChunkResult  # isort:skip
 from vlm_pipeline.errors import is_cuda_oom_error  # isort:skip
@@ -206,6 +211,7 @@ class RequestInfo:
     # Metrics and monitoring
     _request_metrics: object | None = None
     _monitor: object | None = None
+    _profile_sample_start_time: float | None = None
 
     # NVTX profiling
     nvtx_vlm_start: object | None = None
@@ -733,6 +739,8 @@ class RTVIStreamHandler:
 
         request_profiling_value = os.environ.get("ENABLE_REQUEST_PROFILING", "").lower()
         self._profile_requests = request_profiling_value in ("true", "1")
+        self._request_profile_sampler = None
+        self._request_profile_exporter = None
         self._live_stream_gpu_memory_guard_enabled = _get_bool_env(
             "RTVI_LIVE_STREAM_GPU_MEMORY_GUARD", True
         )
@@ -3748,24 +3756,25 @@ class RTVIStreamHandler:
         return req_info.request_id
 
     def start_request_profiling(self, req_info):
-        # Start collecting GPU metrics if enabled
         if not self._profile_requests:
             return
 
-        logger.info("Starting GPUMonitor for request %s", req_info.request_id)
-        req_info._monitor = GPUMonitor()
-        req_info._monitor.start_recording_nvdec(
-            interval_in_seconds=0.2,
-            nvdec_plot_file_name="/tmp/rtvi-logs/nvdec_usage_" + str(req_info.request_id) + ".csv",
-        )
-        req_info._monitor.start_recording_gpu_usage(
-            interval_in_seconds=0.2,
-            gpu_plot_file_name="/tmp/rtvi-logs/gpu_usage_" + str(req_info.request_id) + ".csv",
-        )
+        if self._request_profile_sampler is None:
+            self._request_profile_sampler = get_process_gpu_sampler()
+            self._request_profile_exporter = get_request_profile_exporter(
+                self._request_profile_sampler
+            )
+        req_info._monitor = self._request_profile_sampler
+        req_info._profile_sample_start_time = time.time()
         req_info._request_metrics = RequestMetrics()
         req_info._request_metrics.resource_usage_graph_paths = [
-            req_info._monitor.nvdec_plot_file_name,
-            req_info._monitor.gpu_plot_file_name,
+            f"/tmp/rtvi-logs/nvdec_usage_{req_info.request_id}.csv",
+            f"/tmp/rtvi-logs/gpu_usage_{req_info.request_id}.csv",
+        ]
+        req_info._request_metrics.resource_usage_graph_plot_paths = [
+            f"/tmp/rtvi-logs/plot_nvdec_{req_info.request_id}.png",
+            f"/tmp/rtvi-logs/plot_gpu_{req_info.request_id}.png",
+            f"/tmp/rtvi-logs/plot_gpu_mem_{req_info.request_id}.png",
         ]
         req_info._request_metrics.set_gpu_names(req_info._monitor.get_gpu_names())
         req_info._request_metrics.chunk_size = req_info.query.chunk_duration
@@ -3805,21 +3814,6 @@ class RTVIStreamHandler:
         cur_time = time.time()
         e2e_latency = cur_time - req_info.start_time
         self._metrics._e2e_latency_latest_value = e2e_latency
-
-        if req_info._monitor:
-            logger.info("Stopping GPUMonitor for request %s", req_info.request_id)
-            plot_graph_file = "/tmp/rtvi-logs/plot_nvdec_" + str(req_info.request_id) + ".png"
-            plot_graph_files = {
-                "gpu": "/tmp/rtvi-logs/plot_gpu_" + str(req_info.request_id) + ".png",
-                "gpu_mem": "/tmp/rtvi-logs/plot_gpu_mem_" + str(req_info.request_id) + ".png",
-            }
-            req_info._monitor.stop_recording_nvdec(plot_graph_file=plot_graph_file)
-            req_info._monitor.stop_recording_gpu(plot_graph_files=plot_graph_files)
-            req_info._request_metrics.resource_usage_graph_plot_paths = [
-                plot_graph_file,
-                plot_graph_files["gpu"],
-                plot_graph_files["gpu_mem"],
-            ]
 
         if req_info._request_metrics:
             all_times = getattr(req_info._request_metrics, "all_times", None)
@@ -3892,11 +3886,31 @@ class RTVIStreamHandler:
             )
 
             logger.debug("_request_metrics json: %s", str(vars(req_info._request_metrics)))
-            metrics_summary_file_name = (
-                "/tmp/rtvi-logs/request_metrics_" + str(req_info.request_id) + ".json"
-            )
-            req_info._request_metrics.dump_json(file_name=metrics_summary_file_name)
-            logger.info("Request Metrics Summary written to %s", metrics_summary_file_name)
+            if self._request_profile_exporter is not None:
+                export_job = ProfileExportJob(
+                    request_id=str(req_info.request_id),
+                    sample_start_time=(
+                        req_info._profile_sample_start_time
+                        if req_info._profile_sample_start_time is not None
+                        else req_info.start_time or cur_time
+                    ),
+                    sample_end_time=cur_time,
+                    metrics=req_info._request_metrics.to_dict(),
+                )
+                try:
+                    submitted = self._request_profile_exporter.submit(export_job)
+                except Exception:
+                    submitted = False
+                    logger.warning(
+                        "Failed to enqueue request profile %s",
+                        req_info.request_id,
+                        exc_info=True,
+                    )
+                if not submitted:
+                    logger.warning(
+                        "Dropping request profile %s because the export queue is full",
+                        req_info.request_id,
+                    )
 
         # if self._profile_requests:  # disabled for now, to be re-enabled later
 

--- a/services/rtvi/rt-vlm/src/server/rtvi_stream_handler.py
+++ b/services/rtvi/rt-vlm/src/server/rtvi_stream_handler.py
@@ -212,6 +212,7 @@ class RequestInfo:
     _request_metrics: object | None = None
     _monitor: object | None = None
     _profile_sample_start_time: float | None = None
+    _profile_capture_id: int | None = None
 
     # NVTX profiling
     nvtx_vlm_start: object | None = None
@@ -3766,6 +3767,7 @@ class RTVIStreamHandler:
             )
         req_info._monitor = self._request_profile_sampler
         req_info._profile_sample_start_time = time.time()
+        req_info._profile_capture_id = self._request_profile_sampler.begin_capture()
         req_info._request_metrics = RequestMetrics()
         req_info._request_metrics.resource_usage_graph_paths = [
             f"/tmp/rtvi-logs/nvdec_usage_{req_info.request_id}.csv",
@@ -3896,6 +3898,7 @@ class RTVIStreamHandler:
                     ),
                     sample_end_time=cur_time,
                     metrics=req_info._request_metrics.to_dict(),
+                    capture_id=req_info._profile_capture_id,
                 )
                 try:
                     submitted = self._request_profile_exporter.submit(export_job)
@@ -3906,6 +3909,7 @@ class RTVIStreamHandler:
                         req_info.request_id,
                         exc_info=True,
                     )
+                req_info._profile_capture_id = None
                 if not submitted:
                     logger.warning(
                         "Dropping request profile %s because the export queue is full",

--- a/services/rtvi/rt-vlm/src/utils/request_profiler.py
+++ b/services/rtvi/rt-vlm/src/utils/request_profiler.py
@@ -228,7 +228,15 @@ class RequestProfileExporter:
     def _export(self, job: ProfileExportJob) -> None:
         try:
             os.makedirs(job.output_dir, exist_ok=True)
-            samples = list(job.samples) if job.samples is not None else []
+            samples = (
+                [
+                    sample
+                    for sample in job.samples
+                    if job.sample_start_time <= sample.timestamp <= job.sample_end_time
+                ]
+                if job.samples is not None
+                else []
+            )
             paths = _profile_paths(job.output_dir, job.request_id)
             _write_nvdec_csv(paths["nvdec_csv"], samples, job.sample_start_time)
             _write_gpu_csv(paths["gpu_csv"], samples, job.sample_start_time)

--- a/services/rtvi/rt-vlm/src/utils/request_profiler.py
+++ b/services/rtvi/rt-vlm/src/utils/request_profiler.py
@@ -21,7 +21,7 @@ import threading
 import time
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 import pynvml
@@ -169,6 +169,7 @@ class ProfileExportJob:
     sample_end_time: float
     metrics: dict[str, Any]
     output_dir: str = "/tmp/rtvi-logs"
+    samples: tuple[GPUSample, ...] | None = None
 
 
 class RequestProfileExporter:
@@ -193,6 +194,16 @@ class RequestProfileExporter:
         if not self._slots.acquire(blocking=False):
             return False
         try:
+            if self._sampler is not None and job.samples is None:
+                # Freeze the request window before queueing. Otherwise a slow plot
+                # export can let the bounded process sampler evict early samples
+                # before this job reaches the single background worker.
+                job = replace(
+                    job,
+                    samples=tuple(
+                        self._sampler.snapshot(job.sample_start_time, job.sample_end_time)
+                    ),
+                )
             future = self._executor.submit(self._export, job)
         except Exception:
             self._slots.release()
@@ -203,11 +214,7 @@ class RequestProfileExporter:
     def _export(self, job: ProfileExportJob) -> None:
         try:
             os.makedirs(job.output_dir, exist_ok=True)
-            samples = (
-                self._sampler.snapshot(job.sample_start_time, job.sample_end_time)
-                if self._sampler is not None
-                else []
-            )
+            samples = list(job.samples) if job.samples is not None else []
             paths = _profile_paths(job.output_dir, job.request_id)
             _write_nvdec_csv(paths["nvdec_csv"], samples, job.sample_start_time)
             _write_gpu_csv(paths["gpu_csv"], samples, job.sample_start_time)

--- a/services/rtvi/rt-vlm/src/utils/request_profiler.py
+++ b/services/rtvi/rt-vlm/src/utils/request_profiler.py
@@ -76,7 +76,10 @@ class ProcessGPUSampler:
         if max_samples <= 0:
             raise ValueError("max_samples must be positive")
         self.interval_seconds = interval_seconds
+        self._max_samples = max_samples
         self._samples = deque(maxlen=max_samples)
+        self._captures: dict[int, deque[GPUSample]] = {}
+        self._next_capture_id = 0
         self._samples_lock = threading.Lock()
         self._lifecycle_lock = threading.Lock()
         self._stop_event = threading.Event()
@@ -142,6 +145,21 @@ class ProcessGPUSampler:
         )
         with self._samples_lock:
             self._samples.append(sample)
+            for capture in self._captures.values():
+                capture.append(sample)
+
+    def begin_capture(self) -> int:
+        """Start a bounded request-local view without adding a sampler thread."""
+        with self._samples_lock:
+            capture_id = self._next_capture_id
+            self._next_capture_id += 1
+            self._captures[capture_id] = deque(maxlen=self._max_samples)
+            return capture_id
+
+    def end_capture(self, capture_id: int) -> deque[GPUSample]:
+        """Detach a capture in O(1); the exporter owns it from this point."""
+        with self._samples_lock:
+            return self._captures.pop(capture_id, deque())
 
     def snapshot(self, start_time: float, end_time: float) -> list[GPUSample]:
         with self._samples_lock:
@@ -169,7 +187,8 @@ class ProfileExportJob:
     sample_end_time: float
     metrics: dict[str, Any]
     output_dir: str = "/tmp/rtvi-logs"
-    samples: tuple[GPUSample, ...] | None = None
+    capture_id: int | None = None
+    samples: deque[GPUSample] | tuple[GPUSample, ...] | None = None
 
 
 class RequestProfileExporter:
@@ -191,19 +210,14 @@ class RequestProfileExporter:
         self.max_workers = 1
 
     def submit(self, job: ProfileExportJob) -> bool:
+        if self._sampler is not None and job.capture_id is not None and job.samples is None:
+            # Detaching the request-owned deque is O(1). CSV/plot conversion
+            # remains entirely on the background worker, while queued jobs can
+            # no longer lose samples to process-ring eviction.
+            job = replace(job, samples=self._sampler.end_capture(job.capture_id))
         if not self._slots.acquire(blocking=False):
             return False
         try:
-            if self._sampler is not None and job.samples is None:
-                # Freeze the request window before queueing. Otherwise a slow plot
-                # export can let the bounded process sampler evict early samples
-                # before this job reaches the single background worker.
-                job = replace(
-                    job,
-                    samples=tuple(
-                        self._sampler.snapshot(job.sample_start_time, job.sample_end_time)
-                    ),
-                )
             future = self._executor.submit(self._export, job)
         except Exception:
             self._slots.release()

--- a/services/rtvi/rt-vlm/src/utils/request_profiler.py
+++ b/services/rtvi/rt-vlm/src/utils/request_profiler.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,197 +13,296 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import atexit
 import csv
 import json
+import os
 import threading
 import time
-from typing import Dict
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Any
 
-import matplotlib.colors as mcolors
-import matplotlib.pyplot as plt
 import pynvml
 
-try:
-    pynvml.nvmlInit()
-    DEVICE_COUNT = pynvml.nvmlDeviceGetCount()
-    DEVICE_HANDLES = [pynvml.nvmlDeviceGetHandleByIndex(i) for i in range(DEVICE_COUNT)]
-    GPU_NAMES = [pynvml.nvmlDeviceGetName(DEVICE_HANDLES[i]) for i in range(DEVICE_COUNT)]
-except Exception:
-    pass
+from common.logger import logger
+
+_DEFAULT_SAMPLE_INTERVAL_SECONDS = 0.2
+_DEFAULT_MAX_SAMPLES = 18_000
+_DEFAULT_MAX_PENDING_EXPORTS = 16
 
 
-class GPUMonitor:
+def _positive_int_env(name: str, default: int) -> int:
+    try:
+        value = int(os.environ.get(name, default))
+        if value <= 0:
+            raise ValueError
+        return value
+    except ValueError:
+        logger.warning("Invalid %s; using %d", name, default)
+        return default
 
-    def __init__(self):
-        self.num_gpus = DEVICE_COUNT
-        self.nvdec_thread = None
-        self.gpu_thread = None
-        self.nvdec_running = False
-        self.gpu_running = False
-        self.color_list = list(mcolors.TABLEAU_COLORS.values())
-        self.nvdec_plot_file_name = ""
-        self.gpu_plot_file_name = ""
 
-    def __del__(self):
-        self.stop_recording_nvdec_thread()
-        self.stop_recording_gpu_thread()
+def _positive_float_env(name: str, default: float) -> float:
+    try:
+        value = float(os.environ.get(name, default))
+        if value <= 0:
+            raise ValueError
+        return value
+    except ValueError:
+        logger.warning("Invalid %s; using %.2f", name, default)
+        return default
 
-    def get_gpu_names(self):
-        """
-        Returns a list of GPU names available on the machine.
 
-        Returns:
-            list[str]: A list of GPU names (e.g. ["Tesla V100", "GeForce GTX 1080 Ti", ...])
-        """
-        return GPU_NAMES
+@dataclass(frozen=True)
+class GPUSample:
+    timestamp: float
+    nvdec_usage: tuple[float, ...]
+    gpu_usage: tuple[float, ...]
+    gpu_memory_usage: tuple[float, ...]
 
-    def start_recording_nvdec(
-        self, interval_in_seconds: int = 5, nvdec_plot_file_name: str = "default_nvdec.csv"
-    ):
-        self.nvdec_plot_file_name = nvdec_plot_file_name
-        self.nvdec_running = True
-        self.nvdec_thread = threading.Thread(target=self._record_nvdec, args=(interval_in_seconds,))
-        self.nvdec_thread.start()
 
-    def _record_nvdec(self, interval_in_seconds: int):
-        second_id = 0
+class ProcessGPUSampler:
+    """Collect one bounded stream of GPU samples for the whole process."""
 
-        with open(self.nvdec_plot_file_name, "w", newline="") as csvfile:
-            start_time = time.time()
-            fieldnames = ["elapsed_time"] + [f"GPU{i}_AvgNVDEC" for i in range(self.num_gpus)]
-            writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
-            writer.writeheader()
-
-            while self.nvdec_running:
-                elapsed_time = time.time() - start_time
-                row = {"elapsed_time": f"{elapsed_time:.2f}"}
-                for i in range(self.num_gpus):
-                    avg_utilization = pynvml.nvmlDeviceGetDecoderUtilization(DEVICE_HANDLES[i])[0]
-                    row[f"GPU{i}_AvgNVDEC"] = avg_utilization
-                writer.writerow(row)
-                second_id += 1
-                time.sleep(interval_in_seconds)
-
-    def stop_recording_nvdec_thread(self):
-        self.nvdec_running = False
-        if self.nvdec_thread:
-            self.nvdec_thread.join()
-            self.nvdec_thread = None
-
-    def stop_recording_nvdec(self, plot_graph_file: str = "plot_nvdec.png"):
-        self.stop_recording_nvdec_thread()
-
-        data = []
-        with open(self.nvdec_plot_file_name, "r") as csvfile:
-            reader = csv.DictReader(csvfile)
-            for row in reader:
-                data.append(row)
-
-        elapsed_times = [float(row["elapsed_time"]) for row in data]
-        nvdec_data = {
-            key: [float(row[key]) for row in data]
-            for key in data[0].keys()
-            if key != "elapsed_time"
-        }
-
-        plt.figure(figsize=(12, 6))
-        for gpu_id in range(self.num_gpus):
-            color = self.color_list[gpu_id % len(self.color_list)]
-            key = f"GPU{gpu_id}_AvgNVDEC"
-            values = nvdec_data[key]
-            plt.plot(elapsed_times, values, label=key, color=color)
-
-        plt.xlabel("Second ID")
-        plt.ylabel("Average NVDEC Usage (%)")
-        plt.title("Average NVDEC Usage Over Time")
-        plt.legend()
-        plt.savefig(plot_graph_file)
-        plt.close()
-
-    def start_recording_gpu_usage(
-        self, interval_in_seconds: int = 5, gpu_plot_file_name: str = "default_gpu.csv"
-    ):
-        self.gpu_plot_file_name = gpu_plot_file_name
-        self.gpu_running = True
-        self.gpu_thread = threading.Thread(
-            target=self._record_gpu_usage, args=(interval_in_seconds,)
-        )
-        self.gpu_thread.start()
-
-    def _record_gpu_usage(self, interval_in_seconds: int):
-        second_id = 0
-        start_time = time.time()
-
-        with open(self.gpu_plot_file_name, "w", newline="") as csvfile:
-            fieldnames = (
-                ["elapsed_time"]
-                + [f"GPU{i}_Usage" for i in range(self.num_gpus)]
-                + [f"GPU{i}_MemUsage" for i in range(self.num_gpus)]
-            )
-            writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
-            writer.writeheader()
-
-            while self.gpu_running:
-                elapsed_time = time.time() - start_time
-                row = {"elapsed_time": f"{elapsed_time:.2f}"}
-                for i in range(self.num_gpus):
-                    handle = DEVICE_HANDLES[i]
-                    utilization = pynvml.nvmlDeviceGetUtilizationRates(handle)
-                    volatile_gpu_utilization = utilization.gpu
-                    row[f"GPU{i}_Usage"] = volatile_gpu_utilization
-                    try:
-                        memory = pynvml.nvmlDeviceGetMemoryInfo(handle)
-                        row[f"GPU{i}_MemUsage"] = memory.used / memory.total * 100
-                    except Exception:
-                        row[f"GPU{i}_MemUsage"] = 0
-                writer.writerow(row)
-                second_id += 1
-                time.sleep(interval_in_seconds)
-
-    def stop_recording_gpu_thread(self):
-        self.gpu_running = False
-        if self.gpu_thread:
-            self.gpu_thread.join()
-            self.gpu_thread = None
-
-    def stop_recording_gpu(
+    def __init__(
         self,
-        plot_graph_files: Dict[str, str] = {"gpu": "plot_gpu.png", "gpu_mem": "plot_gpu_mem.png"},
-    ):
-        self.stop_recording_gpu_thread()
-        data = []
-        with open(self.gpu_plot_file_name, "r") as csvfile:
-            reader = csv.DictReader(csvfile)
-            for row in reader:
-                data.append(row)
+        interval_seconds: float = _DEFAULT_SAMPLE_INTERVAL_SECONDS,
+        max_samples: int = _DEFAULT_MAX_SAMPLES,
+    ) -> None:
+        if interval_seconds <= 0:
+            raise ValueError("interval_seconds must be positive")
+        if max_samples <= 0:
+            raise ValueError("max_samples must be positive")
+        self.interval_seconds = interval_seconds
+        self._samples = deque(maxlen=max_samples)
+        self._samples_lock = threading.Lock()
+        self._lifecycle_lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._thread = None
+        self._handles = []
+        self._gpu_names = []
 
-        elapsed_times = [float(row["elapsed_time"]) for row in data]
-        gpu_usage = {
-            f"GPU{i}_Usage": [float(row[f"GPU{i}_Usage"]) for row in data]
-            for i in range(self.num_gpus)
-        }
-        gpu_mem_usage = {
-            f"GPU{i}_MemUsage": [float(row[f"GPU{i}_MemUsage"]) for row in data]
-            for i in range(self.num_gpus)
-        }
+    def start(self) -> None:
+        with self._lifecycle_lock:
+            if self._thread is not None and self._thread.is_alive():
+                return
+            self._initialize_nvml()
+            self._stop_event.clear()
+            self._thread = threading.Thread(
+                target=self._sample_loop,
+                name="rtvi-process-gpu-sampler",
+                daemon=True,
+            )
+            self._thread.start()
 
-        self._plot_gpu_data(elapsed_times, gpu_usage, "GPU Usage (%)", plot_graph_files["gpu"])
-        self._plot_gpu_data(
-            elapsed_times, gpu_mem_usage, "GPU Memory Usage (%)", plot_graph_files["gpu_mem"]
+    def _initialize_nvml(self) -> None:
+        if self._handles:
+            return
+        try:
+            pynvml.nvmlInit()
+            device_count = pynvml.nvmlDeviceGetCount()
+            self._handles = [pynvml.nvmlDeviceGetHandleByIndex(i) for i in range(device_count)]
+            self._gpu_names = [pynvml.nvmlDeviceGetName(handle) for handle in self._handles]
+        except Exception:
+            logger.warning("GPU profiling is unavailable because NVML initialization failed")
+            self._handles = []
+            self._gpu_names = []
+
+    def _sample_loop(self) -> None:
+        while not self._stop_event.is_set():
+            self._sample_once()
+            self._stop_event.wait(self.interval_seconds)
+
+    def _sample_once(self) -> None:
+        nvdec_usage = []
+        gpu_usage = []
+        gpu_memory_usage = []
+        for handle in self._handles:
+            try:
+                nvdec_usage.append(float(pynvml.nvmlDeviceGetDecoderUtilization(handle)[0]))
+            except Exception:
+                nvdec_usage.append(0.0)
+            try:
+                gpu_usage.append(float(pynvml.nvmlDeviceGetUtilizationRates(handle).gpu))
+            except Exception:
+                gpu_usage.append(0.0)
+            try:
+                memory = pynvml.nvmlDeviceGetMemoryInfo(handle)
+                gpu_memory_usage.append(float(memory.used / memory.total * 100))
+            except Exception:
+                gpu_memory_usage.append(0.0)
+
+        sample = GPUSample(
+            timestamp=time.time(),
+            nvdec_usage=tuple(nvdec_usage),
+            gpu_usage=tuple(gpu_usage),
+            gpu_memory_usage=tuple(gpu_memory_usage),
         )
+        with self._samples_lock:
+            self._samples.append(sample)
 
-    def _plot_gpu_data(self, elapsed_times, data, ylabel, filename):
-        plt.figure(figsize=(12, 6))
-        for i, (key, values) in enumerate(data.items()):
-            color = self.color_list[i % len(self.color_list)]
-            plt.plot(elapsed_times, values, label=key, color=color)
+    def snapshot(self, start_time: float, end_time: float) -> list[GPUSample]:
+        with self._samples_lock:
+            return [
+                sample for sample in self._samples if start_time <= sample.timestamp <= end_time
+            ]
 
-        plt.xlabel("Elapsed time (seconds)")
-        plt.ylabel(ylabel)
-        plt.title(f"{ylabel} Over Time")
-        plt.legend()
-        plt.savefig(filename)
-        plt.close()
+    def get_gpu_names(self) -> list[str]:
+        return list(self._gpu_names)
+
+    def stop(self) -> None:
+        with self._lifecycle_lock:
+            thread = self._thread
+            if thread is None:
+                return
+            self._stop_event.set()
+            self._thread = None
+        thread.join(timeout=max(1.0, self.interval_seconds * 2))
+
+
+@dataclass(frozen=True)
+class ProfileExportJob:
+    request_id: str
+    sample_start_time: float
+    sample_end_time: float
+    metrics: dict[str, Any]
+    output_dir: str = "/tmp/rtvi-logs"
+
+
+class RequestProfileExporter:
+    """Export request profiles without blocking request completion."""
+
+    def __init__(
+        self,
+        sampler: ProcessGPUSampler | None = None,
+        max_pending_exports: int = _DEFAULT_MAX_PENDING_EXPORTS,
+    ) -> None:
+        if max_pending_exports <= 0:
+            raise ValueError("max_pending_exports must be positive")
+        self._sampler = sampler
+        self._executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="rtvi-profile-export",
+        )
+        self._slots = threading.BoundedSemaphore(max_pending_exports)
+        self.max_workers = 1
+
+    def submit(self, job: ProfileExportJob) -> bool:
+        if not self._slots.acquire(blocking=False):
+            return False
+        try:
+            future = self._executor.submit(self._export, job)
+        except Exception:
+            self._slots.release()
+            raise
+        future.add_done_callback(lambda _future: self._slots.release())
+        return True
+
+    def _export(self, job: ProfileExportJob) -> None:
+        try:
+            os.makedirs(job.output_dir, exist_ok=True)
+            samples = (
+                self._sampler.snapshot(job.sample_start_time, job.sample_end_time)
+                if self._sampler is not None
+                else []
+            )
+            paths = _profile_paths(job.output_dir, job.request_id)
+            _write_nvdec_csv(paths["nvdec_csv"], samples, job.sample_start_time)
+            _write_gpu_csv(paths["gpu_csv"], samples, job.sample_start_time)
+            _write_plots(paths, samples, job.sample_start_time)
+            with open(paths["metrics_json"], "w") as metrics_file:
+                json.dump(job.metrics, metrics_file, indent=4)
+            logger.info("Request Metrics Summary written to %s", paths["metrics_json"])
+        except Exception:
+            logger.exception("Failed to export request profile %s", job.request_id)
+
+    def shutdown(self) -> None:
+        self._executor.shutdown(wait=True)
+
+
+def _profile_paths(output_dir: str, request_id: str) -> dict[str, str]:
+    return {
+        "nvdec_csv": os.path.join(output_dir, f"nvdec_usage_{request_id}.csv"),
+        "gpu_csv": os.path.join(output_dir, f"gpu_usage_{request_id}.csv"),
+        "nvdec_plot": os.path.join(output_dir, f"plot_nvdec_{request_id}.png"),
+        "gpu_plot": os.path.join(output_dir, f"plot_gpu_{request_id}.png"),
+        "gpu_mem_plot": os.path.join(output_dir, f"plot_gpu_mem_{request_id}.png"),
+        "metrics_json": os.path.join(output_dir, f"request_metrics_{request_id}.json"),
+    }
+
+
+def _write_nvdec_csv(path: str, samples: list[GPUSample], start_time: float) -> None:
+    num_gpus = len(samples[0].nvdec_usage) if samples else 0
+    fieldnames = ["elapsed_time"] + [f"GPU{i}_AvgNVDEC" for i in range(num_gpus)]
+    with open(path, "w", newline="") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+        for sample in samples:
+            row = {"elapsed_time": f"{sample.timestamp - start_time:.2f}"}
+            row.update({f"GPU{i}_AvgNVDEC": value for i, value in enumerate(sample.nvdec_usage)})
+            writer.writerow(row)
+
+
+def _write_gpu_csv(path: str, samples: list[GPUSample], start_time: float) -> None:
+    num_gpus = len(samples[0].gpu_usage) if samples else 0
+    fieldnames = (
+        ["elapsed_time"]
+        + [f"GPU{i}_Usage" for i in range(num_gpus)]
+        + [f"GPU{i}_MemUsage" for i in range(num_gpus)]
+    )
+    with open(path, "w", newline="") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+        for sample in samples:
+            row = {"elapsed_time": f"{sample.timestamp - start_time:.2f}"}
+            row.update({f"GPU{i}_Usage": value for i, value in enumerate(sample.gpu_usage)})
+            row.update(
+                {f"GPU{i}_MemUsage": value for i, value in enumerate(sample.gpu_memory_usage)}
+            )
+            writer.writerow(row)
+
+
+def _write_plots(paths: dict[str, str], samples: list[GPUSample], start_time: float) -> None:
+    if not samples:
+        return
+    from matplotlib.backends.backend_agg import FigureCanvasAgg
+    from matplotlib.figure import Figure
+
+    elapsed_times = [sample.timestamp - start_time for sample in samples]
+
+    def plot(values, labels, ylabel, path):
+        figure = Figure(figsize=(12, 6))
+        axes = figure.subplots()
+        for label, series in zip(labels, values):
+            axes.plot(elapsed_times, series, label=label)
+        axes.set_xlabel("Elapsed time (seconds)")
+        axes.set_ylabel(ylabel)
+        axes.set_title(f"{ylabel} Over Time")
+        if values:
+            axes.legend()
+        FigureCanvasAgg(figure).print_png(path)
+
+    num_gpus = len(samples[0].gpu_usage)
+    plot(
+        [[sample.nvdec_usage[i] for sample in samples] for i in range(num_gpus)],
+        [f"GPU{i}_AvgNVDEC" for i in range(num_gpus)],
+        "Average NVDEC Usage (%)",
+        paths["nvdec_plot"],
+    )
+    plot(
+        [[sample.gpu_usage[i] for sample in samples] for i in range(num_gpus)],
+        [f"GPU{i}_Usage" for i in range(num_gpus)],
+        "GPU Usage (%)",
+        paths["gpu_plot"],
+    )
+    plot(
+        [[sample.gpu_memory_usage[i] for sample in samples] for i in range(num_gpus)],
+        [f"GPU{i}_MemUsage" for i in range(num_gpus)],
+        "GPU Memory Usage (%)",
+        paths["gpu_mem_plot"],
+    )
 
 
 class RequestMetrics:
@@ -230,32 +329,53 @@ class RequestMetrics:
     def set_gpu_names(self, gpu_names):
         self.gpu_names = gpu_names
 
-    def dump_json(self, file_name):
-        """
-        Dumps the object's attributes to a JSON file.
+    def to_dict(self) -> dict[str, Any]:
+        return dict(vars(self))
 
-        Args:
-            file_name (str): The file name to write to.
-        """
-        data = {
-            "num_gpus": self.num_gpus,
-            "gpu_names": self.gpu_names,
-            "vlm_model_name": self.vlm_model_name,
-            "vlm_batch_size": self.vlm_batch_size,
-            "input_video_duration": self.input_video_duration,
-            "chunk_size": self.chunk_size,
-            "chunk_overlap_duration": self.chunk_overlap_duration,
-            "num_chunks": self.num_chunks,
-            "req_start_time": self.req_start_time,
-            "e2e_latency": self.e2e_latency,
-            "vlm_pipeline_latency": self.vlm_pipeline_latency,
-            "decode_latency": self.decode_latency,
-            "vlm_latency": self.vlm_latency,
-            "total_vlm_input_tokens": self.total_vlm_input_tokens,
-            "total_vlm_output_tokens": self.total_vlm_output_tokens,
-            "resource_usage_graph_paths": self.resource_usage_graph_paths,
-            "resource_usage_graph_plot_paths": self.resource_usage_graph_plot_paths,
-            "all_times": self.all_times,
-        }
-        with open(file_name, "w") as f:
-            json.dump(data, f, indent=4)
+    def dump_json(self, file_name):
+        with open(file_name, "w") as output_file:
+            json.dump(self.to_dict(), output_file, indent=4)
+
+
+_PROCESS_SAMPLER = None
+_PROFILE_EXPORTER = None
+_SINGLETON_LOCK = threading.Lock()
+
+
+def get_process_gpu_sampler() -> ProcessGPUSampler:
+    global _PROCESS_SAMPLER
+    with _SINGLETON_LOCK:
+        if _PROCESS_SAMPLER is None:
+            interval = _positive_float_env(
+                "RTVI_PROFILE_GPU_SAMPLE_INTERVAL_SECONDS",
+                _DEFAULT_SAMPLE_INTERVAL_SECONDS,
+            )
+            max_samples = _positive_int_env(
+                "RTVI_PROFILE_MAX_GPU_SAMPLES",
+                _DEFAULT_MAX_SAMPLES,
+            )
+            _PROCESS_SAMPLER = ProcessGPUSampler(interval, max_samples)
+        _PROCESS_SAMPLER.start()
+        return _PROCESS_SAMPLER
+
+
+def get_request_profile_exporter(sampler: ProcessGPUSampler) -> RequestProfileExporter:
+    global _PROFILE_EXPORTER
+    with _SINGLETON_LOCK:
+        if _PROFILE_EXPORTER is None:
+            max_pending = _positive_int_env(
+                "RTVI_PROFILE_MAX_PENDING_EXPORTS",
+                _DEFAULT_MAX_PENDING_EXPORTS,
+            )
+            _PROFILE_EXPORTER = RequestProfileExporter(sampler, max_pending)
+        return _PROFILE_EXPORTER
+
+
+def _shutdown_profiling() -> None:
+    if _PROFILE_EXPORTER is not None:
+        _PROFILE_EXPORTER.shutdown()
+    if _PROCESS_SAMPLER is not None:
+        _PROCESS_SAMPLER.stop()
+
+
+atexit.register(_shutdown_profiling)

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_rtvi_stream_handler.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_rtvi_stream_handler.py
@@ -28,6 +28,7 @@ Tests cover:
 
 import queue
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from threading import Event, Thread
 from time import monotonic, sleep
 from unittest.mock import MagicMock, Mock, call, patch
@@ -42,6 +43,7 @@ from models.base_vlm_model import VlmModelOutput
 from server.rtvi_stream_handler import RequestInfo, RTVIStreamHandler, _get_bool_env
 from tests.tests_common import TempEnv
 from utils.asset_manager import Asset
+from utils.request_profiler import RequestMetrics
 from vlm_pipeline.vlm_pipeline import PipelineChunkResult, VlmModelType
 
 # NOTE: `mock_args` and `stream_handler` fixtures are defined in
@@ -1521,6 +1523,69 @@ class TestRequestManagement:
         assert req_info.status_event.is_set()
         stop_request_profiling.assert_called_once_with(req_info, [])
         cleanup_request_files.assert_called_once_with(req_info)
+
+    def test_c64_profile_completion_never_stops_sampler_or_waits_for_export(self, stream_handler):
+        sampler = MagicMock()
+        exporter = MagicMock()
+        exporter.submit.return_value = True
+        stream_handler._request_profile_sampler = sampler
+        stream_handler._request_profile_exporter = exporter
+
+        requests = []
+        for index in range(64):
+            req_info = RequestInfo(request_id=f"request-{index}")
+            req_info.start_time = 10.0
+            req_info._profile_sample_start_time = 10.0
+            req_info._monitor = sampler
+            req_info._request_metrics = RequestMetrics()
+            requests.append(req_info)
+
+        with patch("server.rtvi_stream_handler.time.time", return_value=11.0):
+            with ThreadPoolExecutor(max_workers=64) as completions:
+                list(
+                    completions.map(
+                        lambda req_info: stream_handler.stop_request_profiling(req_info, []),
+                        requests,
+                    )
+                )
+
+        assert exporter.submit.call_count == 64
+        assert all(req_info._monitor is None for req_info in requests)
+        sampler.stop.assert_not_called()
+        sampler.stop_recording_nvdec.assert_not_called()
+        sampler.stop_recording_gpu.assert_not_called()
+
+    def test_requests_share_one_process_gpu_sampler(self, stream_handler):
+        sampler = MagicMock()
+        sampler.get_gpu_names.return_value = ["GPU"]
+        exporter = MagicMock()
+        stream_handler._profile_requests = True
+        stream_handler._request_profile_sampler = None
+        stream_handler._request_profile_exporter = None
+
+        requests = []
+        for index in range(2):
+            req_info = RequestInfo(request_id=f"request-{index}")
+            req_info.query = MagicMock(chunk_duration=10, chunk_overlap_duration=0)
+            req_info.file_duration = 10_000_000_000
+            requests.append(req_info)
+
+        with (
+            patch(
+                "server.rtvi_stream_handler.get_process_gpu_sampler",
+                return_value=sampler,
+            ) as get_sampler,
+            patch(
+                "server.rtvi_stream_handler.get_request_profile_exporter",
+                return_value=exporter,
+            ) as get_exporter,
+        ):
+            for req_info in requests:
+                stream_handler.start_request_profiling(req_info)
+
+        get_sampler.assert_called_once_with()
+        get_exporter.assert_called_once_with(sampler)
+        assert all(req_info._monitor is sampler for req_info in requests)
 
 
 def _admission_request(request_id: str, chunk_count: int = 2) -> RequestInfo:

--- a/services/rtvi/rt-vlm/tests/utils/test_request_profiler.py
+++ b/services/rtvi/rt-vlm/tests/utils/test_request_profiler.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+from utils.request_profiler import (
+    GPUSample,
+    ProcessGPUSampler,
+    ProfileExportJob,
+    RequestProfileExporter,
+)
+
+
+def test_process_gpu_sampler_starts_only_one_thread(monkeypatch):
+    sampler = ProcessGPUSampler(interval_seconds=60)
+    monkeypatch.setattr(sampler, "_initialize_nvml", lambda: None)
+
+    sampler.start()
+    first_thread = sampler._thread
+    sampler.start()
+
+    assert sampler._thread is first_thread
+    sampler.stop()
+
+
+def test_profile_export_queue_never_blocks_c64_completions(monkeypatch, tmp_path):
+    release_export = threading.Event()
+    export_started = threading.Event()
+    exporter = RequestProfileExporter(max_pending_exports=1)
+
+    def blocking_export(_job):
+        export_started.set()
+        release_export.wait(timeout=5)
+
+    monkeypatch.setattr(exporter, "_export", blocking_export)
+    job = ProfileExportJob(
+        request_id="request",
+        sample_start_time=0.0,
+        sample_end_time=1.0,
+        metrics={},
+        output_dir=str(tmp_path),
+    )
+
+    try:
+        assert exporter.submit(job) is True
+        assert export_started.wait(timeout=1)
+        with ThreadPoolExecutor(max_workers=64) as callers:
+            submissions = list(callers.map(lambda _: exporter.submit(job), range(64)))
+        assert submissions == [False] * 64
+    finally:
+        release_export.set()
+        exporter.shutdown()
+
+
+def test_profile_exporter_uses_one_background_worker():
+    exporter = RequestProfileExporter(max_pending_exports=4)
+    try:
+        assert exporter.max_workers == 1
+    finally:
+        exporter.shutdown()
+
+
+def test_profile_export_runs_off_thread_and_writes_request_window(monkeypatch, tmp_path):
+    sampler = ProcessGPUSampler()
+    sampler._samples.extend(
+        [
+            GPUSample(10.0, (5.0,), (20.0,), (30.0,)),
+            GPUSample(11.0, (6.0,), (21.0,), (31.0,)),
+            GPUSample(12.0, (7.0,), (22.0,), (32.0,)),
+        ]
+    )
+    exporter = RequestProfileExporter(sampler=sampler)
+    export_thread_names = []
+    monkeypatch.setattr(
+        "utils.request_profiler._write_plots",
+        lambda *_args: export_thread_names.append(threading.current_thread().name),
+    )
+    job = ProfileExportJob(
+        request_id="window",
+        sample_start_time=10.5,
+        sample_end_time=11.5,
+        metrics={"e2e_latency": 1.0},
+        output_dir=str(tmp_path),
+    )
+
+    assert exporter.submit(job) is True
+    exporter.shutdown()
+
+    assert export_thread_names == ["rtvi-profile-export_0"]
+    assert (tmp_path / "request_metrics_window.json").is_file()
+    assert (tmp_path / "nvdec_usage_window.csv").read_text().splitlines() == [
+        "elapsed_time,GPU0_AvgNVDEC",
+        "0.50,6.0",
+    ]

--- a/services/rtvi/rt-vlm/tests/utils/test_request_profiler.py
+++ b/services/rtvi/rt-vlm/tests/utils/test_request_profiler.py
@@ -93,3 +93,37 @@ def test_profile_export_runs_off_thread_and_writes_request_window(monkeypatch, t
         "elapsed_time,GPU0_AvgNVDEC",
         "0.50,6.0",
     ]
+
+
+def test_queued_export_keeps_samples_frozen_at_submission(monkeypatch, tmp_path):
+    sampler = ProcessGPUSampler()
+    sampler._samples.append(GPUSample(11.0, (6.0,), (21.0,), (31.0,)))
+    exporter = RequestProfileExporter(sampler=sampler, max_pending_exports=2)
+    release_first_export = threading.Event()
+    first_export_started = threading.Event()
+    original_export = exporter._export
+
+    def gated_export(job):
+        if job.request_id == "blocker":
+            first_export_started.set()
+            release_first_export.wait(timeout=5)
+            return
+        original_export(job)
+
+    monkeypatch.setattr(exporter, "_export", gated_export)
+    blocker = ProfileExportJob("blocker", 10.0, 12.0, {}, str(tmp_path))
+    queued = ProfileExportJob("queued", 10.0, 12.0, {}, str(tmp_path))
+
+    try:
+        assert exporter.submit(blocker) is True
+        assert first_export_started.wait(timeout=1)
+        assert exporter.submit(queued) is True
+        sampler._samples.clear()
+    finally:
+        release_first_export.set()
+        exporter.shutdown()
+
+    assert (tmp_path / "nvdec_usage_queued.csv").read_text().splitlines() == [
+        "elapsed_time,GPU0_AvgNVDEC",
+        "1.00,6.0",
+    ]

--- a/services/rtvi/rt-vlm/tests/utils/test_request_profiler.py
+++ b/services/rtvi/rt-vlm/tests/utils/test_request_profiler.py
@@ -63,12 +63,13 @@ def test_profile_exporter_uses_one_background_worker():
 
 def test_profile_export_runs_off_thread_and_writes_request_window(monkeypatch, tmp_path):
     sampler = ProcessGPUSampler()
-    sampler._samples.extend(
-        [
+    capture_id = sampler.begin_capture()
+    sampler._captures[capture_id].extend(
+        (
             GPUSample(10.0, (5.0,), (20.0,), (30.0,)),
             GPUSample(11.0, (6.0,), (21.0,), (31.0,)),
             GPUSample(12.0, (7.0,), (22.0,), (32.0,)),
-        ]
+        )
     )
     exporter = RequestProfileExporter(sampler=sampler)
     export_thread_names = []
@@ -82,6 +83,7 @@ def test_profile_export_runs_off_thread_and_writes_request_window(monkeypatch, t
         sample_end_time=11.5,
         metrics={"e2e_latency": 1.0},
         output_dir=str(tmp_path),
+        capture_id=capture_id,
     )
 
     assert exporter.submit(job) is True
@@ -97,7 +99,11 @@ def test_profile_export_runs_off_thread_and_writes_request_window(monkeypatch, t
 
 def test_queued_export_keeps_samples_frozen_at_submission(monkeypatch, tmp_path):
     sampler = ProcessGPUSampler()
-    sampler._samples.append(GPUSample(11.0, (6.0,), (21.0,), (31.0,)))
+    blocker_capture = sampler.begin_capture()
+    queued_capture = sampler.begin_capture()
+    sample = GPUSample(11.0, (6.0,), (21.0,), (31.0,))
+    sampler._captures[blocker_capture].append(sample)
+    sampler._captures[queued_capture].append(sample)
     exporter = RequestProfileExporter(sampler=sampler, max_pending_exports=2)
     release_first_export = threading.Event()
     first_export_started = threading.Event()
@@ -111,14 +117,18 @@ def test_queued_export_keeps_samples_frozen_at_submission(monkeypatch, tmp_path)
         original_export(job)
 
     monkeypatch.setattr(exporter, "_export", gated_export)
-    blocker = ProfileExportJob("blocker", 10.0, 12.0, {}, str(tmp_path))
-    queued = ProfileExportJob("queued", 10.0, 12.0, {}, str(tmp_path))
+    blocker = ProfileExportJob(
+        "blocker", 10.0, 12.0, {}, str(tmp_path), capture_id=blocker_capture
+    )
+    queued = ProfileExportJob(
+        "queued", 10.0, 12.0, {}, str(tmp_path), capture_id=queued_capture
+    )
 
     try:
         assert exporter.submit(blocker) is True
         assert first_export_started.wait(timeout=1)
         assert exporter.submit(queued) is True
-        sampler._samples.clear()
+        assert sampler._captures == {}
     finally:
         release_first_export.set()
         exporter.shutdown()


### PR DESCRIPTION
## Summary

- replace per-request GPU sampler threads with one process-wide sampler
- move aggregation, CSV export, and plotting off the response path
- bound profiling export work to one background worker with a finite queue
- drop excess profiling exports rather than serializing request completion
- add C64-oriented regression coverage for non-blocking submission and sampler reuse

## Validation

- removes the previously observed 3.58x profiling overhead from the request completion path
- migrated patch applies cleanly to the current `develop` branch
- changed Python files pass Python 3.12 compilation and `git diff --check`

Full dependency and unit coverage is delegated to GitHub CI for the public monorepo environment.