### PR TITLE
fix(helm): anchor every ingress rewrite, and run the route verifier in CI

### DIFF
--- a/.github/osrb/inventory.csv
+++ b/.github/osrb/inventory.csv
@@ -638,7 +638,7 @@ acorn-jsx,5.3.2,MIT,services/vios,node,lockfile,services/vios/ui/streaming-lib/p
 actions/checkout,11d5960a326750d5838078e36cf38b85af677262,MIT,.github,github-action,ci,.github/workflows/model-routing-notebook.yml,ci,no,no,no,ci-tooling,None
 actions/checkout,34e114876b0b11c390a56381ad16ebd13914f8d5,MIT,.github,github-action,ci,.github/workflows/build-dev-images.yml,ci,no,no,no,ci-tooling,None
 actions/checkout,de0fac2e4500dabe0009e67214ff5f5447ce83dd,MIT,.github,github-action,ci,.github/workflows/fern-docs-ci.yml,ci,no,no,no,ci-tooling,None
-actions/checkout,v4,MIT,.github,github-action,ci,.github/workflows/helm-sync.yml,ci,no,no,no,ci-tooling,None
+actions/checkout,v4,MIT,.github,github-action,ci,.github/workflows/helm-ingress-live.yml,ci,no,no,no,ci-tooling,None
 actions/download-artifact,d3f86a106a0bac45b974a628896c90dbdf5c8093,MIT,.github,github-action,ci,.github/workflows/build-dev-images.yml,ci,no,no,no,ci-tooling,None
 actions/setup-node,48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e,MIT,.github,github-action,ci,.github/workflows/fern-docs-ci.yml,ci,no,no,no,ci-tooling,None
 actions/setup-node,49933ea5288caeca8642d1e84afbd3f7d6820020,MIT,.github,github-action,ci,.github/workflows/ci.yml,ci,no,no,no,ci-tooling,None

--- a/.github/workflows/helm-ingress-live.yml
+++ b/.github/workflows/helm-ingress-live.yml
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Guards the Helm ingress *routes*: renders the four developer profiles and
+# asserts the Ingress objects against the canonical route table in
+# services/common (deploy/helm/scripts/verify-ingress-routes.py). Six seconds,
+# no cluster.
+#
+# The script existed before this workflow and nothing ran it -- it was a
+# developer-only step documented in deploy/helm/services/common/README.md. That
+# is how ten of the eleven rewriting routes came to render unanchored in Helm
+# while every `replace-path` rule on the Docker edge was anchored: the drift was
+# only ever visible to whoever remembered to run the script by hand.
+#
+# A second, live pass -- .github/scripts/test_helm_ingress_live.py, deploying
+# these objects to a throwaway kind cluster with a real HAProxy ingress
+# controller and asserting which backend each request reaches and with what
+# path -- lands with PR #1983 and extends this file. It is kept out of here so
+# this workflow needs no Docker, pulls no controller chart and cannot fail on a
+# network blip. The static pass reads only the Ingress objects of
+# templates/vss-ingress.yaml, so Service-scoped `backend-config-snippet`
+# annotations stay the live pass's job. Neither pass covers the Docker edge.
+#
+# Separate from the lint job in ci.yml because this needs helm and a vendoring
+# step; no product image, GPU or NGC credential is involved.
+name: Helm ingress routes
+
+on:
+  pull_request:
+    paths:
+      - "deploy/helm/**"
+      - ".github/workflows/helm-ingress-live.yml"
+      # The check asserts that every mount `vss configure` probes exists in the
+      # route table, so a new INGRESS_SERVICES entry has to run it too.
+      - "services/agent/packages/vss_cli/src/vss_cli/config.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: helm-ingress-routes-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  routes:
+    name: Static route table
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: false
+
+      # The check parses `helm template` output, and the CI interpreter carries
+      # no PyYAML (see .github/osrb/README.md). Pinned to the version OSRB
+      # approved, and installed explicitly so a PyPI blip reads as a failed
+      # install rather than an opaque ModuleNotFoundError.
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Install PyYAML
+        run: pip install --quiet 'PyYAML==6.0.3'
+
+      - name: Install helm
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/bin"
+          curl -sSL https://get.helm.sh/helm-v3.16.4-linux-amd64.tar.gz | tar -xz -C /tmp
+          install -m 0755 /tmp/linux-amd64/helm "$HOME/bin/helm"
+          echo "$HOME/bin" >> "$GITHUB_PATH"
+
+      - name: Vendor chart dependencies
+        # The umbrella charts have file:// dependencies, so this resolves
+        # offline; `helm template` cannot render them until it has run.
+        #
+        # This MUST precede the check, and is why the check does not vendor
+        # lazily. A profile renders services/common from the charts/*.tgz
+        # vendored here, not from the source tree, so an edit to services/common
+        # that is not re-vendored is invisible to a render -- the check then
+        # passes on the vendored copy and reports on charts nobody is about to
+        # deploy. Verified by hand on this branch: un-anchoring the template and
+        # re-running the check without re-vendoring still printed OK.
+        #
+        # The .tgz artifacts are gitignored, so a fresh checkout always has to
+        # build them; that is what keeps this honest.
+        run: |
+          set -euo pipefail
+          for chart in \
+            deploy/helm/developer-profiles/dev-profile-base \
+            deploy/helm/developer-profiles/dev-profile-alerts \
+            deploy/helm/developer-profiles/dev-profile-lvs \
+            deploy/helm/developer-profiles/dev-profile-search
+          do
+            helm dependency update "$chart" >/dev/null
+          done
+
+      - name: Verify the rendered Ingress routes against the canonical table
+        run: python3 deploy/helm/scripts/verify-ingress-routes.py

