### PR TITLE
helm(agent): extraEnv may use valueFrom and overrides same-named env entries

### DIFF
--- a/deploy/helm/services/agent/charts/agent/templates/deployment.yaml
+++ b/deploy/helm/services/agent/charts/agent/templates/deployment.yaml
@@ -113,11 +113,18 @@ spec:
           env:
             {{- /*
               Option B: container env is the explicit list `env` (each value may use Helm `tpl` with .Values / .Release).
-              `extraEnv` is appended last (duplicate names: last wins). No envOverrides layer.
+              `extraEnv` entries override same-named `env` entries (a Kubernetes env list must not
+              repeat a name, and server-side apply rejects duplicates), and may use `valueFrom`
+              (e.g. secretKeyRef) so credentials never have to be written into values files.
             */}}
+            {{- $extra := .Values.extraEnv | default list }}
+            {{- $overridden := dict }}
+            {{- range $extra }}{{- $_ := set $overridden .name true }}{{- end }}
             {{- range .Values.env }}
+            {{- if not (hasKey $overridden .name) }}
             - name: {{ .name }}
               value: {{ tpl (.value | default "" | toString) $ | quote }}
+            {{- end }}
             {{- end }}
             {{- $videoIngestTimeouts := .Values.videoIngestTimeouts | default dict }}
             {{- with get $videoIngestTimeouts "vstUploadTimeoutSeconds" }}
@@ -136,9 +143,14 @@ spec:
             - name: VIDEO_INGEST_RTVI_EMBED_TIMEOUT_SECONDS
               value: {{ tpl (. | toString) $ | quote }}
             {{- end }}
-            {{- range (.Values.extraEnv | default list) }}
+            {{- range $extra }}
             - name: {{ .name }}
+              {{- if .valueFrom }}
+              valueFrom:
+                {{- toYaml .valueFrom | nindent 16 }}
+              {{- else }}
               value: {{ tpl (.value | default "" | toString) $ | quote }}
+              {{- end }}
             {{- end }}
           {{- with .Values.startupProbe }}
           startupProbe:


### PR DESCRIPTION
## Problem

The `dev-profile-base` README points users at `agent.vss-agent.extraEnv` for "late overrides (secrets / ad-hoc vars)", but the agent chart renders `extraEnv` entries as `value:` only and appends them after the chart's own `env` list. Two consequences:

- an `extraEnv` entry with `valueFrom` (e.g. `secretKeyRef` for `NVIDIA_API_KEY`) silently renders as `value: ""`;
- re-declaring a name that already exists in `env` (as `NVIDIA_API_KEY` and `OPENAI_API_KEY` do, with empty defaults) produces a Deployment with duplicate env names. Kubernetes server-side apply rejects that, so ArgoCD cannot compute a diff and the Application stops syncing (`duplicate entries for key [name="NVIDIA_API_KEY"]`).

Today the only working way to give the agent an API key with this chart is to write the key into a values file.

## Change

One template, `deploy/helm/services/agent/charts/agent/templates/deployment.yaml`:

- `extraEnv` entries replace the `env` entry of the same name instead of being appended alongside it;
- an `extraEnv` entry may carry `valueFrom`, rendered verbatim; otherwise `value` is rendered through `tpl` as before.

Default rendering is unchanged when `extraEnv` is empty.

## Verification

Rendered `dev-profile-base` with `helm template` using an override of

```yaml
agent:
  vss-agent:
    extraEnv:
      - name: NVIDIA_API_KEY
        valueFrom: {secretKeyRef: {name: vss-inference-api, key: NVIDIA_API_KEY}}
```

The `vss-agent` container has 40 env entries, no duplicate names, and `NVIDIA_API_KEY` sourced from the Secret. Applied on a k3s cluster through ArgoCD with server-side apply; the ComparisonError cleared and the release synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)