### PR TITLE
fix(rtvi-vlm): accept string IDs in streams/add

### DIFF
--- a/services/rtvi/rt-vlm/src/api_models/live_stream.py
+++ b/services/rtvi/rt-vlm/src/api_models/live_stream.py
@@ -42,6 +42,7 @@ from .common import (
 )
 
 LIVE_STREAM_URL_PATTERN = r"^rtsp://"
+STREAM_ID_PATTERN = r"^[^/\r\n]+$"
 # CV-compatible URL pattern: accepts rtsp://, file://, http://, https://.
 # Empty VIOS camera_add registration URLs are handled by the VIOS-specific pattern.
 CV_STREAM_URL_PATTERN = r"^(rtsp://|file://|https?://)"
@@ -143,7 +144,7 @@ class AddLiveStream(CommonBaseModel):
             "The identifier of the live stream. If not provided, a new ID will be generated."
         ),
         max_length=256,
-        pattern=ANY_CHAR_PATTERN,
+        pattern=STREAM_ID_PATTERN,
         examples=["camera-01"],
     )
     sensor_name: str = Field(
@@ -161,7 +162,7 @@ class AddLiveStreamResponse(CommonBaseModel):
     id: str = Field(
         description="The stream identifier, which can be referenced in the API endpoints.",
         max_length=256,
-        pattern=ANY_CHAR_PATTERN,
+        pattern=STREAM_ID_PATTERN,
     )
 
 

--- a/services/rtvi/rt-vlm/src/api_models/live_stream.py
+++ b/services/rtvi/rt-vlm/src/api_models/live_stream.py
@@ -42,7 +42,7 @@ from .common import (
 )
 
 LIVE_STREAM_URL_PATTERN = r"^rtsp://"
-STREAM_ID_PATTERN = r"^[^/\r\n]+$"
+STREAM_ID_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._-]{0,255}$"
 # CV-compatible URL pattern: accepts rtsp://, file://, http://, https://.
 # Empty VIOS camera_add registration URLs are handled by the VIOS-specific pattern.
 CV_STREAM_URL_PATTERN = r"^(rtsp://|file://|https?://)"