--- a/deploy/helm/developer-profiles/dev-profile-alerts/vss-ingress-example-rewrites.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/vss-ingress-example-rewrites.yaml
@@ -33,21 +33,21 @@ metadata:
   annotations:
     haproxy.org/path-rewrite: |
       ^/storage/(.*) /vst/storage/\1
-      ^/storage /vst/storage
-      /va-mcp/(.*) /\1
-      /va-mcp /
-      /alert-bridge/(.*) /\1
-      /alert-bridge /
-      /video-analytics-api/(.*) /\1
-      /video-analytics-api /
-      /elasticsearch/(.*) /\1
-      /elasticsearch /
-      /rtvi-cv/(.*) /\1
-      /rtvi-cv /
-      /phoenix/(.*) /\1
-      /phoenix /
-      /llm/(.*) /\1
-      /llm /
+      ^/storage$ /vst/storage
+      ^/va-mcp/(.*) /\1
+      ^/va-mcp$ /
+      ^/alert-bridge/(.*) /\1
+      ^/alert-bridge$ /
+      ^/video-analytics-api/(.*) /\1
+      ^/video-analytics-api$ /
+      ^/elasticsearch/(.*) /\1
+      ^/elasticsearch$ /
+      ^/rtvi-cv/(.*) /\1
+      ^/rtvi-cv$ /
+      ^/phoenix/(.*) /\1
+      ^/phoenix$ /
+      ^/llm/(.*) /\1
+      ^/llm$ /
 spec:
   ingressClassName: haproxy
   rules:

--- a/deploy/helm/developer-profiles/dev-profile-base/vss-ingress-example-rewrites.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-base/vss-ingress-example-rewrites.yaml
@@ -33,13 +33,13 @@ metadata:
   annotations:
     haproxy.org/path-rewrite: |
       ^/storage/(.*) /vst/storage/\1
