### PR TITLE
ci: gate skill eval dispatch by runner labels

### DIFF
--- a/.github/skill-eval/docs/matrix-dispatch-design.md
+++ b/.github/skill-eval/docs/matrix-dispatch-design.md
@@ -47,6 +47,7 @@ push to pull-request/<N>
 │ plan  (lightweight runner, no GPU, no brev)                    │
 │  • diff vs PR base                                             │
 │  • map each changed path → target (skill, spec) set (rules ↓)  │
+│  • attach spec-derived GitHub runner labels to every leg        │
 │  • cheap missing-adapter check → collapse those skills         │
 │  • emit matrix JSON + has_targets flag                         │
 └───────────────┬──────────────────────────────────────────────┘
@@ -55,6 +56,7 @@ push to pull-request/<N>
 ┌──────────────────────────────────────────────────────────────┐
 │ eval  (strategy.matrix, one leg per (spec, platform))          │
 │  runs-on: [self-hosted, vss-skill-eval-runner]                 │
+│    (default; optional direct dispatch consumes matrix.runs_on)   │
 │  fail-fast: false   max-parallel: <≈ box count>                │
 │                                                                │
 │  each leg:  EVAL_SKILL / EVAL_SPEC set                         │
@@ -118,6 +120,32 @@ runner) and makes the per-`(spec,platform)` output root automatic.
 `max-parallel` is capped near the `vss-eval-*` box count so legs don't
 all grab runner slots only to wait inside `run_leg.py`. `fail-fast: false` so one
 failing leg doesn't cancel the others.
+
+## Spec-derived runner labels (default off)
+
+`plan_matrix.py` maps each existing `resources.platforms` GPU-name key and
+`gpu_count` to a GitHub Actions label array such as
+`["self-hosted", "vss-eval", "gpu-l40s", "gpus-1"]`. These are GitHub
+**labels** (the equivalent GitLab concept is called tags). Specs keep their
+current GPU-name keys; this preparation does not replace them with compute
+capability or VRAM requirements.
+
+Both eval workflows can consume that array through the manual
+`direct_runner_dispatch` input. The input defaults to `false`, including for
+PR pushes and scheduled daily runs, so merging this change leaves the
+production coordinator + Brev path unchanged.
+
+Before setting it to `true`, operators must:
+
+1. Register direct VM runners with every label requested by their intended
+   matrix legs. GitHub ANDs all labels, so a missing `self-hosted`, `vss-eval`,
+   `gpu-*`, or `gpus-N` label leaves the job queued; queueing is not fallback.
+2. Complete and canary local execution on those runners. The current eval body
+   loads coordinator-only files and `run_leg.py` selects and SSHes to a Brev
+   box. Enabling label routing before replacing or short-circuiting that path
+   would double-dispatch instead of evaluating on the selected runner.
+3. Verify one canary leg, then enable broader manual sweeps. Roll back by
+   dispatching with the input off (or reverting the later activation change).
 
 ## What changes in code
 

--- a/.github/skill-eval/plan_matrix.py
+++ b/.github/skill-eval/plan_matrix.py
@@ -29,9 +29,10 @@ Each leg also carries `runs_on`: the runner label set implied by the
 spec's own `resources.platforms.<PLATFORM>` block (see runs_on_labels).
 This resolves the spec -> hardware mapping at PLAN time, where today
 run_leg.py re-derives it at LEG time from `brev ls` under a flock.
-Nothing consumes `runs_on` yet — it is emitted so the mapping can be
-reviewed against current placement before the GPU boxes are registered
-as runners in their own right.
+The eval workflows consume `runs_on` only behind their default-off
+`direct_runner_dispatch` manual input. Normal PR, manual, and scheduled
+runs remain on the coordinator until GPU boxes are registered with every
+required label and the eval leg can execute locally without a second Brev hop.
 
 Env:
     PR_BASE        base branch, e.g. develop (diffed as FETCH_HEAD...HEAD)
@@ -151,12 +152,11 @@ EXCLUDED_SPEC_NAMES = frozenset({"evals.json"})
 
 # --- Runner labels -----------------------------------------------------
 # Every leg carries a `runs_on` label set derived from the spec's own
