### PR TITLE
feat(rt-vlm): add persistent CUDA ring and token-aware admission

### DIFF
--- a/services/rtvi/rt-vlm/docker/rtvi_vlm/package_file_list.txt
+++ b/services/rtvi/rt-vlm/docker/rtvi_vlm/package_file_list.txt
@@ -55,6 +55,7 @@ utils/media_file_info.py
 utils/otel_helper.py
 utils/request_profiler.py
 vlm_pipeline/__init__.py
+vlm_pipeline/cuda_frame_ring.py
 vlm_pipeline/errors.py
 vlm_pipeline/ipc_frame_source.py
 vlm_pipeline/model_path_policy.py

--- a/services/rtvi/rt-vlm/scripts/rt_vlm_release_file_list.txt
+++ b/services/rtvi/rt-vlm/scripts/rt_vlm_release_file_list.txt
@@ -60,6 +60,7 @@ src/vllm_cosmos3/model.py
 src/vlm_pipeline/errors.py
 src/vlm_pipeline/__init__.py
 src/vlm_pipeline/ipc_frame_source.py
+src/vlm_pipeline/cuda_frame_ring.py
 src/vlm_pipeline/model_path_policy.py
 src/vlm_pipeline/ngc_model_downloader.py
 src/vlm_pipeline/process_base.py

--- a/services/rtvi/rt-vlm/src/models/vllm_compatible/adaptive_preprocess_limiter.py
+++ b/services/rtvi/rt-vlm/src/models/vllm_compatible/adaptive_preprocess_limiter.py
@@ -69,6 +69,7 @@ class PreprocessAdmission:
     workload_key: str
     payload_mb: int
     estimated_mb: int
+    encoder_tokens: int
     free_memory_before_mb: int | None
     admitted_at: float
     enforced: bool
@@ -83,6 +84,8 @@ class AdaptivePreprocessSnapshot:
     queued: int
     effective_limit: int
     pending_reserved_mb: int
+    pending_encoder_tokens: int
+    encoder_cache_capacity_tokens: int | None
     admissions: int
     policy_denials: int
     shadow_denials: int
@@ -100,11 +103,11 @@ class AdaptivePreprocessSnapshot:
 
 
 class AdaptivePreprocessLimiter:
-    """Admit preprocessing work without overcommitting one free-memory snapshot.
+    """Admit multimodal work without overcommitting memory or encoder tokens.
 
     The vLLM executor remains fixed at ``config.max_workers``. This controller