-      ^/storage /vst/storage
-      /rtvi-vlm/(.*) /\1
-      /rtvi-vlm /
-      /phoenix/(.*) /\1
-      /phoenix /
-      /llm/(.*) /\1
-      /llm /
+      ^/storage$ /vst/storage
+      ^/rtvi-vlm/(.*) /\1
+      ^/rtvi-vlm$ /
+      ^/phoenix/(.*) /\1
+      ^/phoenix$ /
+      ^/llm/(.*) /\1
+      ^/llm$ /
 spec:
   ingressClassName: haproxy
   rules:

--- a/deploy/helm/developer-profiles/dev-profile-lvs/vss-ingress-example-rewrites.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/vss-ingress-example-rewrites.yaml
@@ -33,17 +33,17 @@ metadata:
   annotations:
     haproxy.org/path-rewrite: |
       ^/storage/(.*) /vst/storage/\1
-      ^/storage /vst/storage
-      /elasticsearch/(.*) /\1
-      /elasticsearch /
-      /rtvi-vlm/(.*) /\1
-      /rtvi-vlm /
-      /lvs/(.*) /\1
-      /lvs /
-      /phoenix/(.*) /\1
-      /phoenix /
-      /llm/(.*) /\1
-      /llm /
+      ^/storage$ /vst/storage
+      ^/elasticsearch/(.*) /\1
+      ^/elasticsearch$ /
+      ^/rtvi-vlm/(.*) /\1
+      ^/rtvi-vlm$ /
+      ^/lvs/(.*) /\1
+      ^/lvs$ /
+      ^/phoenix/(.*) /\1
+      ^/phoenix$ /
+      ^/llm/(.*) /\1
+      ^/llm$ /
 spec:
   ingressClassName: haproxy
   rules:

--- a/deploy/helm/scripts/verify-ingress-routes.py
+++ b/deploy/helm/scripts/verify-ingress-routes.py
@@ -96,6 +96,16 @@ def canonical_table() -> list[dict]:
     return rows
 
 