--- a/services/rtvi/rt-vlm/src/api_models/live_stream.py
+++ b/services/rtvi/rt-vlm/src/api_models/live_stream.py
@@ -20,7 +20,6 @@ and CV-compatible models (/v1/stream/*) for cross-service interoperability.
 
 from datetime import datetime
 from typing import Annotated, Any, Optional, Union
-from uuid import UUID
 
 from pydantic import ConfigDict, Field, field_validator
 
@@ -138,10 +137,14 @@ class AddLiveStream(CommonBaseModel):
         ge=-1000000,
         le=1000000,
     )
-    id: Optional[UUID] = Field(
+    id: Optional[str] = Field(
         default=None,
-        description="The UUID of the live stream. If not provided, a new ID will be generated.",
-        examples=["cc06804c-7f11-4865-bb00-6b2db072086f"],
+        description=(
+            "The identifier of the live stream. If not provided, a new ID will be generated."
+        ),
+        max_length=256,
+        pattern=ANY_CHAR_PATTERN,
+        examples=["camera-01"],
     )
     sensor_name: str = Field(
         default="",
@@ -155,8 +158,10 @@ class AddLiveStream(CommonBaseModel):
 class AddLiveStreamResponse(CommonBaseModel):
     """Response schema for the add live stream API."""
 
-    id: UUID = Field(
-        description="The stream identifier, which can be referenced in the API endpoints."
+    id: str = Field(
+        description="The stream identifier, which can be referenced in the API endpoints.",
+        max_length=256,
+        pattern=ANY_CHAR_PATTERN,
     )
 
 

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_rtvi_vlm_server.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_rtvi_vlm_server.py
@@ -463,6 +463,23 @@ class TestLiveStreamEndpoints:
         )
         assert response.status_code in [400, 422]
 
+    def test_add_live_stream_rejects_path_separator_in_id(self, test_client):
+        """Stream IDs must fit in the single-stream delete route."""
+        response = test_client.post(
+            f"{API_PREFIX}/streams/add",
+            json={
+                "streams": [
+                    {
+                        "id": "camera/01",
+                        "liveStreamUrl": "rtsp://example.com/stream",
+                        "description": "test",
+                    }
+                ]
+            },
+        )
+
+        assert response.status_code == 422
+
     def test_delete_live_stream_not_found(self, test_client):
         """Test deleting non-existent live stream"""
         fake_id = str(uuid.uuid4())

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_rtvi_vlm_server.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_rtvi_vlm_server.py
@@ -551,12 +551,14 @@ class TestLiveStreamEndpoints:
         assert "deleted" in data
         assert "errors" in data
 
-    def test_add_live_stream_rejects_duplicate_stream_id(self, monkeypatch, test_client):
-        """POST /v1/streams/add must reject duplicate caller-provided stream IDs."""
+    def test_add_live_stream_accepts_non_uuid_id_and_rejects_duplicate(
+        self, monkeypatch, test_client
+    ):
+        """POST /v1/streams/add accepts external IDs and rejects duplicates."""
         import server.rtvi_vlm_server as rtvi_vlm_server
 
         monkeypatch.setattr(rtvi_vlm_server, "_SKIP_INPUT_MEDIA_VERIFICATION", False)
-        stream_id = str(uuid.uuid4())
+        stream_id = "camera-01"
         body = {
             "streams": [
                 {
@@ -571,12 +573,19 @@ class TestLiveStreamEndpoints:
         assert first_response.status_code == 200
         assert first_response.json()["results"] == [{"id": stream_id}]
 
+        list_response = test_client.get(f"{API_PREFIX}/streams/get-stream-info")
+        assert list_response.status_code == 200
+        assert [stream["id"] for stream in list_response.json()] == [stream_id]
+
         duplicate_response = test_client.post(f"{API_PREFIX}/streams/add", json=body)
         assert duplicate_response.status_code == 200
         data = duplicate_response.json()
         assert data["results"] == []
         assert data["errors"][0]["error_code"] == "DuplicateStreamId"
         assert data["errors"][0]["status_code"] == 409
+
+        delete_response = test_client.delete(f"{API_PREFIX}/streams/delete/{stream_id}")
+        assert delete_response.status_code == 200
 
 
 class TestCaptionGeneration:

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_rtvi_vlm_server.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_rtvi_vlm_server.py
@@ -463,14 +463,18 @@ class TestLiveStreamEndpoints:
         )
         assert response.status_code in [400, 422]
 
-    def test_add_live_stream_rejects_path_separator_in_id(self, test_client):
-        """Stream IDs must fit in the single-stream delete route."""
+    @pytest.mark.parametrize(
+        "stream_id",
+        ["camera/01", ".", "..", "camera 01", "camera?01", "camera#01", "camera\t01"],
+    )
+    def test_add_live_stream_rejects_unsafe_id(self, test_client, stream_id):
+        """Stream IDs must be safe as URL and filesystem path segments."""
         response = test_client.post(
             f"{API_PREFIX}/streams/add",
             json={
                 "streams": [
                     {
-                        "id": "camera/01",
+                        "id": stream_id,
                         "liveStreamUrl": "rtsp://example.com/stream",
                         "description": "test",
                     }


### PR DESCRIPTION
## Summary
- accept bounded string identifiers in `POST /v1/streams/add` requests and responses
- cover a `camera-01` add, list, duplicate rejection, and delete lifecycle
- follow up #2080, which fixed listing existing non-UUID stream IDs

## Validation
- Pydantic request/response schema validation on macOS
- Python compilation for both changed files
- `git diff --check`

The focused endpoint test is included but was not executed locally because the macOS environment does not provide `cuda.bindings`; Linux/CUDA CI should execute it.

NVBUG 6735416