### PR TITLE
fix(agent-ui): stop sending Search tab filters as chat context

### DIFF
--- a/services/ui/packages/nv-metropolis-bp-vss-ui/search/__tests__/components/SearchComponent.sidebar-events.test.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/search/__tests__/components/SearchComponent.sidebar-events.test.tsx
@@ -143,7 +143,7 @@ describe('SearchComponent sidebar events', () => {
     expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
 
-  it('pushes current Search filters into Chat context before paint', () => {
+  it('does not push Search filters into Chat context', () => {
     const addChatQueryContext = jest.fn();
     render(
       <SearchComponent
@@ -152,23 +152,15 @@ describe('SearchComponent sidebar events', () => {
       />,
     );
 
-    expect(addChatQueryContext).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 'vss-search-filters',
-        data: expect.objectContaining({
-          top_k: 10,
-          min_cosine_similarity: 0.5,
-        }),
-      }),
-    );
+    expect(addChatQueryContext).not.toHaveBeenCalled();
   });
 
-  it('does not re-push filter context when the host rebuilds addChatQueryContext', () => {
+  it('does not re-register controls when the host rebuilds addChatQueryContext', () => {
     const addChatQueryContext = jest.fn();
     const onControlsReady = jest.fn();
     // Home builds a fresh addChatQueryContext on every render; that must not
-    // make Search re-run its sync effect or rebuild its controls, or the two
-    // components drive each other into an infinite render loop.
+    // rebuild Search controls or the two components drive each other into an
+    // infinite render loop.
     const { rerender } = render(
       <SearchComponent
         {...defaultProps}
@@ -178,7 +170,7 @@ describe('SearchComponent sidebar events', () => {
       />,
     );
 
-    expect(addChatQueryContext).toHaveBeenCalledTimes(1);
+    expect(addChatQueryContext).not.toHaveBeenCalled();
     const controlsCallsAfterMount = onControlsReady.mock.calls.length;
 
     for (let i = 0; i < 3; i += 1) {
@@ -192,7 +184,7 @@ describe('SearchComponent sidebar events', () => {
       );
     }
 
-    expect(addChatQueryContext).toHaveBeenCalledTimes(1);
+    expect(addChatQueryContext).not.toHaveBeenCalled();
     expect(onControlsReady).toHaveBeenCalledTimes(controlsCallsAfterMount);
   });
 

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/search/__tests__/components/SearchComponent.sidebar-events.test.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/search/__tests__/components/SearchComponent.sidebar-events.test.tsx
@@ -1,13 +1,46 @@
 // SPDX-License-Identifier: MIT
 import React from 'react';
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useVideoModal } from 'common';
 
 import { SearchComponent } from '../../lib-src/SearchComponent';
 import { useFilter } from '../../lib-src/hooks/useFilter';
+import { useSearchByImage } from '../../lib-src/hooks/useSearchByImage';
 
 jest.mock('../../lib-src/hooks/useFilter');
+jest.mock('../../lib-src/hooks/useSearchByImage');
+jest.mock('common', () => ({
+  ...jest.requireActual('common'),
+  useVideoModal: jest.fn(),
+}));
+jest.mock('next/dynamic', () => () => {
+  const DynamicOverlay = ({ onSelectObject }: { onSelectObject: (id: string) => void }) =>
+    React.createElement('button', {
+      type: 'button',
+      'data-testid': 'select-search-by-image-object',
+      onClick: () => onSelectObject('42'),
+    });
+  return DynamicOverlay;
+});
 
 const mockUseFilter = useFilter as jest.MockedFunction<typeof useFilter>;
+const mockUseSearchByImage = useSearchByImage as jest.MockedFunction<typeof useSearchByImage>;
+const mockUseVideoModal = useVideoModal as jest.MockedFunction<typeof useVideoModal>;
+
+const inactiveSearchByImage = {
+  searchByImageActive: false,
+  searchByImageLoading: false,
+  searchByImageError: null,
+  searchByImageFrameData: null,
+  startSearchByImage: jest.fn(),
+  cancelSearchByImage: jest.fn(),
+};
+
+const closedVideoModal = {
+  videoModal: { isOpen: false, videoUrl: '', title: '' },
+  openVideoModal: jest.fn(),
+  closeVideoModal: jest.fn(),
+};
 
 describe('SearchComponent sidebar events', () => {
   const defaultProps = {
@@ -32,6 +65,8 @@ describe('SearchComponent sidebar events', () => {
       filterTags: [],
       refetch: jest.fn(),
     });
+    mockUseSearchByImage.mockReturnValue({ ...inactiveSearchByImage });
+    mockUseVideoModal.mockReturnValue({ ...closedVideoModal });
   });
 
   it('clears search results on sidebar messageSubmitted even when Search tab is not focused', () => {
@@ -231,5 +266,50 @@ describe('SearchComponent sidebar events', () => {
 
     expect(screen.queryByText('low.mp4')).not.toBeInTheDocument();
     expect(screen.getByText('high.mp4')).toBeInTheDocument();
+  });
+
+  it('submits an unprefixed Search-by-Image object_id prompt', async () => {
+    const submitChatMessage = jest.fn();
+    const cancelSearchByImage = jest.fn();
+    const closeVideoModal = jest.fn();
+
+    mockUseVideoModal.mockReturnValue({
+      videoModal: { isOpen: true, videoUrl: 'http://vst.test/clip.mp4', title: 'clip' },
+      openVideoModal: jest.fn(),
+      closeVideoModal,
+    });
+    mockUseSearchByImage.mockReturnValue({
+      searchByImageActive: true,
+      searchByImageLoading: false,
+      searchByImageError: null,
+      searchByImageFrameData: {
+        frameImage: {} as HTMLImageElement,
+        objects: [{ id: '42', bbox: { leftX: 0, topY: 0, rightX: 1, bottomY: 1 }, type: 'Person' }],
+        sensorId: 's1',
+        sensorName: 'cam',
+        timestamp: '2024-01-01T00:00:00',
+      },
+      startSearchByImage: jest.fn(),
+      cancelSearchByImage,
+    });
+
+    render(
+      <SearchComponent
+        {...defaultProps}
+        submitChatMessage={submitChatMessage}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('select-search-by-image-object')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId('select-search-by-image-object'));
+    fireEvent.click(screen.getByTestId('search-by-image-search-button'));
+
+    expect(submitChatMessage).toHaveBeenCalledTimes(1);
+    expect(submitChatMessage).toHaveBeenCalledWith('Find similar objects matching object_id=42');
+    expect(submitChatMessage.mock.calls[0][0]).not.toContain('[Context:');
+    expect(cancelSearchByImage).toHaveBeenCalledTimes(1);
+    expect(closeVideoModal).toHaveBeenCalledTimes(1);
   });
 });

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/search/__tests__/utils/searchFilters.test.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/search/__tests__/utils/searchFilters.test.ts
@@ -1,10 +1,5 @@
 // SPDX-License-Identifier: MIT
-import {
-  applySearchResultFilters,
-  buildSearchFilterChatContext,
-  prefixMessageWithSearchFilters,
-  SEARCH_FILTER_CONTEXT_ID,
-} from '../../lib-src/utils/searchFilters';
+import { applySearchResultFilters } from '../../lib-src/utils/searchFilters';
 import type { SearchData, StreamInfo } from '../../lib-src/types';
 
 const clip = (overrides: Partial<SearchData> = {}): SearchData => ({
@@ -120,34 +115,5 @@ describe('applySearchResultFilters', () => {
   it('keeps results with unparseable timestamps when no time range is set', () => {
     const results = [clip({ video_name: 'blank.mp4', start_time: '', end_time: '' })];
     expect(applySearchResultFilters(results, {}, streams).map((r) => r.video_name)).toEqual(['blank.mp4']);
-  });
-});
-
-describe('buildSearchFilterChatContext', () => {
-  it('serializes active filters for Chat [Context] payload', () => {
-    const ctx = buildSearchFilterChatContext({
-      sourceType: 'rtsp',
-      topK: 5,
-      videoSources: ['cam-1'],
-      similarity: 0.4,
-      startDate: new Date(2024, 0, 15, 9, 0, 0),
-    });
-    expect(ctx.id).toBe(SEARCH_FILTER_CONTEXT_ID);
-    expect(ctx.data).toEqual({
-      source_type: 'rtsp',
-      top_k: 5,
-      video_sources: ['cam-1'],
-      timestamp_start: '2024-01-15T09:00:00',
-      min_cosine_similarity: 0.4,
-    });
-  });
-});
-
-describe('prefixMessageWithSearchFilters', () => {
-  it('prefixes the user message with Context JSON', () => {
-    const prefixed = prefixMessageWithSearchFilters('find people', { sourceType: 'video_file', topK: 10 });
-    expect(prefixed.startsWith('[Context: ')).toBe(true);
-    expect(prefixed).toContain('find people');
-    expect(prefixed).toContain('"source_type":"video_file"');
   });
 });

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/search/lib-src/SearchComponent.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/search/lib-src/SearchComponent.tsx
@@ -14,7 +14,7 @@ import { InfoRound as InfoRoundIcon } from '@rsuite/icons';
 import { VideoModalTooltip } from 'common';
 
 // Types
-import { SearchComponentProps, SearchData, SearchParams } from './types';
+import { SearchComponentProps, SearchData } from './types';
 
 // Hooks
 import { useSearchByImage } from './hooks/useSearchByImage';
@@ -22,11 +22,7 @@ import {
   extractSearchResultsFromAgentResponse,
   normalizeSearchResultMediaUrls,
 } from './utils/agentResponseParser';
-import {
-  applySearchResultFilters,
-  buildSearchFilterChatContext,
-  prefixMessageWithSearchFilters,
-} from './utils/searchFilters';
+import { applySearchResultFilters } from './utils/searchFilters';
 
 // Components
 import { SearchHeader } from './components/SearchHeader';
@@ -82,29 +78,6 @@ export const SearchComponent: React.FC<SearchComponentProps> = ({
 
   const { videoModal, openVideoModal, closeVideoModal } = useVideoModal(vstApiUrl);  
   const { streams, filterParams, setFilterParams, addFilter, removeFilterTag, filterTags, refetch: refetchStreams } = useFilter({vstApiUrl});
-  const filterParamsRef = React.useRef(filterParams);
-  filterParamsRef.current = filterParams;
-
-  // Home rebuilds addChatQueryContext on every render, so hold it in a ref:
-  // callbacks below must keep a stable identity or the controls memo and the
-  // filter-sync effect re-fire on each render.
-  const addChatQueryContextRef = React.useRef(addChatQueryContext);
-  addChatQueryContextRef.current = addChatQueryContext;
-
-  const syncSearchFiltersToChat = React.useCallback((params: SearchParams) => {
-    addChatQueryContextRef.current?.(buildSearchFilterChatContext(params));
-  }, []);
-
-  const setFilterParamsAndSyncChat = React.useCallback(
-    (params: SearchParams | ((prev: SearchParams) => SearchParams)) => {
-      const prev = filterParamsRef.current;
-      const next = typeof params === 'function' ? params(prev) : { ...prev, ...(params ?? {}) };
-      filterParamsRef.current = next;
-      setFilterParams(next);
-      syncSearchFiltersToChat(next);
-    },
-    [setFilterParams, syncSearchFiltersToChat],
-  );
 
   // Map streamId (UUID) -> sensor name for /frames API lookup
   const sensorIdToNameMap = React.useMemo(() => {
@@ -163,16 +136,11 @@ export const SearchComponent: React.FC<SearchComponentProps> = ({
 
   const handleSearchByImageConfirm = React.useCallback((objectId: string) => {
     if (!submitChatMessage) return;
-    const prompt = prefixMessageWithSearchFilters(
-      `Find similar objects matching object_id=${objectId}`,
-      filterParamsRef.current,
-    );
-    submitChatMessage(prompt);
-    syncSearchFiltersToChat(filterParamsRef.current);
+    submitChatMessage(`Find similar objects matching object_id=${objectId}`);
     cancelSearchByImage();
     closeVideoModal();
     setActiveVideoData(null);
-  }, [submitChatMessage, syncSearchFiltersToChat, cancelSearchByImage, closeVideoModal]);
+  }, [submitChatMessage, cancelSearchByImage, closeVideoModal]);
 
   const refetchStreamsRef = React.useRef(refetchStreams);
 
@@ -185,17 +153,6 @@ export const SearchComponent: React.FC<SearchComponentProps> = ({
       refetchStreamsRef.current();
     }
   }, [isActive]);
-
-  // Keyed on the serialized payload, not on filterParams identity, so the chip
-  // is written once per actual filter change.
-  const filterChatContextKey = React.useMemo(
-    () => JSON.stringify(buildSearchFilterChatContext(filterParams).data),
-    [filterParams],
-  );
-
-  React.useLayoutEffect(() => {
-    syncSearchFiltersToChat(filterParamsRef.current);
-  }, [syncSearchFiltersToChat, filterChatContextKey]);
 
   // Stable forwarder + ref so Home's register callback stays identity-stable while we always invoke the latest parser/setState.
   const deliverAgentAnswerRef = React.useRef<(answer: string) => boolean>(() => false);
@@ -222,11 +179,10 @@ export const SearchComponent: React.FC<SearchComponentProps> = ({
     const unsubscribe = registerSidebarChatEventSubscriber((event) => {
       if (event.type === 'messageSubmitted') {
         setAgentSearchResults(null);
-        syncSearchFiltersToChat(filterParamsRef.current);
       }
     });
     return typeof unsubscribe === 'function' ? unsubscribe : undefined;
-  }, [registerSidebarChatEventSubscriber, syncSearchFiltersToChat]);
+  }, [registerSidebarChatEventSubscriber]);
 
   const contentDisabled = !chatSidebarCollapsed || chatSidebarBusy;
 
@@ -248,7 +204,7 @@ export const SearchComponent: React.FC<SearchComponentProps> = ({
         outerPadding={renderControlsInLeftSidebar ? '8px 8px 12px' : 0}
         streams={streams}
         filterParams={filterParams}
-        setFilterParams={setFilterParamsAndSyncChat}
+        setFilterParams={setFilterParams}
         addFilter={addFilter}
         removeFilterTag={removeFilterTag}
         filterTags={filterTags}
@@ -260,7 +216,7 @@ export const SearchComponent: React.FC<SearchComponentProps> = ({
       renderControlsInLeftSidebar,
       streams,
       filterParams,
-      setFilterParamsAndSyncChat,
+      setFilterParams,
       addFilter,
       removeFilterTag,
       filterTags,
@@ -370,7 +326,7 @@ export const SearchComponent: React.FC<SearchComponentProps> = ({
             theme={isDark ? 'dark' : 'light'}
             streams={streams}
             filterParams={filterParams}
-            setFilterParams={setFilterParamsAndSyncChat}
+            setFilterParams={setFilterParams}
             addFilter={addFilter}
             removeFilterTag={removeFilterTag}
             filterTags={filterTags}

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/search/lib-src/utils/searchFilters.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/search/lib-src/utils/searchFilters.ts
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: MIT
-import type { QueryDataContext, SearchData, SearchParams, StreamInfo } from '../types';
-import { formatDateToLocalISO, parseDateAsLocal } from './Formatter';
-import { DEFAULT_TOP_K } from '../hooks/useFilter';
-
-export const SEARCH_FILTER_CONTEXT_ID = 'vss-search-filters';
+import type { SearchData, SearchParams, StreamInfo } from '../types';
+import { parseDateAsLocal } from './Formatter';
 
 function sourceTypeToStreamType(sourceType?: string): string | null {
   if (sourceType === 'rtsp') return 'sensor_rtsp';
@@ -68,33 +65,4 @@ export function applySearchResultFilters(
     return filtered.slice(0, limit);
   }
   return filtered;
-}
-
-export function buildSearchFilterChatContext(params: SearchParams): QueryDataContext {
-  const data: Record<string, unknown> = {
-    source_type: params.sourceType || 'video_file',
-    top_k: params.topK ?? DEFAULT_TOP_K,
-  };
-  if (params.videoSources && params.videoSources.length > 0) {
-    data.video_sources = params.videoSources;
-  }
-  const timestampStart = formatDateToLocalISO(params.startDate ?? null);
-  const timestampEnd = formatDateToLocalISO(params.endDate ?? null);
-  if (timestampStart) data.timestamp_start = timestampStart;
-  if (timestampEnd) data.timestamp_end = timestampEnd;
-  const minSimilarity = Number(params.similarity);
-  if (Number.isFinite(minSimilarity) && minSimilarity !== 0) {
-    data.min_cosine_similarity = Number(minSimilarity.toFixed(2));
-  }
-  return {
-    id: SEARCH_FILTER_CONTEXT_ID,
-    label: 'Search filters',
-    contextType: 'search/filters',
-    data,
-  };
-}
-
-export function prefixMessageWithSearchFilters(message: string, params: SearchParams): string {
-  const ctx = buildSearchFilterChatContext(params);
-  return `[Context: ${JSON.stringify([ctx.data])}]\n\n${message}`;
 }


### PR DESCRIPTION
## Summary
- Stop auto-attaching Search-tab filters as a Chat sidebar `[Context]` chip (and stop prefixing Search-by-Image prompts the same way).
- The Search agent does not consume those fields; the prefix also collides with clip `[Context]` used for `video_understanding`.
- Search-tab result cards still apply filters client-side. Per-clip "+ Chat" context is unchanged.

## Test plan
- [ ] On Search + Chat sidebar, confirm no "Search filters" chip appears in the chat input on load or filter changes.
- [ ] Send a search query from the sidebar and confirm the user message has no filter `[Context: …]` prefix.
- [ ] Confirm "+ Chat" on a result still adds clip context.
- [ ] Confirm Search-tab filter bar still filters displayed result cards (similarity, sources, dates, top K).
- [ ] Confirm Search-by-Image confirm still submits the object-id query without a filter context prefix.