-    provides the runtime-effective limit and reserves memory atomically before
-    an admitted coroutine starts allocating CUDA tensors.
+    provides the runtime-effective limit, reserves frontend memory atomically,
+    and retains encoder-cache tokens until the visual encoder consumes them.
     """
 
     def __init__(
@@ -112,19 +115,34 @@ class AdaptivePreprocessLimiter:
         config: AdaptivePreprocessConfig,
         free_memory_mb: Callable[[], int],
         gpu_utilization_percent: Callable[[], float] | None = None,
+        encoder_cache_capacity_tokens: int | None = None,
         clock: Callable[[], float] = time.monotonic,
     ):
         self.config = config
         self._free_memory_mb = free_memory_mb
         self._gpu_utilization_percent = gpu_utilization_percent
+        self._encoder_cache_capacity_tokens = (
+            max(1, int(encoder_cache_capacity_tokens))
+            if encoder_cache_capacity_tokens is not None
+            else None
+        )
         self._clock = clock
         self._condition = asyncio.Condition()
         self._state_lock = threading.Lock()
-        self._effective_limit = config.min_workers
+        # A model-reported token budget is a stronger initial bound than an
+        # uncalibrated worker count. Start at the executor ceiling and let the
+        # token and memory reservations provide portable backpressure.
+        self._effective_limit = (
+            config.max_workers
+            if self._encoder_cache_capacity_tokens is not None
+            else config.min_workers
+        )
         self._active = 0
         self._queued = 0
         self._pending_reserved_mb = 0
+        self._pending_encoder_tokens = 0
         self._admissions: dict[str, PreprocessAdmission] = {}
+        self._preprocess_released_request_ids: set[str] = set()
         self._minimum_free_mb_by_request: dict[str, int] = {}
         self._overlapped_request_ids: set[str] = set()
         self._estimated_mb_by_workload: dict[str, int] = {}
@@ -179,6 +197,12 @@ class AdaptivePreprocessLimiter:
                     "pending_reserved_mb",
                     "Memory reserved for admitted multimodal preprocessing requests",
                     "MiBy",
+                ),
+                (
+                    "rtvi_vlm_preprocess_reserved_encoder_tokens",
+                    "pending_encoder_tokens",
+                    "Encoder-cache tokens reserved by admitted multimodal requests",
+                    "{token}",
                 ),
                 (
                     "rtvi_vlm_preprocess_admission_timeouts",
@@ -252,12 +276,24 @@ class AdaptivePreprocessLimiter:
         self,
         workload_key: str,
         payload_mb: int,
+        encoder_tokens: int = 0,
         *,
         require_calibration: bool = True,
     ) -> tuple[bool, int, int | None]:
         estimate_mb = self._request_estimate_locked(workload_key, payload_mb)
         free_mb = self._sample_free_memory_locked()
         worker_available = self._active < self._effective_limit
+        if self._encoder_cache_capacity_tokens is None or encoder_tokens == 0:
+            encoder_cache_available = True
+        elif encoder_tokens > self._encoder_cache_capacity_tokens:
+            # Let vLLM either chunk or reject an individually oversized item,
+            # but never deadlock it behind a budget it cannot satisfy.
+            encoder_cache_available = self._active == 0 and self._pending_encoder_tokens == 0
+        else:
+            encoder_cache_available = (
+                self._pending_encoder_tokens + encoder_tokens
+                <= self._encoder_cache_capacity_tokens
+            )
         # Calibrate a previously unseen workload without overlap. This avoids
         # carrying assumptions from one model processor or media shape to another.
         calibration_available = (
@@ -270,7 +306,10 @@ class AdaptivePreprocessLimiter:
             and free_mb - self._pending_reserved_mb >= self.config.gpu_headroom_mb + estimate_mb
         )
         return (
-            worker_available and calibration_available and memory_available,
+            worker_available
+            and calibration_available
+            and memory_available
+            and encoder_cache_available,
             estimate_mb,
             free_mb,
         )
@@ -351,11 +390,14 @@ class AdaptivePreprocessLimiter:
         request_id: str,
         workload_key: str,
         payload_mb: int,
+        encoder_tokens: int = 0,
     ) -> PreprocessAdmission:
         if not workload_key:
             raise ValueError("workload_key must not be empty")
         if payload_mb < 1:
             raise ValueError("payload_mb must be greater than or equal to 1")
+        if encoder_tokens < 0:
+            raise ValueError("encoder_tokens must be greater than or equal to 0")
         loop = asyncio.get_running_loop()
         started_at = self._clock()
         deadline = loop.time() + self.config.admission_timeout_seconds
@@ -370,6 +412,7 @@ class AdaptivePreprocessLimiter:
                         would_admit, estimate_mb, free_mb = self._policy_decision_locked(
                             workload_key,
                             payload_mb,
+                            encoder_tokens,
                         )
                         if self.config.shadow_mode or would_admit:
                             if queued:
@@ -377,7 +420,8 @@ class AdaptivePreprocessLimiter:
                                 queued = False
                             if self.config.shadow_mode and not would_admit:
                                 self._shadow_denials += 1
-                            if self._active:
+                            had_overlap = bool(self._active or self._pending_encoder_tokens)
+                            if had_overlap:
                                 self._overlapped_request_ids.update(self._admissions)
                                 self._overlapped_request_ids.add(request_id)
                             self._active += 1
@@ -386,17 +430,19 @@ class AdaptivePreprocessLimiter:
                                 self._active,
                             )
                             self._pending_reserved_mb += estimate_mb
+                            self._pending_encoder_tokens += encoder_tokens
                             self._admission_count += 1
                             admission = PreprocessAdmission(
                                 request_id=request_id,
                                 workload_key=workload_key,
                                 payload_mb=payload_mb,
                                 estimated_mb=estimate_mb,
+                                encoder_tokens=encoder_tokens,
                                 free_memory_before_mb=free_mb,
                                 admitted_at=started_at,
                                 enforced=not self.config.shadow_mode,
                                 policy_would_admit=would_admit,
-                                exclusive=self._active == 1,
+                                exclusive=not had_overlap,
                                 wait_seconds=self._clock() - started_at,
                             )
                             self._admissions[request_id] = admission
@@ -447,6 +493,108 @@ class AdaptivePreprocessLimiter:
                         self._queued -= 1
                     self._condition.notify_all()
 
+    def _release_preprocess_locked(
+        self,
+        admission: PreprocessAdmission,
+        *,
+        observed_allocation_mb: int | None,
+        success: bool,
+        memory_pressure: bool,
+    ) -> None:
+        current = self._admissions.get(admission.request_id)
+        if current is None or admission.request_id in self._preprocess_released_request_ids:
+            return
+        self._preprocess_released_request_ids.add(admission.request_id)
+        minimum_free_mb = self._minimum_free_mb_by_request.pop(
+            admission.request_id,
+            None,
+        )
+        had_overlap = admission.request_id in self._overlapped_request_ids
+        self._overlapped_request_ids.discard(admission.request_id)
+        self._active -= 1
+        self._pending_reserved_mb = max(
+            0,
+            self._pending_reserved_mb - current.estimated_mb,
+        )
+
+        if (
+            not had_overlap
+            and observed_allocation_mb is None
+            and current.free_memory_before_mb is not None
+            and minimum_free_mb is not None
+        ):
+            observed_allocation_mb = max(
+                0,
+                current.free_memory_before_mb - minimum_free_mb,
+            )
+
+        if (
+            success
+            and not memory_pressure
+            and not had_overlap
+            and observed_allocation_mb is not None
+        ):
+            observed_mb = max(
+                self.config.initial_estimated_request_mb,
+                current.payload_mb,
+                observed_allocation_mb,
+            )
+            previous = self._estimated_mb_by_workload.get(
+                current.workload_key,
+                max(self.config.initial_estimated_request_mb, current.payload_mb),
+            )
+            if observed_mb >= previous:
+                updated = observed_mb
+            else:
+                alpha = self.config.estimate_ewma_alpha
+                updated = math.ceil((1 - alpha) * previous + alpha * observed_mb)
+            self._estimated_mb_by_workload[current.workload_key] = updated
+            sample_count = self._calibration_samples_by_workload.get(current.workload_key, 0) + 1
+            self._calibration_samples_by_workload[current.workload_key] = sample_count
+            if sample_count >= self.config.calibration_samples_required:
+                self._calibrated_workloads.add(current.workload_key)
+
+        self._update_limit_after_release_locked(
+            current,
+            success=success,
+            memory_pressure=memory_pressure,
+        )
+
+    def _release_encoder_locked(self, admission: PreprocessAdmission) -> None:
+        current = self._admissions.pop(admission.request_id, None)
+        if current is None:
+            return
+        self._preprocess_released_request_ids.discard(admission.request_id)
+        self._overlapped_request_ids.discard(admission.request_id)
+        self._pending_encoder_tokens = max(
+            0,
+            self._pending_encoder_tokens - current.encoder_tokens,
+        )
+
+    async def release_preprocess(
+        self,
+        admission: PreprocessAdmission,
+        *,
+        observed_allocation_mb: int | None = None,
+        success: bool = True,
+        memory_pressure: bool = False,
+    ) -> None:
+        async with self._condition:
+            with self._state_lock:
+                self._release_preprocess_locked(
+                    admission,
+                    observed_allocation_mb=observed_allocation_mb,
+                    success=success,
+                    memory_pressure=memory_pressure,
+                )
+            self._condition.notify_all()
+
+    async def release_encoder(self, admission: PreprocessAdmission) -> None:
+        async with self._condition:
+            with self._state_lock:
+                self._release_encoder_locked(admission)
+            self._condition.notify_all()
+
     async def release(
         self,
         admission: PreprocessAdmission,
@@ -457,65 +605,13 @@ class AdaptivePreprocessLimiter:
     ) -> None:
         async with self._condition:
             with self._state_lock:
-                current = self._admissions.pop(admission.request_id, None)
-                if current is None:
-                    return
-                minimum_free_mb = self._minimum_free_mb_by_request.pop(
-                    admission.request_id,
-                    None,
-                )
-                had_overlap = admission.request_id in self._overlapped_request_ids
-                self._overlapped_request_ids.discard(admission.request_id)
-                self._active -= 1
-                self._pending_reserved_mb = max(
-                    0,
-                    self._pending_reserved_mb - current.estimated_mb,
-                )
-
-                if (
-                    not had_overlap
-                    and observed_allocation_mb is None
-                    and current.free_memory_before_mb is not None
-                ):
-                    if minimum_free_mb is not None:
-                        observed_allocation_mb = max(
-                            0,
-                            current.free_memory_before_mb - minimum_free_mb,
-                        )
-
-                if (
-                    success
-                    and not memory_pressure
-                    and not had_overlap
-                    and observed_allocation_mb is not None
-                ):
-                    observed_mb = max(
-                        self.config.initial_estimated_request_mb,
-                        current.payload_mb,
-                        observed_allocation_mb,
-                    )
-                    previous = self._estimated_mb_by_workload.get(
-                        current.workload_key,
-                        max(self.config.initial_estimated_request_mb, current.payload_mb),
-                    )
-                    if observed_mb >= previous:
-                        updated = observed_mb
-                    else:
-                        alpha = self.config.estimate_ewma_alpha
-                        updated = math.ceil((1 - alpha) * previous + alpha * observed_mb)
-                    self._estimated_mb_by_workload[current.workload_key] = updated
-                    sample_count = (
-                        self._calibration_samples_by_workload.get(current.workload_key, 0) + 1
-                    )
-                    self._calibration_samples_by_workload[current.workload_key] = sample_count
-                    if sample_count >= self.config.calibration_samples_required:
-                        self._calibrated_workloads.add(current.workload_key)
-
-                self._update_limit_after_release_locked(
-                    current,
+                self._release_preprocess_locked(
+                    admission,
+                    observed_allocation_mb=observed_allocation_mb,
                     success=success,
                     memory_pressure=memory_pressure,
                 )
+                self._release_encoder_locked(admission)
             self._condition.notify_all()
 
     def note_backpressure(self) -> None:
@@ -545,6 +641,7 @@ class AdaptivePreprocessLimiter:
             would_admit, _, _ = self._policy_decision_locked(
                 workload_key,
                 payload_mb,
+                0,
                 require_calibration=False,
             )
             return would_admit
@@ -562,6 +659,8 @@ class AdaptivePreprocessLimiter:
                 queued=self._queued,
                 effective_limit=self._effective_limit,
                 pending_reserved_mb=self._pending_reserved_mb,
+                pending_encoder_tokens=self._pending_encoder_tokens,
+                encoder_cache_capacity_tokens=self._encoder_cache_capacity_tokens,
                 admissions=self._admission_count,
                 policy_denials=self._policy_denials,
                 shadow_denials=self._shadow_denials,

--- a/services/rtvi/rt-vlm/src/models/vllm_compatible/vllm_compatible_model.py
+++ b/services/rtvi/rt-vlm/src/models/vllm_compatible/vllm_compatible_model.py
@@ -18,6 +18,7 @@ import concurrent.futures
 import contextlib
 import copy
 import hashlib
+import inspect
 import json
 import math
 import os
@@ -32,6 +33,7 @@ import uuid
 from typing import List, Optional
 
 import numpy
+import nvtx
 import torch
 import torchvision.transforms.functional as TF
 from filelock import FileLock
@@ -58,6 +60,7 @@ _RTVI_VLLM_ENV_ALIASES = {
     "VLLM_ENABLE_PREFIX_CACHING": "RTVI_VLLM_ENABLE_PREFIX_CACHING",
     "VLLM_ENFORCE_EAGER": "RTVI_VLLM_ENFORCE_EAGER",
     "VLLM_CUDAGRAPH_MODE": "RTVI_VLLM_CUDAGRAPH_MODE",
+    "VLLM_COMPILE_MM_ENCODER": "RTVI_VLLM_COMPILE_MM_ENCODER",
     "VLLM_DISABLE_MM_PREPROCESSOR_CACHE": "RTVI_VLLM_DISABLE_MM_PREPROCESSOR_CACHE",
     "VLLM_MM_PROCESSOR_CACHE_GB": "RTVI_VLLM_MM_PROCESSOR_CACHE_GB",
     "VLLM_MM_PROCESSOR_CACHE_TYPE": "RTVI_VLLM_MM_PROCESSOR_CACHE_TYPE",
@@ -102,6 +105,19 @@ _BLANK_DEFAULT_VLLM_IMPORT_ENV_VARS = (
     "VLLM_LOGGING_LEVEL",
     "VLLM_NVFP4_GEMM_BACKEND",
 )
+
+
+@contextlib.contextmanager
+def _nvtx_stage(message: str):
+    """Emit opt-in request-stage ranges without changing the production fast path."""
+    if os.environ.get("RTVI_VLM_NVTX_STAGES", "false").lower() not in ("true", "1"):
+        yield
+        return
+    range_id = nvtx.start_range(message=message, color="green")
+    try:
+        yield
+    finally:
+        nvtx.end_range(range_id)
 
 
 def _is_cuda_oom_error(error: object) -> bool:
@@ -260,13 +276,17 @@ def _get_num_preprocess_workers() -> int:
 
 def _get_vllm_compilation_config(model_architecture: str) -> dict[str, object] | None:
     raw_mode = (_get_rtvi_vllm_env("VLLM_CUDAGRAPH_MODE", "") or "").strip()
+    compile_mm_encoder = _parse_bool_env("VLLM_COMPILE_MM_ENCODER", False)
     if not raw_mode:
         if _is_cosmos3_edge_arch(model_architecture):
-            return {
+            config = {
                 "mode": "VLLM_COMPILE",
                 "cudagraph_mode": "PIECEWISE",
             }
-        return None
+            if compile_mm_encoder:
+                config["compile_mm_encoder"] = True
+            return config
+        return {"compile_mm_encoder": True} if compile_mm_encoder else None
     cudagraph_mode = raw_mode.upper()
     if cudagraph_mode not in _VLLM_CUDAGRAPH_MODES:
         supported = ", ".join(sorted(_VLLM_CUDAGRAPH_MODES))
@@ -277,6 +297,8 @@ def _get_vllm_compilation_config(model_architecture: str) -> dict[str, object] |
         "mode": "VLLM_COMPILE",
         "cudagraph_mode": cudagraph_mode,
     }
+    if compile_mm_encoder:
+        config["compile_mm_encoder"] = True
     return config
 
 
@@ -1336,6 +1358,9 @@ class VllmCompatible(BaseVlmModel):
         self._use_cuda_mm_tensor_ipc = False
         self._cuda_mm_legacy_preprocess_semaphore = None
         self._multimodal_preprocess_limiter = None
+        self._multimodal_processor_info = None
+        self._encoder_cache_capacity_tokens = None
+        self._logged_admission_token_workloads = set()
         self._adaptive_preprocess_pending_submission_ids = set()
         self._cuda_mm_pending_submission_ids = set()
         self._cuda_mm_resident_units_by_request = {}
@@ -1666,6 +1691,12 @@ class VllmCompatible(BaseVlmModel):
 
                 engine_args = AsyncEngineArgs(**engine_args_kwargs)
                 self._llm = AsyncLLMEngine.from_engine_args(engine_args)
+                self._encoder_cache_capacity_tokens = self._get_encoder_cache_capacity_tokens(
+                    self._llm
+                )
+                self._multimodal_processor_info = self._get_multimodal_processor_info(self._llm)
+                if not self._supports_visual_token_geometry(self._multimodal_processor_info):
+                    self._encoder_cache_capacity_tokens = None
                 self._processor = AutoProcessor.from_pretrained(
                     self.model_path, trust_remote_code=vlm_trust_remote_code
                 )
@@ -1700,6 +1731,7 @@ class VllmCompatible(BaseVlmModel):
                     adaptive_config,
                     self._get_cuda_free_memory_mb,
                     self._get_cuda_utilization_percent,
+                    encoder_cache_capacity_tokens=self._encoder_cache_capacity_tokens,
                 )
                 self._multimodal_preprocess_limiter.register_otel_metrics()
                 logger.info(
@@ -1707,7 +1739,7 @@ class VllmCompatible(BaseVlmModel):
                     "shadow_mode=%s, workers=%d..%d, headroom=%d MiB, "
                     "initial_estimate=%d MiB/request, safety_factor=%.2f, timeout=%.1fs, "
                     "scale_up_cooldown=%.1fs, scale_up_gpu_threshold=%.1f%%, "
-                    "calibration_samples=%d, tensor_ipc=%s",
+                    "calibration_samples=%d, encoder_cache=%s tokens, tensor_ipc=%s",
                     adaptive_config.shadow_mode,
                     adaptive_config.min_workers,
                     adaptive_config.max_workers,
@@ -1718,6 +1750,7 @@ class VllmCompatible(BaseVlmModel):
                     adaptive_config.scale_up_cooldown_seconds,
                     adaptive_config.scale_up_gpu_utilization_threshold_percent,
                     adaptive_config.calibration_samples_required,
+                    self._encoder_cache_capacity_tokens,
                     self._use_cuda_mm_tensor_ipc,
                 )
             if self._use_cuda_mm_tensor_ipc:
@@ -1971,6 +2004,127 @@ class VllmCompatible(BaseVlmModel):
         workload_key = hashlib.sha256(signature.encode("utf-8")).hexdigest()[:16]
         return workload_key, max(1, math.ceil(payload_bytes / (1024 * 1024)))
 
+    @staticmethod
+    def _get_encoder_cache_capacity_tokens(llm) -> int | None:
+        """Return vLLM's effective encoder-cache capacity when exposed."""
+        input_processor = getattr(llm, "input_processor", None)
+        value = getattr(input_processor, "mm_encoder_cache_size", None)
+        try:
+            value = int(value)
+        except (TypeError, ValueError):
+            return None
+        return value if value > 0 else None
+
+    @staticmethod
+    def _get_multimodal_processor_info(llm):
+        """Return vLLM's model-owned token geometry helper when available."""
+        renderer = getattr(llm, "renderer", None)
+        get_processor = getattr(renderer, "get_mm_processor", None)
+        if not callable(get_processor):
+            return None
+        try:
+            return getattr(get_processor(), "info", None)
+        except (AttributeError, TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _supports_visual_token_geometry(processor_info) -> bool:
+        """Return whether model-owned image or video token geometry is available."""
+        if processor_info is None:
+            return False
+        return any(
+            callable(getattr(processor_info, estimator, None))
+            for estimator in ("get_num_video_tokens", "get_num_image_tokens")
+        )
+
+    @staticmethod
+    def _multimodal_encoder_tokens(llm_inputs, processor_info) -> int | None:
+        """Estimate encoder-cache tokens from media geometry without processing pixels.
+
+        vLLM processing-info implementations own resize and patch geometry. RTVI
+        capability-detects those helpers so the policy follows the installed
+        model instead of encoding GPU- or architecture-specific constants.
+        """
+        if processor_info is None:
+            return None
+        multi_modal_data = llm_inputs.get("multi_modal_data", {})
+        if not isinstance(multi_modal_data, dict) or not multi_modal_data:
+            return 0
+        mm_kwargs = llm_inputs.get("mm_processor_kwargs", {})
+        if not isinstance(mm_kwargs, dict):
+            mm_kwargs = {}
+
+        total_tokens = 0
+        for modality, value in multi_modal_data.items():
+            estimator = getattr(processor_info, f"get_num_{modality}_tokens", None)
+            if not callable(estimator):
+                return None
+            items = value if isinstance(value, list) else [value]
+            for item in items:
+                media = item[0] if isinstance(item, tuple) and item else item
+                shape = tuple(int(dimension) for dimension in getattr(media, "shape", ()))
+                if modality == "video" and len(shape) == 4:
+                    if shape[-1] in (1, 3, 4):
+                        num_frames, image_height, image_width = shape[:3]
+                    elif shape[1] in (1, 3, 4):
+                        num_frames, image_height, image_width = shape[0], shape[2], shape[3]
+                    else:
+                        return None
+                elif modality == "image" and len(shape) == 3:
+                    num_frames = 1
+                    if shape[-1] in (1, 3, 4):
+                        image_height, image_width = shape[:2]
+                    elif shape[0] in (1, 3, 4):
+                        image_height, image_width = shape[1:]
+                    else:
+                        return None
+                else:
+                    return None
+
+                available = {
+                    "image_width": image_width,
+                    "image_height": image_height,
+                    "num_frames": num_frames,
+                    "mm_kwargs": mm_kwargs,
+                }
+                get_media_processor = getattr(
+                    processor_info,
+                    f"get_{modality}_processor",
+                    None,
+                )
+                if callable(get_media_processor):
+                    try:
+                        available["image_processor"] = get_media_processor(**mm_kwargs)
+                    except TypeError:
+                        available["image_processor"] = get_media_processor()
+
+                try:
+                    parameters = inspect.signature(estimator).parameters
+                except (TypeError, ValueError):
+                    return None
+                required = {
+                    name
+                    for name, parameter in parameters.items()
+                    if parameter.default is inspect.Parameter.empty
+                    and parameter.kind
+                    in (
+                        inspect.Parameter.POSITIONAL_ONLY,
+                        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                        inspect.Parameter.KEYWORD_ONLY,
+                    )
+                }
+                if not required.issubset(available):
+                    return None
+                call_kwargs = {name: available[name] for name in parameters if name in available}
+                try:
+                    item_tokens = int(estimator(**call_kwargs))
+                except (TypeError, ValueError):
+                    return None
+                if item_tokens < 1:
+                    return None
+                total_tokens += item_tokens
+        return total_tokens
+
     def _ensure_legacy_preprocess_semaphore(self):
         if self._cuda_mm_legacy_preprocess_semaphore is None:
             self._cuda_mm_legacy_preprocess_semaphore = asyncio.Semaphore(
@@ -1987,33 +2141,35 @@ class VllmCompatible(BaseVlmModel):
     async def _add_multimodal_request(self, request_id, llm_inputs, vllm_sampling_params):
         # Decoder backpressure may spill raw video frames to CPU. Promote only
         # after admission so concurrent copies cannot recreate a residency burst.
-        multi_modal_data = llm_inputs.get("multi_modal_data")
-        if isinstance(multi_modal_data, dict):
-            video_items = multi_modal_data.get("video")
-            if isinstance(video_items, list) and video_items:
-                video_item = video_items[0]
-                if isinstance(video_item, tuple):
-                    video_tensor, video_metadata = video_item
-                else:
-                    video_tensor, video_metadata = video_item, None
-                if (
-                    self._use_cuda_mm_tensor_ipc
-                    and isinstance(video_tensor, torch.Tensor)
-                    and not video_tensor.is_cuda
-                ):
-                    video_tensor = video_tensor.to(
-                        device=torch.device("cuda", torch.cuda.current_device())
-                    )
-                    video_items[0] = (
-                        (video_tensor, video_metadata)
-                        if isinstance(video_item, tuple)
-                        else video_tensor
-                    )
-        return await self._llm.add_request(
-            request_id,
-            llm_inputs,
-            vllm_sampling_params,
-        )
+        with _nvtx_stage("rtvi.tensor_ipc_input_prepare"):
+            multi_modal_data = llm_inputs.get("multi_modal_data")
+            if isinstance(multi_modal_data, dict):
+                video_items = multi_modal_data.get("video")
+                if isinstance(video_items, list) and video_items:
+                    video_item = video_items[0]
+                    if isinstance(video_item, tuple):
+                        video_tensor, video_metadata = video_item
+                    else:
+                        video_tensor, video_metadata = video_item, None
+                    if (
+                        self._use_cuda_mm_tensor_ipc
+                        and isinstance(video_tensor, torch.Tensor)
+                        and not video_tensor.is_cuda
+                    ):
+                        video_tensor = video_tensor.to(
+                            device=torch.device("cuda", torch.cuda.current_device())
+                        )
+                        video_items[0] = (
+                            (video_tensor, video_metadata)
+                            if isinstance(video_item, tuple)
+                            else video_tensor
+                        )
+        with _nvtx_stage("rtvi.vllm_preprocess_tensor_ipc_engine_submit"):
+            return await self._llm.add_request(
+                request_id,
+                llm_inputs,
+                vllm_sampling_params,
+            )
 
     async def _generate_with_preprocess_admission(
         self,
@@ -2024,7 +2180,8 @@ class VllmCompatible(BaseVlmModel):
         """Submit a multimodal prompt with bounded frontend preprocessing.
 
         AsyncLLM.add_request() returns after its threaded InputProcessor finishes.
-        The default RPC path retains admission until the first EngineCore output,
+        Frontend memory and worker reservations end after input processing. The
+        encoder-token reservation remains until the first EngineCore output,
         which proves the visual encoder has consumed the processed request.
         """
         from vllm.v1.engine.async_llm import STREAM_FINISHED
@@ -2034,15 +2191,16 @@ class VllmCompatible(BaseVlmModel):
         preprocess_success = False
         preprocess_memory_pressure = False
         memory_sampler_task = None
+        preprocess_released = False
 
         async def sample_memory_until_release():
-            while admission is not None:
+            while admission is not None and not preprocess_released:
                 limiter.sample_active_memory(request_id)
                 await asyncio.sleep(limiter.config.poll_interval_seconds)
 
-        async def release_admission():
-            nonlocal admission, memory_sampler_task
-            if admission is None:
+        async def release_preprocess_admission():
+            nonlocal memory_sampler_task, preprocess_released
+            if admission is None or preprocess_released:
                 return
             workload_key = admission.workload_key
             limiter.sample_active_memory(request_id)
@@ -2052,12 +2210,12 @@ class VllmCompatible(BaseVlmModel):
                     await memory_sampler_task
                 memory_sampler_task = None
             previous_snapshot = limiter.snapshot()
-            await limiter.release(
+            await limiter.release_preprocess(
                 admission,
                 success=preprocess_success,
                 memory_pressure=preprocess_memory_pressure,
             )
-            admission = None
+            preprocess_released = True
             snapshot = limiter.snapshot()
             if snapshot.effective_limit != previous_snapshot.effective_limit:
                 logger.info(
@@ -2086,32 +2244,71 @@ class VllmCompatible(BaseVlmModel):
                 snapshot.pending_reserved_mb,
             )
 
+        async def release_encoder_admission():
+            nonlocal admission
+            if admission is None:
+                return
+            await release_preprocess_admission()
+            await limiter.release_encoder(admission)
+            admission = None
+
         try:
             workload_key, payload_mb = self._multimodal_preprocess_workload(
                 llm_inputs,
                 vllm_sampling_params,
             )
+            encoder_tokens = self._multimodal_encoder_tokens(
+                llm_inputs,
+                getattr(self, "_multimodal_processor_info", None),
+            )
             limiter = self._multimodal_preprocess_limiter
             if limiter is not None:
-                try:
-                    admission = await limiter.acquire(
-                        request_id,
-                        workload_key,
-                        payload_mb,
+                logged_workloads = getattr(self, "_logged_admission_token_workloads", set())
+                encoder_capacity = limiter.snapshot().encoder_cache_capacity_tokens
+                if (
+                    encoder_tokens
+                    and encoder_capacity
+                    and workload_key not in logged_workloads
+                ):
+                    token_width = max(
+                        1,
+                        min(limiter.config.max_workers, encoder_capacity // encoder_tokens),
                     )
+                    logger.info(
+                        "Adaptive multimodal token geometry: workload=%s, "
+                        "encoder_tokens=%d, encoder_cache=%d, token_width=%d",
+                        workload_key,
+                        encoder_tokens,
+                        encoder_capacity,
+                        token_width,
+                    )
+                    logged_workloads.add(workload_key)
+                    self._logged_admission_token_workloads = logged_workloads
+                try:
+                    with _nvtx_stage("rtvi.cache_token_admission"):
+                        admission = await limiter.acquire(
+                            request_id,
+                            workload_key,
+                            payload_mb,
+                            encoder_tokens=encoder_tokens or 0,
+                        )
                     memory_sampler_task = asyncio.create_task(sample_memory_until_release())
                 except PreprocessAdmissionTimeout as exc:
                     snapshot = limiter.snapshot()
                     logger.warning(
                         "Adaptive multimodal preprocessing admission timed out: "
                         "request=%s, workload=%s, payload=%d MiB, active=%d, queued=%d, "
-                        "limit=%d, free=%s MiB, reserved=%d MiB",
+                        "limit=%d, encoder_tokens=%s, pending_encoder_tokens=%d/%s, "
+                        "free=%s MiB, reserved=%d MiB",
                         request_id,
                         workload_key,
                         payload_mb,
                         snapshot.active,
                         snapshot.queued,
                         snapshot.effective_limit,
+                        encoder_tokens,
+                        snapshot.pending_encoder_tokens,
+                        snapshot.encoder_cache_capacity_tokens,
                         snapshot.last_free_memory_mb,
                         snapshot.pending_reserved_mb,
                     )
@@ -2123,12 +2320,13 @@ class VllmCompatible(BaseVlmModel):
                     ) from exc
                 logger.debug(
                     "Multimodal preprocessing admission: request=%s, workload=%s, "
-                    "payload=%d MiB, estimate=%d MiB, wait=%.3fs, enforced=%s, "
-                    "would_admit=%s",
+                    "payload=%d MiB, estimate=%d MiB, encoder_tokens=%d, "
+                    "wait=%.3fs, enforced=%s, would_admit=%s",
                     request_id,
                     workload_key,
                     payload_mb,
                     admission.estimated_mb,
+                    admission.encoder_tokens,
                     admission.wait_seconds,
                     admission.enforced,
                     admission.policy_would_admit,
@@ -2157,7 +2355,7 @@ class VllmCompatible(BaseVlmModel):
                 raise
             finally:
                 if self._use_cuda_mm_tensor_ipc:
-                    await release_admission()
+                    await release_preprocess_admission()
             if self._use_cuda_mm_tensor_ipc:
                 self._finish_cuda_mm_submission(request_id)
 
@@ -2170,14 +2368,23 @@ class VllmCompatible(BaseVlmModel):
             llm_inputs.clear()
 
             finished = False
+            first_output = True
             while not finished:
-                output = output_queue.get_nowait() or await output_queue.get()
+                stage = (
+                    _nvtx_stage("rtvi.visual_encoder_to_first_token")
+                    if first_output
+                    else contextlib.nullcontext()
+                )
+                with stage:
+                    output = output_queue.get_nowait() or await output_queue.get()
                 finished = output.finished
                 if output is not STREAM_FINISHED:
-                    await release_admission()
-                    self._finish_preprocess_submission(request_id)
-                    if self._use_cuda_mm_tensor_ipc:
-                        self._release_cuda_mm_residency(request_id)
+                    with _nvtx_stage("rtvi.first_token"):
+                        await release_encoder_admission()
+                        self._finish_preprocess_submission(request_id)
+                        if self._use_cuda_mm_tensor_ipc:
+                            self._release_cuda_mm_residency(request_id)
+                    first_output = False
                     yield output
         except (asyncio.CancelledError, GeneratorExit):
             preprocess_success = False
@@ -2191,7 +2398,7 @@ class VllmCompatible(BaseVlmModel):
                 await self._llm.abort(output_queue.request_id, internal=True)
             raise
         finally:
-            await release_admission()
+            await release_encoder_admission()
             self._finish_preprocess_submission(request_id)
             if self._use_cuda_mm_tensor_ipc:
                 self._finish_cuda_mm_submission(request_id)

--- a/services/rtvi/rt-vlm/src/vlm_pipeline/cuda_frame_ring.py
+++ b/services/rtvi/rt-vlm/src/vlm_pipeline/cuda_frame_ring.py
@@ -6,10 +6,26 @@
 from __future__ import annotations
 
 import bisect
+import os
 import threading
+from contextlib import contextmanager
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Hashable, Optional, Sequence
+
+import nvtx
+
+
+@contextmanager
+def _ring_nvtx_stage(message: str):
+    if os.environ.get("RTVI_VLM_NVTX_STAGES", "false").lower() not in ("true", "1"):
+        yield
+        return
+    range_id = nvtx.start_range(message=message, color="blue")
+    try:
+        yield
+    finally:
+        nvtx.end_range(range_id)
 
 
 @dataclass(frozen=True)
@@ -72,9 +88,13 @@ class CudaFrameRing:
 
     def wait_for_fill(self, source_id: Hashable, epoch: Hashable, timeout: float) -> bool:
         key = (source_id, epoch)
-        with self._condition:
-            completed = self._condition.wait_for(lambda: key not in self._fills, timeout=timeout)
-            return bool(completed and key in self._windows)
+        with _ring_nvtx_stage("rtvi.decode_ring_wait"):
+            with self._condition:
+                completed = self._condition.wait_for(
+                    lambda: key not in self._fills,
+                    timeout=timeout,
+                )
+                return bool(completed and key in self._windows)
 
     def abort_fill(self, source_id: Hashable, epoch: Hashable) -> None:
         key = (source_id, epoch)
@@ -278,16 +298,17 @@ class CudaFrameRing:
         selection_key: Hashable,
     ) -> Optional[tuple[object, list[int]]]:
         key = (source_id, epoch)
-        with self._condition:
-            window = self._windows.get(key)
-            if window is None:
-                return None
-            selections = dict(window.selections)
-            selection = selections.get(selection_key)
-            if selection is None:
-                return None
-            self._windows.move_to_end(key)
-            return selection.frames, list(selection.pts_ns)
+        with _ring_nvtx_stage("rtvi.decode_ring_lookup_packed"):
+            with self._condition:
+                window = self._windows.get(key)
+                if window is None:
+                    return None
+                selections = dict(window.selections)
+                selection = selections.get(selection_key)
+                if selection is None:
+                    return None
+                self._windows.move_to_end(key)
+                return selection.frames, list(selection.pts_ns)
 
     def acquire(
         self,
@@ -300,35 +321,36 @@ class CudaFrameRing:
         select_all: bool = False,
     ) -> Optional[tuple[list[object], list[int]]]:
         key = (source_id, epoch)
-        with self._condition:
-            window = self._windows.get(key)
-            if (
-                window is None
-                or start_ns < window.coverage_start_ns
-                or end_ns > window.coverage_end_ns
-            ):
-                return None
-            self._windows.move_to_end(key)
-
-            if select_all:
-                first = bisect.bisect_left(window.pts_ns, start_ns)
-                last = bisect.bisect_right(window.pts_ns, end_ns)
-                indices = range(first, last)
-            elif target_indices is not None:
-                if any(index < 0 or index >= len(window.frames) for index in target_indices):
+        with _ring_nvtx_stage("rtvi.decode_ring_lookup"):
+            with self._condition:
+                window = self._windows.get(key)
+                if (
+                    window is None
+                    or start_ns < window.coverage_start_ns
+                    or end_ns > window.coverage_end_ns
+                ):
                     return None
-                indices = target_indices
-            else:
-                indices = []
-                for target in target_pts_ns or ():
-                    index = bisect.bisect_left(window.pts_ns, target)
-                    if index >= len(window.pts_ns) or window.pts_ns[index] > end_ns:
-                        return None
-                    indices.append(index)
+                self._windows.move_to_end(key)
 
-            selected_frames = [window.frames[index] for index in indices]
-            selected_pts = [window.pts_ns[index] for index in indices]
-            return selected_frames, selected_pts
+                if select_all:
+                    first = bisect.bisect_left(window.pts_ns, start_ns)
+                    last = bisect.bisect_right(window.pts_ns, end_ns)
+                    indices = range(first, last)
+                elif target_indices is not None:
+                    if any(index < 0 or index >= len(window.frames) for index in target_indices):
+                        return None
+                    indices = target_indices
+                else:
+                    indices = []
+                    for target in target_pts_ns or ():
+                        index = bisect.bisect_left(window.pts_ns, target)
+                        if index >= len(window.pts_ns) or window.pts_ns[index] > end_ns:
+                            return None
+                        indices.append(index)
+
+                selected_frames = [window.frames[index] for index in indices]
+                selected_pts = [window.pts_ns[index] for index in indices]
+                return selected_frames, selected_pts
 
     def acquire_exact(
         self,

--- a/services/rtvi/rt-vlm/src/vlm_pipeline/cuda_frame_ring.py
+++ b/services/rtvi/rt-vlm/src/vlm_pipeline/cuda_frame_ring.py
@@ -56,6 +56,33 @@ def _frame_nbytes(frame) -> int:
     return 0
 
 
+def select_frame_indices(
+    pts_ns: Sequence[int],
+    start_ns: int,
+    end_ns: int,
+    target_pts_ns: Optional[Sequence[int]] = None,
+    target_indices: Optional[Sequence[int]] = None,
+    select_all: bool = False,
+) -> list[int]:
+    """Match sparse selection: consume coincident targets once, without EOS padding."""
+    if select_all:
+        first = bisect.bisect_left(pts_ns, start_ns)
+        last = bisect.bisect_right(pts_ns, end_ns)
+        return list(range(first, last))
+    if target_indices is not None:
+        return list(dict.fromkeys(index for index in target_indices if 0 <= index < len(pts_ns)))
+
+    indices = []
+    for target in target_pts_ns or ():
+        index = bisect.bisect_left(pts_ns, target)
+        if index >= len(pts_ns) or pts_ns[index] > end_ns:
+            continue
+        # Sparse decode consumes every reached target when it emits this frame.
+        if not indices or index != indices[-1]:
+            indices.append(index)
+    return indices
+
+
 class CudaFrameRing:
     """Retain complete dense frame windows under a strict byte budget.
 
@@ -227,7 +254,11 @@ class CudaFrameRing:
             return False
         if pts_ns:
             window = _FrameWindow(
-                coverage_start_ns=max(window.coverage_start_ns, pts_ns[0]),
+                coverage_start_ns=(
+                    max(window.coverage_start_ns, pts_ns[0])
+                    if len(frames) < len(window.frames)
+                    else window.coverage_start_ns
+                ),
                 coverage_end_ns=window.coverage_end_ns,
                 pts_ns=tuple(pts_ns),
                 frames=tuple(frames),
@@ -332,21 +363,9 @@ class CudaFrameRing:
                     return None
                 self._windows.move_to_end(key)
 
-                if select_all:
-                    first = bisect.bisect_left(window.pts_ns, start_ns)
-                    last = bisect.bisect_right(window.pts_ns, end_ns)
-                    indices = range(first, last)
-                elif target_indices is not None:
-                    if any(index < 0 or index >= len(window.frames) for index in target_indices):
-                        return None
-                    indices = target_indices
-                else:
-                    indices = []
-                    for target in target_pts_ns or ():
-                        index = bisect.bisect_left(window.pts_ns, target)
-                        if index >= len(window.pts_ns) or window.pts_ns[index] > end_ns:
-                            return None
-                        indices.append(index)
+                indices = select_frame_indices(
+                    window.pts_ns, start_ns, end_ns, target_pts_ns, target_indices, select_all
+                )
 
                 selected_frames = [window.frames[index] for index in indices]
                 selected_pts = [window.pts_ns[index] for index in indices]

--- a/services/rtvi/rt-vlm/src/vlm_pipeline/cuda_frame_ring.py
+++ b/services/rtvi/rt-vlm/src/vlm_pipeline/cuda_frame_ring.py
@@ -1,0 +1,353 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bounded, thread-safe frame retention indexed by source epoch and PTS."""
+
+from __future__ import annotations
+
+import bisect
+import threading
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Hashable, Optional, Sequence
+
+
+@dataclass(frozen=True)
+class _FrameWindow:
+    coverage_start_ns: int
+    coverage_end_ns: int
+    pts_ns: tuple[int, ...]
+    frames: tuple[object, ...]
+    size_bytes: int
+    selections: tuple[tuple[Hashable, "_PackedSelection"], ...] = ()
+
+
+@dataclass(frozen=True)
+class _PackedSelection:
+    frames: object
+    pts_ns: tuple[int, ...]
+    size_bytes: int
+
+
+def _frame_nbytes(frame) -> int:
+    nbytes = getattr(frame, "nbytes", None)
+    if nbytes is not None:
+        return int(nbytes)
+    element_size = getattr(frame, "element_size", None)
+    numel = getattr(frame, "numel", None)
+    if callable(element_size) and callable(numel):
+        return int(element_size() * numel())
+    return 0
+
+
+class CudaFrameRing:
+    """Retain complete dense frame windows under a strict byte budget.
+
+    The ring is tensor-library agnostic: CUDA tensors remain on device because
+    it stores references only. Eviction removes ring ownership but cannot
+    invalidate references already acquired by a request.
+    """
+
+    def __init__(self, max_bytes: int):
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be positive")
+        self.max_bytes = int(max_bytes)
+        self._bytes_used = 0
+        self._windows: OrderedDict[tuple[Hashable, Hashable], _FrameWindow] = OrderedDict()
+        self._fills: set[tuple[Hashable, Hashable]] = set()
+        self._condition = threading.Condition()
+
+    @property
+    def bytes_used(self) -> int:
+        with self._condition:
+            return self._bytes_used
+
+    def claim_fill(self, source_id: Hashable, epoch: Hashable) -> bool:
+        key = (source_id, epoch)
+        with self._condition:
+            if key in self._fills:
+                return False
+            self._fills.add(key)
+            return True
+
+    def wait_for_fill(self, source_id: Hashable, epoch: Hashable, timeout: float) -> bool:
+        key = (source_id, epoch)
+        with self._condition:
+            completed = self._condition.wait_for(lambda: key not in self._fills, timeout=timeout)
+            return bool(completed and key in self._windows)
+
+    def abort_fill(self, source_id: Hashable, epoch: Hashable) -> None:
+        key = (source_id, epoch)
+        with self._condition:
+            self._fills.discard(key)
+            self._condition.notify_all()
+
+    def discard(self, source_id: Hashable, epoch: Optional[Hashable] = None) -> None:
+        """Release retained ownership for one source epoch or every source epoch."""
+        with self._condition:
+            keys = [
+                key
+                for key in self._windows
+                if key[0] == source_id and (epoch is None or key[1] == epoch)
+            ]
+            for key in keys:
+                self._bytes_used -= self._windows.pop(key).size_bytes
+                self._fills.discard(key)
+            self._condition.notify_all()
+
+    def publish(
+        self,
+        source_id: Hashable,
+        epoch: Hashable,
+        coverage_start_ns: int,
+        coverage_end_ns: int,
+        pts_ns: Sequence[int],
+        frames: Sequence[object],
+        complete_fill: bool = True,
+    ) -> bool:
+        if len(pts_ns) != len(frames):
+            raise ValueError("pts_ns and frames must have the same length")
+        if any(left >= right for left, right in zip(pts_ns, pts_ns[1:])):
+            raise ValueError("pts_ns must be strictly increasing")
+        if coverage_start_ns > coverage_end_ns:
+            raise ValueError("coverage_start_ns must not exceed coverage_end_ns")
+
+        key = (source_id, epoch)
+        window = _FrameWindow(
+            coverage_start_ns=int(coverage_start_ns),
+            coverage_end_ns=int(coverage_end_ns),
+            pts_ns=tuple(int(pts) for pts in pts_ns),
+            frames=tuple(frames),
+            size_bytes=sum(_frame_nbytes(frame) for frame in frames),
+        )
+        with self._condition:
+            previous = self._windows.pop(key, None)
+            if previous is not None:
+                self._bytes_used -= previous.size_bytes
+
+            if previous is not None and (
+                window.coverage_start_ns <= previous.coverage_end_ns
+                and previous.coverage_start_ns <= window.coverage_end_ns
+            ):
+                merged = dict(zip(previous.pts_ns, previous.frames))
+                merged.update(zip(window.pts_ns, window.frames))
+                merged_pts = tuple(sorted(merged))
+                merged_frames = tuple(merged[pts] for pts in merged_pts)
+                window = _FrameWindow(
+                    coverage_start_ns=min(
+                        previous.coverage_start_ns,
+                        window.coverage_start_ns,
+                    ),
+                    coverage_end_ns=max(previous.coverage_end_ns, window.coverage_end_ns),
+                    pts_ns=merged_pts,
+                    frames=merged_frames,
+                    size_bytes=(
+                        sum(_frame_nbytes(frame) for frame in merged_frames)
+                        + sum(selection.size_bytes for _, selection in previous.selections)
+                    ),
+                    selections=previous.selections,
+                )
+
+            stored = self._store_window_locked(key, window)
+
+            if complete_fill:
+                self._fills.discard(key)
+                self._condition.notify_all()
+            return stored
+
+    def append(
+        self,
+        source_id: Hashable,
+        epoch: Hashable,
+        pts_ns: int,
+        frame: object,
+    ) -> bool:
+        """Append one live frame and evict the oldest retained PTS when full."""
+        key = (source_id, epoch)
+        with self._condition:
+            previous = self._windows.pop(key, None)
+            if previous is not None:
+                self._bytes_used -= previous.size_bytes
+                by_pts = dict(zip(previous.pts_ns, previous.frames))
+                by_pts[int(pts_ns)] = frame
+                ordered_pts = tuple(sorted(by_pts))
+                frames = tuple(by_pts[pts] for pts in ordered_pts)
+                coverage_start_ns = min(previous.coverage_start_ns, int(pts_ns))
+                coverage_end_ns = max(previous.coverage_end_ns, int(pts_ns))
+            else:
+                ordered_pts = (int(pts_ns),)
+                frames = (frame,)
+                coverage_start_ns = coverage_end_ns = int(pts_ns)
+            window = _FrameWindow(
+                coverage_start_ns=coverage_start_ns,
+                coverage_end_ns=coverage_end_ns,
+                pts_ns=ordered_pts,
+                frames=frames,
+                size_bytes=sum(_frame_nbytes(item) for item in frames),
+            )
+            return self._store_window_locked(key, window)
+
+    def _store_window_locked(
+        self,
+        key: tuple[Hashable, Hashable],
+        window: _FrameWindow,
+    ) -> bool:
+        selections = list(window.selections)
+        size_bytes = window.size_bytes
+        while selections and size_bytes > self.max_bytes:
+            _, selection = selections.pop(0)
+            size_bytes -= selection.size_bytes
+
+        pts_ns = list(window.pts_ns)
+        frames = list(window.frames)
+        while frames and size_bytes > self.max_bytes:
+            size_bytes -= _frame_nbytes(frames.pop(0))
+            pts_ns.pop(0)
+        if not frames and window.frames:
+            return False
+        if pts_ns:
+            window = _FrameWindow(
+                coverage_start_ns=max(window.coverage_start_ns, pts_ns[0]),
+                coverage_end_ns=window.coverage_end_ns,
+                pts_ns=tuple(pts_ns),
+                frames=tuple(frames),
+                size_bytes=size_bytes,
+                selections=tuple(selections),
+            )
+        self._windows[key] = window
+        self._bytes_used += window.size_bytes
+        while self._bytes_used > self.max_bytes and self._windows:
+            _, evicted = self._windows.popitem(last=False)
+            self._bytes_used -= evicted.size_bytes
+        return key in self._windows
+
+    def publish_selection(
+        self,
+        source_id: Hashable,
+        epoch: Hashable,
+        selection_key: Hashable,
+        frames: object,
+        pts_ns: Sequence[int],
+    ) -> bool:
+        """Retain one immutable packed tensor to avoid per-request D2D repacking."""
+        key = (source_id, epoch)
+        selection = _PackedSelection(
+            frames=frames,
+            pts_ns=tuple(int(pts) for pts in pts_ns),
+            size_bytes=_frame_nbytes(frames),
+        )
+        with self._condition:
+            window = self._windows.pop(key, None)
+            if window is None:
+                self._fills.discard(key)
+                self._condition.notify_all()
+                return False
+            self._bytes_used -= window.size_bytes
+            selections = OrderedDict(window.selections)
+            previous = selections.pop(selection_key, None)
+            candidate_size = window.size_bytes - (previous.size_bytes if previous else 0)
+            candidate_size += selection.size_bytes
+            if candidate_size > self.max_bytes:
+                self._windows[key] = window
+                self._bytes_used += window.size_bytes
+                self._fills.discard(key)
+                self._condition.notify_all()
+                return False
+            selections[selection_key] = selection
+            updated = _FrameWindow(
+                coverage_start_ns=window.coverage_start_ns,
+                coverage_end_ns=window.coverage_end_ns,
+                pts_ns=window.pts_ns,
+                frames=window.frames,
+                size_bytes=candidate_size,
+                selections=tuple(selections.items()),
+            )
+            self._windows[key] = updated
+            self._bytes_used += updated.size_bytes
+            while self._bytes_used > self.max_bytes and self._windows:
+                _, evicted = self._windows.popitem(last=False)
+                self._bytes_used -= evicted.size_bytes
+            self._fills.discard(key)
+            self._condition.notify_all()
+            return key in self._windows
+
+    def acquire_selection(
+        self,
+        source_id: Hashable,
+        epoch: Hashable,
+        selection_key: Hashable,
+    ) -> Optional[tuple[object, list[int]]]:
+        key = (source_id, epoch)
+        with self._condition:
+            window = self._windows.get(key)
+            if window is None:
+                return None
+            selections = dict(window.selections)
+            selection = selections.get(selection_key)
+            if selection is None:
+                return None
+            self._windows.move_to_end(key)
+            return selection.frames, list(selection.pts_ns)
+
+    def acquire(
+        self,
+        source_id: Hashable,
+        epoch: Hashable,
+        start_ns: int,
+        end_ns: int,
+        target_pts_ns: Optional[Sequence[int]] = None,
+        target_indices: Optional[Sequence[int]] = None,
+        select_all: bool = False,
+    ) -> Optional[tuple[list[object], list[int]]]:
+        key = (source_id, epoch)
+        with self._condition:
+            window = self._windows.get(key)
+            if (
+                window is None
+                or start_ns < window.coverage_start_ns
+                or end_ns > window.coverage_end_ns
+            ):
+                return None
+            self._windows.move_to_end(key)
+
+            if select_all:
+                first = bisect.bisect_left(window.pts_ns, start_ns)
+                last = bisect.bisect_right(window.pts_ns, end_ns)
+                indices = range(first, last)
+            elif target_indices is not None:
+                if any(index < 0 or index >= len(window.frames) for index in target_indices):
+                    return None
+                indices = target_indices
+            else:
+                indices = []
+                for target in target_pts_ns or ():
+                    index = bisect.bisect_left(window.pts_ns, target)
+                    if index >= len(window.pts_ns) or window.pts_ns[index] > end_ns:
+                        return None
+                    indices.append(index)
+
+            selected_frames = [window.frames[index] for index in indices]
+            selected_pts = [window.pts_ns[index] for index in indices]
+            return selected_frames, selected_pts
+
+    def acquire_exact(
+        self,
+        source_id: Hashable,
+        epoch: Hashable,
+        pts_ns: Sequence[int],
+    ) -> Optional[tuple[list[object], list[int]]]:
+        """Acquire exact live-frame PTS references without nearest-frame substitution."""
+        key = (source_id, epoch)
+        with self._condition:
+            window = self._windows.get(key)
+            if window is None:
+                return None
+            indices_by_pts = {pts: index for index, pts in enumerate(window.pts_ns)}
+            if any(int(pts) not in indices_by_pts for pts in pts_ns):
+                return None
+            self._windows.move_to_end(key)
+            indices = [indices_by_pts[int(pts)] for pts in pts_ns]
+            return (
+                [window.frames[index] for index in indices],
+                [window.pts_ns[index] for index in indices],
+            )

--- a/services/rtvi/rt-vlm/src/vlm_pipeline/process_base.py
+++ b/services/rtvi/rt-vlm/src/vlm_pipeline/process_base.py
@@ -65,6 +65,7 @@ if _USE_CUDA_MM_TENSOR_IPC:
 _TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
 _FALSE_ENV_VALUES = {"0", "false", "no", "off", ""}
 QUEUE_DECODED_FRAMES_ON_GPU_ENV = "RTVI_QUEUE_DECODED_FRAMES_ON_GPU"
+CUDA_MM_TRANSPORT_BACKPRESSURE_ENV = "RTVI_CUDA_MM_TRANSPORT_BACKPRESSURE"
 
 
 def _parse_bool_env(name: str, default: bool = False) -> bool:
@@ -117,6 +118,19 @@ def _contains_cuda_tensor(value):
     if isinstance(value, dict):
         return any(_contains_cuda_tensor(item) for item in value.values())
     return False
+
+
+def _wait_for_cuda_transport_slot(
+    output_queue,
+    slots: int,
+    stop_event,
+    poll_seconds: float = 0.001,
+) -> bool:
+    """Bound CUDA frame residency without a device-host-device spill."""
+    while output_queue.qsize() >= slots:
+        if stop_event.wait(poll_seconds):
+            return False
+    return True
 
 
 def _safe_cuda_empty_cache(force=False):
@@ -352,23 +366,29 @@ class ProcessBase(mp_ctx.Process):
                                 1, int(getattr(self, "_num_decoders_per_gpu", 8))
                             )
                             if self._output_queue.qsize() >= raw_transport_slots:
-                                # A blocked live decoder otherwise retains one
-                                # full GPU chunk per stream while waiting for a
-                                # transport slot. At high stream counts that
-                                # backpressure storage, rather than inference,
-                                # exhausts device memory. Preserve direct CUDA
-                                # IPC when a slot is available; spill only the
-                                # overloaded tail to host memory.
-                                ret_item["frames"] = _spill_cuda_frames_to_cpu(ret_item["frames"])
-                                logger.debug(
-                                    "Spilled decoded CUDA frames to CPU while the "
-                                    "%d-slot decoder-to-VLM queue was full",
-                                    raw_transport_slots,
-                                )
-                            # The multiprocessing transport retains the Python
-                            # baseline's global 128-request capacity. Only its
-                            # on-device window is bounded above; host-spilled
-                            # chunks can continue filling that global queue.
+                                if _parse_bool_env(CUDA_MM_TRANSPORT_BACKPRESSURE_ENV):
+                                    if not _wait_for_cuda_transport_slot(
+                                        self._output_queue,
+                                        raw_transport_slots,
+                                        self._stop,
+                                    ):
+                                        return
+                                else:
+                                    # Preserve the established fallback unless
+                                    # bounded no-spill transport is explicitly
+                                    # enabled and qualified on the target.
+                                    ret_item["frames"] = _spill_cuda_frames_to_cpu(
+                                        ret_item["frames"]
+                                    )
+                                    logger.debug(
+                                        "Spilled decoded CUDA frames to CPU while the "
+                                        "%d-slot decoder-to-VLM queue was full",
+                                        raw_transport_slots,
+                                    )
+                            # The transport retains the global 128-request
+                            # capacity while bounding its on-device window.
+                            # Overload either waits here or uses the established
+                            # host-spill fallback, according to the opt-in mode.
                         self._output_queue.put(ret_item)
         elif isinstance(result, dict):
             # Empty dict returned by process method, send the chunk to final output queue

--- a/services/rtvi/rt-vlm/src/vlm_pipeline/process_base.py
+++ b/services/rtvi/rt-vlm/src/vlm_pipeline/process_base.py
@@ -177,6 +177,10 @@ class ProcessBase(mp_ctx.Process):
         self._disabled = disabled
         self._num_futures_threads = 5
         self._description = description
+        # Decoder result callbacks can run concurrently. Keep the raw CUDA
+        # queue-size check and enqueue atomic so they cannot over-admit the
+        # configured on-device transport window.
+        self._cuda_transport_admission_lock = mp_ctx.Lock()
 
     def start(self) -> None:
         """Start the process"""
@@ -352,6 +356,7 @@ class ProcessBase(mp_ctx.Process):
                     if "error" in ret_item and ret_item["error"]:
                         self._final_output_queue.put(ret_item)
                     else:
+                        enqueued_cuda_frames = False
                         if _USE_CUDA_MM_TENSOR_IPC and _contains_cuda_tensor(
                             ret_item.get("frames")
                         ):
@@ -365,31 +370,36 @@ class ProcessBase(mp_ctx.Process):
                             raw_transport_slots = max(
                                 1, int(getattr(self, "_num_decoders_per_gpu", 8))
                             )
-                            if self._output_queue.qsize() >= raw_transport_slots:
-                                if _parse_bool_env(CUDA_MM_TRANSPORT_BACKPRESSURE_ENV):
-                                    if not _wait_for_cuda_transport_slot(
-                                        self._output_queue,
-                                        raw_transport_slots,
-                                        self._stop,
-                                    ):
-                                        return
-                                else:
-                                    # Preserve the established fallback unless
-                                    # bounded no-spill transport is explicitly
-                                    # enabled and qualified on the target.
-                                    ret_item["frames"] = _spill_cuda_frames_to_cpu(
-                                        ret_item["frames"]
-                                    )
-                                    logger.debug(
-                                        "Spilled decoded CUDA frames to CPU while the "
-                                        "%d-slot decoder-to-VLM queue was full",
-                                        raw_transport_slots,
-                                    )
+                            with self._cuda_transport_admission_lock:
+                                if self._output_queue.qsize() >= raw_transport_slots:
+                                    if _parse_bool_env(CUDA_MM_TRANSPORT_BACKPRESSURE_ENV):
+                                        if not _wait_for_cuda_transport_slot(
+                                            self._output_queue,
+                                            raw_transport_slots,
+                                            self._stop,
+                                        ):
+                                            return
+                                    else:
+                                        # Preserve the established fallback unless
+                                        # bounded no-spill transport is explicitly
+                                        # enabled and qualified on the target.
+                                        ret_item["frames"] = _spill_cuda_frames_to_cpu(
+                                            ret_item["frames"]
+                                        )
+                                        logger.debug(
+                                            "Spilled decoded CUDA frames to CPU while the "
+                                            "%d-slot decoder-to-VLM queue was full",
+                                            raw_transport_slots,
+                                        )
+                                if _contains_cuda_tensor(ret_item.get("frames")):
+                                    self._output_queue.put(ret_item)
+                                    enqueued_cuda_frames = True
                             # The transport retains the global 128-request
                             # capacity while bounding its on-device window.
                             # Overload either waits here or uses the established
                             # host-spill fallback, according to the opt-in mode.
-                        self._output_queue.put(ret_item)
+                        if not enqueued_cuda_frames:
+                            self._output_queue.put(ret_item)
         elif isinstance(result, dict):
             # Empty dict returned by process method, send the chunk to final output queue
             for idx in range(num_items):

--- a/services/rtvi/rt-vlm/src/vlm_pipeline/video_file_frame_getter.py
+++ b/services/rtvi/rt-vlm/src/vlm_pipeline/video_file_frame_getter.py
@@ -60,6 +60,7 @@ from torchvision.transforms import InterpolationMode, v2
 from common.chunk_info import ChunkInfo
 from common.logger import TimeMeasure, logger
 from utils.media_file_info import MediaFileInfo
+from vlm_pipeline.cuda_frame_ring import CudaFrameRing
 from vlm_pipeline.errors import format_cuda_oom_error
 from vlm_pipeline.ipc_frame_source import (
     DEFAULT_IPC_META_DESERIALIZATION_LIB,
@@ -862,6 +863,18 @@ class VideoFileFrameGetter:
         self._gop_decode_opt_enabled = os.environ.get(
             "RTVI_ENABLE_GOP_DECODE_OPT", "true"
         ).lower() not in ("false", "0", "no", "off")
+        try:
+            ring_mb = max(
+                1,
+                int(os.environ.get("RTVI_PERSISTENT_CUDA_FRAME_RING_MB", "512")),
+            )
+        except ValueError:
+            ring_mb = 512
+        self._persistent_cuda_frame_ring_enabled = _env_bool(
+            "RTVI_PERSISTENT_CUDA_FRAME_RING", False
+        )
+        self._live_cuda_frame_ring = CudaFrameRing(ring_mb * 1024 * 1024)
+        self._live_stream_epoch = 0
 
         if "gdino_engine" in self._cv_pipeline_configs:
             self._gdino_engine = self._cv_pipeline_configs["gdino_engine"]
@@ -931,6 +944,15 @@ class VideoFileFrameGetter:
             with self._live_stream_frame_selectors_lock:
                 for fs_data in self._live_stream_frame_selectors.values():
                     fs_data.cached_frames = []
+        if (
+            getattr(self, "_persistent_cuda_frame_ring_enabled", False)
+            and getattr(self, "_live_cuda_frame_ring", None) is not None
+        ):
+            source_id = getattr(self, "_ipc_stream_identity", "") or getattr(
+                self, "_current_stream_id", ""
+            )
+            if source_id:
+                self._live_cuda_frame_ring.discard(source_id)
         try:
             torch.cuda.empty_cache()
         except RuntimeError:
@@ -1127,9 +1149,25 @@ class VideoFileFrameGetter:
                 or (len(fs._selected_pts_array) == 0 and not fs.selects_all_frames)
                 or flush
             ):
-                if len(fs_data.cached_pts) == len(fs_data.cached_frames) or flush:
+                ring_frames = None
+                if self._persistent_cuda_frame_ring_enabled and fs_data.cached_pts:
+                    acquired = self._live_cuda_frame_ring.acquire_exact(
+                        self._ipc_stream_identity or self._current_stream_id,
+                        self._live_stream_epoch,
+                        [int(round(pts * 1_000_000_000)) for pts in fs_data.cached_pts],
+                    )
+                    if acquired is not None:
+                        ring_frames = acquired[0]
+                frames_ready = (
+                    ring_frames is not None
+                    or len(fs_data.cached_pts) == len(fs_data.cached_frames)
+                    or flush
+                )
+                if frames_ready:
                     try:
-                        cached_frames = self._preprocess(fs_data.cached_frames)
+                        cached_frames = self._preprocess(
+                            ring_frames if ring_frames is not None else fs_data.cached_frames
+                        )
                     except torch.OutOfMemoryError as exc:
                         self._handle_cuda_oom(
                             exc,
@@ -2167,9 +2205,19 @@ class VideoFileFrameGetter:
                 # Cache the pre-processed frame / jpeg and its timestamp. Convert
                 # the timestamps from nanoseconds to seconds.
                 if self._is_live:
+                    if self._persistent_cuda_frame_ring_enabled:
+                        self._live_cuda_frame_ring.append(
+                            self._ipc_stream_identity or self._current_stream_id,
+                            self._live_stream_epoch,
+                            int(buffer.pts),
+                            image_tensor,
+                        )
                     with self._live_stream_frame_selectors_lock:
                         for _, fs_data in self._live_stream_frame_selectors.items():
                             if buffer.pts / 1e9 in fs_data.cached_pts:
+                                # The selector's reference pins the frame until its
+                                # request completes, even if bounded ring eviction
+                                # removes the stream-owned reference first.
                                 fs_data.cached_frames.append(image_tensor)
                         self._process_finished_chunks(buffer.pts)
                 else:
@@ -3335,6 +3383,12 @@ class VideoFileFrameGetter:
             self._live_stream_ntp_pts = 0
             self._cached_transcripts = []
 
+            if self._persistent_cuda_frame_ring_enabled and self._live_stream_epoch:
+                self._live_cuda_frame_ring.discard(
+                    self._ipc_stream_identity,
+                    self._live_stream_epoch,
+                )
+            self._live_stream_epoch += 1
             self._pipeline = self._create_pipeline(live_stream_url, username, password)
 
             # Start input, output audio ASR in a separate process if audio is enabled,
@@ -3471,6 +3525,8 @@ class VideoFileFrameGetter:
         self._pipeline = None
         self._clear_pipeline_elements()
         self._live_stream_frame_selectors.clear()
+        if self._persistent_cuda_frame_ring_enabled:
+            self._live_cuda_frame_ring.discard(self._ipc_stream_identity)
         self._live_stream_chunk_decoded_callback = None
         self._on_stream_error_callback = None
         if self._copy_stream is not None:

--- a/services/rtvi/rt-vlm/src/vlm_pipeline/video_file_frame_getter.py
+++ b/services/rtvi/rt-vlm/src/vlm_pipeline/video_file_frame_getter.py
@@ -713,6 +713,7 @@ class VideoFileFrameGetter:
         data_type_int8=False,
         audio_support=False,
         cv_pipeline_configs={},
+        cuda_frame_ring: Optional[CudaFrameRing] = None,
     ) -> None:
         self._selected_pts_array = deque()
         self._last_gst_buffer = None
@@ -873,7 +874,7 @@ class VideoFileFrameGetter:
         self._persistent_cuda_frame_ring_enabled = _env_bool(
             "RTVI_PERSISTENT_CUDA_FRAME_RING", False
         )
-        self._live_cuda_frame_ring = CudaFrameRing(ring_mb * 1024 * 1024)
+        self._live_cuda_frame_ring = cuda_frame_ring or CudaFrameRing(ring_mb * 1024 * 1024)
         self._live_stream_epoch = 0
 
         if "gdino_engine" in self._cv_pipeline_configs:

--- a/services/rtvi/rt-vlm/src/vlm_pipeline/vlm_pipeline.py
+++ b/services/rtvi/rt-vlm/src/vlm_pipeline/vlm_pipeline.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+import bisect
 import concurrent.futures
 import multiprocessing
 import os
@@ -71,6 +72,9 @@ FAST_IMAGE_ASSET_CHUNK_DECODE_ENV = "RTVI_FAST_IMAGE_ASSET_CHUNK_DECODE"
 STRICT_FIXED_FRAME_CHUNK_DECODE_ENV = "RTVI_STRICT_FIXED_FRAME_CHUNK_DECODE"
 VLM_QUEUE_MAXSIZE_ENV = "RTVI_VLM_QUEUE_MAXSIZE"
 IMAGE_ASSET_EXTENSIONS = frozenset((".jpg", ".jpeg", ".png", ".bmp", ".webp"))
+PERSISTENT_CUDA_FRAME_RING_ENV = "RTVI_PERSISTENT_CUDA_FRAME_RING"
+PERSISTENT_CUDA_FRAME_RING_MB_ENV = "RTVI_PERSISTENT_CUDA_FRAME_RING_MB"
+DEFAULT_PERSISTENT_CUDA_FRAME_RING_MB = 512
 
 
 def _decode_max_attempts() -> int:
@@ -128,6 +132,103 @@ def _fast_image_asset_chunk_decode_enabled() -> bool:
         "yes",
         "on",
     )
+
+
+def _persistent_cuda_frame_ring_enabled() -> bool:
+    return os.environ.get(PERSISTENT_CUDA_FRAME_RING_ENV, "false").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def _persistent_cuda_frame_ring_bytes() -> int:
+    raw_value = os.environ.get(
+        PERSISTENT_CUDA_FRAME_RING_MB_ENV,
+        str(DEFAULT_PERSISTENT_CUDA_FRAME_RING_MB),
+    )
+    try:
+        megabytes = max(1, int(raw_value))
+    except ValueError:
+        logger.warning(
+            "Invalid %s=%r; using default %d MiB",
+            PERSISTENT_CUDA_FRAME_RING_MB_ENV,
+            raw_value,
+            DEFAULT_PERSISTENT_CUDA_FRAME_RING_MB,
+        )
+        megabytes = DEFAULT_PERSISTENT_CUDA_FRAME_RING_MB
+    return megabytes * 1024 * 1024
+
+
+def _file_ring_identity(chunk: ChunkInfo, width: int, height: int, video_codec: str):
+    """Return a content-versioned ring identity, or None for unsupported inputs."""
+    if (
+        not chunk.file
+        or ";" in chunk.file
+        or "://" in chunk.file
+        or os.path.splitext(chunk.file)[1].lower() in IMAGE_ASSET_EXTENSIONS
+    ):
+        return None
+    try:
+        stat = os.stat(chunk.file)
+    except OSError:
+        return None
+    source_id = (os.path.realpath(chunk.file), int(width), int(height), video_codec)
+    epoch = (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns, stat.st_ctime_ns)
+    return source_id, epoch
+
+
+def _selector_ring_query(frame_selector, chunk: ChunkInfo) -> dict:
+    """Freeze a selector's request before a dense decode mutates another selector."""
+    frame_selector.set_chunk(chunk)
+    return {
+        "start_ns": int(frame_selector._selection_start_pts),
+        "end_ns": int(frame_selector._selection_end_pts),
+        "target_pts_ns": list(frame_selector._selected_pts_array),
+        "target_indices": (
+            list(frame_selector._selected_frame_indices_array)
+            if frame_selector.selects_by_frame_index
+            else None
+        ),
+        "select_all": frame_selector.selects_all_frames,
+    }
+
+
+def _ring_selection_key(query: dict) -> tuple:
+    return (
+        query["start_ns"],
+        query["end_ns"],
+        tuple(query["target_pts_ns"]),
+        tuple(query["target_indices"] or ()),
+        query["select_all"],
+    )
+
+
+def _select_dense_frames(frames, frame_times, query):
+    """Apply the existing first-frame-at-or-after sampling contract to dense frames."""
+    pts_ns = [int(round(frame_time * 1_000_000_000)) for frame_time in frame_times]
+    if query["select_all"]:
+        first = bisect.bisect_left(pts_ns, query["start_ns"])
+        last = bisect.bisect_right(pts_ns, query["end_ns"])
+        indices = list(range(first, last))
+    elif query["target_indices"] is not None:
+        indices = query["target_indices"]
+        if any(index < 0 or index >= len(pts_ns) for index in indices):
+            return None
+    else:
+        indices = []
+        for target in query["target_pts_ns"]:
+            index = bisect.bisect_left(pts_ns, target)
+            if index >= len(pts_ns) or pts_ns[index] > query["end_ns"]:
+                return None
+            indices.append(index)
+
+    if isinstance(frames, torch.Tensor):
+        selected_frames = frames[indices]
+    else:
+        selected_frames = [frames[index] for index in indices]
+    return selected_frames, [pts_ns[index] / 1_000_000_000.0 for index in indices]
 
 
 def _split_local_image_asset_paths(chunk_file: str) -> Optional[list[str]]:
@@ -378,6 +479,7 @@ class DecoderProcess(ProcessBase):
         )
 
     def _initialize(self):
+        from .cuda_frame_ring import CudaFrameRing
         from .video_file_frame_getter import DefaultFrameSelector, VideoFileFrameGetter
 
         self._live_stream_handle_info: dict[str, dict] = {}
@@ -396,6 +498,7 @@ class DecoderProcess(ProcessBase):
         self._width = 0
         self._height = 0
         self._data_type_int8 = False
+        self._cuda_frame_ring = CudaFrameRing(_persistent_cuda_frame_ring_bytes())
 
         # Populate model-specific frame pre-processing parameters
         # Use model-specific decoder configuration for all other models
@@ -603,6 +706,115 @@ class DecoderProcess(ProcessBase):
                 use_fps_for_chunking=self._use_fps_for_chunking,
             )
 
+        ring_key = None
+        ring_query = None
+        ring_selection_key = None
+        ring_fill_owner = False
+        ring_enabled = (
+            _persistent_cuda_frame_ring_enabled()
+            and not vlm_query.enable_audio
+            and not self._enable_jpeg_tensors
+            and hasattr(self, "_cuda_frame_ring")
+        )
+        if ring_enabled:
+            ring_key = _file_ring_identity(
+                chunk,
+                vlm_query.vlm_input_width or self._width,
+                vlm_query.vlm_input_height or self._height,
+                video_codec,
+            )
+        if ring_key is not None:
+            ring_query = _selector_ring_query(frame_selector, chunk)
+            ring_selection_key = _ring_selection_key(ring_query)
+            packed = self._cuda_frame_ring.acquire_selection(
+                *ring_key,
+                ring_selection_key,
+            )
+            cached = (
+                None
+                if packed is not None
+                else self._cuda_frame_ring.acquire(
+                    *ring_key,
+                    **ring_query,
+                )
+            )
+            if packed is None and cached is None:
+                ring_fill_owner = self._cuda_frame_ring.claim_fill(*ring_key)
+                if not ring_fill_owner:
+                    if self._cuda_frame_ring.wait_for_fill(*ring_key, timeout=120.0):
+                        packed = self._cuda_frame_ring.acquire_selection(
+                            *ring_key,
+                            ring_selection_key,
+                        )
+                        if packed is None:
+                            cached = self._cuda_frame_ring.acquire(*ring_key, **ring_query)
+                    else:
+                        ring_fill_owner = self._cuda_frame_ring.claim_fill(*ring_key)
+            if packed is not None or cached is not None:
+                if packed is not None:
+                    frames, cached_pts_ns = packed
+                    # Keep the ring-owned allocation private.  The downstream
+                    # tensor IPC transport may transfer or otherwise retain an
+                    # input allocation beyond this request; exporting the same
+                    # allocation concurrently can mix CPU/CUDA batches in the
+                    # engine.  A single contiguous clone is substantially
+                    # cheaper than rebuilding the batch from per-frame views.
+                    if isinstance(frames, torch.Tensor):
+                        frames = frames.clone()
+                else:
+                    frame_refs, cached_pts_ns = cached
+                    frames = frame_refs
+                try:
+                    if packed is None and frames and isinstance(frames[0], torch.Tensor):
+                        frames = torch.stack(frames)
+                        self._cuda_frame_ring.publish_selection(
+                            *ring_key,
+                            ring_selection_key,
+                            frames.clone(),
+                            cached_pts_ns,
+                        )
+                except Exception:
+                    with self._fgetter_handoff_lock:
+                        self._fgetters.append(fgetter)
+                    raise
+                with self._fgetter_handoff_lock:
+                    self._fgetters.append(fgetter)
+                decode_end_time = time.time()
+                nvtx.end_range(nvtx_decode_start)
+                logger.log(
+                    LOG_STATUS_LEVEL,
+                    "Chunk (%s) acquired %d frames from persistent CUDA ring",
+                    chunk,
+                    len(frames),
+                )
+                return {
+                    "chunk": chunk,
+                    "frames": frames,
+                    "error": None,
+                    "error_status_code": 500,
+                    "frame_times": [
+                        float("%.2f" % (pts / 1_000_000_000.0)) for pts in cached_pts_ns
+                    ],
+                    "audio_frames": [],
+                    "audio_transcript": [],
+                    "decode_start_time": decode_start_time,
+                    "decode_end_time": decode_end_time,
+                    "decode_retry_count": 0,
+                    "is_live_stream": False,
+                    **kwargs,
+                }
+
+            if ring_fill_owner:
+                # Populate a dense window once. Subsequent identical or overlapping
+                # requests sample retained PTS references without seek/reset work.
+                frame_selector_for_decode = DefaultFrameSelector(DefaultFrameSelector.ALL_FRAMES)
+            else:
+                # A timed-out waiter preserves availability by using the existing
+                # sparse decode path without publishing over the active owner.
+                frame_selector_for_decode = frame_selector
+        else:
+            frame_selector_for_decode = frame_selector
+
         min_required_frames = _required_file_chunk_frame_count(
             chunk,
             num_frames_per_second_or_fixed_frames_chunk or self._nfrms,
@@ -674,7 +886,7 @@ class DecoderProcess(ProcessBase):
             try:
                 frames, frame_times, audio_frames, error = fgetter.get_frames(
                     chunk,
-                    frame_selector,
+                    frame_selector_for_decode,
                     enable_audio,
                     request_id=kwargs["request_id"],
                     frame_width=vlm_input_width,
@@ -689,6 +901,10 @@ class DecoderProcess(ProcessBase):
                 frame_times = []
                 audio_frames = []
                 break
+            except Exception:
+                if ring_fill_owner and ring_key is not None:
+                    self._cuda_frame_ring.abort_fill(*ring_key)
+                raise
             decoded_frame_count = len(frames)
             if not error and decoded_frame_count >= min_required_frames:
                 break
@@ -724,6 +940,54 @@ class DecoderProcess(ProcessBase):
                     chunk,
                     ex,
                 )
+        if ring_fill_owner and ring_key is not None:
+            if not error and len(frames):
+                dense_frames = (
+                    list(frames.unbind(0)) if isinstance(frames, torch.Tensor) else list(frames)
+                )
+                dense_pts_ns = [
+                    int(round(frame_time * 1_000_000_000)) for frame_time in frame_times
+                ]
+                try:
+                    stored = self._cuda_frame_ring.publish(
+                        *ring_key,
+                        coverage_start_ns=ring_query["start_ns"],
+                        coverage_end_ns=ring_query["end_ns"],
+                        pts_ns=dense_pts_ns,
+                        frames=dense_frames,
+                        complete_fill=False,
+                    )
+                except ValueError as ex:
+                    logger.warning("CUDA frame ring rejected chunk %s: %s", chunk, ex)
+                    self._cuda_frame_ring.abort_fill(*ring_key)
+                    stored = False
+                selected = (
+                    self._cuda_frame_ring.acquire(*ring_key, **ring_query) if stored else None
+                )
+                if selected is not None:
+                    selected_frames, selected_pts_ns = selected
+                    frames = (
+                        torch.stack(selected_frames)
+                        if selected_frames and isinstance(selected_frames[0], torch.Tensor)
+                        else selected_frames
+                    )
+                    frame_times = [pts / 1_000_000_000.0 for pts in selected_pts_ns]
+                else:
+                    selected = _select_dense_frames(frames, frame_times, ring_query)
+                    if selected is not None:
+                        frames, frame_times = selected
+                if selected is not None and isinstance(frames, torch.Tensor):
+                    self._cuda_frame_ring.publish_selection(
+                        *ring_key,
+                        ring_selection_key,
+                        frames.clone(),
+                        [int(round(frame_time * 1_000_000_000)) for frame_time in frame_times],
+                    )
+                else:
+                    self._cuda_frame_ring.abort_fill(*ring_key)
+            else:
+                self._cuda_frame_ring.abort_fill(*ring_key)
+
         frame_times = [float("%.2f" % frame_ele) for frame_ele in frame_times]
 
         nvtx.end_range(nvtx_decode_start)
@@ -1078,7 +1342,7 @@ class DecoderProcess(ProcessBase):
         fgetter.stream(
             live_stream_url=asset.path,
             chunk_duration=vlm_query.chunk_duration,
-            chunk_overlap_duration=0,
+            chunk_overlap_duration=vlm_query.chunk_overlap_duration,
             username=asset.username,
             password=asset.password,
             live_stream_id=asset.asset_id,

--- a/services/rtvi/rt-vlm/src/vlm_pipeline/vlm_pipeline.py
+++ b/services/rtvi/rt-vlm/src/vlm_pipeline/vlm_pipeline.py
@@ -556,6 +556,7 @@ class DecoderProcess(ProcessBase):
                 enable_jpeg_output=self._enable_jpeg_tensors,
                 data_type_int8=self._data_type_int8,
                 audio_support=self._enable_audio,
+                cuda_frame_ring=self._cuda_frame_ring,
             )
             for _ in range(self._num_decoders_per_gpu)
         ]
@@ -1190,6 +1191,7 @@ class DecoderProcess(ProcessBase):
             enable_jpeg_output=self._enable_jpeg_tensors,
             data_type_int8=self._data_type_int8,
             audio_support=self._enable_audio,
+            cuda_frame_ring=self._cuda_frame_ring,
         )
 
         with self._live_stream_handle_info_lock:

--- a/services/rtvi/rt-vlm/src/vlm_pipeline/vlm_pipeline.py
+++ b/services/rtvi/rt-vlm/src/vlm_pipeline/vlm_pipeline.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
-import bisect
 import concurrent.futures
 import multiprocessing
 import os
@@ -43,6 +42,7 @@ from models.base_vlm_model import VlmGenerationConfig, VlmModelOutput
 from models.dynamic_model_loader import DynamicModelLoader, load_model
 from utils.asset_manager import Asset
 
+from .cuda_frame_ring import select_frame_indices
 from .errors import CUDA_OOM_STATUS_CODE, format_cuda_oom_error, is_cuda_oom_error
 from .ipc_frame_source import DEFAULT_IPC_SOCKET_DIR, select_ipc_stream_identity
 from .model_path_policy import validate_model_config, validate_model_path_source
@@ -208,21 +208,7 @@ def _ring_selection_key(query: dict) -> tuple:
 def _select_dense_frames(frames, frame_times, query):
     """Apply the existing first-frame-at-or-after sampling contract to dense frames."""
     pts_ns = [int(round(frame_time * 1_000_000_000)) for frame_time in frame_times]
-    if query["select_all"]:
-        first = bisect.bisect_left(pts_ns, query["start_ns"])
-        last = bisect.bisect_right(pts_ns, query["end_ns"])
-        indices = list(range(first, last))
-    elif query["target_indices"] is not None:
-        indices = query["target_indices"]
-        if any(index < 0 or index >= len(pts_ns) for index in indices):
-            return None
-    else:
-        indices = []
-        for target in query["target_pts_ns"]:
-            index = bisect.bisect_left(pts_ns, target)
-            if index >= len(pts_ns) or pts_ns[index] > query["end_ns"]:
-                return None
-            indices.append(index)
+    indices = select_frame_indices(pts_ns, **query)
 
     if isinstance(frames, torch.Tensor):
         selected_frames = frames[indices]
@@ -707,6 +693,16 @@ class DecoderProcess(ProcessBase):
                 use_fps_for_chunking=self._use_fps_for_chunking,
             )
 