-# hardware declaration, so the eval job *can* be placed by Actions with
-# `runs-on: ${{ matrix.runs_on }}` once the GPU boxes are registered as
-# runners in their own right. NOTHING CONSUMES THIS YET — skills-eval.yml
-# still pins the coordinator pool and run_leg.py still does fleet
-# selection + flock. This computes and publishes the mapping so it can be
-# reviewed and diffed against today's placement before any runner moves.
+# hardware declaration. The eval workflows can consume it through their
+# default-off `direct_runner_dispatch` input once GPU boxes are registered
+# with the complete label set and legs execute locally. The default path
+# still pins the coordinator pool, where run_leg.py does fleet selection
+# and flock-based reservation.
 
 # Labels the GPU boxes themselves would carry. Deliberately NOT
 # `vss-skill-eval-runner`: that label is on the coordinator's runner
@@ -501,9 +501,10 @@ def emit(include: list[dict]) -> None:
     print(f"has_targets={has_targets}")
     print(f"legs={len(include)}")
     for leg in include:
-        # runs_on is trace only and nothing consumes it yet, so a leg built
-        # without it must not fail the plan — unlike slug, which is checked
-        # strictly above because downstream paths depend on it.
+        # runs_on is consumed only by the default-off direct-runner path, so
+        # a legacy/test leg built without it must not fail the plan — unlike
+        # slug, which is checked strictly because default-path artifacts and
+        # scratch directories depend on it.
         runs_on = " ".join(leg.get("runs_on") or []) or "-"
         print(f"  - {leg['name']}  [{leg['kind']}]  runs_on={runs_on}")
     print(f"matrix={matrix}")

--- a/.github/skill-eval/tests/test_python_runtime_contract.py
+++ b/.github/skill-eval/tests/test_python_runtime_contract.py
@@ -33,3 +33,20 @@ def test_ci_executes_harness_contracts_on_production_python() -> None:
     workflow = (REPO_ROOT / ".github/workflows/ci.yml").read_text()
     assert f'SKILL_EVAL_EXPECTED_PYTHON_VERSION: "{PYTHON_VERSION}"' in workflow
     assert f'uvx --python {PYTHON_VERSION} --from "pytest==9.1.1" pytest' in workflow
+
+
+def test_direct_runner_label_dispatch_stays_default_off() -> None:
+    """PR, daily, and scheduled evals retain coordinator routing by default."""
+    gated_runs_on = (
+        "runs-on: ${{ inputs.direct_runner_dispatch && "
+        "fromJSON(toJSON(matrix.runs_on)) || "
+        "fromJSON('[\"self-hosted\",\"vss-skill-eval-runner\"]') }}"
+    )
+    for relative_path in (
+        ".github/workflows/skills-eval.yml",
+        ".github/workflows/skills-eval-daily.yml",
+    ):
+        workflow = (REPO_ROOT / relative_path).read_text()
+        assert "direct_runner_dispatch:" in workflow
+        assert "default: false" in workflow
+        assert gated_runs_on in workflow

--- a/.github/skill-eval/tests/test_python_runtime_contract.py
+++ b/.github/skill-eval/tests/test_python_runtime_contract.py
@@ -47,6 +47,9 @@ def test_direct_runner_label_dispatch_stays_default_off() -> None:
         ".github/workflows/skills-eval-daily.yml",
     ):
         workflow = (REPO_ROOT / relative_path).read_text()
-        assert "direct_runner_dispatch:" in workflow
-        assert "default: false" in workflow
+        marker = "      direct_runner_dispatch:\n"
+        _, separator, remainder = workflow.partition(marker)
+        assert separator, f"{relative_path} is missing the direct runner input"
+        direct_runner_input = remainder.partition("\n\n")[0]
+        assert "\n        default: false\n" in f"\n{direct_runner_input}\n"
         assert gated_runs_on in workflow

--- a/.github/workflows/skills-eval-daily.yml
+++ b/.github/workflows/skills-eval-daily.yml
@@ -32,6 +32,11 @@ on:
         options:
           - claude-code
           - codex
