### PR TITLE
fix(rt-vlm): package Thor NVJPEG runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -938,6 +938,7 @@ jobs:
             --noconftest \
             -m test_in_ci \
             tests/model/vllm_compatible/test_input_error_handling.py \
+            tests/rtvi_vlm/test_vlm_thor_runtime.py \
             -v
 
       - name: Run rt-embed unit tests

--- a/services/rtvi/rt-vlm/docker/Dockerfile
+++ b/services/rtvi/rt-vlm/docker/Dockerfile
@@ -55,7 +55,7 @@ ENV NVIDIA_DRIVER_CAPABILITIES=$NVIDIA_DRIVER_CAPABILITIES,video \
     TRITON_NVDISASM_PATH=/usr/local/cuda/bin/nvdisasm \
     TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas \
     GST_PLUGIN_PATH=/opt/nvidia/rtvi/gst-plugins:/opt/nvidia/deepstream/deepstream/lib/gst-plugins \
-    LD_LIBRARY_PATH=/usr/local/lib/python3.12/dist-packages/nvidia/nvshmem/lib:/opt/hpcx/ucx/lib:/usr/lib/aarch64-linux-gnu/nvidia:/opt/nvidia/deepstream/deepstream/lib:/opt/nvidia/deepstream/deepstream-9.1/lib:/usr/local/nvidia/lib64:/usr/local/cuda/targets/x86_64-linux/lib:${LD_LIBRARY_PATH}
+    LD_LIBRARY_PATH=/usr/local/lib/python3.12/dist-packages/nvidia/nvshmem/lib:/opt/hpcx/ucx/lib:/usr/lib/aarch64-linux-gnu/nvidia:/opt/nvidia/deepstream/deepstream/lib:/opt/nvidia/deepstream/deepstream-9.1/lib:/usr/local/nvidia/lib64:/usr/local/cuda/targets/x86_64-linux/lib:/usr/local/cuda/targets/sbsa-linux/lib:${LD_LIBRARY_PATH}
 
 # Install only RTVI runtime dependencies directly on vLLM. Native build
 # dependencies are confined to pyds-builder and native-builder below.
@@ -178,8 +178,8 @@ RUN --mount=from=triton-cuda-runtime,source=/usr/local/cuda/targets,target=/tmp/
         cp -a /tmp/triton-cuda-targets/x86_64-linux/lib/libnpp*.so* /usr/local/cuda/targets/x86_64-linux/lib/ \
         && cp -a /tmp/triton-cuda-targets/x86_64-linux/lib/libnvjpeg.so* /usr/local/cuda/targets/x86_64-linux/lib/; \
     elif [ "$TARGETARCH" = "arm64" ]; then \
-        for library in /tmp/triton-cuda-targets/aarch64-linux/lib/libnpp*.so* /tmp/triton-cuda-targets/aarch64-linux/lib/libnvjpeg.so*; do \
-            if [ -e "$library" ]; then cp -a "$library" /usr/local/cuda/targets/aarch64-linux/lib/; fi; \
+        for library in /tmp/triton-cuda-targets/sbsa-linux/lib/libnpp*.so* /tmp/triton-cuda-targets/sbsa-linux/lib/libnvjpeg.so*; do \
+            if [ -e "$library" ]; then cp -a "$library" /usr/local/cuda/targets/sbsa-linux/lib/; fi; \
         done; \
     fi \
     && ldconfig

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_vlm_thor_runtime.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_vlm_thor_runtime.py
@@ -4,9 +4,12 @@
 
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).parents[2]
 
 
+@pytest.mark.test_in_ci
 def test_vlm_image_copies_and_loads_arm_nvjpeg_from_sbsa_target():
     dockerfile = (ROOT / "docker" / "Dockerfile").read_text()
     sbsa_nvjpeg = "/tmp/triton-cuda-targets/sbsa-linux/lib/libnvjpeg.so*"

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_vlm_thor_runtime.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_vlm_thor_runtime.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.  # noqa: E501
+# SPDX-License-Identifier: Apache-2.0
+"""Thor runtime packaging regression tests."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).parents[2]
+
+
+def test_vlm_image_copies_and_loads_arm_nvjpeg_from_sbsa_target():
+    dockerfile = (ROOT / "docker" / "Dockerfile").read_text()
+    sbsa_nvjpeg = "/tmp/triton-cuda-targets/sbsa-linux/lib/libnvjpeg.so*"
+    arm_nvjpeg = "/tmp/triton-cuda-targets/aarch64-linux/lib/libnvjpeg.so*"
+    sbsa_dir = "/usr/local/cuda/targets/sbsa-linux/lib"
+    sbsa_ld_path = f"{sbsa_dir}:${{LD_LIBRARY_PATH}}"
+
+    assert sbsa_nvjpeg in dockerfile
+    assert sbsa_ld_path in dockerfile
+    assert arm_nvjpeg not in dockerfile


### PR DESCRIPTION
## Summary
- copy ARM CUDA NPP/NVJPEG libraries from the SBSA target directory
- add the SBSA CUDA library directory to the runtime loader path
- add a regression check for the Thor packaging path

## Root cause
The ARM image looked under `targets/aarch64-linux`, but CUDA 13 on Thor/SBSA stores these libraries under `targets/sbsa-linux`. The optional copy loop therefore omitted `libnvjpeg.so.13`, causing `nvjpegdec` to fail at runtime.

Fixes NVBUG 6741592.

## Validation
- reproduced `nvjpegdec` error 77 with the affected image on NVIDIA Thor
- corrected derivative image passed 40/40 JPEG decodes: 20 direct `nvjpegdec` and 20 `parsebin -> decodebin` runs
- static regression check passes
- flake8, Black, and `git diff --check` pass