### PR TITLE
fix(agent-ui): open agent parameters panel above its trigger

### DIFF
--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/__tests__/AgentParams.test.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/__tests__/AgentParams.test.ts
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { getAgentParamsPosition } from '../lib-src/agentParamsPosition';
+
+describe('getAgentParamsPosition', () => {
+  it('opens above a trigger near the bottom of the viewport', () => {
+    expect(
+      getAgentParamsPosition({
+        anchorRect: { top: 700, bottom: 720, right: 390 },
+        viewportHeight: 800,
+        viewportWidth: 400,
+      }),
+    ).toEqual({ bottom: 108, right: 10, maxHeight: 684 });
+  });
+
+  it('falls back below the trigger when there is not enough room above', () => {
+    expect(
+      getAgentParamsPosition({
+        anchorRect: { top: 50, bottom: 70, right: 390 },
+        viewportHeight: 500,
+        viewportWidth: 400,
+      }),
+    ).toEqual({ top: 78, right: 10, maxHeight: 414 });
+  });
+
+  it('constrains the panel to the available space in a short viewport', () => {
+    expect(
+      getAgentParamsPosition({
+        anchorRect: { top: 120, bottom: 140, right: 390 },
+        viewportHeight: 220,
+        viewportWidth: 400,
+      }),
+    ).toEqual({ bottom: 108, right: 10, maxHeight: 104 });
+  });
+});

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/AgentParams.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/AgentParams.tsx
@@ -260,7 +260,7 @@ export const AgentParams: React.FC<AgentParamsProps> = ({
         className="fixed z-[100] w-72 rounded-md border border-gray-200 bg-white p-3 shadow-lg dark:border-gray-700 dark:bg-black"
         style={{ right, overflowY: 'auto', ...position }}
       >
-        <p className="mb-2 text-sm font-medium text-gray-700 dark:text-gray-200">
+        <p className="mb-2 text-center text-sm font-medium text-gray-700 dark:text-gray-200">
           Agent parameters
         </p>
         <div className="flex flex-col gap-3">

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/AgentParams.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/AgentParams.tsx
@@ -20,6 +20,11 @@ import type { CustomAgentParamsValues, ParamField, ParamFieldConfig } from './ty
 
 const STORAGE_KEY = 'vss-chat-custom-agent-params';
 
+/** Space kept between the panel and both the trigger and the viewport edge. */
+const GAP = 8;
+/** Below this the panel is too short to be usable and is flipped instead. */
+const MIN_PANEL_HEIGHT = 160;
+
 export const fieldsToParams = (fields: ParamField[]): CustomAgentParamsValues =>
   (fields || []).reduce((acc, field) => {
     if (field.name) acc[field.name] = field.value;
@@ -230,8 +235,21 @@ export const AgentParams: React.FC<AgentParamsProps> = ({
     }
   };
 
-  const top = anchorRect ? anchorRect.bottom + 8 : 80;
-  const right = anchorRect ? Math.max(8, window.innerWidth - anchorRect.right) : 16;
+  const right = anchorRect ? Math.max(GAP, window.innerWidth - anchorRect.right) : 16;
+
+  // The trigger lives in the chat input at the bottom of the panel, so the
+  // space below it is a few pixels of gradient — open upwards, and only flip
+  // down when the room above cannot hold the panel at all.
+  const viewportHeight = window.innerHeight;
+  const spaceAbove = anchorRect ? anchorRect.top - GAP * 2 : 0;
+  const spaceBelow = anchorRect ? viewportHeight - anchorRect.bottom - GAP * 2 : 0;
+  const openDown = !anchorRect || (spaceAbove < MIN_PANEL_HEIGHT && spaceBelow > spaceAbove);
+
+  const position: React.CSSProperties = !anchorRect
+    ? { top: 80, maxHeight: '60vh' }
+    : openDown
+      ? { top: anchorRect.bottom + GAP, maxHeight: spaceBelow }
+      : { bottom: viewportHeight - anchorRect.top + GAP, maxHeight: spaceAbove };
 
   return createPortal(
     <>
@@ -240,7 +258,7 @@ export const AgentParams: React.FC<AgentParamsProps> = ({
         role="dialog"
         aria-label="Agent parameters"
         className="fixed z-[100] w-72 rounded-md border border-gray-200 bg-white p-3 shadow-lg dark:border-gray-700 dark:bg-black"
-        style={{ top, right, maxHeight: '60vh', overflowY: 'auto' }}
+        style={{ right, overflowY: 'auto', ...position }}
       >
         <p className="mb-2 text-sm font-medium text-gray-700 dark:text-gray-200">
           Agent parameters

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/AgentParams.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/AgentParams.tsx
@@ -15,15 +15,11 @@
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
+import { getAgentParamsPosition } from './agentParamsPosition';
 import { createRandomId } from './id';
 import type { CustomAgentParamsValues, ParamField, ParamFieldConfig } from './types';
 
 const STORAGE_KEY = 'vss-chat-custom-agent-params';
-
-/** Space kept between the panel and both the trigger and the viewport edge. */
-const GAP = 8;
-/** Below this the panel is too short to be usable and is flipped instead. */
-const MIN_PANEL_HEIGHT = 160;
 
 export const fieldsToParams = (fields: ParamField[]): CustomAgentParamsValues =>
   (fields || []).reduce((acc, field) => {
@@ -235,21 +231,14 @@ export const AgentParams: React.FC<AgentParamsProps> = ({
     }
   };
 
-  const right = anchorRect ? Math.max(GAP, window.innerWidth - anchorRect.right) : 16;
-
   // The trigger lives in the chat input at the bottom of the panel, so the
   // space below it is a few pixels of gradient — open upwards, and only flip
   // down when the room above cannot hold the panel at all.
-  const viewportHeight = window.innerHeight;
-  const spaceAbove = anchorRect ? anchorRect.top - GAP * 2 : 0;
-  const spaceBelow = anchorRect ? viewportHeight - anchorRect.bottom - GAP * 2 : 0;
-  const openDown = !anchorRect || (spaceAbove < MIN_PANEL_HEIGHT && spaceBelow > spaceAbove);
-
-  const position: React.CSSProperties = !anchorRect
-    ? { top: 80, maxHeight: '60vh' }
-    : openDown
-      ? { top: anchorRect.bottom + GAP, maxHeight: spaceBelow }
-      : { bottom: viewportHeight - anchorRect.top + GAP, maxHeight: spaceAbove };
+  const position = getAgentParamsPosition({
+    anchorRect,
+    viewportHeight: window.innerHeight,
+    viewportWidth: window.innerWidth,
+  });
 
   return createPortal(
     <>
@@ -258,7 +247,7 @@ export const AgentParams: React.FC<AgentParamsProps> = ({
         role="dialog"
         aria-label="Agent parameters"
         className="fixed z-[100] w-72 rounded-md border border-gray-200 bg-white p-3 shadow-lg dark:border-gray-700 dark:bg-black"
-        style={{ right, overflowY: 'auto', ...position }}
+        style={{ overflowY: 'auto', ...position }}
       >
         <p className="mb-2 text-center text-sm font-medium text-gray-700 dark:text-gray-200">
           Agent parameters

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/agentParamsPosition.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/agentParamsPosition.ts
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: MIT AND Apache-2.0
+import type React from 'react';
+
+const GAP = 8;
+const MIN_PANEL_HEIGHT = 160;
+
+interface AgentParamsPositionInput {
+  anchorRect: Pick<DOMRect, 'top' | 'bottom' | 'right'> | null;
+  viewportHeight: number;
+  viewportWidth: number;
+}
+
+export function getAgentParamsPosition({
+  anchorRect,
+  viewportHeight,
+  viewportWidth,
+}: AgentParamsPositionInput): React.CSSProperties {
+  if (!anchorRect) {
+    return { top: 80, right: 16, maxHeight: '60vh' };
+  }
+
+  const right = Math.max(GAP, viewportWidth - anchorRect.right);
+  const spaceAbove = anchorRect.top - GAP * 2;
+  const spaceBelow = viewportHeight - anchorRect.bottom - GAP * 2;
+  const openDown = spaceAbove < MIN_PANEL_HEIGHT && spaceBelow > spaceAbove;
+
+  return openDown
+    ? { top: anchorRect.bottom + GAP, right, maxHeight: spaceBelow }
+    : {
+        bottom: viewportHeight - anchorRect.top + GAP,
+        right,
+        maxHeight: spaceAbove,
+      };
+}


### PR DESCRIPTION
The panel is portalled to <body> and positioned by hand, and it was pinned to the trigger's bottom edge. The trigger sits in the chat input at the bottom of the sidebar, so the panel rendered past the viewport edge and could not be reached.

Anchor its bottom edge above the button instead, flipping downward only when the space above cannot hold it, and size maxHeight to the room actually available so a long parameter list scrolls in place.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
