### PR TITLE
Add GB300 and RTX4500 to per profile per platform GPU requirements

### DIFF
--- a/docs/prerequisites.mdx
+++ b/docs/prerequisites.mdx
@@ -10,6 +10,7 @@ This section covers the prerequisites for deploying and using the VSS Blueprint.
 The VSS Blueprint has been validated and tested on the following NVIDIA GPUs:
 
 - NVIDIA H100
+- NVIDIA GB300
 - NVIDIA RTX PRO 6000 Blackwell
 - NVIDIA L40S
 - NVIDIA DGX SPARK
@@ -260,6 +261,21 @@ The following tables show the number of GPUs needed for each development profile
 | [dev-profile-search](/vss/vision-agent/agent-workflows/search) <sup>2</sup> | 3 | 4 | 3 | 2 | 2 |
 
 </Tab>
+<Tab title="GB300">
+
+All supported profiles use one GB300 GPU. The profile quickstarts assign every
+local service to that GPU; a remote model option offloads the selected model but
+does not remove the GPU required by the profile services.
+
+| **Profile** | **Default / local models** | **Remote LLM** | **Remote VLM** | **Remote LLM + VLM** |
+| --- | --- | --- | --- | --- |
+| [dev-profile-base](/vss/getting-started/quickstart) | 1 | 1 | 1 | 1 |
+| [dev-profile-lvs](/vss/vision-agent/agent-workflows/video-summarization) | 1 | 1 | 1 | 1 |
+| [dev-profile-alerts (Alert verification with VLM)](/vss/vision-agent/agent-workflows/alert-verification) <sup>1</sup> | 1 | 1 | 1 | 1 |
+| [dev-profile-alerts (Real-Time Alerts with VLM)](/vss/vision-agent/agent-workflows/real-time-alerts) <sup>1</sup> | 1 | 1 | — | — |
+| [dev-profile-search](/vss/vision-agent/agent-workflows/search) <sup>2</sup> | 1 | 1 | 1 | 1 |
+
+</Tab>
 <Tab title="RTXPRO6000BW">
 
 | **Profile** | **Shared GPU** | **Dedicated GPU** | **Remote LLM** | **Remote VLM** | **Remote LLM + VLM** |
@@ -269,6 +285,19 @@ The following tables show the number of GPUs needed for each development profile
 | [dev-profile-alerts (Alert verification with VLM)](/vss/vision-agent/agent-workflows/alert-verification) <sup>1</sup> | 2 | 3 | 2 | 2 | 1 |
 | [dev-profile-alerts (Real-Time Alerts with VLM)](/vss/vision-agent/agent-workflows/real-time-alerts) <sup>1</sup> | 2 | 3 | 2 | — | — |
 | [dev-profile-search](/vss/vision-agent/agent-workflows/search) <sup>2</sup> | 3 | 4 | 3 | 2 | 2 |
+
+</Tab>
+<Tab title="RTXPRO4500BW">
+
+RTX PRO 4500 Blackwell is supported only for the alerts profile with a remote
+LLM. Set `HARDWARE_PROFILE=RTXPRO4500BW` explicitly when automatic detection
+does not identify the GPU; the alerts quickstarts recommend NVIDIA driver
+580.126.09 or later.
+
+| **Profile** | **Remote LLM** |
+| --- | --- |
+| [dev-profile-alerts (Alert verification with VLM)](/vss/vision-agent/agent-workflows/alert-verification) <sup>1</sup> | 2 |
+| [dev-profile-alerts (Real-Time Alerts with VLM)](/vss/vision-agent/agent-workflows/real-time-alerts) <sup>1</sup> | 2 |
 
 </Tab>
 <Tab title="L40S">


### PR DESCRIPTION
## Summary

Align GPU prerequisites with the validated hardware options exposed in profile quickstarts.

## Plan

- Review profile quickstart GPU tabsets.
- Add missing validated hardware coverage to prerequisites.
- Verify tab structure and whitespace.

## Related Issue

Bug 6723778

## Changes

- Added NVIDIA GB300 to validated hardware requirements.
- Added GB300 GPU requirements for base, LVS, alerts, and search profiles.
- Added RTX PRO 4500 Blackwell requirements for alerts with a remote LLM.
- Documented the recommended driver and explicit HARDWARE_PROFILE setting for RTX PRO 4500 Blackwell.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.
