### PR TITLE
fix(agent-ui): stop sidebar chat GET /v1/search/last after every answer

### DIFF
--- a/services/ui/apps/nv-metropolis-bp-vss-ui/__tests__/components/Home.test.tsx
+++ b/services/ui/apps/nv-metropolis-bp-vss-ui/__tests__/components/Home.test.tsx
@@ -10,11 +10,23 @@ jest.mock("next/dynamic", () => ({
     const source = loader.toString();
 
     if (source.includes("ChatPanel")) {
-      return ({ onAnswer }: { onAnswer?: (answer: string) => void }) => (
+      return ({
+        onAnswer,
+        endpoint,
+      }: {
+        onAnswer?: (answer: string, conversationId: string) => void;
+        endpoint?: { surface?: string };
+      }) => (
         <button
           type="button"
-          data-testid="deliver-search-artifact"
-          onClick={() => onAnswer?.('{"data":[{"id":"retained-hit"}]}')}
+          data-testid={
+            endpoint?.surface === "vss-ui-sidebar"
+              ? "deliver-sidebar-answer"
+              : "deliver-search-artifact"
+          }
+          onClick={() =>
+            onAnswer?.('{"data":[{"id":"retained-hit"}]}', "conversation-1")
+          }
         >
           Deliver search artifact
         </button>
@@ -94,7 +106,10 @@ describe("Home tab lifecycle", () => {
     "NEXT_PUBLIC_ENABLE_DASHBOARD_TAB",
     "NEXT_PUBLIC_ENABLE_MAP_TAB",
     "NEXT_PUBLIC_ENABLE_VIDEO_MANAGEMENT_TAB",
+    "NEXT_PUBLIC_AGENT_ADAPTER_ENABLED",
   ] as const;
+
+  const originalFetch = global.fetch;
 
   beforeEach(() => {
     sessionStorage.clear();
@@ -104,10 +119,16 @@ describe("Home tab lifecycle", () => {
     process.env.NEXT_PUBLIC_ENABLE_DASHBOARD_TAB = "false";
     process.env.NEXT_PUBLIC_ENABLE_MAP_TAB = "false";
     process.env.NEXT_PUBLIC_ENABLE_VIDEO_MANAGEMENT_TAB = "false";
+    delete process.env.NEXT_PUBLIC_AGENT_ADAPTER_ENABLED;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({}),
+    }) as unknown as typeof fetch;
   });
 
   afterEach(() => {
     for (const variable of featureVariables) delete process.env[variable];
+    global.fetch = originalFetch;
   });
 
   it("retains an agent search artifact when leaving the full-page Chat tab", () => {
@@ -123,5 +144,15 @@ describe("Home tab lifecycle", () => {
     expect(screen.getByTestId("search-artifact-state")).toHaveTextContent(
       "retained-hit",
     );
+  });
+
+  // A sidebar answer used to be followed by a last-search read against a route
+  // no deployed agent serves, which surfaced as a 404 on every turn.
+  it("issues no follow-up request after a sidebar answer", () => {
+    render(<Home />);
+    fireEvent.click(screen.getByTestId("sidebar-tab-search"));
+    fireEvent.click(screen.getByTestId("deliver-sidebar-answer"));
+
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 });

--- a/services/ui/apps/nv-metropolis-bp-vss-ui/__tests__/pages/api/vss-chat.test.ts
+++ b/services/ui/apps/nv-metropolis-bp-vss-ui/__tests__/pages/api/vss-chat.test.ts
@@ -53,28 +53,41 @@ describe("toolkit-free chat proxy", () => {
     originalEnvironment.clear();
   });
 
-  it.each([
-    ["GET", "sidebar"],
-    ["POST", "main"],
-  ])(
-    "returns a clear 503 for %s when no %s backend is configured",
-    async (method, surface) => {
-      const request = {
-        method,
-        query: {},
-        body: {},
-        on: jest.fn(),
-      } as unknown as NextApiRequest;
-      const response = mockResponse();
+  it("returns a clear 503 for POST when no main backend is configured", async () => {
+    const request = {
+      method: "POST",
+      query: {},
+      body: {},
+      on: jest.fn(),
+    } as unknown as NextApiRequest;
+    const response = mockResponse();
 
-      await handler(request, response);
+    await handler(request, response);
 
-      expect(response.statusCode).toBe(503);
-      expect(response.body).toEqual({
-        error: `no backend configured for surface: ${surface}`,
-      });
-    },
-  );
+    expect(response.statusCode).toBe(503);
+    expect(response.body).toEqual({
+      error: "no backend configured for surface: main",
+    });
+  });
+
+  // The Search tab's last-search hydrator was a client for a POC sidecar that
+  // no deployed agent replaces; artifacts on the stream carry hits now.
+  it("rejects GET, which no longer proxies a last-search read", async () => {
+    process.env.VSS_CHAT_BACKEND_SIDEBAR = "http://vss-agent:8000/chat/stream";
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock;
+    const request = {
+      method: "GET",
+      query: { surface: "sidebar", conversation: "conversation-1" },
+      on: jest.fn(),
+    } as unknown as NextApiRequest;
+    const response = mockResponse();
+
+    await handler(request, response);
+
+    expect(response.statusCode).toBe(405);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 
   it("proxies interaction responses to the agent origin", async () => {
     process.env.VSS_CHAT_BACKEND_MAIN = "http://vss-agent:8000/v1/chat/stream";

--- a/services/ui/apps/nv-metropolis-bp-vss-ui/components/Home.tsx
+++ b/services/ui/apps/nv-metropolis-bp-vss-ui/components/Home.tsx
@@ -98,27 +98,6 @@ const VssChatPanel = dynamic(
   { ssr: false },
 );
 
-/** Point an absolute VSS media URL at this app's same-origin proxy. */
-const proxyMediaUrl = (value: unknown): unknown => {
-  if (typeof value !== 'string' || !/^https?:\/\//.test(value)) return value;
-  try {
-    const { pathname, search } = new URL(value);
-    return `/api/proxy${pathname}${search}`;
-  } catch {
-    return value;
-  }
-};
-
-/** Rewrite every *_url field on each legacy search hit. */
-const withProxiedMedia = (hits: Array<Record<string, unknown>>) =>
-  hits.map((hit) => {
-    const next: Record<string, unknown> = { ...hit };
-    for (const key of Object.keys(next)) {
-      if (key.endsWith('_url')) next[key] = proxyMediaUrl(next[key]);
-    }
-    return next;
-  });
-
 const readEnv = (key: string) => env(key) || process.env[key] || '';
 
 /**
@@ -615,28 +594,7 @@ export default function Home({ alertsData, searchData, dashboardData, mapData, v
           // Structured artifact events are appended to this callback payload
           // by the chat transport, without leaking transport markup into the
           // visible assistant message.
-          onAnswer={(answer: string, conversationId: string) => {
-            handleSidebarAnswerCompleteWithContent(answer);
-            if (vssSidebarChatEndpoint.transport === 'agent-api') return;
-
-            // Legacy chat-SSE adapters expose search results through a
-            // conversation-scoped follow-up read rather than artifact events.
-            void (async () => {
-              try {
-                const response = await fetch(
-                  `/api/vss-chat?surface=sidebar&conversation=${encodeURIComponent(conversationId)}`,
-                );
-                if (!response.ok) return;
-                const last = await response.json();
-                if (!last?.data?.length) return;
-                handleSidebarAnswerCompleteWithContent(
-                  JSON.stringify({ data: withProxiedMedia(last.data) }),
-                );
-              } catch {
-                // Non-fatal: the chat answer has already been delivered.
-              }
-            })();
-          }}
+          onAnswer={handleSidebarAnswerCompleteWithContent}
           onSubmit={() => handleSidebarMessageSubmitted()}
         />
     ),

--- a/services/ui/apps/nv-metropolis-bp-vss-ui/pages/api/vss-chat.ts
+++ b/services/ui/apps/nv-metropolis-bp-vss-ui/pages/api/vss-chat.ts
@@ -40,36 +40,6 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
 ) {
-  // GET returns the most recent search result from the adapter, so the Search
-  // tab can render hits that never passed through the model's reply text.
-  if (req.method === "GET") {
-    const surface = String(req.query.surface ?? "sidebar");
-    const target = backendFor(surface);
-    if (!target) {
-      res
-        .status(503)
-        .json({ error: `no backend configured for surface: ${surface}` });
-      return;
-    }
-    const base = target.replace(/(?:\/v1)?\/chat\/stream$/, "");
-    // Forward the conversation so the adapter serves only that conversation's
-    // result rather than whatever ran last, process-wide.
-    const conversation = String(req.query.conversation ?? "");
-    const qs = conversation
-      ? `?conversation=${encodeURIComponent(conversation)}`
-      : "";
-    try {
-      const upstream = await fetch(`${base}/v1/search/last${qs}`);
-      res.status(upstream.status).json(await upstream.json());
-    } catch (err) {
-      res.status(502).json({
-        error: "could not read last search result",
-        detail: err instanceof Error ? err.message : String(err),
-      });
-    }
-    return;
-  }
-
   if (req.method !== "POST") {
     res.status(405).json({ error: "method not allowed" });
     return;

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/README.md
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/README.md
@@ -146,9 +146,18 @@ accepts the original line protocol:
 | `data: {"choices":[{"delta":{"content":"…"}}]}` | assistant text |
 | `data: [DONE]` | turn complete |
 | `intermediate_data: {…}` | tool/skill step (`parent_id` nests it) |
+| `artifact_data: {…}` | validated artifact delivered to `onAnswer`, not rendered as prose |
 | `error_data: {…}` | turn-level failure |
 | `interaction_data: {…}` | unsupported-interaction error |
 | `: keepalive` | ignored |
+
+`artifact_data` carries the same `{version, kind, payload}` frame as the agent
+API's `artifact.created`, is validated the same way, and gets the same
+`mediaProxyUrl` rewriting. Any `vss.*` kind travels; which tab acts on one is
+decided by that tab's answer handler, so a new kind needs no transport change.
+Without this frame an agent answering in prose leaves the feature tabs empty,
+and embedding the payload in the reply text costs tokens and invites truncated
+or invented fields.
 
 Legacy content is also read from `choices[0].message.content` and the plain
 `value` / `output` / `answer` fields because agent servers differ.

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/__tests__/steps.test.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/__tests__/steps.test.ts
@@ -67,6 +67,51 @@ describe('SseParser extras', () => {
     );
     expect(events).toEqual([{ kind: 'token', text: 'hi' }, { kind: 'done' }]);
   });
+
+  it('emits an artifact frame without adding it to the assistant text', () => {
+    const artifact = {
+      version: '1.0',
+      kind: 'vss.search.results',
+      payload: { data: [{ video_name: 'clip1.mp4' }] },
+    };
+    const events = new SseParser().feed(`artifact_data: ${JSON.stringify(artifact)}\n`);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ kind: 'artifact' });
+    const { envelope } = events[0] as { envelope: string };
+    expect(envelope).toContain('vss.search.results');
+    expect(envelope).toContain('clip1.mp4');
+  });
+
+  it('carries any versioned kind, so a new tab needs no transport change', () => {
+    const artifact = {
+      version: '1.0',
+      kind: 'vss.alert.incidents',
+      payload: { incidents: [] },
+    };
+    const events = new SseParser().feed(`artifact_data: ${JSON.stringify(artifact)}\n`);
+    expect((events[0] as { envelope: string }).envelope).toContain('vss.alert.incidents');
+  });
+
+  it('rebases artifact media onto the app proxy', () => {
+    const artifact = {
+      version: '1.0',
+      kind: 'vss.search.results',
+      payload: { data: [{ screenshot_url: 'http://vst-internal:81/vst/frame.jpg' }] },
+    };
+    const events = new SseParser('/api/proxy').feed(
+      `artifact_data: ${JSON.stringify(artifact)}\n`,
+    );
+    expect((events[0] as { envelope: string }).envelope).toContain('/api/proxy/vst/frame.jpg');
+  });
+
+  it('drops a malformed or unversioned artifact rather than failing the turn', () => {
+    const parser = new SseParser();
+    expect(parser.feed('artifact_data: {"kind":"vss.search.results"}\n')).toEqual([]);
+    expect(parser.feed('artifact_data: not json\n')).toEqual([]);
+    expect(
+      parser.feed('artifact_data: {"version":"2.0","kind":"vss.x","payload":{}}\n'),
+    ).toEqual([]);
+  });
 });
 
 describe('buildContextPrefix', () => {

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/agentApi.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/agentApi.ts
@@ -143,7 +143,13 @@ const proxyArtifactMedia = (value: unknown, mediaProxyUrl?: string, key = ''): u
   return value;
 };
 
-const artifactEnvelope = (data: JsonObject, mediaProxyUrl?: string): string | null => {
+/**
+ * Wrap a `{version, kind, payload}` frame as the envelope the tab parsers read.
+ *
+ * Shared with the chat-SSE parser: both transports carry the same artifact
+ * contract, and a second copy of this validation would let them drift.
+ */
+export const artifactEnvelope = (data: JsonObject, mediaProxyUrl?: string): string | null => {
   const version = asString(data.version);
   const kind = asString(data.kind);
   const payload = data.payload;

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/sse.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/sse.ts
@@ -8,6 +8,7 @@
  *   data: {"choices":[{"delta":{"content":"..."}}]}   assistant text
  *   data: [DONE]                                      terminal
  *   intermediate_data: {...}                          tool/skill progress
+ *   artifact_data: {...}                              structured tab payload
  *   error_data: {...}                                 turn-level failure
  *   interaction_data: {...}                           unsupported interaction
  *   : keepalive                                       comment, ignored
@@ -20,11 +21,13 @@
  * the one piece where a silent mistake shows up as "the agent said nothing".
  */
 
+import { artifactEnvelope } from './agentApi';
 import type { ChatStep } from './types';
 
 export type SseEvent =
   | { kind: 'token'; text: string }
   | { kind: 'step'; step: ChatStep }
+  | { kind: 'artifact'; envelope: string }
   | { kind: 'interaction'; interaction: InteractionRequest }
   | { kind: 'error'; message: string }
   | { kind: 'done' };
@@ -85,6 +88,7 @@ const PREFIXES = {
   event: 'event:',
   data: 'data:',
   step: 'intermediate_data: ',
+  artifact: 'artifact_data: ',
   error: 'error_data: ',
   interaction: 'interaction_data: ',
 } as const;
@@ -104,6 +108,12 @@ export class SseParser {
   private stepIndex = 0;
   private eventType = '';
   private dataLines: string[] = [];
+
+  /**
+   * @param mediaProxyUrl Rebases `*_url` fields in artifact payloads, so hits
+   * carrying a container-local VST host stay playable from the browser.
+   */
+  constructor(private readonly mediaProxyUrl?: string) {}
 
   feed(chunk: string): SseEvent[] {
     // Normalise CRLF first: a proxy that rewrites line endings would otherwise
@@ -151,6 +161,12 @@ export class SseParser {
     if (line.startsWith(PREFIXES.step)) {
       const step = this.parseStep(line.slice(PREFIXES.step.length));
       if (step) events.push({ kind: 'step', step });
+      return;
+    }
+
+    if (line.startsWith(PREFIXES.artifact)) {
+      const envelope = this.parseArtifact(line.slice(PREFIXES.artifact.length));
+      if (envelope) events.push({ kind: 'artifact', envelope });
       return;
     }
 
@@ -212,6 +228,22 @@ export class SseParser {
         index: typeof d.index === 'number' ? d.index : this.stepIndex++,
         parentId: parentId == null ? undefined : String(parentId),
       };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Structured payload for a feature tab, kept out of the assistant text.
+   *
+   * The alternative is the agent transcribing every hit into the reply, which
+   * costs a large payload of tokens and invites truncated or invented fields.
+   */
+  private parseArtifact(payload: string): string | null {
+    try {
+      const parsed: unknown = JSON.parse(payload);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+      return artifactEnvelope(parsed as Record<string, unknown>, this.mediaProxyUrl);
     } catch {
       return null;
     }

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/useChatStream.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/chat/lib-src/useChatStream.ts
@@ -328,7 +328,7 @@ export function useChatStream(
 
           const reader = response.body.getReader();
           const decoder = new TextDecoder();
-          const parser = new SseParser();
+          const parser = new SseParser(endpointRef.current.mediaProxyUrl);
           for (;;) {
             const { done, value } = await reader.read();
             if (done) break;


### PR DESCRIPTION
That follow-up was a client for a removed search adapter and 404s on vss-agent. Search still hydrates from scrapeable JSON in the reply; chat-SSE can also carry an artifact_data frame when a backend emits it.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
