### PR TITLE
fix(warehouse): stop few-shot timestamps from pinning incident querie…

### DIFF
--- a/deploy/docker/industry-profiles/warehouse-operations/vss-agent/configs/config.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/vss-agent/configs/config.yml
@@ -288,33 +288,22 @@ workflow:
     - User wants incident summaries or aggregated view
     - User wants to see incident statistics/charts
 
-    The system message includes "current time: <ISO timestamp>".
-    That value is NOW. Compute every start_time/end_time from it.
-    NEVER copy timestamps from this prompt.
+    The system message includes "current time: <ISO timestamp>" (NOW).
+    Compute any start_time/end_time from it; never copy dates from this prompt.
 
     multi_report_agent parameters (pass as DIRECT fields, NOT in additional_context):
-    - user_query: The original user question (REQUIRED)
-    - sensor_id: The sensor ID (REQUIRED)
-    - start_time: Start of time range (optional). Omit for "last N incidents"
-      so the tool returns the most recent incidents.
-    - end_time: End of time range (optional). Omit together with start_time
-      for "last N incidents".
-    - max_result_size: Number of incidents to return (use N for "last N")
+    - source: sensor or place ID (REQUIRED)
+    - source_type: "sensor" or "place" (REQUIRED; use "sensor" for cameras)
+    - start_time, end_time: optional ISO timestamps. Omit both for last-N / most recent.
+    - max_result_size: N when the user asks for last N
     - vlm_verified: true only if the current message asks for verified/VLM verified incidents; otherwise omit
 
-    Example tool call for "List the last 3 incidents for Camera_01"
-    (omit times; do NOT invent a historical date):
+    Example (last 3 incidents, no time window):
     {{
-      "user_query": "List the last 3 incidents for Camera_01",
-      "sensor_id": "Camera_01",
+      "source": "Camera_01",
+      "source_type": "sensor",
       "max_result_size": 3
     }}
-
-    If a time window is required (charts, "last hour", pagination with an
-    explicit range), compute it from NOW:
-    - end_time = the current time from this prompt
-    - start_time = NOW minus the requested duration (default 24 hours
-      when the user asks for last N incidents but a window is needed)
 
     Example user queries for multi_report_agent:
     - "List all incidents from sensor X in the last hour"
@@ -331,7 +320,7 @@ workflow:
        previous multi_report_agent call
     3. Extract the LAST incident's timestamp from that block
        (look for the last incident entry)
-    4. Extract the sensor_id that was used in the
+    4. Extract the source and source_type from the
        previous query
     5. Do NOT reuse vlm_verified from prior turns; set it only from the current message (see PARAMETER EXTRACTION)
     6. Calculate new time range:
@@ -374,15 +363,15 @@ workflow:
 
     PARAMETER EXTRACTION:
     - vlm_verified (current query only): Set vlm_verified=true when the **current** user message explicitly asks for "verified" or "VLM verified" incidents or reports (e.g. "Generate a verified incident report for incident X"). If the current message does not mention verified, omit vlm_verified (do not pass true or false; use default). Never inherit vlm_verified from prior turns — e.g. after a verified-incidents request, "list all incidents" means regular incidents (omit vlm_verified).
-    - If sensor_id is not provided AND there is no previous query context, use vst_sensor_list to show available sensors and ask user to choose
+    - If source is not provided AND there is no previous query context, use vst_sensor_list to show available sensors and ask user to choose
     - Parse time expressions like "last 5 minutes", "yesterday", "between 2pm-3pm" into ISO timestamps
-    - Extract max_incidents from phrases like "last 5", "show 10", etc.
+    - Extract max_result_size from phrases like "last 5", "show 10", etc.
 
     CONVERSATION HISTORY & CONTEXT EXTRACTION:
     - The conversation history includes a "PRESERVED STRUCTURED DATA" section that contains <incidents> blocks
     - Each <incidents> block is a JSON structure with incident details including timestamps
     - When user asks for "next", "more", or refers to "the Nth incident", look in this preserved data
-    - Extract sensor_id, timestamps, and incident_ids from these blocks to provide context continuity
+    - Extract source, timestamps, and incident_ids from these blocks to provide context continuity
     - This allows you to support follow-up queries without asking the user to repeat information
 
     TIME CALCULATION RULES (IMPORTANT - BE CAREFUL WITH MATH):

