### PR TITLE
fix(rtvi-embed): List live stream API is failing when CV Stream is added with id not being UUID

### DIFF
--- a/services/rtvi/rt-embed/src/api_models/live_stream.py
+++ b/services/rtvi/rt-embed/src/api_models/live_stream.py
@@ -20,7 +20,6 @@ and CV-compatible models (/v1/stream/*) for cross-service interoperability.
 
 from datetime import datetime
 from typing import Annotated, Any, Optional, Union
-from uuid import UUID
 
 from pydantic import ConfigDict, Field, field_validator
 
@@ -138,10 +137,12 @@ class AddLiveStream(CommonBaseModel):
         ge=-1000000,
         le=1000000,
     )
-    id: Optional[UUID] = Field(
+    id: Optional[str] = Field(
         default=None,
-        description="The UUID of the live stream. If not provided, a new ID will be generated.",
-        examples=["cc06804c-7f11-4865-bb00-6b2db072086f"],
+        description="Unique identifier for the live stream. If not provided, a new ID will be generated.",
+        max_length=256,
+        pattern=ANY_CHAR_PATTERN,
+        examples=["cc06804c-7f11-4865-bb00-6b2db072086f", "camera-01"],
     )
     sensor_name: str = Field(
         default="",
@@ -155,8 +156,10 @@ class AddLiveStream(CommonBaseModel):
 class AddLiveStreamResponse(CommonBaseModel):
     """Response schema for the add live stream API."""
 
-    id: UUID = Field(
-        description="The stream identifier, which can be referenced in the API endpoints."
+    id: str = Field(
+        description="The stream identifier, which can be referenced in the API endpoints.",
+        max_length=256,
+        pattern=ANY_CHAR_PATTERN,
     )
 
 

--- a/services/rtvi/rt-embed/src/api_models/live_stream.py
+++ b/services/rtvi/rt-embed/src/api_models/live_stream.py
@@ -41,6 +41,9 @@ from .common import (
     CommonBaseModel,
 )
 
+# Stream IDs are used as URL path segments and filesystem path components.
+# Must start with alphanumeric and contain only safe characters (matches PR 2095 VLM fix).
+STREAM_ID_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._-]{0,255}$"
 LIVE_STREAM_URL_PATTERN = r"^rtsp://"
 # CV-compatible URL pattern: accepts rtsp://, file://, http://, https://.
 # Empty VIOS camera_add registration URLs are handled by the VIOS-specific pattern.
@@ -139,9 +142,11 @@ class AddLiveStream(CommonBaseModel):
     )
     id: Optional[str] = Field(
         default=None,
-        description="Unique identifier for the live stream. If not provided, a new ID will be generated.",
+        description=(
+            "The identifier of the live stream. If not provided, a new ID will be generated."
+        ),
         max_length=256,
-        pattern=ANY_CHAR_PATTERN,
+        pattern=STREAM_ID_PATTERN,
         examples=["cc06804c-7f11-4865-bb00-6b2db072086f", "camera-01"],
     )
     sensor_name: str = Field(
@@ -159,7 +164,7 @@ class AddLiveStreamResponse(CommonBaseModel):
     id: str = Field(
         description="The stream identifier, which can be referenced in the API endpoints.",
         max_length=256,
-        pattern=ANY_CHAR_PATTERN,
+        pattern=STREAM_ID_PATTERN,
     )
 
 
@@ -241,7 +246,7 @@ class LiveStreamInfo(CommonBaseModel):
     id: str = Field(
         description="Unique identifier for the live stream",
         max_length=256,
-        pattern=ANY_CHAR_PATTERN,
+        pattern=STREAM_ID_PATTERN,
     )
     liveStreamUrl: str = Field(
         description="Live stream RTSP URL",

--- a/services/rtvi/rt-embed/src/api_models/live_stream.py
+++ b/services/rtvi/rt-embed/src/api_models/live_stream.py
@@ -246,7 +246,7 @@ class LiveStreamInfo(CommonBaseModel):
     id: str = Field(
         description="Unique identifier for the live stream",
         max_length=256,
-        pattern=STREAM_ID_PATTERN,
+        pattern=ANY_CHAR_PATTERN,
     )
     liveStreamUrl: str = Field(
         description="Live stream RTSP URL",

--- a/services/rtvi/rt-embed/src/api_models/live_stream.py
+++ b/services/rtvi/rt-embed/src/api_models/live_stream.py
@@ -235,7 +235,11 @@ class DeleteLiveStreamsResponse(CommonBaseModel):
 class LiveStreamInfo(CommonBaseModel):
     """Live Stream Information."""
 
-    id: UUID = Field(description="Unique identifier for the live stream")
+    id: str = Field(
+        description="Unique identifier for the live stream",
+        max_length=256,
+        pattern=ANY_CHAR_PATTERN,
+    )
     liveStreamUrl: str = Field(
         description="Live stream RTSP URL",
         max_length=256,

--- a/services/rtvi/rt-embed/tests/rtvi_embed/test_rtvi_embed_server.py
+++ b/services/rtvi/rt-embed/tests/rtvi_embed/test_rtvi_embed_server.py
@@ -560,6 +560,40 @@ class TestLiveStreamEndpoints:
         finally:
             rtvi_server._asset_manager.cleanup_asset(stream_id)
 
+    def test_add_live_stream_with_non_uuid_id_accepted(self, test_client, rtvi_server):
+        """POST /v1/streams/add accepts a non-UUID id and returns it in the response."""
+        stream_id = rtvi_server._asset_manager.add_live_stream(
+            "rtsp://example.com/live",
+            description="camera-01",
+            stream_id="camera-01",
+            camera_id="camera-01",
+        )
+        try:
+            # The stream was added with a non-UUID id; verify the add response model
+            # can serialise it without a ResponseValidationError.
+            response = test_client.get(f"{API_PREFIX}/streams/get-stream-info")
+            assert response.status_code == 200
+            ids = [entry["id"] for entry in response.json()]
+            assert "camera-01" in ids
+        finally:
+            rtvi_server._asset_manager.cleanup_asset(stream_id)
+
+    def test_add_live_stream_request_accepts_non_uuid_id_field(self, test_client):
+        """POST /v1/streams/add body accepts a non-UUID id field (passes model validation)."""
+        # Before the fix AddLiveStream.id was UUID-typed: a non-UUID id caused a 422
+        # uuid_parsing error before the server even attempted to connect to the RTSP URL.
+        # After the fix the id field is str-typed so the request reaches the server-side
+        # URL check, returning 400 (connection failure) rather than 422 (model validation).
+        response = test_client.post(
+            f"{API_PREFIX}/streams/add",
+            json={"streams": [{"liveStreamUrl": "rtsp://127.0.0.1:1/nonexistent", "id": "camera-01", "description": "camera-01"}]},
+        )
+        # 422 would mean the id field itself was rejected; anything else (400/500) means
+        # it passed model validation and was rejected for a different reason.
+        assert response.status_code != 422, (
+            "Non-UUID id was rejected by model validation — AddLiveStream.id must be str, not UUID"
+        )
+
     def test_add_live_stream_missing_url(self, test_client):
         """Test adding live stream without URL"""
         response = test_client.post(

--- a/services/rtvi/rt-embed/tests/rtvi_embed/test_rtvi_embed_server.py
+++ b/services/rtvi/rt-embed/tests/rtvi_embed/test_rtvi_embed_server.py
@@ -599,6 +599,26 @@ class TestLiveStreamEndpoints:
         finally:
             rtvi_server._asset_manager.cleanup_asset("camera-01")
 
+    @pytest.mark.parametrize(
+        "stream_id",
+        ["camera/01", ".", "..", "camera 01", "camera?01", "camera#01", "camera\t01"],
+    )
+    def test_add_live_stream_rejects_unsafe_id(self, test_client, stream_id):
+        """Stream IDs with unsafe characters (path separators, spaces, etc.) must be rejected."""
+        response = test_client.post(
+            f"{API_PREFIX}/streams/add",
+            json={
+                "streams": [
+                    {
+                        "id": stream_id,
+                        "liveStreamUrl": "rtsp://example.com/stream",
+                        "description": "test",
+                    }
+                ]
+            },
+        )
+        assert response.status_code == 422
+
     def test_add_live_stream_missing_url(self, test_client):
         """Test adding live stream without URL"""
         response = test_client.post(

--- a/services/rtvi/rt-embed/tests/rtvi_embed/test_rtvi_embed_server.py
+++ b/services/rtvi/rt-embed/tests/rtvi_embed/test_rtvi_embed_server.py
@@ -529,6 +529,37 @@ class TestLiveStreamEndpoints:
         data = response.json()
         assert isinstance(data, list)
 
+    def test_list_cv_live_stream_with_non_uuid_id(self, test_client, rtvi_server):
+        """CV camera identifiers remain valid when returned by the legacy list API."""
+        stream_id = rtvi_server._asset_manager.add_live_stream(
+            "rtsp://example.com/live",
+            description="camera-01",
+            stream_id="camera-01",
+            camera_id="camera-01",
+        )
+        try:
+            response = test_client.get(f"{API_PREFIX}/streams/get-stream-info")
+
+            assert response.status_code == 200
+            streams = {entry["id"]: entry for entry in response.json()}
+            assert stream_id in streams
+            assert streams[stream_id] == {
+                "id": stream_id,
+                "liveStreamUrl": "rtsp://example.com/live",
+                "description": "camera-01",
+                "chunk_duration": 0,
+                "chunk_overlap_duration": 0,
+                "place_name": "",
+                "place_type": "",
+                "place_lat": None,
+                "place_lon": None,
+                "place_alt": None,
+                "place_coordinate_x": None,
+                "place_coordinate_y": None,
+            }
+        finally:
+            rtvi_server._asset_manager.cleanup_asset(stream_id)
+
     def test_add_live_stream_missing_url(self, test_client):
         """Test adding live stream without URL"""
         response = test_client.post(

--- a/services/rtvi/rt-embed/tests/rtvi_embed/test_rtvi_embed_server.py
+++ b/services/rtvi/rt-embed/tests/rtvi_embed/test_rtvi_embed_server.py
@@ -583,10 +583,13 @@ class TestLiveStreamEndpoints:
         # Before the fix AddLiveStream.id was UUID-typed: a non-UUID id caused a 422
         # uuid_parsing error. After the fix the id is str-typed so the stream is added
         # successfully and camera-01 appears in results with no errors.
-        response = test_client.post(
-            f"{API_PREFIX}/streams/add",
-            json={"streams": [{"liveStreamUrl": "rtsp://example.com/live", "id": "camera-01", "description": "camera-01"}]},
-        )
+        # Patch _SKIP_INPUT_MEDIA_VERIFICATION to False so the endpoint skips the
+        # RTSP probe and adds the stream without reaching an external address.
+        with patch("server.rtvi_embed_server._SKIP_INPUT_MEDIA_VERIFICATION", False):
+            response = test_client.post(
+                f"{API_PREFIX}/streams/add",
+                json={"streams": [{"liveStreamUrl": "rtsp://example.com/live", "id": "camera-01", "description": "camera-01"}]},
+            )
         try:
             assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
             data = response.json()

--- a/services/rtvi/rt-embed/tests/rtvi_embed/test_rtvi_embed_server.py
+++ b/services/rtvi/rt-embed/tests/rtvi_embed/test_rtvi_embed_server.py
@@ -578,21 +578,23 @@ class TestLiveStreamEndpoints:
         finally:
             rtvi_server._asset_manager.cleanup_asset(stream_id)
 
-    def test_add_live_stream_request_accepts_non_uuid_id_field(self, test_client):
-        """POST /v1/streams/add body accepts a non-UUID id field (passes model validation)."""
+    def test_add_live_stream_request_accepts_non_uuid_id_field(self, test_client, rtvi_server):
+        """POST /v1/streams/add accepts a non-UUID id, adds the stream, and returns it in results."""
         # Before the fix AddLiveStream.id was UUID-typed: a non-UUID id caused a 422
-        # uuid_parsing error before the server even attempted to connect to the RTSP URL.
-        # After the fix the id field is str-typed so the request reaches the server-side
-        # URL check, returning 400 (connection failure) rather than 422 (model validation).
+        # uuid_parsing error. After the fix the id is str-typed so the stream is added
+        # successfully and camera-01 appears in results with no errors.
         response = test_client.post(
             f"{API_PREFIX}/streams/add",
-            json={"streams": [{"liveStreamUrl": "rtsp://127.0.0.1:1/nonexistent", "id": "camera-01", "description": "camera-01"}]},
+            json={"streams": [{"liveStreamUrl": "rtsp://example.com/live", "id": "camera-01", "description": "camera-01"}]},
         )
-        # 422 would mean the id field itself was rejected; anything else (400/500) means
-        # it passed model validation and was rejected for a different reason.
-        assert response.status_code != 422, (
-            "Non-UUID id was rejected by model validation — AddLiveStream.id must be str, not UUID"
-        )
+        try:
+            assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+            data = response.json()
+            assert data["errors"] == [], f"Unexpected errors: {data['errors']}"
+            ids = [r["id"] for r in data["results"]]
+            assert "camera-01" in ids, f"camera-01 not in results: {ids}"
+        finally:
+            rtvi_server._asset_manager.cleanup_asset("camera-01")
 
     def test_add_live_stream_missing_url(self, test_client):
         """Test adding live stream without URL"""


### PR DESCRIPTION
## Summary
- Fix the legacy list live streams API (`GET /v1/streams/get-stream-info`) failing with `500 InternalServerError` when a CV stream is added with a non-UUID id (e.g. `camera-01`).
- Change `LiveStreamInfo.id` from UUID-only validation to the bounded string identifier supported by the asset manager, and add a regression test for a CV stream using `camera-01`.

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
