### PR TITLE
update RT-VLM GPU memory utilizaion for alert profile: SPARK/THOR/GB300

### DIFF
--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -489,6 +489,20 @@ function mask_external_ip_args() {
 function get_rtvi_vllm_gpu_memory_utilization() {
   local _hardware_profile="${1}"
   local _vlm_mode="${2}"
+  local _profile="${3}"
+
+  if [[ "${_profile}" == "alerts" ]]; then
+    case "${_hardware_profile}" in
+      GB300)
+        echo "0.2"
+        return
+        ;;
+      DGX-SPARK)
+        echo "0.35"
+        return
+        ;;
+    esac
+  fi
 
   if [[ "${_vlm_mode}" == "local_shared" ]]; then
     case "${_hardware_profile}" in
@@ -1833,7 +1847,7 @@ function state_up() {
     # RTVI local VLM memory utilization. Remote VLM uses rtvi-vlm as a proxy, so
     # vLLM memory sizing only applies when rtvi-vlm hosts the model locally.
     if [[ "${vlm_mode}" != "remote" ]] && [[ "${hardware_profile}" != "IGX-THOR" ]] && [[ "${hardware_profile}" != "AGX-THOR" ]]; then
-      set_env_var "RTVI_VLLM_GPU_MEMORY_UTILIZATION" "$(get_rtvi_vllm_gpu_memory_utilization "${hardware_profile}" "${vlm_mode}")"
+      set_env_var "RTVI_VLLM_GPU_MEMORY_UTILIZATION" "$(get_rtvi_vllm_gpu_memory_utilization "${hardware_profile}" "${vlm_mode}" "${profile}")"
       if [[ "${hardware_profile}" == "GB300" ]]; then
         set_env_var "RTVI_VLLM_ATTENTION_BACKEND" "TRITON_ATTN"
       fi
@@ -1863,8 +1877,11 @@ function state_up() {
       fi
     fi
     if [[ "${hardware_profile}" == "IGX-THOR" ]] || [[ "${hardware_profile}" == "AGX-THOR" ]]; then
-      # Base/Thor default fraction when host env did not override; alerts/LVS keep host value as-is.
-      if [[ "${profile}" == "base" ]]; then
+      # Base/alerts Thor default fraction when host env did not override; LVS and
+      # search keep host value as-is. Without a default the empty value reaches
+      # RT-VLM, which then applies its own 0.7 -- ~87 GiB of Thor's shared pool,
+      # which aborts at startup once the LLM is resident.
+      if [[ "${profile}" == "base" ]] || [[ "${profile}" == "alerts" ]]; then
         set_env_var "RTVI_VLLM_GPU_MEMORY_UTILIZATION" "${RTVI_VLLM_GPU_MEMORY_UTILIZATION:-0.35}"
       else
         set_env_var "RTVI_VLLM_GPU_MEMORY_UTILIZATION" "${RTVI_VLLM_GPU_MEMORY_UTILIZATION}"

--- a/deploy/docker/scripts/vss_orchestrator_mcp_config.yml
+++ b/deploy/docker/scripts/vss_orchestrator_mcp_config.yml
@@ -127,11 +127,13 @@ function_groups:
             base:
               VLM_NIM_KVCACHE_PERCENT: "0.2"
             # Unified alerts value, matching dev-profile.sh
-            # get_rtvi_vllm_gpu_memory_utilization (DGX-SPARK local_shared -> 0.4).
+            # get_rtvi_vllm_gpu_memory_utilization (DGX-SPARK alerts -> 0.35;
+            # the 0.4 local_shared value it uses elsewhere leaves too little of
+            # Spark's 128 GB unified pool once the LLM and RT-CV are resident).
             # The old per-mode 0.25/0.3 split was #477 bring-up tuning with no
             # counterpart in the bash flow.
             alerts:
-              RTVI_VLLM_GPU_MEMORY_UTILIZATION: "0.4"
+              RTVI_VLLM_GPU_MEMORY_UTILIZATION: "0.35"
           IGX-THOR:
             VLM_NAME_SLUG: none
             VLM_NAME: nim_nvidia_cosmos3-nano-reasoner_bf16-final

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -708,24 +708,39 @@ run_dry_run_test "edge (IGX-THOR) alerts verification uses device ID 0" up -p al
 run_dry_run_test "edge (AGX-THOR) alerts verification uses device ID 0" up -p alerts -i 127.0.0.1 -m verification -H AGX-THOR -d
 run_dry_run_test "edge (IGX-THOR) alerts real-time uses device ID 0 (no VLM overrides)" up -p alerts -i 127.0.0.1 -m real-time -H IGX-THOR -d
 run_dry_run_test "edge (AGX-THOR) alerts real-time uses device ID 0 (no VLM overrides)" up -p alerts -i 127.0.0.1 -m real-time -H AGX-THOR -d
-# Alerts on IGX-THOR / AGX-THOR: RT_VLM_DEVICE_ID hardcoded to 0; RTVI_VLLM_GPU_MEMORY_UTILIZATION is an option (mirrors NIM hw-H100.env pattern: ${VLM_NIM_KVCACHE_PERCENT}), flows through from env (unset → empty).
+# Alerts on IGX-THOR / AGX-THOR: RT_VLM_DEVICE_ID hardcoded to 0; RTVI_VLLM_GPU_MEMORY_UTILIZATION defaults to the Thor 0.35 fraction when the host env does not set it (an unset value would otherwise reach RT-VLM, which applies its own 0.7 and aborts on the shared pool).
 run_dry_run_up_and_check_generated_env "generated.env alerts IGX-THOR VLM vars (RT_VLM_DEVICE_ID=0)" "alerts" \
   -i 127.0.0.1 -m verification -H IGX-THOR -d -- \
-  "VLM_NAME_SLUG" "none" "VLM_NAME" "nim_nvidia_cosmos3-nano-reasoner_bf16-final" "VLM_BASE_URL" "http://rtvi-vlm:8000" "RTVI_VLM_MODEL_PATH" "ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final" "RTVI_VLM_MODEL_TO_USE" "cosmos-reason3" "RT_VLM_DEVICE_ID" "0"
+  "VLM_NAME_SLUG" "none" "VLM_NAME" "nim_nvidia_cosmos3-nano-reasoner_bf16-final" "VLM_BASE_URL" "http://rtvi-vlm:8000" "RTVI_VLM_MODEL_PATH" "ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final" "RTVI_VLM_MODEL_TO_USE" "cosmos-reason3" "RT_VLM_DEVICE_ID" "0" "RTVI_VLLM_GPU_MEMORY_UTILIZATION" "0.35"
 run_dry_run_up_and_check_generated_env "generated.env alerts AGX-THOR VLM vars (RT_VLM_DEVICE_ID=0)" "alerts" \
   -i 127.0.0.1 -m verification -H AGX-THOR -d -- \
-  "VLM_NAME_SLUG" "none" "VLM_NAME" "nim_nvidia_cosmos3-nano-reasoner_bf16-final" "VLM_BASE_URL" "http://rtvi-vlm:8000" "RTVI_VLM_MODEL_PATH" "ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final" "RTVI_VLM_MODEL_TO_USE" "cosmos-reason3" "RT_VLM_DEVICE_ID" "0"
-# Alerts on IGX-THOR/AGX-THOR: RTVI_VLLM_GPU_MEMORY_UTILIZATION env var flows through to generated.env (option pattern, like ${VLM_NIM_KVCACHE_PERCENT} in NIM hw-H100.env).
+  "VLM_NAME_SLUG" "none" "VLM_NAME" "nim_nvidia_cosmos3-nano-reasoner_bf16-final" "VLM_BASE_URL" "http://rtvi-vlm:8000" "RTVI_VLM_MODEL_PATH" "ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final" "RTVI_VLM_MODEL_TO_USE" "cosmos-reason3" "RT_VLM_DEVICE_ID" "0" "RTVI_VLLM_GPU_MEMORY_UTILIZATION" "0.35"
+# Both alerts modes take the default: real-time runs the same local RT-VLM as verification.
+run_dry_run_up_and_check_generated_env "generated.env alerts IGX-THOR real-time RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.35" "alerts" \
+  -i 127.0.0.1 -m real-time -H IGX-THOR -d -- \
+  "RTVI_VLLM_GPU_MEMORY_UTILIZATION" "0.35"
+run_dry_run_up_and_check_generated_env "generated.env alerts AGX-THOR real-time RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.35" "alerts" \
+  -i 127.0.0.1 -m real-time -H AGX-THOR -d -- \
+  "RTVI_VLLM_GPU_MEMORY_UTILIZATION" "0.35"
+# Alerts on IGX-THOR/AGX-THOR: a host RTVI_VLLM_GPU_MEMORY_UTILIZATION still overrides that default (option pattern, like ${VLM_NIM_KVCACHE_PERCENT} in NIM hw-H100.env).
 RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.5 run_dry_run_up_and_check_generated_env "generated.env alerts IGX-THOR RTVI_VLLM_GPU_MEMORY_UTILIZATION env passes through" "alerts" \
   -i 127.0.0.1 -m verification -H IGX-THOR -d -- \
   "RTVI_VLLM_GPU_MEMORY_UTILIZATION" "0.5"
 RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.6 run_dry_run_up_and_check_generated_env "generated.env alerts AGX-THOR RTVI_VLLM_GPU_MEMORY_UTILIZATION env passes through" "alerts" \
   -i 127.0.0.1 -m verification -H AGX-THOR -d -- \
   "RTVI_VLLM_GPU_MEMORY_UTILIZATION" "0.6"
-# Alerts RT-VLM local VLM memory sizing.
-run_dry_run_up_and_check_generated_env "generated.env alerts DGX-SPARK shared RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.4" "alerts" \
+run_dry_run_up_and_check_generated_env "generated.env alerts DGX-SPARK shared RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.35" "alerts" \
   -i 127.0.0.1 -m verification -H DGX-SPARK -d -- \
-  "RTVI_VLLM_GPU_MEMORY_UTILIZATION" "0.4"
+  "RTVI_VLLM_GPU_MEMORY_UTILIZATION" "0.35"
+run_dry_run_up_and_check_generated_env "generated.env alerts DGX-SPARK real-time RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.35" "alerts" \
+  -i 127.0.0.1 -m real-time -H DGX-SPARK -d -- \
+  "RTVI_VLLM_GPU_MEMORY_UTILIZATION" "0.35"
+run_dry_run_up_and_check_generated_env "generated.env alerts GB300 RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.2" "alerts" \
+  -i 127.0.0.1 -m verification -H GB300 --llm-device-id 1 --vlm-device-id 1 -d -- \
+  "RTVI_VLLM_GPU_MEMORY_UTILIZATION" "0.2"
+run_dry_run_up_and_check_generated_env "generated.env alerts GB300 real-time RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.2" "alerts" \
+  -i 127.0.0.1 -m real-time -H GB300 --llm-device-id 1 --vlm-device-id 1 -d -- \
+  "RTVI_VLLM_GPU_MEMORY_UTILIZATION" "0.2"
 run_dry_run_up_and_check_generated_env "generated.env alerts H100 shared RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.4" "alerts" \
   -i 127.0.0.1 -m verification -H H100 -d -- \
   "RTVI_VLLM_GPU_MEMORY_UTILIZATION" "0.4"

--- a/skills/deployment/vss-deploy-profile/references/alerts.md
+++ b/skills/deployment/vss-deploy-profile/references/alerts.md
@@ -136,14 +136,20 @@ The skill writes these env vars to `dev-profile-alerts/generated.env` itself; th
 
 | Layout | Hardware | Value |
 |---|---|---|
-| RT-VLM shares GPU with LLM (`VLM_MODE=local_shared`) | DGX-SPARK, H100, RTXPRO6000BW | **0.4** |
+| RT-VLM shares GPU with LLM (`VLM_MODE=local_shared`) | H100, RTXPRO6000BW | **0.4** |
 | RT-VLM shares GPU with LLM (`VLM_MODE=local_shared`) | RTXPRO4500BW | **0.8** |
 | RT-VLM shares GPU with LLM (`VLM_MODE=local_shared`) | OTHER | **0.7** |
 | RT-VLM on its own GPU (`VLM_MODE=local`) | L40S, RTXPRO4500BW | **0.8** (RTX 4500 also needs `RTVI_VLM_MAX_MODEL_LEN=18000` — see [§ RTX 4500](#rtx-4500-32-gb)) |
 | RT-VLM on its own GPU (`VLM_MODE=local`) | H100, RTXPRO6000BW, OTHER | **0.7** |
-| RT-VLM on edge (`IGX-THOR` / `AGX-THOR`) | unified memory | passthrough from env (unset → empty; function skipped) |
+| RT-VLM on the shared deployment GPU | DGX-SPARK | **0.35** (alerts-only; `0.4` elsewhere) |
+| RT-VLM on the shared deployment GPU | GB300 | **0.2** (alerts-only; `0.3` elsewhere — the same GPU also carries RT-Embed, which has no fraction knob) |
+| RT-VLM on edge (`IGX-THOR` / `AGX-THOR`) | unified memory | **0.35** default; a host `RTVI_VLLM_GPU_MEMORY_UTILIZATION` overrides it |
 
 > Values mirror `dev-profile.sh`'s `get_rtvi_vllm_gpu_memory_utilization()`.
+> **DGX-SPARK and GB300 take alerts-specific fractions** — lower than the
+> `local_shared` values the other profiles use, because alerts keeps RT-VLM
+> resident next to the LLM and RT-CV for the whole run. Both alerts modes
+> (`verification` and `real-time`) resolve the same value.
 > **DGX-SPARK is always `local_shared`** (single GPU, device 0 reserved).
 > **L40S cannot be `local_shared`** — the script rejects sharing its device ID, so
 > it is `local`-only (RT-VLM on its own GPU @ 0.8) or remote.

--- a/skills/deployment/vss-deploy-profile/references/edge.md
+++ b/skills/deployment/vss-deploy-profile/references/edge.md
@@ -145,7 +145,9 @@ awk -v f="$free" -v t="$total" 'BEGIN{u=f/t-0.2; if(u<0)u=0; printf "max util ~ 
 The conservative per-service defaults already aim for this on a clean box (each
 fraction ≈ 0.4, so two co-resident services sum to ≤ 0.8): the Lightning NIM's
 shared env sets `NIM_GPU_MEM_FRACTION=0.30`, and `dev-profile.sh`
-sets RT-VLM to `0.4` on DGX Spark and `0.35` on AGX/IGX Thor for `base`. If other
+sets RT-VLM to `0.4` on DGX Spark for `base` and `0.35` on both boards for
+`alerts` (AGX/IGX Thor use `0.35` for `base` too, and a host
+`RTVI_VLLM_GPU_MEMORY_UTILIZATION` still overrides it). If other
 tenants are resident (so `free` is lower than the formula's value), **lower the
 fractions to fit** — for the LLM that means lowering `NIM_GPU_MEM_FRACTION` in
 `services/nim/nemotron-3.5-lightning-30b-a3b/hw-<profile>-shared.env` (the FP8


### PR DESCRIPTION
## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