--- a/deploy/docker/industry-profiles/warehouse-operations/vss-agent/configs/config.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/vss-agent/configs/config.yml
@@ -288,20 +288,33 @@ workflow:
     - User wants incident summaries or aggregated view
     - User wants to see incident statistics/charts
 
+    The system message includes "current time: <ISO timestamp>".
+    That value is NOW. Compute every start_time/end_time from it.
+    NEVER copy timestamps from this prompt.
+
     multi_report_agent parameters (pass as DIRECT fields, NOT in additional_context):
     - user_query: The original user question (REQUIRED)
     - sensor_id: The sensor ID (REQUIRED)
-    - start_time: Start of time range (datetime, REQUIRED)
-    - end_time: End of time range (datetime, REQUIRED)
+    - start_time: Start of time range (optional). Omit for "last N incidents"
+      so the tool returns the most recent incidents.
+    - end_time: End of time range (optional). Omit together with start_time
+      for "last N incidents".
+    - max_result_size: Number of incidents to return (use N for "last N")
     - vlm_verified: true only if the current message asks for verified/VLM verified incidents; otherwise omit
 
-    Example tool call:
+    Example tool call for "List the last 3 incidents for Camera_01"
+    (omit times; do NOT invent a historical date):
     {{
-      "user_query": "List the last 5 incidents for Camera_01",
+      "user_query": "List the last 3 incidents for Camera_01",
       "sensor_id": "Camera_01",
-      "start_time": "2025-11-13T16:00:00.000Z",
-      "end_time": "2025-11-13T17:00:00.000Z"
+      "max_result_size": 3
     }}
+
+    If a time window is required (charts, "last hour", pagination with an
+    explicit range), compute it from NOW:
+    - end_time = the current time from this prompt
+    - start_time = NOW minus the requested duration (default 24 hours
+      when the user asks for last N incidents but a window is needed)
 
     Example user queries for multi_report_agent:
     - "List all incidents from sensor X in the last hour"
@@ -344,13 +357,11 @@ workflow:
     - end_time: End of time range (optional, for finding last incident)
     - vlm_verified: true when the current message asks for a verified/VLM verified incident report; otherwise omit
 
-    Example tool call:
+    Example tool call for "last incident" (omit times so the tool
+    finds the most recent; do NOT invent a historical date):
     {{
-      "user_query": "Generate a detailed report for the
-        last incident at Camera_01",
-      "sensor_id": "Camera_01",
-      "start_time": "2025-11-13T16:00:00.000Z",
-      "end_time": "2025-11-13T17:00:00.000Z"
+      "user_query": "Generate a detailed report for the last incident at Camera_01",
+      "sensor_id": "Camera_01"
     }}
 
     Example user queries for report_agent:
@@ -375,10 +386,14 @@ workflow:
     - This allows you to support follow-up queries without asking the user to repeat information
 
     TIME CALCULATION RULES (IMPORTANT - BE CAREFUL WITH MATH):
+    - NOW is the "current time" ISO timestamp in this system message.
+      Use that clock. Never reuse example dates from this prompt.
+    - "last N incidents" (no time range given): OMIT start_time and
+      end_time; set max_result_size = N.
     - "last X minutes" means: end_time = NOW, start_time = NOW - X minutes
-      Example: If NOW is 20:35:00, "last 20 minutes" means 20:15:00 to 20:35:00
     - "last X hours" means: end_time = NOW, start_time = NOW - X hours
-      Example: If NOW is 20:35:00, "last 2 hours" means 18:35:00 to 20:35:00
+    - "today" means: start_time = today 00:00:00.000Z, end_time = NOW
+      (date taken from the current time in this prompt)
     - ALWAYS double-check your time calculations before making tool calls
     - Time format: YYYY-MM-DDTHH:MM:SS.sssZ (ISO 8601 with milliseconds and Z timezone)
 
@@ -387,9 +402,8 @@ workflow:
     (start_time, end_time), you MUST use this exact format:
     YYYY-MM-DDTHH:MM:SS.sssZ
 
-    Examples:
-    - 2020-01-01T00:00:00.000Z
-    - 2025-11-12T14:19:30.000Z
+    Use the current time from this prompt as the template.
+    Do not copy calendar dates from this prompt.
 
     NEVER use formats like "2020-01-01T00:00:00+00:00" or "2020-01-01T00:00:00Z"
     ALWAYS include milliseconds (.000) and use Z for timezone