+def rewrite_mount(src: str) -> str:
+    """The mount a `haproxy.org/path-rewrite` source came from.
+
+    Both rendered forms are anchored, and the bare form is terminated as well,
+    so recovering `/llm` needs the `^` and the `$` off `^/llm$` -- stripping
+    `/(.*)` alone leaves the terminator behind and every mount reads as surplus.
+    """
+    return src.removeprefix("^").removesuffix("$").replace("/(.*)", "")
+
+
 def render(profile: str, extra: list[str]) -> list[dict]:
     out = subprocess.run(
         [
@@ -185,10 +195,9 @@ def check_profile(profile: str, rows: list[dict], verbose: bool) -> list[str]:
                 if path in strips:
                     mounted_strip.add(path)
                     to = "" if row["rewrite"] == "strip" else row["rewrite"]
-                    anchor = "^" if row.get("anchored", False) else ""
                     for src, want in (
-                        (f"{anchor}{path}/(.*)", f"{to}/\\1"),
-                        (f"{anchor}{path}", to or "/"),
+                        (f"^{path}/(.*)", f"{to}/\\1"),
+                        (f"^{path}$", to or "/"),
                     ):
                         got = rewrites.get(src)
                         if got is None:
@@ -200,9 +209,7 @@ def check_profile(profile: str, rows: list[dict], verbose: bool) -> list[str]:
                                 f"{profile}: {src!r} rewrites to {got!r}, table says {want!r}"
                             )
 
-        surplus = {
-            src.removeprefix("^").replace("/(.*)", "") for src in rewrites
-        } - mounted_strip
+        surplus = {rewrite_mount(src) for src in rewrites} - mounted_strip
         if surplus:
             fails.append(f"{profile}: rewritten but not mounted: {sorted(surplus)}")
 

--- a/deploy/helm/services/common/README.md
+++ b/deploy/helm/services/common/README.md
@@ -127,6 +127,18 @@ stream affinity sits on `vss-rtvi-cv` / `vss-rtvi-embed`, the long server timeou
 `elasticsearch` Service. `path-rewrite` is Ingress-scope only, so the route shaping stays on
 the `Ingress`.
 
+**Every rewrite is anchored, and there is no per-row opt-out.** Each rewriting row renders
+`^<path>/(.*)` and `^<path>$`, matching the ~30 `replace-path` rules on the Docker edge.
+`replace-path` matches its regex *anywhere* in the path, and being Ingress-scope the pair
+reaches every backend of the Ingress that carries it — the NVStreamer and Kibana hosts
+included. A mid-path match is never intent: `path` is also the `pathType: Prefix` path, and
+the controller picks a backend on the *start* of the request path, so a request that matches
+a rewrite mid-path was routed there by a different row and rewriting it can only corrupt it.
+Unanchored, `/storage/(.*)` also matched NVStreamer's `POST /api/v1/storage/file` and VST's
+own `/vst/api/v1/storage/`, which is the 404 that
+[#2005](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/2005)
+fixed for that one mount.
+
 `timeout-client` and `timeout-tunnel` are **ConfigMap-only** in this controller. The LVS and
 search charts still render them for continuity with earlier releases, but they have never had
 any effect as Ingress annotations — raising those means a cluster-wide controller setting,
@@ -147,7 +159,16 @@ the main object makes it easy to miss.
 
 ## Checking it
 
+Runs in CI on every pull request touching `deploy/helm/**`
+(`.github/workflows/helm-ingress-live.yml`). To run it yourself:
+
 ```bash
+# Vendoring first is load-bearing: a profile renders services/common from its
+# vendored charts/*.tgz, so an edit here that is not re-vendored is invisible to
+# the check and it reports OK on the stale copy.
+for p in base alerts lvs search; do
+  helm dependency update "deploy/helm/developer-profiles/dev-profile-$p"
+done
 python3 deploy/helm/scripts/verify-ingress-routes.py --verbose
 ```
 

--- a/deploy/helm/services/common/templates/_ingress-routes.tpl
+++ b/deploy/helm/services/common/templates/_ingress-routes.tpl
@@ -40,7 +40,13 @@
     rewrite  none  -> forwarded with the prefix intact
              strip -> prefix removed before the backend sees it
              /x    -> prefix replaced with /x
-    anchored prepend ^ to the HAProxy rewrite source when true
+
+  There is no per-row anchoring field. `path` is both the Ingress `pathType:
+  Prefix` path and the source of the rewrite, and the controller selects a
+  backend on the *start* of the request path -- so a request that matches a
+  rewrite mid-path was routed here by some other row, and rewriting it is
+  damage rather than intent. Every rewrite is anchored; see
+  `vss.ingress.pathRewrites` below.
 
   Ordering is the rendered order: the UI's /api/* routes before the agent's
   /api catch-all, and the UI / catch-all last. The HAProxy controller matches
@@ -111,7 +117,6 @@
   path: /storage
   pathType: Prefix
   rewrite: /vst/storage
-  anchored: true
 - key: va-mcp
   path: /va-mcp
   pathType: Prefix
@@ -280,6 +285,17 @@ port: {{ index $svc "port" | default 8000 }}
   mounted route that rewrites, derived from the same table as the paths, so the
   two can never disagree about which prefix is stripped (FR-16).
 
+  Both forms are anchored, and have to be. HAProxy's `replace-path` matches its
+  regex anywhere in the path, and `path-rewrite` is Ingress-scope only, so every
+  pair here reaches every backend of the Ingress that carries it -- the
+  NVStreamer and Kibana hosts included. Unanchored, `/storage/(.*)` also matches
+  NVStreamer's `POST /api/v1/storage/file` and VST's own `/vst/api/v1/storage/`,
+  and the backend answers 404 on the mangled path. The Docker edge anchors the
+  same pair (services/infra/haproxy/haproxy.cfg.template:bk_vst_storage_compat),
+  and every other `replace-path` it carries, which is why there is no opt-out
+  here either: /storage is the mount the collision was found on, not the only
+  one able to collide.
+
   Emitted at zero indent with no leading or trailing blank line; the caller
   applies `nindent`.
 */}}
