### PR TITLE
Notify RTVI on LVS camera add and reword in-progress caption copy

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-lvs/vios/configs/notification_config.json
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vios/configs/notification_config.json
@@ -17,6 +17,21 @@
     "items": [
       {
         "enabled": true,
+        "camera_status_change": "camera_add",
+        "request": [
+          {
+            "url": "http://rtvi-vlm:8000/v1/stream/add",
+            "method": "POST",
+            "headers": {"Content-Type": "application/json", "x-stream-id": "{{event.camera_id}}"},
+            "query_params": {"change": "{{event.change}}"},
+            "camera_type": ["rtsp", "file"],
+            "timeout_ms": 5000,
+            "retry": {"max_attempts": 3, "backoff_ms": [1000, 5000, 15000], "retry_on_status": [408, 429, 500, 502, 503, 504]}
+          }
+        ]
+      },
+      {
+        "enabled": true,
         "camera_status_change": "camera_streaming",
         "request": [
           {

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_config_media.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_config_media.py
@@ -47,7 +47,9 @@ logger = logging.getLogger(__name__)
 
 
 GENERATE_CAPTIONS_ENDPOINT = "/v1/generate_captions"
-CAPTION_GENERATION_STARTED_MESSAGE = "Caption generation started. Please try again later."
+CAPTION_GENERATION_STARTED_MESSAGE = (
+    "Caption generation has started and is in progress. You can wait while it continues."
+)
 LVS_CONFIG_MEDIA_TOOL_NAME = "lvs_config_media"
 LVS_CONFIG_MEDIA_BLOCKED_MESSAGE = (
     "lvs_config_media was not executed. Caption generation starts only after the user "

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_config_media.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_config_media.py
@@ -48,7 +48,7 @@ logger = logging.getLogger(__name__)
 
 GENERATE_CAPTIONS_ENDPOINT = "/v1/generate_captions"
 CAPTION_GENERATION_STARTED_MESSAGE = (
-    "Caption generation has started and is in progress. You can wait while it continues."
+    "Caption generation has started and is in progress. Captions will become available shortly."
 )
 LVS_CONFIG_MEDIA_TOOL_NAME = "lvs_config_media"
 LVS_CONFIG_MEDIA_BLOCKED_MESSAGE = (

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_config_media.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_config_media.py
@@ -93,10 +93,10 @@ class TestLVSConfigMediaModels:
             media_name="CAM_1",
             media_id="stream-uuid",
             configured=True,
-            message="Caption generation started. Please try again later.",
+            message="Caption generation has started and is in progress. You can wait while it continues.",
         )
 
-        assert output.summary == "Caption generation started. Please try again later."
+        assert output.summary == "Caption generation has started and is in progress. You can wait while it continues."
 
 
 class TestUserRequestedCaptionGeneration:
@@ -206,7 +206,7 @@ class TestLVSConfigMediaInner:
         assert result.status == LVSMediaStatus.ACCEPTED
         assert result.configured is True
         assert result.media_id == "stream-uuid"
-        assert result.message == "Caption generation started. Please try again later."
+        assert result.message == "Caption generation has started and is in progress. You can wait while it continues."
         remembered_media = configured_media("stream", "cam_1")
         assert remembered_media is not None
         assert remembered_media.media_id == "stream-uuid"

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_config_media.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_config_media.py
@@ -93,10 +93,10 @@ class TestLVSConfigMediaModels:
             media_name="CAM_1",
             media_id="stream-uuid",
             configured=True,
-            message="Caption generation has started and is in progress. You can wait while it continues.",
+            message="Caption generation has started and is in progress. Captions will become available shortly.",
         )
 
-        assert output.summary == "Caption generation has started and is in progress. You can wait while it continues."
+        assert output.summary == "Caption generation has started and is in progress. Captions will become available shortly."
 
 
 class TestUserRequestedCaptionGeneration:
@@ -206,7 +206,7 @@ class TestLVSConfigMediaInner:
         assert result.status == LVSMediaStatus.ACCEPTED
         assert result.configured is True
         assert result.media_id == "stream-uuid"
-        assert result.message == "Caption generation has started and is in progress. You can wait while it continues."
+        assert result.message == "Caption generation has started and is in progress. Captions will become available shortly."
         remembered_media = configured_media("stream", "cam_1")
         assert remembered_media is not None
         assert remembered_media.media_id == "stream-uuid"

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_stream_understanding.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_stream_understanding.py
@@ -286,8 +286,8 @@ class TestLVSStreamUnderstandingInner:
                 )
 
         assert result.status == LVSMediaStatus.ACCEPTED
-        assert result.message == "Caption generation started. Please try again later."
-        assert result.summary == "Caption generation started. Please try again later."
+        assert result.message == "Caption generation has started and is in progress. You can wait while it continues."
+        assert result.summary == "Caption generation has started and is in progress. You can wait while it continues."
 
     @pytest.mark.asyncio
     async def test_configured_stream_is_scoped_to_conversation(self):

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_stream_understanding.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_stream_understanding.py
@@ -286,8 +286,8 @@ class TestLVSStreamUnderstandingInner:
                 )
 
         assert result.status == LVSMediaStatus.ACCEPTED
-        assert result.message == "Caption generation has started and is in progress. You can wait while it continues."
-        assert result.summary == "Caption generation has started and is in progress. You can wait while it continues."
+        assert result.message == "Caption generation has started and is in progress. Captions will become available shortly."
+        assert result.summary == "Caption generation has started and is in progress. Captions will become available shortly."
 
     @pytest.mark.asyncio
     async def test_configured_stream_is_scoped_to_conversation(self):


### PR DESCRIPTION
## Summary
- Add an LVS `camera_add` webhook to RTVI (`/v1/stream/add`) so streams are registered when cameras are added, not only when they start streaming.
- Reword `CAPTION_GENERATION_STARTED_MESSAGE` to say caption generation is in progress instead of asking the user to try again later.
- Update unit tests that assert the caption-started copy.

## Test plan
- [ ] Confirm LVS `notification_config.json` includes the `camera_add` webhook alongside `camera_streaming` and `camera_remove`.
- [ ] Add an RTSP or file camera in the LVS profile and confirm RTVI receives `/v1/stream/add` for the `camera_add` event.
- [ ] Trigger caption generation and confirm the agent reports in-progress copy rather than “Please try again later.”
- [ ] Run `services/agent` unit tests for `test_lvs_config_media.py` and `test_lvs_stream_understanding.py`.