--- a/deploy/helm/industry-profiles/warehouse-operations/warehouse-2d-app/configs/vss-agent/config.yml
+++ b/deploy/helm/industry-profiles/warehouse-operations/warehouse-2d-app/configs/vss-agent/config.yml
@@ -430,8 +430,10 @@ workflow:
          * action="get_incidents": Query detected incidents (requires sensor_name)
          * action="get_sensor_uuid": Get UUID for a sensor name (required before incident_report_agent)
        - For get_incidents, optional parameters:
-         * start_time, end_time: ISO 8601 format
-         * max_count: number of incidents (default 10)
+         * start_time, end_time: ISO 8601 format computed from the
+           "current time" in this prompt. Omit both for "last N incidents"
+           so the tool returns the most recent.
+         * max_count: number of incidents (use N for "last N"; default 10)
        - Returns: Id, timestamp, end, sensorId, plus category and info when present
        - Use when: User asks "show alerts", "list incidents", "start/stop monitoring"
 
@@ -453,12 +455,19 @@ workflow:
     When calling ANY tool that requires timestamps (start_time, end_time), you MUST use this exact format:
     YYYY-MM-DDTHH:MM:SS.sssZ.
 
-    If user does not specify time range when asking to retrieve a video or to generate a report, assume
-    start_time=jan 1 2025 and end_time is the current time. Otherwise, use the time range provided by the user.
+    NOW is the "current time" ISO timestamp in this system message.
+    NEVER copy calendar dates from this prompt.
 
-    Examples:
-    - 2020-01-01T00:00:00.000Z
-    - 2025-11-12T14:19:30.000Z
+    If the user does not specify a time range:
+    - For "last N incidents" / "last incident": omit start_time and end_time
+      (most recent). Set max_count = N when listing.
+    - For retrieve-video or generate-report with no range: end_time = NOW,
+      start_time = NOW minus 24 hours.
+    Otherwise, use the time range provided by the user, computed from NOW
+    (e.g. "last hour" = NOW minus 1 hour through NOW; "today" = today 00:00:00.000Z through NOW).
+
+    Use the current time from this prompt as the timestamp template.
+    Do not copy example dates from this prompt.
 
     NEVER use formats like "2020-01-01T00:00:00+00:00" or "2020-01-01T00:00:00Z"
     ALWAYS include milliseconds (.000) and use Z for timezone

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/incidents.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/incidents.py
@@ -91,8 +91,14 @@ class VARetrievalInput(BaseModel):
     )
 
     # High-level incident retrieval mode
-    start_time: str | None = Field(None, description="Start time in ISO format (e.g., 2025-11-13T16:00:00.000Z)")
-    end_time: str | None = Field(None, description="End time in ISO format (e.g., 2025-11-13T17:00:00.000Z)")
+    start_time: str | None = Field(
+        None,
+        description="Start time in ISO 8601 UTC with milliseconds (YYYY-MM-DDTHH:MM:SS.sssZ). Omit with end_time to fetch the most recent incidents.",
+    )
+    end_time: str | None = Field(
+        None,
+        description="End time in ISO 8601 UTC with milliseconds (YYYY-MM-DDTHH:MM:SS.sssZ). Omit with start_time to fetch the most recent incidents.",
+    )
     source: str | None = Field(None, description="Source ID (e.g., sensor ID or place ID)")
     source_type: str | None = Field(None, description="Source type: 'sensor' or 'place'")
     max_count: int = Field(10, description="Maximum number of incidents to return")
@@ -411,8 +417,8 @@ async def va_retrieval(config: VARetrievalConfig, _builder: Builder) -> AsyncGen
         sql_query: SQL query string (required if action='query')
 
     High-level Mode Input:
-        start_time: ISO timestamp (e.g., "2025-11-13T16:00:00.000Z")
-        end_time: ISO timestamp
+        start_time: ISO 8601 UTC timestamp with milliseconds (YYYY-MM-DDTHH:MM:SS.sssZ)
+        end_time: ISO 8601 UTC timestamp with milliseconds; omit both times to fetch most recent incidents
         source: sensor ID or place ID (optional)
         source_type: 'sensor' or 'place' (optional)
         max_count: maximum incidents to return (default: 10)


### PR DESCRIPTION
Teach last-N incident tool calls to omit times (or compute from the injected current time) instead of copying stale example ISO dates.

Fixes CI/CD failures

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
