### PR TITLE
fix(ci): preserve Stage Fern Docs after merge

### DIFF
--- a/.github/scripts/cancel_stale_pr_ci.py
+++ b/.github/scripts/cancel_stale_pr_ci.py
@@ -30,7 +30,9 @@ ACTIVE_STATUSES = frozenset(
 )
 # Close handlers that must finish after merge. Everything else on the PR,
 # required or not, is leftover work.
-PROTECTED_WORKFLOWS = frozenset({"Cancel Stale PR CI", "Cleanup PR Tags"})
+PROTECTED_WORKFLOWS = frozenset(
+    {"Cancel Stale PR CI", "Cleanup PR Tags", "Stage Fern Docs"}
+)
 PR_EVENTS = ("pull_request", "pull_request_target")
 
 

--- a/.github/scripts/test_cancel_stale_pr_ci.py
+++ b/.github/scripts/test_cancel_stale_pr_ci.py
@@ -113,6 +113,16 @@ class ShouldCancelTest(unittest.TestCase):
             )
         )
 
+    def test_closed_pr_does_not_cancel_stage_fern_docs(self):
+        self.assertFalse(
+            module.should_cancel_run(
+                run=run() | {"name": "Stage Fern Docs"},
+                matches_source=True,
+                closed=True,
+                this_run_id=99,
+            )
+        )
+
     def test_does_not_cancel_self(self):
         self.assertFalse(
             module.should_cancel_run(


### PR DESCRIPTION
## Summary

Stage Fern Docs is a post-merge delivery workflow: after a docs or Fern change is merged into `develop`, it publishes the merged repository state to the persistent Fern staging site. This PR prevents the stale-PR cleanup automation from cancelling that delivery run immediately after it starts.

The issue was reproduced by the latest `develop` update at the time of investigation: PR #2093 merged documentation changes into `develop`, Stage Fern Docs started, reached its `Stage docs` step, and was then cancelled. The workflow was not skipped by its trigger or path filter.

## Plan

1. Preserve post-merge workflows that must finish after a PR closes.
2. Keep cancellation of stale PR CI runs unchanged.
3. Add regression coverage for the Stage Fern Docs exemption.

## Related Issue

None. Regression identified from post-merge execution of PR #2093.

## Changes

- Add `Stage Fern Docs` to `PROTECTED_WORKFLOWS` in `.github/scripts/cancel_stale_pr_ci.py`.
- Retain the existing close-path cleanup behavior for all non-protected PR workflows.
- Add a unit test verifying that an active `Stage Fern Docs` run is not cancelled when its PR closes.

Why this is necessary: both workflows listen for `pull_request.closed`. On close, `cancel_stale_pr_ci.py` collects active native `pull_request` runs for the source branch. Its close-path decision cancels every active matching run unless the workflow name is protected. Stage Fern Docs was not on that allowlist, so the cleanup workflow explicitly cancelled it. `cancel-in-progress: false` in Stage Fern Docs only protects its concurrency group; it does not prevent an explicit cancellation through the GitHub Actions API.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes; no user-facing documentation changes are required for this CI-only fix.
- [x] No secrets, API keys, or credentials committed.

Validation: `python3 .github/scripts/test_cancel_stale_pr_ci.py` (20 tests passed).