+        min_required_frames = _required_file_chunk_frame_count(
+            chunk,
+            num_frames_per_second_or_fixed_frames_chunk or self._nfrms,
+            (
+                use_fps_for_chunking
+                if num_frames_per_second_or_fixed_frames_chunk
+                else self._use_fps_for_chunking
+            ),
+        )
+
         ring_key = None
         ring_query = None
         ring_selection_key = None
@@ -751,7 +747,9 @@ class DecoderProcess(ProcessBase):
                             cached = self._cuda_frame_ring.acquire(*ring_key, **ring_query)
                     else:
                         ring_fill_owner = self._cuda_frame_ring.claim_fill(*ring_key)
-            if packed is not None or cached is not None:
+            if (packed is not None and len(packed[0]) >= min_required_frames) or (
+                cached is not None and len(cached[0]) >= min_required_frames
+            ):
                 if packed is not None:
                     frames, cached_pts_ns = packed
                     # Keep the ring-owned allocation private.  The downstream
@@ -815,16 +813,6 @@ class DecoderProcess(ProcessBase):
                 frame_selector_for_decode = frame_selector
         else:
             frame_selector_for_decode = frame_selector
-
-        min_required_frames = _required_file_chunk_frame_count(
-            chunk,
-            num_frames_per_second_or_fixed_frames_chunk or self._nfrms,
-            (
-                use_fps_for_chunking
-                if num_frames_per_second_or_fixed_frames_chunk
-                else self._use_fps_for_chunking
-            ),
-        )
 
         enable_audio = vlm_query.enable_audio
         vlm_input_width = vlm_query.vlm_input_width