@@ -294,9 +310,8 @@ port: {{ index $svc "port" | default 8000 }}
 {{- $rw := $row.rewrite | default "none" }}
 {{- if and $b.service (ne $rw "none") }}
 {{- $to := ternary "" $rw (eq $rw "strip") }}
-{{- $anchor := ternary "^" "" ($row.anchored | default false) }}
-{{ $anchor }}{{ $row.path }}/(.*) {{ $to }}/\1
-{{ $anchor }}{{ $row.path }} {{ $to | default "/" }}
+^{{ $row.path }}/(.*) {{ $to }}/\1
+^{{ $row.path }}$ {{ $to | default "/" }}
 {{- end }}
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
> **Proposal, not a fait accompli.** This generalises a scoping decision @munjalp6 made
> deliberately in #2005, so I would rather it be agreed than merged. If there is a route you
> had in mind that wants a mid-path match, say so and this recommendation changes — see
> [Where I could be wrong](#where-i-could-be-wrong). Please don't merge without a nod from
> @munjalp6.

### The problem

`develop` renders **10 of the 11** rewriting routes in the shared Helm route table
*unanchored*, while **every one** of the ~30 `replace-path` rules on the Docker edge
(`deploy/docker/services/infra/haproxy/haproxy.cfg.template`) is `^`-anchored. Docker/Helm
parity is a repo invariant — `helm-sync.yml` exists to enforce it — so this is a break in it.

`dev-profile-alerts` on `develop`:

```text
^/storage/(.*) /vst/storage/\1     <- anchored (#2005)
^/storage /vst/storage             <- anchored, but no `$`; Docker has ^/storage$
/va-mcp/(.*) /\1                   <- unanchored
/va-mcp /
/alert-bridge/(.*) /\1
/alert-bridge /
/video-analytics-api/(.*) /\1
/video-analytics-api /
/elasticsearch/(.*) /\1
/elasticsearch /
/rtvi-cv/(.*) /\1
/rtvi-cv /
/phoenix/(.*) /\1
/phoenix /
/llm/(.*) /\1
/llm /
```

`replace-path` matches its regex **anywhere** in the path, and `path-rewrite` is Ingress-scope
only, so each of those pairs reaches every backend of the Ingress that carries it — the
NVStreamer and Kibana hosts included.

### Why no route wants a mid-path match

This is the load-bearing claim, so here is how it was established rather than asserted. In
the route table, a row's `path` is used for two things: it is the Ingress `pathType: Prefix`
path, and it is the source of the rewrite — the same string, in
`vss.ingress.pathRows` and `vss.ingress.pathRewriteRows`. The controller selects a backend by
matching the **start** of the request path. So a request that matches a rewrite mid-path is,
by construction, a request some *other* row routed here; rewriting it corrupts a path the
intended backend was about to serve correctly. There is no row for which a mid-path hit is
the intent, which leaves nothing for a per-row flag to express.

That is why this drops `anchored` rather than flipping its default: an opt-out would be an
opt-out from correctness.

### The change

1. **`_ingress-routes.tpl`** — drop the `$anchor` ternary; render `^<path>/(.*)` and
   `^<path>$` for every row. `anchored: true` comes off the `/storage` row and the `anchored`
   line comes out of the field documentation, replaced by a note on why there is no opt-out.
   The comment on `vss.ingress.pathRewrites` is **@trannguyenanhhien's wording**, not mine
   (see below) — it is the clearest statement of the reasoning I found.
2. **`verify-ingress-routes.py`** — expect `f"^{path}/(.*)"` and `f"^{path}$"` unconditionally.
   A `rewrite_mount()` helper is needed for the surplus check: stripping `/(.*)` alone no
   longer recovers `/llm` from `^/llm$`, and without it every mount reads as surplus.
3. **The three `vss-ingress-example-rewrites.yaml` files** regenerated. **Every** rewrite pair
   changes, not just `/storage`.
4. **CI.** ← the part that matters most.

The one already-anchored route also gains its missing terminator: Helm rendered `^/storage`
where Docker has `^/storage$`, so on `develop` a request to `/storage-old` rewrites on Helm
and does not on Docker. That is now aligned too.

### The CI gap is the real defect here

`verify-ingress-routes.py` on `develop` is a hand-run developer script, documented only in
`deploy/helm/services/common/README.md`. **Nothing runs it.** That is exactly how ten
unanchored routes and a stale `/storage` terminator survived in a table whose whole purpose is
to be the single source of these strings — the drift was only ever visible to whoever
remembered to run the script.

So this ports `.github/workflows/helm-ingress-live.yml` from #1983, reduced to the vendoring
step plus the static pass: ~6 seconds, no cluster, no Docker, no NGC credential. The kind-based
live pass from #1983 extends the same file and lands with that PR — same filename on purpose,
so the two converge on one workflow rather than two overlapping ones.

**The vendoring step ahead of the check is load-bearing, not tidiness.** A profile renders
`services/common` from its vendored `charts/*.tgz`, not from the source tree, so a template
edit that is not re-vendored is invisible to a render. I confirmed that on this branch: after
un-anchoring the template, re-running the check *without* re-vendoring printed a clean `OK`.
The `.tgz` artifacts are gitignored, so a fresh CI checkout always has to build them.

### Proof

**Rendered-annotation diff** (`helm template … --show-only templates/vss-ingress.yaml`, this
branch vs `develop`, all four profiles). The `haproxy.org/path-rewrite` annotation is the only
thing that changes — no path, `pathType`, backend, or other annotation moves:

| profile | rewriting mounts | newly anchored | `$` added |
|---|---|---|---|
| `dev-profile-base` | 4 | 3 | `/storage` |
| `dev-profile-alerts` | 8 | 7 | `/storage` |
| `dev-profile-lvs` | 6 | 5 | `/storage` |
| `dev-profile-search` | 8 | 7 | `/storage` |

11 distinct routes across the profiles; 10 newly anchored; the 11th (`/storage`) gains `$`.

**The verifier assertions are live, not decorative.** Un-anchored the template, re-vendored,
re-ran — **52 failures**, four profiles, every rewriting mount, both forms:

```text
FAIL dev-profile-base: /storage mounted but '^/storage/(.*)' is not rewritten
FAIL dev-profile-base: /storage mounted but '^/storage$' is not rewritten
FAIL dev-profile-base: /rtvi-vlm mounted but '^/rtvi-vlm/(.*)' is not rewritten
FAIL dev-profile-base: /rtvi-vlm mounted but '^/rtvi-vlm$' is not rewritten
FAIL dev-profile-base: /phoenix mounted but '^/phoenix/(.*)' is not rewritten
FAIL dev-profile-base: /phoenix mounted but '^/phoenix$' is not rewritten
FAIL dev-profile-base: /llm mounted but '^/llm/(.*)' is not rewritten
FAIL dev-profile-base: /llm mounted but '^/llm$' is not rewritten
FAIL dev-profile-alerts: /storage mounted but '^/storage/(.*)' is not rewritten
…
FAIL dev-profile-search: /llm$ is not rewritten
```

Restored and re-vendored: `OK  4 profiles render from one table (26 distinct mounts); CLI
probe mounts present; 9 disabled-component cases drop their route; examples current` in 6.7s.

**The HAProxy ingress controller accepts the `$` terminator** — established by running it,
not by trusting that #1983's live test passes. A throwaway kind cluster with
`haproxytech/kubernetes-ingress` 1.49.0 (installed the way the warehouse READMEs say to),
`traefik/whoami` stubs behind the `dev-profile-search` Ingress as this branch renders it, and
`curl` through the node's `:80`. Each stub echoes the path it was handed:

```text
PASS  GET /elasticsearch              -> elasticsearch                  received '/'                     (HTTP 200)
PASS  GET /elasticsearch/_cat/indices -> elasticsearch                  received '/_cat/indices'         (HTTP 200)
PASS  GET /llm                        -> nemotron-35-lightning-30b-a3b  received '/'                     (HTTP 200)
PASS  GET /llm/v1/models              -> nemotron-35-lightning-30b-a3b  received '/v1/models'            (HTTP 200)
PASS  GET /rtvi-embed                 -> vss-rtvi-embed                 received '/'                     (HTTP 200)
PASS  GET /storage                    -> vss-vios-ingress               received '/vst/storage'          (HTTP 200)
PASS  GET /storage/clip.mp4           -> vss-vios-ingress               received '/vst/storage/clip.mp4' (HTTP 200)
PASS  GET /vst/storage/clip.mp4       -> vss-vios-ingress               received '/vst/storage/clip.mp4' (HTTP 200)
```

The bare forms are the answer to the question: `GET /elasticsearch` can only arrive as `/` if
the controller compiled *and matched* `^/elasticsearch$`. Had it rejected the rule, the
backend would have been handed `/elasticsearch`. Confirmed directly in the controller's own
generated config as well:

```text
http-request replace-path ^/elasticsearch$ / if { var(txn.path_match) -m dom 5254a0f5c4a9… }
http-request replace-path ^/llm$ / if { var(txn.path_match) -m dom febfdc1828ab… }
```

### Honest caveat: this is a parity break, not a live outage

**No request path collides today** on any profile, apart from the `/storage` case #2005
already fixed. Nothing is broken on `develop` right now, and I do not want to oversell this.
The argument for landing it is the parity invariant and the missing CI coverage, not an
incident.

It does become live on the gateway branch (#1983), which adds an `/alerts` alias. Unanchored,
that pair fires a *second* time on the output of the `/alert-bridge` strip and turns
`GET /api/v1/alerts/health` into `/api/v1/health`. That is a consequence, not the case for
this PR — the point is that the class of bug recurs and the table is where it should be shut
off once.

Landing this on `develop` also removes a file that #1983 currently keeps re-conflicting on.
Useful, but not the justification.

### Credit

- **@munjalp6** found the real bug (#2005, `44734d5e3`) — the NVStreamer upload 404 from
  `/api/v1/storage/file` being rewritten — and scoped the fix to `/storage`, saying so
  plainly in the PR body: *"Only `/storage` is anchored. All other ingress rewrite rules
  remain unchanged."* That was a defensible call for a fix going in under a bug; this PR is
  the wider version of it, which is why I would like your agreement rather than your review
  after the fact.
- **@trannguyenanhhien** wrote this exact universal fix independently the same day, from the
  same base commit, as `7c031e3a4` on `origin/fix/helm-issue` — template, verifier and all
  three example files. He never opened a PR and approved the narrower version instead. The
  explanatory comment in `_ingress-routes.tpl` here is his text, lightly extended to say why
  there is no opt-out; the `rewrite_mount()` helper is the same logic as his surplus fix.

### Where I could be wrong

The whole change rests on "no route wants a mid-path match." I checked all 11 rewriting rows
and found none that does. If any of these is meant to match mid-path, anchoring it is a
regression and I would rather hear that now:

`/storage` `/va-mcp` `/alert-bridge` `/video-analytics-api` `/elasticsearch` `/rtvi-vlm`
`/rtvi-cv` `/rtvi-embed` `/lvs` `/phoenix` `/llm`

The second thing worth a second opinion is the reduced workflow. If you would rather see the
kind-based live pass land with it in one PR instead of following in #1983, I will fold it in.