+      direct_runner_dispatch:
+        description: "EXPERIMENTAL: route eval legs by spec-derived runner labels (requires fully prepared local-execution runners)."
+        required: false
+        default: false
+        type: boolean
 
 # Authenticate as github-actions[bot] for all GitHub operations (gh pr
 # comment, gh pr create, git push of eval-bot/* branches). The agent
@@ -138,7 +143,12 @@ jobs:
     name: ${{ matrix.name }}
     needs: [resolve_ref, plan]
     if: needs.plan.outputs.has_targets == 'true'
-    runs-on: [self-hosted, vss-skill-eval-runner]
+    # Scheduled runs and ordinary manual runs stay on the coordinator.
+    # matrix.runs_on is already an array after the plan output is parsed;
+    # explicitly round-trip it so both expression branches are label arrays.
+    # Do not enable until labeled runners execute trials locally rather than
+    # invoking run_leg.py's second-hop Brev dispatch.
+    runs-on: ${{ inputs.direct_runner_dispatch && fromJSON(toJSON(matrix.runs_on)) || fromJSON('["self-hosted","vss-skill-eval-runner"]') }}
     strategy:
       # One slow/failed spec must not cancel its siblings.
       fail-fast: false

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -45,6 +45,11 @@ on:
         options:
           - claude-code
           - nemoclaw
+      direct_runner_dispatch:
+        description: "EXPERIMENTAL: route eval legs by spec-derived runner labels (requires fully prepared local-execution runners)."
+        required: false
+        default: false
+        type: boolean
 
 # Authenticate as github-actions[bot] for all GitHub operations (gh pr
 # comment + git push of the adapter commit to the contributor's branch).
@@ -156,7 +161,12 @@ jobs:
     name: ${{ matrix.name }}
     needs: plan
     if: needs.plan.outputs.has_targets == 'true'
-    runs-on: [self-hosted, vss-skill-eval-runner]
+    # Default-off preparation for direct VM runners. plan_matrix.py's output
+    # has already been parsed with fromJSON, so matrix.runs_on is an array;
+    # the round trip keeps both branches explicitly typed as label arrays.
+    # Do not enable until runners carry every requested label AND execute
+    # trials locally (otherwise run_leg.py would double-dispatch through Brev).
+    runs-on: ${{ inputs.direct_runner_dispatch && fromJSON(toJSON(matrix.runs_on)) || fromJSON('["self-hosted","vss-skill-eval-runner"]') }}
     strategy:
       # One slow/failed spec must not cancel its siblings.
       fail-fast: false


### PR DESCRIPTION
## Summary

- Wire each skill-eval matrix leg's existing `runs_on` array into both eval workflows behind a default-off `direct_runner_dispatch` manual input. GitHub calls these runner selectors **labels** (GitLab calls the equivalent concept tags).
- Preserve the current coordinator + Brev production path for PR pushes, scheduled runs, and ordinary manual runs. The `plan` job remains on the coordinator.
- Keep eval specs unchanged: `resources.platforms` continues using GPU-name keys plus `gpu_count`; `plan_matrix.py` maps those values to labels such as `vss-eval`, `gpu-l40s`, and `gpus-1`.
- Document activation prerequisites and double-dispatch risk, and add a contract test that prevents the gate from becoming default-on accidentally.

Live runner inspection on 2026-09-08 found no runner satisfying all currently emitted label sets: direct GPU runners do not advertise `self-hosted`, and the registered GPU cohorts do not yet cover emitted L40S/H100 labels. Activating now would leave jobs queued. The existing eval body also loads coordinator-only state and calls `run_leg.py`, so direct VM execution must short-circuit the Brev SSH hop before this gate is enabled.

After OpenShell VM runners carry every required label and local execution is canaried, manually dispatch either workflow with `direct_runner_dispatch: true`. Roll back by dispatching with the input off; no production routing changes on merge.

## Test plan

- `python3 -m pytest .github/skill-eval/tests/test_plan_matrix.py .github/skill-eval/tests/test_python_runtime_contract.py -v` (42 passed)
- Parsed both modified workflow YAML files with PyYAML.
- `git diff --check`