@@ -975,8 +963,7 @@ class DecoderProcess(ProcessBase):
                     frame_times = [pts / 1_000_000_000.0 for pts in selected_pts_ns]
                 else:
                     selected = _select_dense_frames(frames, frame_times, ring_query)
-                    if selected is not None:
-                        frames, frame_times = selected
+                    frames, frame_times = selected
                 if selected is not None and isinstance(frames, torch.Tensor):
                     self._cuda_frame_ring.publish_selection(
                         *ring_key,

--- a/services/rtvi/rt-vlm/tests/model/vllm_compatible/test_adaptive_preprocess_limiter.py
+++ b/services/rtvi/rt-vlm/tests/model/vllm_compatible/test_adaptive_preprocess_limiter.py
@@ -88,6 +88,143 @@ def test_atomic_pending_reservations_prevent_snapshot_over_admission():
     asyncio.run(run())
 
 
+def test_encoder_tokens_remain_reserved_after_preprocessing_until_encoder_release():
+    async def run():
+        limiter = AdaptivePreprocessLimiter(
+            _config(min_workers=4, max_workers=4, admission_timeout_seconds=1),
+            _FreeMemory(10000),
+            encoder_cache_capacity_tokens=100,
+        )
+        first = await limiter.acquire(
+            "first",
+            "video-shape-a",
+            payload_mb=100,
+            encoder_tokens=60,
+        )
+
+        await limiter.release_preprocess(first, observed_allocation_mb=500)
+        snapshot = limiter.snapshot()
+        assert snapshot.active == 0
+        assert snapshot.pending_reserved_mb == 0
+        assert snapshot.pending_encoder_tokens == 60
+
+        second_task = asyncio.create_task(
+            limiter.acquire(
+                "second",
+                "video-shape-a",
+                payload_mb=100,
+                encoder_tokens=60,
+            )
+        )
+        while limiter.snapshot().queued == 0:
+            await asyncio.sleep(0)
+        assert second_task.done() is False
+
+        await limiter.release_encoder(first)
+        second = await second_task
+        assert limiter.snapshot().pending_encoder_tokens == 60
+        await limiter.release(second)
+        assert limiter.snapshot().pending_encoder_tokens == 0
+
+    asyncio.run(run())
+
+
+def test_encoder_token_budget_admits_an_exact_fit():
+    async def run():
+        limiter = AdaptivePreprocessLimiter(
+            _config(min_workers=2, max_workers=2),
+            _FreeMemory(10000),
+            encoder_cache_capacity_tokens=100,
+        )
+        await _calibrate(limiter)
+        first = await limiter.acquire(
+            "first",
+            "video-shape-a",
+            payload_mb=100,
+            encoder_tokens=40,
+        )
+        second = await limiter.acquire(
+            "second",
+            "video-shape-a",
+            payload_mb=100,
+            encoder_tokens=60,
+        )
+
+        snapshot = limiter.snapshot()
+        assert snapshot.active == 2
+        assert snapshot.pending_encoder_tokens == 100
+        assert snapshot.encoder_cache_capacity_tokens == 100
+        await limiter.release(first)
+        await limiter.release(second)
+
+    asyncio.run(run())
+
+
+def test_encoder_token_budget_starts_at_executor_ceiling():
+    limiter = AdaptivePreprocessLimiter(
+        _config(min_workers=1, max_workers=16),
+        _FreeMemory(10000),
+        encoder_cache_capacity_tokens=32768,
+    )
+
+    assert limiter.snapshot().effective_limit == 16
+
+
+def test_encoder_overlap_is_not_treated_as_exclusive_memory_calibration():
+    async def run():
+        limiter = AdaptivePreprocessLimiter(
+            _config(min_workers=2, max_workers=2),
+            _FreeMemory(10000),
+            encoder_cache_capacity_tokens=100,
+        )
+        first = await limiter.acquire(
+            "first",
+            "video-shape-a",
+            payload_mb=100,
+            encoder_tokens=60,
+        )
+        await limiter.release_preprocess(first, observed_allocation_mb=500)
+
+        second = await limiter.acquire(
+            "second",
+            "video-shape-a",
+            payload_mb=100,
+            encoder_tokens=40,
+        )
+
+        assert first.exclusive is True
+        assert second.exclusive is False
+        await limiter.release(second, observed_allocation_mb=2000)
+        assert limiter.snapshot().estimated_mb_by_workload == {"video-shape-a": 500}
+        await limiter.release_encoder(first)
+        assert limiter._overlapped_request_ids == set()
+
+    asyncio.run(run())
+
+
+def test_single_request_larger_than_encoder_budget_is_admitted_exclusively():
+    async def run():
+        limiter = AdaptivePreprocessLimiter(
+            _config(min_workers=2, max_workers=2),
+            _FreeMemory(10000),
+            encoder_cache_capacity_tokens=100,
+        )
+
+        admission = await limiter.acquire(
+            "oversized",
+            "video-shape-a",
+            payload_mb=100,
+            encoder_tokens=120,
+        )
+
+        assert admission.encoder_tokens == 120
+        assert admission.exclusive is True
+        assert limiter.snapshot().pending_encoder_tokens == 120
+        await limiter.release(admission)
+
+    asyncio.run(run())
+
+
 def test_duplicate_request_id_does_not_overwrite_reservation():
     async def run():
         limiter = AdaptivePreprocessLimiter(

--- a/services/rtvi/rt-vlm/tests/model/vllm_compatible/test_input_error_handling.py
+++ b/services/rtvi/rt-vlm/tests/model/vllm_compatible/test_input_error_handling.py
@@ -46,6 +46,30 @@ class _FailingLLM:
         yield
 
 
+def test_nvtx_stage_is_opt_in_and_balances_ranges(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        vllm_compatible_model.nvtx,
+        "start_range",
+        lambda **kwargs: calls.append(("start", kwargs["message"])) or 7,
+    )
+    monkeypatch.setattr(
+        vllm_compatible_model.nvtx,
+        "end_range",
+        lambda range_id: calls.append(("end", range_id)),
+    )
+
+    monkeypatch.delenv("RTVI_VLM_NVTX_STAGES", raising=False)
+    with vllm_compatible_model._nvtx_stage("disabled"):
+        pass
+    assert calls == []
+
+    monkeypatch.setenv("RTVI_VLM_NVTX_STAGES", "true")
+    with vllm_compatible_model._nvtx_stage("enabled"):
+        pass
+    assert calls == [("start", "enabled"), ("end", 7)]
+
+
 class _RecordingLLM:
     def __init__(self):
         self.llm_inputs = None
@@ -667,6 +691,27 @@ def test_vllm_compilation_config_is_opt_in(monkeypatch, value):
     assert vllm_compatible_model._get_vllm_compilation_config("") is None
 
 
+def test_vllm_compilation_config_enables_multimodal_encoder(monkeypatch):
+    monkeypatch.delenv("VLLM_CUDAGRAPH_MODE", raising=False)
+    monkeypatch.delenv("RTVI_VLLM_CUDAGRAPH_MODE", raising=False)
+    monkeypatch.setenv("VLLM_COMPILE_MM_ENCODER", "true")
+
+    assert vllm_compatible_model._get_vllm_compilation_config("") == {
+        "compile_mm_encoder": True,
+    }
+
+
+def test_vllm_compilation_config_combines_encoder_and_cudagraph(monkeypatch):
+    monkeypatch.setenv("VLLM_CUDAGRAPH_MODE", "PIECEWISE")
+    monkeypatch.setenv("VLLM_COMPILE_MM_ENCODER", "true")
+
+    assert vllm_compatible_model._get_vllm_compilation_config("") == {
+        "mode": "VLLM_COMPILE",
+        "cudagraph_mode": "PIECEWISE",
+        "compile_mm_encoder": True,
+    }
+
+
 def test_vllm_compilation_config_defaults_edge_to_compiled_execution(monkeypatch):
     monkeypatch.delenv("VLLM_CUDAGRAPH_MODE", raising=False)
     monkeypatch.delenv("RTVI_VLLM_CUDAGRAPH_MODE", raising=False)
@@ -957,6 +1002,69 @@ def test_multimodal_preprocess_workload_buckets_prompt_and_output_tokens():
     assert osl_one_key != osl_hundred_key
 
 
+def test_multimodal_encoder_tokens_use_model_processor_capability():
+    class _ProcessorInfo:
+        def get_video_processor(self, **kwargs):
+            return SimpleNamespace()
+
+        def get_num_video_tokens(
+            self,
+            *,
+            image_width,
+            image_height,
+            num_frames,
+            image_processor,
+            mm_kwargs,
+        ):
+            assert image_width == 608
+            assert image_height == 320
+            assert num_frames == 20
+            assert image_processor is not None
+            assert mm_kwargs == {"do_sample_frames": False}
+            return 1980
+
+    tensor = torch.empty((20, 320, 608, 3), dtype=torch.uint8, device="meta")
+    llm_inputs = {
+        "multi_modal_data": {"video": [(tensor, {})]},
+        "mm_processor_kwargs": {"do_sample_frames": False},
+    }
+
+    assert VllmCompatible._multimodal_encoder_tokens(llm_inputs, _ProcessorInfo()) == 1980
+
+
+def test_multimodal_encoder_tokens_fall_back_when_processor_cannot_estimate():
+    tensor = torch.empty((20, 320, 608, 3), dtype=torch.uint8, device="meta")
+    llm_inputs = {"multi_modal_data": {"video": [(tensor, {})]}}
+
+    assert VllmCompatible._multimodal_encoder_tokens(llm_inputs, object()) is None
+
+
+def test_encoder_cache_capacity_uses_vllm_input_processor_budget():
+    llm = SimpleNamespace(
+        input_processor=SimpleNamespace(mm_encoder_cache_size=32768),
+    )
+
+    assert VllmCompatible._get_encoder_cache_capacity_tokens(llm) == 32768
+
+
+def test_encoder_cache_capacity_disables_token_gate_when_budget_is_missing():
+    assert VllmCompatible._get_encoder_cache_capacity_tokens(SimpleNamespace()) is None
+
+
+@pytest.mark.parametrize(
+    ("processor_info", "expected"),
+    [
+        (SimpleNamespace(get_num_video_tokens=lambda: 1), True),
+        (SimpleNamespace(get_num_image_tokens=lambda: 1), True),
+        (SimpleNamespace(get_num_audio_tokens=lambda: 1), False),
+        (object(), False),
+        (None, False),
+    ],
+)
+def test_visual_token_geometry_capability_is_detected(processor_info, expected):
+    assert VllmCompatible._supports_visual_token_geometry(processor_info) is expected
+
+
 def test_cuda_free_memory_uses_lowest_visible_device(monkeypatch):
     monkeypatch.setattr(torch.cuda, "device_count", lambda: 3)
     free_by_device = {
@@ -1018,6 +1126,101 @@ def test_default_path_holds_admission_until_first_engine_output():
         async for _ in stream:
             pass
         assert model._llm.queue.closed is True
+
+    asyncio.run(run())
+
+
+def test_tensor_ipc_releases_preprocess_memory_but_holds_encoder_tokens():
+    async def run():
+        limiter = AdaptivePreprocessLimiter(
+            AdaptivePreprocessConfig(
+                enabled=True,
+                shadow_mode=False,
+                min_workers=1,
+                max_workers=4,
+                gpu_headroom_mb=100,
+                initial_estimated_request_mb=500,
+            ),
+            lambda: 10000,
+            encoder_cache_capacity_tokens=32768,
+        )
+        allow_output = asyncio.Event()
+
+        class _BlockingQueue:
+            request_id = "req-1"
+
+            def get_nowait(self):
+                return None
+
+            async def get(self):
+                await allow_output.wait()
+                return SimpleNamespace(finished=True)
+
+            def close(self):
+                pass
+
+        class _LLM:
+            def __init__(self):
+                self.added = asyncio.Event()
+
+            async def add_request(self, *args, **kwargs):
+                self.added.set()
+                return _BlockingQueue()
+
+            async def abort(self, *args, **kwargs):
+                return None
+
+        class _ProcessorInfo:
+            def get_video_processor(self, **kwargs):
+                return SimpleNamespace()
+
+            def get_num_video_tokens(
+                self,
+                *,
+                image_width,
+                image_height,
+                num_frames,
+                image_processor,
+                mm_kwargs,
+            ):
+                return 1980
+
+        model = VllmCompatible.__new__(VllmCompatible)
+        model._use_cuda_mm_tensor_ipc = True
+        model._multimodal_preprocess_limiter = limiter
+        model._multimodal_processor_info = _ProcessorInfo()
+        model._llm = _LLM()
+        async def add_without_cuda_promotion(request_id, inputs, sampling_params):
+            return await model._llm.add_request(request_id, inputs, sampling_params)
+
+        model._add_multimodal_request = add_without_cuda_promotion
+        model._finish_cuda_mm_submission = lambda request_id: None
+        model._finish_preprocess_submission = lambda request_id: None
+        model._release_cuda_mm_residency = lambda request_id: None
+        llm_inputs = {
+            "multi_modal_data": {
+                "video": [(torch.empty((20, 320, 608, 3), device="meta"), {})]
+            }
+        }
+
+        stream = model._generate_with_preprocess_admission(
+            llm_inputs,
+            SimpleNamespace(),
+            "req-1",
+        )
+        next_output = asyncio.create_task(stream.__anext__())
+        await model._llm.added.wait()
+        while limiter.snapshot().active:
+            await asyncio.sleep(0)
+
+        snapshot = limiter.snapshot()
+        assert snapshot.pending_reserved_mb == 0
+        assert snapshot.pending_encoder_tokens == 1980
+
+        allow_output.set()
+        await next_output
+        assert limiter.snapshot().pending_encoder_tokens == 0
+        await stream.aclose()
 
     asyncio.run(run())
 

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/run_rtvi_tests.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/run_rtvi_tests.py
@@ -187,6 +187,7 @@ def main():
             "test_rtvi_stream_handler.py",
             "test_rtvi_client_cli.py",
             "test_frame_sampling.py",
+            "test_cuda_frame_ring.py",
             "test_media_file_info.py",
             "test_vlm_pipeline_live_subscribers.py",
             "test_vllm_qwen3_cache_reuse_patch.py",

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_cuda_frame_ring.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_cuda_frame_ring.py
@@ -3,6 +3,8 @@
 
 import threading
 
+import pytest
+
 from vlm_pipeline.cuda_frame_ring import CudaFrameRing
 
 
@@ -69,6 +71,48 @@ def test_ring_rejects_incomplete_window_and_stale_epoch():
             target_pts_ns=[1_500],
         )
         is None
+    )
+
+
+@pytest.mark.parametrize(
+    "targets, expected",
+    [([0, 50, 100], [0, 100]), ([0, 100, 150], [0, 100]), ([150], [])],
+)
+def test_ring_consumes_each_available_frame_once_at_eos(targets, expected):
+    ring = CudaFrameRing(max_bytes=16)
+    frames = [FakeFrame("first"), FakeFrame("last")]
+    ring.publish("video", "epoch", 0, 200, [0, 100], frames)
+
+    selected_frames, selected_pts = ring.acquire("video", "epoch", 0, 200, targets)
+
+    assert selected_pts == expected
+    assert selected_frames == [frames[index // 100] for index in expected]
+
+
+def test_ring_preserves_decoded_coverage_before_first_frame():
+    ring = CudaFrameRing(max_bytes=16)
+    frame = FakeFrame("delayed-first-frame")
+    ring.publish("video", "epoch", 0, 200, [70], [frame])
+
+    assert ring.acquire("video", "epoch", 0, 200, [0, 25, 50, 75]) == ([frame], [70])
+
+
+def test_ring_evicted_prefix_is_not_claimed_as_complete_coverage():
+    ring = CudaFrameRing(max_bytes=2)
+    ring.publish("video", "epoch", 0, 300, [0, 100, 200], [FakeFrame(i) for i in range(3)])
+
+    assert ring.acquire("video", "epoch", 0, 300, [0]) is None
+    assert ring.acquire("video", "epoch", 100, 300, [100, 200])[1] == [100, 200]
+
+
+def test_ring_index_sampling_does_not_pad_short_clips():
+    ring = CudaFrameRing(max_bytes=16)
+    frames = [FakeFrame("first"), FakeFrame("last")]
+    ring.publish("video", "epoch", 0, 200, [0, 100], frames)
+
+    assert ring.acquire("video", "epoch", 0, 200, target_indices=[0, 0, 1, 1, 2]) == (
+        frames,
+        [0, 100],
     )
 
 

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_cuda_frame_ring.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_cuda_frame_ring.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import threading
+
+from vlm_pipeline.cuda_frame_ring import CudaFrameRing
+
+
+class FakeFrame:
+    def __init__(self, value, nbytes=1):
+        self.value = value
+        self.nbytes = nbytes
+
+
+def test_ring_samples_first_frame_at_or_after_each_target_without_copying():
+    ring = CudaFrameRing(max_bytes=16)
+    frames = [FakeFrame("f0"), FakeFrame("f1"), FakeFrame("f2"), FakeFrame("f3")]
+    ring.publish(
+        source_id="video-a",
+        epoch="v1",
+        coverage_start_ns=0,
+        coverage_end_ns=4_000,
+        pts_ns=[0, 1_000, 2_000, 3_000],
+        frames=frames,
+    )
+
+    acquired = ring.acquire(
+        source_id="video-a",
+        epoch="v1",
+        start_ns=500,
+        end_ns=3_500,
+        target_pts_ns=[500, 2_500],
+    )
+
+    assert acquired is not None
+    selected_frames, selected_pts = acquired
+    assert selected_frames == [frames[1], frames[3]]
+    assert selected_frames[0] is frames[1]
+    assert selected_pts == [1_000, 3_000]
+
+
+def test_ring_rejects_incomplete_window_and_stale_epoch():
+    ring = CudaFrameRing(max_bytes=16)
+    ring.publish(
+        source_id="video-a",
+        epoch="v1",
+        coverage_start_ns=1_000,
+        coverage_end_ns=4_000,
+        pts_ns=[1_000, 2_000, 3_000],
+        frames=[FakeFrame("f1"), FakeFrame("f2"), FakeFrame("f3")],
+    )
+
+    assert (
+        ring.acquire(
+            source_id="video-a",
+            epoch="v1",
+            start_ns=0,
+            end_ns=3_000,
+            target_pts_ns=[500],
+        )
+        is None
+    )
+    assert (
+        ring.acquire(
+            source_id="video-a",
+            epoch="v2",
+            start_ns=1_000,
+            end_ns=3_000,
+            target_pts_ns=[1_500],
+        )
+        is None
+    )
+
+
+def test_ring_eviction_is_bounded_and_acquired_references_remain_valid():
+    ring = CudaFrameRing(max_bytes=3)
+    first = FakeFrame("first", nbytes=2)
+    ring.publish("video-a", "v1", 0, 1_000, [0], [first])
+    acquired = ring.acquire("video-a", "v1", 0, 1_000, [0])
+    assert acquired is not None
+
+    ring.publish("video-b", "v1", 0, 1_000, [0], [FakeFrame("second", nbytes=2)])
+
+    assert ring.bytes_used <= ring.max_bytes
+    assert ring.acquire("video-a", "v1", 0, 1_000, [0]) is None
+    assert acquired[0][0].value == "first"
+
+
+def test_ring_keeps_streams_isolated_when_pts_are_identical():
+    ring = CudaFrameRing(max_bytes=16)
+    frame_a = FakeFrame("a")
+    frame_b = FakeFrame("b")
+    ring.publish("video-a", "v1", 0, 1_000, [0], [frame_a])
+    ring.publish("video-b", "v1", 0, 1_000, [0], [frame_b])
+
+    assert ring.acquire("video-a", "v1", 0, 1_000, [0])[0] == [frame_a]
+    assert ring.acquire("video-b", "v1", 0, 1_000, [0])[0] == [frame_b]
+
+
+def test_ring_single_flight_waiter_observes_published_frames():
+    ring = CudaFrameRing(max_bytes=16)
+    assert ring.claim_fill("video-a", "v1")
+    assert not ring.claim_fill("video-a", "v1")
+
+    waiter_result = []
+
+    def wait_for_fill():
+        waiter_result.append(ring.wait_for_fill("video-a", "v1", timeout=1.0))
+
+    waiter = threading.Thread(target=wait_for_fill)
+    waiter.start()
+    ring.publish("video-a", "v1", 0, 1_000, [0], [FakeFrame("ready")])
+    waiter.join()
+
+    assert waiter_result == [True]
+
+
+def test_ring_aborted_fill_wakes_waiters_without_exposing_partial_data():
+    ring = CudaFrameRing(max_bytes=16)
+    assert ring.claim_fill("video-a", "v1")
+    waiter_result = []
+
+    def wait_for_fill():
+        waiter_result.append(ring.wait_for_fill("video-a", "v1", timeout=1.0))
+
+    waiter = threading.Thread(target=wait_for_fill)
+    waiter.start()
+    ring.abort_fill("video-a", "v1")
+    waiter.join()
+
+    assert waiter_result == [False]
+
+
+def test_ring_merges_overlapping_dense_windows_for_rolling_file_chunks():
+    ring = CudaFrameRing(max_bytes=16)
+    frames = [FakeFrame(f"f{index}") for index in range(6)]
+    ring.publish("video-a", "v1", 0, 4_000, [0, 1_000, 2_000, 3_000], frames[:4])
+    ring.publish(
+        "video-a",
+        "v1",
+        2_000,
+        6_000,
+        [2_000, 3_000, 4_000, 5_000],
+        frames[2:],
+    )
+
+    acquired = ring.acquire("video-a", "v1", 1_000, 6_000, [1_500, 4_500])
+
+    assert acquired is not None
+    assert acquired[0] == [frames[2], frames[5]]
+    assert acquired[1] == [2_000, 5_000]
+
+
+def test_append_retains_bounded_live_pts_and_exact_acquisition():
+    ring = CudaFrameRing(max_bytes=3)
+    frames = [FakeFrame(f"f{index}") for index in range(4)]
+    for index, frame in enumerate(frames):
+        ring.append("live-a", "connection-1", index * 1_000, frame)
+
+    assert ring.bytes_used == 3
+    assert ring.acquire_exact("live-a", "connection-1", [1_000, 3_000]) == (
+        [frames[1], frames[3]],
+        [1_000, 3_000],
+    )
+    assert ring.acquire_exact("live-a", "connection-1", [0]) is None
+
+
+def test_ring_reuses_packed_tensor_for_identical_sampling_contract():
+    ring = CudaFrameRing(max_bytes=16)
+    ring.publish(
+        "video-a",
+        "v1",
+        0,
+        4_000,
+        [0, 1_000, 2_000, 3_000],
+        [FakeFrame("f0"), FakeFrame("f1"), FakeFrame("f2"), FakeFrame("f3")],
+    )
+    packed = FakeFrame("packed", nbytes=4)
+
+    assert ring.publish_selection("video-a", "v1", "sample-0-2", packed, [0, 2_000])
+    acquired = ring.acquire_selection("video-a", "v1", "sample-0-2")
+
+    assert acquired is not None
+    assert acquired[0] is packed
+    assert acquired[1] == [0, 2_000]
+
+
+def test_dense_publish_can_keep_waiters_blocked_until_packed_selection_is_ready():
+    ring = CudaFrameRing(max_bytes=16)
+    assert ring.claim_fill("video-a", "v1")
+    ring.publish(
+        "video-a",
+        "v1",
+        0,
+        2_000,
+        [0, 1_000],
+        [FakeFrame("f0"), FakeFrame("f1")],
+        complete_fill=False,
+    )
+
+    assert not ring.claim_fill("video-a", "v1")
+    packed = FakeFrame("packed")
+    ring.publish_selection("video-a", "v1", "sample", packed, [0])
+
+    assert ring.wait_for_fill("video-a", "v1", timeout=0.01)
+    assert ring.acquire_selection("video-a", "v1", "sample")[0] is packed
+
+
+def test_ring_declines_packed_tensor_that_would_exceed_source_budget():
+    ring = CudaFrameRing(max_bytes=4)
+    ring.publish("video-a", "v1", 0, 2_000, [0, 1_000], [FakeFrame("f0"), FakeFrame("f1")])
+
+    assert not ring.publish_selection(
+        "video-a", "v1", "oversized", FakeFrame("packed", nbytes=3), [0]
+    )
+    assert ring.acquire_selection("video-a", "v1", "oversized") is None

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_decode_retry.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_decode_retry.py
@@ -151,6 +151,7 @@ def _make_live_decoder():
     decoder._ipc_frame_copy = False
     decoder._ipc_socket_dir = "/run/rtvi-ipc"
     decoder._ipc_socket_template = "nvds_ipc_{camera_id}.sock"
+    decoder._cuda_frame_ring = CudaFrameRing(max_bytes=1024)
     return decoder
 
 
@@ -818,5 +819,6 @@ def test_live_stream_fallback_frame_selector_honors_server_fps_default(monkeypat
     assert created_selectors[0].args == (3,)
     assert created_selectors[0].kwargs["use_fps_for_chunking"] is True
     assert created_getters[0].destroyed == 1
+    assert created_getters[0].kwargs["cuda_frame_ring"] is decoder._cuda_frame_ring
     assert created_getters[0].stream_kwargs["chunk_overlap_duration"] == 2
     assert decoder._final_output_queue.items[-1]["live_stream_ended"] is True

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_decode_retry.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_decode_retry.py
@@ -23,6 +23,7 @@ import torch
 
 from common.chunk_info import ChunkInfo
 from vlm_pipeline import vlm_pipeline as vlm_pipeline_module
+from vlm_pipeline.cuda_frame_ring import CudaFrameRing
 from vlm_pipeline.vlm_pipeline import DecoderProcess
 
 
@@ -147,6 +148,9 @@ def _make_live_decoder():
     decoder._enable_jpeg_tensors = False
     decoder._data_type_int8 = False
     decoder._enable_audio = False
+    decoder._ipc_frame_copy = False
+    decoder._ipc_socket_dir = "/run/rtvi-ipc"
+    decoder._ipc_socket_template = "nvds_ipc_{camera_id}.sock"
     return decoder
 
 
@@ -156,6 +160,7 @@ def _make_vlm_query():
         use_fps_for_chunking=False,
         enable_audio=False,
         chunk_duration=10,
+        chunk_overlap_duration=0,
         vlm_input_width=None,
         vlm_input_height=None,
     )
@@ -602,6 +607,91 @@ def test_decode_chunk_reuses_decoder_after_clean_success_by_default(monkeypatch)
 
 
 @pytest.mark.no_gpu
+def test_persistent_ring_decodes_file_once_and_reuses_pts_frames(monkeypatch, tmp_path):
+    class DenseFrameGetter(CleanFrameGetter):
+        def get_frames(self, chunk, frame_selector, *args, **kwargs):
+            self.calls += 1
+            frame_selector.set_chunk(chunk)
+            assert frame_selector.selects_all_frames
+            return torch.arange(4).reshape(4, 1), [0.0, 1.0, 2.0, 3.0], [], None
+
+    class UnexpectedDecodeFrameGetter(CleanFrameGetter):
+        def get_frames(self, *args, **kwargs):
+            raise AssertionError("ring hit must not invoke GStreamer decode")
+
+    monkeypatch.setenv("RTVI_PERSISTENT_CUDA_FRAME_RING", "true")
+    monkeypatch.setattr(vlm_pipeline_module.nvtx, "start_range", lambda *args, **kwargs: object())
+    monkeypatch.setattr(vlm_pipeline_module.nvtx, "end_range", lambda *args, **kwargs: None)
+
+    decoder = _make_decoder()
+    decoder._cuda_frame_ring = CudaFrameRing(max_bytes=1024)
+    query = _make_vlm_query()
+    query.num_frames_per_second_or_fixed_frames_chunk = 2
+    video = tmp_path / "fixture.mp4"
+    video.write_bytes(b"content-version-1")
+    chunk = ChunkInfo(file=str(video), start_pts=0, end_pts=4_000_000_000)
+
+    first_getter = DenseFrameGetter()
+    first = decoder._decode_chunk(
+        first_getter,
+        chunk,
+        query,
+        video_codec="HEVC",
+        request_id="first-request",
+    )
+    decoder._fgetters.clear()
+    second = decoder._decode_chunk(
+        UnexpectedDecodeFrameGetter(),
+        chunk,
+        query,
+        video_codec="HEVC",
+        request_id="second-request",
+    )
+
+    assert first_getter.calls == 1
+    assert first["frames"].flatten().tolist() == [0, 2]
+    assert second["frames"].flatten().tolist() == [0, 2]
+    assert second["frame_times"] == [0.0, 2.0]
+
+
+@pytest.mark.no_gpu
+def test_persistent_ring_aborts_single_flight_when_decode_raises(monkeypatch, tmp_path):
+    class ExplodingFrameGetter(CleanFrameGetter):
+        def get_frames(self, *args, **kwargs):
+            raise RuntimeError("decoder failed")
+
+    monkeypatch.setenv("RTVI_PERSISTENT_CUDA_FRAME_RING", "true")
+    monkeypatch.setattr(vlm_pipeline_module.nvtx, "start_range", lambda *args, **kwargs: object())
+
+    decoder = _make_decoder()
+    decoder._cuda_frame_ring = CudaFrameRing(max_bytes=1024)
+    video = tmp_path / "fixture.mp4"
+    video.write_bytes(b"content-version-1")
+    chunk = ChunkInfo(file=str(video), start_pts=0, end_pts=4_000_000_000)
+    ring_key = vlm_pipeline_module._file_ring_identity(chunk, 0, 0, "HEVC")
+
+    with pytest.raises(RuntimeError, match="decoder failed"):
+        decoder._decode_chunk(
+            ExplodingFrameGetter(),
+            chunk,
+            _make_vlm_query(),
+            video_codec="HEVC",
+            request_id="failed-request",
+        )
+
+    assert decoder._cuda_frame_ring.claim_fill(*ring_key)
+
+
+@pytest.mark.no_gpu
+def test_persistent_ring_does_not_claim_static_images(tmp_path):
+    image = tmp_path / "fixture.jpg"
+    image.write_bytes(b"image")
+    chunk = ChunkInfo(file=str(image), start_pts=0, end_pts=1_000_000_000)
+
+    assert vlm_pipeline_module._file_ring_identity(chunk, 608, 320, "JPEG") is None
+
+
+@pytest.mark.no_gpu
 def test_fast_image_decode_rejects_underfilled_fixed_frame_chunk(monkeypatch):
     _install_fake_frame_selector(monkeypatch)
     monkeypatch.setattr(vlm_pipeline_module.nvtx, "start_range", lambda *args, **kwargs: object())
@@ -709,14 +799,18 @@ def test_live_stream_fallback_frame_selector_honors_server_fps_default(monkeypat
     decoder = _make_live_decoder()
     asset = SimpleNamespace(
         asset_id="live-stream-id",
+        camera_id="camera-id",
+        sensor_name="sensor-name",
         path="rtsp://example.test/stream.mp4",
         username="",
         password="",
     )
 
+    query = _make_vlm_query()
+    query.chunk_overlap_duration = 2
     decoder._live_stream(
         asset,
-        _make_vlm_query(),
+        query,
         request_id="test-request",
         request_params=object(),
     )
@@ -724,4 +818,5 @@ def test_live_stream_fallback_frame_selector_honors_server_fps_default(monkeypat
     assert created_selectors[0].args == (3,)
     assert created_selectors[0].kwargs["use_fps_for_chunking"] is True
     assert created_getters[0].destroyed == 1
+    assert created_getters[0].stream_kwargs["chunk_overlap_duration"] == 2
     assert decoder._final_output_queue.items[-1]["live_stream_ended"] is True

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_decode_retry.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_decode_retry.py
@@ -608,7 +608,10 @@ def test_decode_chunk_reuses_decoder_after_clean_success_by_default(monkeypatch)
 
 
 @pytest.mark.no_gpu
-def test_persistent_ring_decodes_file_once_and_reuses_pts_frames(monkeypatch, tmp_path):
+@pytest.mark.parametrize("requested_frames, expected", [(2, [0, 2]), (8, [0, 1, 2, 3])])
+def test_persistent_ring_decodes_file_once_and_reuses_pts_frames(
+    monkeypatch, tmp_path, requested_frames, expected
+):
     class DenseFrameGetter(CleanFrameGetter):
         def get_frames(self, chunk, frame_selector, *args, **kwargs):
             self.calls += 1
@@ -627,7 +630,7 @@ def test_persistent_ring_decodes_file_once_and_reuses_pts_frames(monkeypatch, tm
     decoder = _make_decoder()
     decoder._cuda_frame_ring = CudaFrameRing(max_bytes=1024)
     query = _make_vlm_query()
-    query.num_frames_per_second_or_fixed_frames_chunk = 2
+    query.num_frames_per_second_or_fixed_frames_chunk = requested_frames
     video = tmp_path / "fixture.mp4"
     video.write_bytes(b"content-version-1")
     chunk = ChunkInfo(file=str(video), start_pts=0, end_pts=4_000_000_000)
@@ -650,9 +653,96 @@ def test_persistent_ring_decodes_file_once_and_reuses_pts_frames(monkeypatch, tm
     )
 
     assert first_getter.calls == 1
-    assert first["frames"].flatten().tolist() == [0, 2]
-    assert second["frames"].flatten().tolist() == [0, 2]
-    assert second["frame_times"] == [0.0, 2.0]
+    assert first["frames"].flatten().tolist() == expected
+    assert second["frames"].flatten().tolist() == expected
+    assert first["frame_times"] == second["frame_times"] == [float(i) for i in expected]
+
+
+@pytest.mark.no_gpu
+@pytest.mark.parametrize("as_tensor", [False, True])
+@pytest.mark.parametrize("mode", ["pts", "indices", "all"])
+@pytest.mark.parametrize(
+    "pts_ns, end_ns",
+    [
+        ([0, 100_000_000], 200_000_000),
+        ([70_000_000, 100_000_000, 130_000_000, 170_000_000], 200_000_000),
+    ],
+)
+def test_dense_and_ring_sampling_match_sparse_selector(
+    monkeypatch, as_tensor, mode, pts_ns, end_ns
+):
+    from vlm_pipeline.video_file_frame_getter import DefaultFrameSelector
+
+    monkeypatch.setenv("RTVI_QWEN_REFERENCE_RESIZE", "false")
+    selector = DefaultFrameSelector(-1 if mode == "all" else 8)
+    chunk = ChunkInfo(file="fixture.mp4", start_pts=0, end_pts=end_ns)
+    query = vlm_pipeline_module._selector_ring_query(selector, chunk)
+    if mode == "indices":
+        query["target_indices"] = [round(i * (len(pts_ns) - 1) / 7) for i in range(8)]
+        selector._select_by_frame_index = True
+        selector._selected_frame_indices_array.extend(query["target_indices"])
+    expected_indices = [i for i, pts in enumerate(pts_ns) if selector.choose_frame(None, pts)]
+    expected_pts = [pts_ns[i] for i in expected_indices]
+    frames = torch.arange(len(pts_ns)).reshape(-1, 1) if as_tensor else list(range(len(pts_ns)))
+
+    selected, selected_times = vlm_pipeline_module._select_dense_frames(
+        frames, [pts / 1e9 for pts in pts_ns], query
+    )
+
+    assert (selected.flatten().tolist() if as_tensor else selected) == expected_indices
+    assert selected_times == [pts / 1e9 for pts in expected_pts]
+    ring = CudaFrameRing(max_bytes=1024)
+    ring.publish("source", "epoch", 0, end_ns, pts_ns, list(range(len(pts_ns))))
+    assert ring.acquire("source", "epoch", **query) == (expected_indices, expected_pts)
+
+
+@pytest.mark.no_gpu
+def test_dense_sampling_with_unavailable_targets_never_returns_full_batch():
+    query = dict(
+        start_ns=0,
+        end_ns=300_000_000,
+        target_pts_ns=[0, 250_000_000],
+        target_indices=None,
+        select_all=False,
+    )
+    assert vlm_pipeline_module._select_dense_frames([0, 1, 2], [0.0, 0.1, 0.2], query) == (
+        [0],
+        [0.0],
+    )
+
+
+@pytest.mark.no_gpu
+@pytest.mark.parametrize("packed", [False, True])
+def test_underfilled_ring_hit_preserves_strict_frame_count_check(monkeypatch, tmp_path, packed):
+    from vlm_pipeline.video_file_frame_getter import DefaultFrameSelector
+
+    monkeypatch.setenv("RTVI_PERSISTENT_CUDA_FRAME_RING", "true")
+    monkeypatch.setenv("RTVI_STRICT_FIXED_FRAME_CHUNK_DECODE", "true")
+    monkeypatch.setenv("RTVI_QWEN_REFERENCE_RESIZE", "false")
+    monkeypatch.setattr(vlm_pipeline_module.nvtx, "start_range", lambda *a, **kw: object())
+    monkeypatch.setattr(vlm_pipeline_module.nvtx, "end_range", lambda *a, **kw: None)
+    decoder = _make_decoder()
+    decoder._cuda_frame_ring = CudaFrameRing(max_bytes=1024)
+    video = tmp_path / "fixture.mp4"
+    video.write_bytes(b"content-version-1")
+    chunk = ChunkInfo(file=str(video), start_pts=0, end_pts=4_000_000_000)
+    key = vlm_pipeline_module._file_ring_identity(chunk, 0, 0, "HEVC")
+    decoder._cuda_frame_ring.publish(*key, 0, 4_000_000_000, [0], [torch.tensor([0])])
+    if packed:
+        selection_key = vlm_pipeline_module._ring_selection_key(
+            vlm_pipeline_module._selector_ring_query(DefaultFrameSelector(2), chunk)
+        )
+        decoder._cuda_frame_ring.publish_selection(*key, selection_key, torch.tensor([[0]]), [0])
+    query = _make_vlm_query()
+    query.num_frames_per_second_or_fixed_frames_chunk = 2
+    getter = UnderfilledFixedFrameGetter()
+
+    result = decoder._decode_chunk(getter, chunk, query, video_codec="HEVC", request_id="strict")
+
+    assert getter.calls == 2
+    assert result["error"] is None
+    assert result["decode_retry_count"] == 1
+    assert len(result["frames"]) == 30
 
 
 @pytest.mark.no_gpu

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_process_base.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_process_base.py
@@ -15,6 +15,7 @@
 
 import concurrent.futures
 import queue
+import time
 from threading import Lock
 from types import SimpleNamespace
 
@@ -85,6 +86,64 @@ def test_cuda_transport_backpressure_waits_without_host_spill():
 
     assert admitted is True
     assert stop.wait_calls == 2
+
+
+def test_cuda_transport_admission_is_atomic_across_callbacks(monkeypatch):
+    class _RacyQueue:
+        def __init__(self):
+            self.items = []
+            self.lock = Lock()
+
+        def qsize(self):
+            with self.lock:
+                size = len(self.items)
+            # Without the admission lock, both callbacks observe the same
+            # pre-enqueue size during this window.
+            time.sleep(0.05)
+            return size
+
+        def put(self, item):
+            with self.lock:
+                self.items.append(item)
+
+    proc = _NoBatchProcess()
+    proc._output_queue = _RacyQueue()
+    proc._final_output_queue = _RecordingQueue()
+    proc._num_decoders_per_gpu = 1
+    proc._cuda_transport_admission_lock = Lock()
+    monkeypatch.setattr(process_base_module, "_USE_CUDA_MM_TENSOR_IPC", True)
+    monkeypatch.setattr(process_base_module, "_move_cuda_frames_to_cpu", lambda value: value)
+    monkeypatch.setattr(
+        process_base_module,
+        "_contains_cuda_tensor",
+        lambda value: value == "cuda-frames",
+    )
+    monkeypatch.setattr(
+        process_base_module,
+        "_spill_cuda_frames_to_cpu",
+        lambda _value: "cpu-frames",
+    )
+    monkeypatch.setattr(process_base_module, "_safe_cuda_empty_cache", lambda **_kwargs: None)
+
+    def publish(chunk_id):
+        proc._handle_result(
+            {
+                "chunk": object(),
+                "chunk_id": chunk_id,
+                "frames": "cuda-frames",
+                "error": None,
+            },
+            chunk=object(),
+            chunk_id=chunk_id,
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        list(executor.map(publish, (1, 2)))
+
+    assert sorted(item["frames"] for item in proc._output_queue.items) == [
+        "cpu-frames",
+        "cuda-frames",
+    ]
 
 
 def test_live_output_handoff_drops_chunk_when_host_backlog_is_full(monkeypatch):

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_process_base.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_process_base.py
@@ -16,6 +16,7 @@
 import concurrent.futures
 import queue
 from threading import Lock
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -53,6 +54,37 @@ class _NoBatchProcess(ProcessBase):
 class _BatchProcess(_NoBatchProcess):
     def _supports_batching(self):
         return True
+
+
+def test_cuda_transport_backpressure_waits_without_host_spill():
+    class _DrainingQueue:
+        def __init__(self):
+            self.sizes = iter((1, 1, 0))
+            self.items = []
+
+        def qsize(self):
+            return next(self.sizes)
+
+        def put(self, item):
+            self.items.append(item)
+
+    output_queue = _DrainingQueue()
+    stop = SimpleNamespace(wait_calls=0)
+
+    def wait(timeout):
+        stop.wait_calls += 1
+        return False
+
+    stop.wait = wait
+    admitted = process_base_module._wait_for_cuda_transport_slot(
+        output_queue,
+        slots=1,
+        stop_event=stop,
+        poll_seconds=0.001,
+    )
+
+    assert admitted is True
+    assert stop.wait_calls == 2
 
 
 def test_live_output_handoff_drops_chunk_when_host_backlog_is_full(monkeypatch):


### PR DESCRIPTION
## Summary

- retain decoded file/live frames in a bounded, PTS-indexed CUDA ring and reuse packed sampled selections
- extend adaptive preprocessing admission with vLLM encoder-cache token capacity and model-owned visual-token geometry
- retain GPU-memory pressure and timeout controls as secondary safeguards
- backpressure CUDA transport instead of spilling full-frame payloads through avoidable host copies
- add opt-in NVTX ranges around ring lookup, preprocessing, transport, admission, encoder overlap, and first-token stages
- expose multimodal encoder compilation as an opt-in capability-gated setting
- keep the policy architecture-neutral: no fixed SM assumptions or H100-only defaults

The CUDA ring and token-aware controller are combined because the admission changes depend on the ring transport and bookkeeping. Both commits are based directly on current `develop`.

## Validation

- frozen FP8 C64 contract: p50 5.102 s to 3.313 s (35.06% improvement), throughput change -2.68%
- Nsight Systems: 96.13% GPU utilization, maximum observed idle gap 11.59 ms, and no full-frame host copy on the tested path
- four distinct 10-second visual sentinel fixtures passed with correct request/frame ordering and no semantic regression
- constrained-device run completed 128/128 requests
- `compile_mm_encoder` was measured separately and remains opt-in because its 0.82% gain missed the 10% acceptance gate
- migrated patch applies cleanly to the current `develop` branch
- changed Python files pass Python 3.12 compilation and `git diff --check`

Full dependency and unit coverage is delegated to GitHub CI for the public monorepo environment.