### PR TITLE
fix(osrb): resolve licences across versions, and stop three false findings

### DIFF
--- a/.github/osrb/inventory.csv
+++ b/.github/osrb/inventory.csv
@@ -643,9 +643,9 @@ actions/download-artifact,d3f86a106a0bac45b974a628896c90dbdf5c8093,MIT,.github,g
 actions/setup-node,48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e,MIT,.github,github-action,ci,.github/workflows/fern-docs-ci.yml,ci,no,no,no,ci-tooling,None
 actions/setup-node,49933ea5288caeca8642d1e84afbd3f7d6820020,MIT,.github,github-action,ci,.github/workflows/ci.yml,ci,no,no,no,ci-tooling,None
 actions/setup-python,a26af69be951a213d495a4c3e4e4022e16d87065,MIT,.github,github-action,ci,.github/workflows/ci.yml,ci,no,no,no,ci-tooling,None
-actions/setup-python,ece7cb06caefa5fff74198d8649806c4678c61a1,UNKNOWN,.github,github-action,ci,.github/workflows/osrb-scan.yml,ci,no,no,no,ci-tooling,Unknown
+actions/setup-python,ece7cb06caefa5fff74198d8649806c4678c61a1,MIT,.github,github-action,ci,.github/workflows/osrb-scan.yml,ci,no,no,no,ci-tooling,None
 actions/setup-python,v5,MIT,.github,github-action,ci,.github/workflows/helm-sync.yml,ci,no,no,no,ci-tooling,None
-actions/upload-artifact,b7c566a772e6b6bfb58ed0dc250532a479d7789f,UNKNOWN,.github,github-action,ci,.github/workflows/osrb-scan.yml,ci,no,no,no,ci-tooling,Unknown
+actions/upload-artifact,b7c566a772e6b6bfb58ed0dc250532a479d7789f,MIT,.github,github-action,ci,.github/workflows/osrb-scan.yml,ci,no,no,no,ci-tooling,None
 actions/upload-artifact,ea165f8d65b6e75b540449e92b4886f43607fa02,MIT,.github,github-action,ci,.github/workflows/build-dev-images.yml,ci,no,no,no,ci-tooling,None
 actions/upload-artifact,v4,MIT,.github,github-action,ci,.github/workflows/skills-eval-daily.yml,ci,no,no,no,ci-tooling,None
 agent-base,6.0.2,MIT,services/vios,node,lockfile,services/vios/ui/vios-ui/package-lock.json,runtime,no,no,no,declared-manifest,None
@@ -715,7 +715,7 @@ anyio,4.10.0,MIT,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/r
 anyio,4.12.1,MIT,services/vios,python,lockfile,services/vios/test/bdd_tests/poetry.lock,runtime,no,no,no,declared-manifest,None
 anyio,4.14.2,MIT,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
 anyio,4.14.2,MIT,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
-anyio,UNKNOWN,UNKNOWN,.github,python,usage,.github/skills-review/review_agent.py,runtime,no,no,no,imported-only,Unknown
+anyio,UNKNOWN,MIT,.github,python,usage,.github/skills-review/review_agent.py,runtime,no,no,no,imported-only,None
 anymatch,3.1.3,ISC,services/analytics/video-analytics-api,node,lockfile,services/analytics/video-analytics-api/test/package-lock.json,runtime,no,no,no,declared-manifest,None
 anymatch,3.1.3,ISC,services/ui,node,lockfile,services/ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 apache-tvm-ffi,0.1.7,Apache Software License,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pyproject.toml;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
@@ -778,8 +778,8 @@ autoconf,UNKNOWN,UNKNOWN,services/vios,deb,container,services/vios/cicd_files/x8
 automake,UNKNOWN,UNKNOWN,services/rtvi/rt-vlm,deb,container,services/rtvi/rt-vlm/docker/Dockerfile,runtime,no,no,yes,container-apt,Unknown
 autoprefixer,10.5.4,MIT,services/ui,node,lockfile,services/ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 av,16.0.1,BSD-3-Clause,services/vios,python,lockfile,services/vios/test/bdd_tests/poetry.lock,runtime,no,no,no,declared-manifest,None
-av,UNKNOWN,UNKNOWN,services/rtvi/rt-embed,python,usage,services/rtvi/rt-embed/src/models/openai_compat/openai_compat_model.py,runtime,no,no,no,imported-only,Unknown
-av,UNKNOWN,UNKNOWN,services/rtvi/rt-vlm,python,usage,services/rtvi/rt-vlm/src/models/openai_compat/openai_compat_model.py,runtime,no,no,no,imported-only,Unknown
+av,UNKNOWN,BSD-3-Clause,services/rtvi/rt-embed,python,usage,services/rtvi/rt-embed/src/models/openai_compat/openai_compat_model.py,runtime,no,no,no,imported-only,None
+av,UNKNOWN,BSD-3-Clause,services/rtvi/rt-vlm,python,usage,services/rtvi/rt-vlm/src/models/openai_compat/openai_compat_model.py,runtime,no,no,no,imported-only,None
 aws,UNKNOWN,Apache-2.0;GPL-2.0-only OR BSD-3-Clause,services/vios,c,usage;vendored,services/vios/include/3rdparty/aws;services/vios/src/framework/unified_storage/common/aws_sdk_manager.cpp,runtime,yes,UNKNOWN,no,imported-only;vendored-source,High
 aws4,1.13.2,MIT,services/vios,node,lockfile,services/vios/ui/vios-ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 axios,1.19.0,MIT,services/vios,node,lockfile,services/vios/ui/vios-ui/package-lock.json,runtime,no,no,no,declared-manifest,None
@@ -932,7 +932,7 @@ charset-normalizer,3.4.7,MIT,services/video-summarization,python,lockfile,servic
 charset-normalizer,3.4.9,MIT,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
 charset-normalizer,3.4.9,MIT,services/configurators/vss-configurator,python,lockfile,services/configurators/vss-configurator/uv.lock,runtime,no,no,no,declared-manifest,None
 charset-normalizer,3.4.9,MIT,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
-charset-normalizer,3.5.1,UNKNOWN,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
+charset-normalizer,3.5.1,MIT,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 check-error,1.0.3,MIT,services/analytics/video-analytics-api,node,lockfile,services/analytics/video-analytics-api/test/package-lock.json,runtime,no,no,no,declared-manifest,None
 chokidar,3.6.0,MIT,services/analytics/video-analytics-api,node,lockfile,services/analytics/video-analytics-api/test/package-lock.json,runtime,no,no,no,declared-manifest,None
 chokidar,3.6.0,MIT,services/ui,node,lockfile,services/ui/package-lock.json,runtime,no,no,no,declared-manifest,None
@@ -963,7 +963,7 @@ cliui,8.0.1,ISC,services/vios,node,lockfile,services/vios/ui/vios-ui/package-loc
 clone,2.1.2,MIT,services/analytics/video-analytics-api,node,lockfile,services/analytics/video-analytics-api/src/app/package-lock.json;services/analytics/video-analytics-api/src/web-api-core/package-lock.json;services/analytics/video-analytics-api/test/package-lock.json,runtime,no,no,no,declared-manifest,None
 clone-response,1.0.3,MIT,services/vios,node,lockfile,services/vios/ui/vios-ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 cloudpickle,3.1.2,BSD-3-Clause,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
-cloudpickle,UNKNOWN,UNKNOWN,services/rtvi/rt-vlm,python,usage,services/rtvi/rt-vlm/docker/rtvi_vlm/patches/evs_vllm_public_files/v1/serial_utils.py,runtime,no,no,no,imported-only,Unknown
+cloudpickle,UNKNOWN,BSD-3-Clause,services/rtvi/rt-vlm,python,usage,services/rtvi/rt-vlm/docker/rtvi_vlm/patches/evs_vllm_public_files/v1/serial_utils.py,runtime,no,no,no,imported-only,None
 clsx,1.2.1,MIT,services/vios,node,lockfile,services/vios/ui/vios-ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 clsx,2.1.1,MIT,services/ui,node,lockfile,services/ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 clsx,2.1.1,MIT,services/vios,node,lockfile,services/vios/ui/vios-ui/package-lock.json,runtime,no,no,no,declared-manifest,None
@@ -1077,7 +1077,7 @@ cuda-bindings,13.3.1,LicenseRef-NVIDIA-SOFTWARE-LICENSE,services/agent,python,lo
 cuda-crt-13-2,UNKNOWN,UNKNOWN,services/vios,deb,container,services/vios/cicd_files/aarch64/devel/Dockerfile,runtime,no,no,yes,container-apt,Unknown
 cuda-pathfinder,1.5.6,Apache-2.0,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 cuda-pathfinder,1.6.0,Apache-2.0,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
-cuda-pathfinder,1.7.0,UNKNOWN,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
+cuda-pathfinder,1.7.0,Apache-2.0,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 cuda-python,13.2.0,LicenseRef-NVIDIA-SOFTWARE-LICENSE,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/pyproject.toml;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,High
 cuda-python,13.2.0,LicenseRef-NVIDIA-SOFTWARE-LICENSE,services/rtvi/rt-vlm,python,container;lockfile;manifest,services/rtvi/rt-vlm/docker/Dockerfile;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pyproject.toml;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,container-pip;declared-manifest,High
 cuda-tile,1.2.0,Apache-2.0,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pyproject.toml;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
@@ -1341,9 +1341,9 @@ fast-levenshtein,2.0.6,MIT,services/vios,node,lockfile,services/vios/ui/streamin
 fast-safe-stringify,2.1.1,MIT,services/analytics/video-analytics-api,node,lockfile,services/analytics/video-analytics-api/test/package-lock.json,runtime,no,no,no,declared-manifest,None
 fast-uri,3.1.5,BSD-3-Clause,services/analytics/video-analytics-api,node,lockfile,services/analytics/video-analytics-api/src/web-api-core/package-lock.json;services/analytics/video-analytics-api/test/package-lock.json,runtime,no,no,no,declared-manifest,None
 fast-uri,3.1.5,BSD-3-Clause,services/vios,node,lockfile,services/vios/ui/vios-ui/package-lock.json,runtime,no,no,no,declared-manifest,None
-fastapi,0.136.3,UNKNOWN,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/pyproject.toml;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
+fastapi,0.136.3,MIT,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/pyproject.toml;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 fastapi,0.139.2,MIT,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
-fastapi,0.141.1,UNKNOWN,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pyproject.toml;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
+fastapi,0.141.1,MIT,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pyproject.toml;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 fastapi,UNKNOWN,MIT,services/alert,python,manifest,services/alert/requirements.txt,runtime,no,no,no,declared-manifest,None
 fastapi,UNKNOWN,MIT,services/video-summarization,python,usage,services/video-summarization/src/via_server.py,runtime,no,no,no,imported-only,None
 fastapi,UNKNOWN,MIT,skills/operations,python,manifest,skills/operations/vss-manage-alerts/scripts/alert-notify/requirements.txt,runtime,no,no,no,declared-manifest,None
@@ -1366,7 +1366,7 @@ file-type,21.3.4,MIT,services/ui,node,lockfile,services/ui/package-lock.json,run
 filelist,1.0.6,Apache-2.0,services/vios,node,lockfile,services/vios/ui/vios-ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 filelock,3.29.7,MIT,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 filelock,3.32.0,MIT,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
-filelock,3.32.4,UNKNOWN,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
+filelock,3.32.4,MIT,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 filename-reserved-regex,4.0.0,MIT,services/ui,node,lockfile,services/ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 filenamify,7.0.2,MIT,services/ui,node,lockfile,services/ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 filetype,1.2.0,MIT License,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
@@ -1502,7 +1502,7 @@ goober,2.1.19,MIT,services/ui,node,lockfile,services/ui/package-lock.json,runtim
 goober,2.1.19,MIT,services/vios,node,lockfile,services/vios/ui/vios-ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 google-api-core,2.34.0,Apache Software License,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 google-auth,2.53.0,Apache-2.0,services/sdrc,python,lockfile,services/sdrc/uv.lock,runtime,no,no,no,declared-manifest,None
-google-auth,2.57.0,UNKNOWN,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
+google-auth,2.57.0,Apache-2.0,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 google-crc32c,1.7.1,Apache 2.0,services/vios,python,lockfile,services/vios/test/bdd_tests/poetry.lock,runtime,no,no,no,declared-manifest,None
 google-protobuf,UNKNOWN,UNKNOWN,services/analytics/video-analytics-api,node,usage,services/analytics/video-analytics-api/src/web-api-core/schemas/proto/schema_pb.js,runtime,no,no,no,imported-only,Unknown
 google-protobuf,UNKNOWN,UNKNOWN,deploy,ruby,usage,deploy/docker/services/infra/elk/logstash/pb_definitions/ruby/ext_pb.rb,runtime,no,no,no,imported-only,Unknown
@@ -1626,7 +1626,7 @@ httpx-sse,0.4.3,MIT,services/agent,python,lockfile,services/agent/uv.lock,runtim
 httpx-sse,0.4.3,MIT,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 huggingface-hub,0.36.2,Apache Software License,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 huggingface-hub,1.24.0,Apache Software License,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
-huggingface-hub,1.28.0,UNKNOWN,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
+huggingface-hub,1.28.0,Apache Software License,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 huggingface_hub,0.36.2,Apache,services/rtvi/rt-cv,python,container,services/rtvi/rt-cv/docker/Dockerfile,runtime,no,no,yes,container-pip,None
 human-signals,2.1.0,Apache-2.0,services/ui,node,lockfile,services/ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 human-signals,5.0.0,Apache-2.0,services/ui,node,lockfile,services/ui/package-lock.json,runtime,no,no,no,declared-manifest,None
@@ -1648,7 +1648,7 @@ idna,3.18,BSD-3-Clause,services/agent,python,lockfile,services/agent/uv.lock,run
 idna,3.18,BSD-3-Clause,services/configurators/vss-configurator,python,lockfile,services/configurators/vss-configurator/uv.lock,runtime,no,no,no,declared-manifest,None
 idna,3.18,BSD-3-Clause,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 idna,3.18,BSD-3-Clause,services/vios,python,lockfile,services/vios/test/bdd_tests/poetry.lock,runtime,no,no,no,declared-manifest,None
-idna,3.19,UNKNOWN,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
+idna,3.19,BSD-3-Clause,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 ieee754,1.2.1,BSD-3-Clause,services/ui,node,lockfile,services/ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 ifaddr,0.2.0,MIT License,services/vios,python,lockfile,services/vios/test/bdd_tests/poetry.lock,runtime,no,no,no,declared-manifest,None
 ignore,5.3.2,MIT,services/vios,node,lockfile,services/vios/ui/streaming-lib/package-lock.json;services/vios/ui/vios-ui/package-lock.json,runtime,no,no,no,declared-manifest,None
@@ -1816,9 +1816,9 @@ joblib,1.5.3,BSD-3-Clause,services/rtvi/rt-vlm,python,lockfile;manifest,services
 joserfc,1.7.4,BSD-3-Clause,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
 jpeginfo,UNKNOWN,UNKNOWN,services/vios,deb,container,services/vios/test/bdd_tests/Dockerfile,runtime,no,no,yes,container-apt,Unknown
 jq,1.7.1-6+deb13u2,MIT,libs/analytics/spatialai-data-utils,deb,container,libs/analytics/spatialai-data-utils/docker/Dockerfile,runtime,no,no,yes,container-apt,None
-jq,1.7.1-6+deb13u3,UNKNOWN,services/analytics/behavior-analytics,deb,container,services/analytics/behavior-analytics/docker/Dockerfile,runtime,no,no,yes,container-apt,Unknown
-jq,UNKNOWN,UNKNOWN,services/rtvi/rt-cv-3d/rt-cv-bev-fusion,deb,container,services/rtvi/rt-cv-3d/rt-cv-bev-fusion/Dockerfiles/measurement-fusion.Dockerfile,runtime,no,no,yes,container-apt,Unknown
-jq,UNKNOWN,UNKNOWN,services/rtvi/rt-cv-3d/rt-cv-config-init,deb,container,services/rtvi/rt-cv-3d/rt-cv-config-init/Dockerfiles/mv3dt-config-init.Dockerfile,runtime,no,no,yes,container-apt,Unknown
+jq,1.7.1-6+deb13u3,MIT,services/analytics/behavior-analytics,deb,container,services/analytics/behavior-analytics/docker/Dockerfile,runtime,no,no,yes,container-apt,None
+jq,UNKNOWN,MIT,services/rtvi/rt-cv-3d/rt-cv-bev-fusion,deb,container,services/rtvi/rt-cv-3d/rt-cv-bev-fusion/Dockerfiles/measurement-fusion.Dockerfile,runtime,no,no,yes,container-apt,None
+jq,UNKNOWN,MIT,services/rtvi/rt-cv-3d/rt-cv-config-init,deb,container,services/rtvi/rt-cv-3d/rt-cv-config-init/Dockerfiles/mv3dt-config-init.Dockerfile,runtime,no,no,yes,container-apt,None
 js-tokens,10.0.0,MIT,services/vios,node,lockfile,services/vios/ui/streaming-lib/package-lock.json,runtime,no,no,no,declared-manifest,None
 js-tokens,4.0.0,MIT,services/analytics/video-analytics-api,node,lockfile,services/analytics/video-analytics-api/test/package-lock.json,runtime,no,no,no,declared-manifest,None
 js-tokens,4.0.0,MIT,services/ui,node,lockfile,services/ui/package-lock.json,runtime,no,no,no,declared-manifest,None
@@ -1917,7 +1917,7 @@ langgraph-checkpoint,4.1.1,MIT,services/agent,python,lockfile,services/agent/uv.
 langgraph-prebuilt,1.1.0,MIT,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
 langgraph-sdk,0.4.2,MIT,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
 langsmith,0.10.10,MIT,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
-langsmith,0.11.1,UNKNOWN,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
+langsmith,0.11.1,MIT,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 langsmith,0.4.31,MIT,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 lap,0.5.12,BSD-2-Clause,libs/analytics/spatialai-data-utils,python,lockfile;manifest,libs/analytics/spatialai-data-utils/Pipfile.lock;libs/analytics/spatialai-data-utils/release/pyproject.toml,runtime,no,no,no,declared-manifest,None
 lap,0.5.12,BSD-2-Clause,services/configurators/vss-configurator,python,lockfile,services/configurators/vss-configurator/uv.lock,runtime,no,no,no,declared-manifest,None
@@ -1944,7 +1944,7 @@ libcurl4,UNKNOWN,UNKNOWN,services/vios,deb,container,services/vios/cicd_files/aa
 libcurl4-openssl-dev,UNKNOWN,UNKNOWN,services/vios,deb,container,services/vios/cicd_files/x86_64/devel/Dockerfile.devel,runtime,no,no,yes,container-apt,Unknown
 libcuvs-linux-x86_64-26.04.00.194111_cuda13-archive.tar.xz,UNKNOWN,UNKNOWN,deploy,source,container,deploy/docker/services/infra/Dockerfiles/elasticsearch-gpu.Dockerfile,runtime,no,no,no,build-fetch,Unknown
 libgdal-dev,3.10.3+dfsg-1,MIT,libs/analytics/spatialai-data-utils,deb,container,libs/analytics/spatialai-data-utils/docker/Dockerfile,runtime,no,no,yes,container-apt,None
-libgdal-dev,UNKNOWN,UNKNOWN,services/analytics/behavior-analytics,deb,container,services/analytics/behavior-analytics/docker/Dockerfile,runtime,no,no,yes,container-apt,Unknown
+libgdal-dev,UNKNOWN,MIT,services/analytics/behavior-analytics,deb,container,services/analytics/behavior-analytics/docker/Dockerfile,runtime,no,no,yes,container-apt,None
 libgirepository-2.0-dev,UNKNOWN,UNKNOWN,services/rtvi/rt-vlm,deb,container,services/rtvi/rt-vlm/docker/Dockerfile,runtime,no,no,yes,container-apt,Unknown
 libgl1,1.7.0-1+b2,MIT,libs/analytics/spatialai-data-utils,deb,container,libs/analytics/spatialai-data-utils/docker/Dockerfile,runtime,no,no,yes,container-apt,None
 libglib2.0-0t64,2.84.4-3~deb13u3,LGPL-2.1-or-later,libs/analytics/spatialai-data-utils,deb,container,libs/analytics/spatialai-data-utils/docker/Dockerfile,runtime,no,no,yes,container-apt,Medium
@@ -1952,7 +1952,7 @@ libglib2.0-dev,UNKNOWN,UNKNOWN,services/rtvi/rt-embed,deb,container,services/rtv
 libglib2.0-dev,UNKNOWN,UNKNOWN,services/rtvi/rt-vlm,deb,container,services/rtvi/rt-vlm/docker/Dockerfile,runtime,no,no,yes,container-apt,Unknown
 libglib2.0-dev-bin,UNKNOWN,UNKNOWN,services/rtvi/rt-vlm,deb,container,services/rtvi/rt-vlm/docker/Dockerfile,runtime,no,no,yes,container-apt,Unknown
 libgomp1,14.2.0-19,LGPL-3.0,libs/analytics/spatialai-data-utils,deb,container,libs/analytics/spatialai-data-utils/docker/Dockerfile,runtime,no,no,yes,container-apt,Medium
-libgomp1,UNKNOWN,UNKNOWN,deploy,deb,container,deploy/docker/services/infra/Dockerfiles/elasticsearch-gpu.Dockerfile,runtime,no,no,yes,container-apt,Unknown
+libgomp1,UNKNOWN,LGPL-3.0,deploy,deb,container,deploy/docker/services/infra/Dockerfiles/elasticsearch-gpu.Dockerfile,runtime,no,no,yes,container-apt,Medium
 libgrpc++1.51t64,UNKNOWN,UNKNOWN,services/vios,deb,container,services/vios/cicd_files/aarch64/Dockerfile.base,runtime,no,no,yes,container-apt,Unknown
 libgstreamer-plugins-base1.0-0,UNKNOWN,UNKNOWN,services/vios,deb,container,services/vios/cicd_files/aarch64/Dockerfile.base,runtime,no,no,yes,container-apt,Unknown
 libgstreamer-plugins-base1.0-dev,UNKNOWN,UNKNOWN,services/rtvi/rt-embed,deb,container,services/rtvi/rt-embed/docker/Dockerfile,runtime,no,no,yes,container-apt,Unknown
@@ -2204,7 +2204,7 @@ mkdirp,3.0.1,MIT,services/analytics/video-analytics-api,node,lockfile,services/a
 mkl,2021.1.1,Other/Proprietary License,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/pyproject.toml;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,High
 mkl,2021.1.1,Other/Proprietary License,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pyproject.toml;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,High
 ml-dtypes,0.5.4,Apache-2.0,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
-ml-dtypes,0.6.0,UNKNOWN,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
+ml-dtypes,0.6.0,Apache-2.0,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 mmh3,5.2.1,MIT License,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
 mocha,10.8.2,MIT,services/analytics/video-analytics-api,node,lockfile,services/analytics/video-analytics-api/test/package-lock.json,runtime,no,no,no,declared-manifest,None
 mocha-junit-reporter,2.2.1,MIT,services/analytics/video-analytics-api,node,lockfile,services/analytics/video-analytics-api/test/package-lock.json,runtime,no,no,no,declared-manifest,None
@@ -2240,7 +2240,7 @@ nanoid,3.3.18,MIT,services/ui,node,lockfile,services/ui/package-lock.json,runtim
 napi-postinstall,0.3.4,MIT,services/ui,node,lockfile,services/ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 narwhals,2.24.0,MIT,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
 narwhals,2.24.0,MIT,services/configurators/vss-configurator,python,lockfile,services/configurators/vss-configurator/uv.lock,runtime,no,no,no,declared-manifest,None
-narwhals,2.25.0,UNKNOWN,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
+narwhals,2.25.0,MIT,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 natural-compare,1.4.0,MIT,services/ui,node,lockfile,services/ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 natural-compare,1.4.0,MIT,services/vios,node,lockfile,services/vios/ui/streaming-lib/package-lock.json;services/vios/ui/vios-ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 nbclient,UNKNOWN,UNKNOWN,deploy,python,usage,deploy/docker/scripts/run_setup_notebook.py,runtime,no,no,no,imported-only,Unknown
@@ -2261,8 +2261,8 @@ next-runtime-env,1.8.0,MIT,services/ui,node,lockfile,services/ui/package-lock.js
 ngcsdk,3.64.2,Apache Software License,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/pyproject.toml;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 ngcsdk,3.64.2,Apache Software License,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pyproject.toml;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 ninja,1.11.1.1,Apache-2.0,libs/analytics/spatialai-data-utils,python,container,libs/analytics/spatialai-data-utils/docker/Dockerfile,runtime,no,no,yes,container-pip,None
-ninja,1.13.0,UNKNOWN,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
-ninja,1.13.0,UNKNOWN,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
+ninja,1.13.0,Apache-2.0,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
+ninja,1.13.0,Apache-2.0,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 ninja-build,UNKNOWN,UNKNOWN,services/agent,deb,container,services/agent/docker/Dockerfile,runtime,no,no,yes,container-apt,Unknown
 ninja-build,UNKNOWN,UNKNOWN,services/rtvi/rt-vlm,deb,container,services/rtvi/rt-vlm/docker/Dockerfile,runtime,no,no,yes,container-apt,Unknown
 nise,6.1.5,BSD-3-Clause,services/analytics/video-analytics-api,node,lockfile,services/analytics/video-analytics-api/test/package-lock.json,runtime,no,no,no,declared-manifest,None
@@ -2366,7 +2366,7 @@ nvidia-nat-profiler,1.8.0,Apache-2.0,services/agent,python,lockfile,services/age
 nvidia-nat-s3,1.8.0,Apache-2.0,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
 nvidia-nccl-cu13,2.29.7,UNKNOWN,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,Unknown
 nvidia-nvshmem-cu13,3.4.5,BSD-3-Clause,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
-nvidia-nvshmem-cu13,3.7.2,UNKNOWN,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
+nvidia-nvshmem-cu13,3.7.2,BSD-3-Clause,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 nvidia-rag,2.6.0,Apache-2.0,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
 nvidia-riva-client,UNKNOWN,UNKNOWN,services/rtvi/rt-embed,python,usage,services/rtvi/rt-embed/src/vlm_pipeline/video_file_frame_getter.py,runtime,no,no,no,imported-only,Unknown
 nvidia-riva-client,UNKNOWN,UNKNOWN,services/rtvi/rt-vlm,python,usage,services/rtvi/rt-vlm/src/vlm_pipeline/video_file_frame_getter.py,runtime,no,no,no,imported-only,Unknown
@@ -2492,9 +2492,9 @@ optionator,0.9.4,MIT,services/vios,node,lockfile,services/vios/ui/streaming-lib/
 org.apache.commons:commons-lang3,3.7,Apache-2.0,tools/logstash-plugins,java,manifest,tools/logstash-plugins/input/redis-stream/build.gradle,runtime,no,no,no,declared-manifest,None
 org.apache.logging.log4j:log4j-api,2.25.4,Apache-2.0,tools/logstash-plugins,java,manifest,tools/logstash-plugins/input/redis-stream/build.gradle,runtime,no,no,no,declared-manifest,None
 org.apache.logging.log4j:log4j-core,2.25.4,Apache-2.0,tools/logstash-plugins,java,manifest,tools/logstash-plugins/input/redis-stream/build.gradle,runtime,no,no,no,declared-manifest,None
-orjson,3.11.2,UNKNOWN,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
+orjson,3.11.2,MPL-2.0 AND (Apache-2.0 OR MIT),services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Medium
 orjson,3.11.9,MPL-2.0 AND (Apache-2.0 OR MIT),services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,Medium
-orjson,3.12.0,UNKNOWN,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
+orjson,3.12.0,MPL-2.0 AND (Apache-2.0 OR MIT),services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Medium
 ormsgpack,1.12.2,Apache-2.0 OR MIT,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
 oscrypto,1.3.0,MIT,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
 osmnx,2.1.0,MIT,services/analytics/behavior-analytics,python,lockfile,services/analytics/behavior-analytics/Pipfile.lock,runtime,no,no,no,declared-manifest,None
@@ -2520,9 +2520,9 @@ p-try,2.2.0,MIT,services/ui,node,lockfile,services/ui/package-lock.json,runtime,
 package-hash,4.0.0,ISC,services/analytics/video-analytics-api,node,lockfile,services/analytics/video-analytics-api/test/package-lock.json,runtime,no,no,no,declared-manifest,None
 package-json-from-dist,1.0.1,BlueOak-1.0.0,services/ui,node,lockfile,services/ui/package-lock.json,runtime,no,no,no,declared-manifest,Unknown
 package-json-from-dist,1.0.1,BlueOak-1.0.0,services/vios,node,lockfile,services/vios/ui/streaming-lib/package-lock.json,runtime,no,no,no,declared-manifest,Unknown
-packaging,25.0,UNKNOWN,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
-packaging,25.0,UNKNOWN,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
-packaging,25.0,UNKNOWN,services/vios,python,lockfile,services/vios/test/bdd_tests/poetry.lock,runtime,no,no,no,declared-manifest,Unknown
+packaging,25.0,Apache-2.0 OR BSD-2-Clause,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
+packaging,25.0,Apache-2.0 OR BSD-2-Clause,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
+packaging,25.0,Apache-2.0 OR BSD-2-Clause,services/vios,python,lockfile,services/vios/test/bdd_tests/poetry.lock,runtime,no,no,no,declared-manifest,None
 packaging,26.2,Apache-2.0 OR BSD-2-Clause,libs/analytics/spatialai-data-utils,python,lockfile,libs/analytics/spatialai-data-utils/Pipfile.lock,runtime,no,no,no,declared-manifest,None
 packaging,26.2,Apache-2.0 OR BSD-2-Clause,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
 packaging,26.2,Apache-2.0 OR BSD-2-Clause,services/analytics/behavior-analytics,python,lockfile,services/analytics/behavior-analytics/Pipfile.lock,runtime,no,no,no,declared-manifest,None
@@ -2611,7 +2611,7 @@ pkg-dir,4.2.0,MIT,services/ui,node,lockfile,services/ui/package-lock.json,runtim
 pkginfo,1.12.1.2,MIT,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
 pkijs,3.4.0,BSD-3-Clause,services/vios,node,lockfile,services/vios/ui/vios-ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 platformdirs,4.11.0,MIT,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
-platformdirs,4.11.4,UNKNOWN,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
+platformdirs,4.11.4,MIT,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 playwright,1.61.0,Apache-2.0,services/vios,python,lockfile,services/vios/test/bdd_tests/poetry.lock,runtime,no,no,no,declared-manifest,None
 plist,3.1.0,MIT,services/vios,node,lockfile,services/vios/ui/vios-ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 pluggy,1.5.0,MIT License,services/vios,python,lockfile,services/vios/test/bdd_tests/poetry.lock,runtime,no,no,no,declared-manifest,None
@@ -2706,7 +2706,7 @@ pyaml_env,UNKNOWN,UNKNOWN,services/video-summarization,python,usage,services/vid
 pyarrow,23.0.1,Apache-2.0,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
 pyasn1,0.6.3,BSD-2-Clause,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pyproject.toml;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 pyasn1,0.6.3,BSD-2-Clause,services/sdrc,python,lockfile,services/sdrc/uv.lock,runtime,no,no,no,declared-manifest,None
-pyasn1,0.6.4,UNKNOWN,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/pyproject.toml;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
+pyasn1,0.6.4,BSD-2-Clause,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/pyproject.toml;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 pyasn1-modules,0.4.2,BSD-2-Clause,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 pyasn1-modules,0.4.2,BSD-2-Clause,services/sdrc,python,lockfile,services/sdrc/uv.lock,runtime,no,no,no,declared-manifest,None
 pybase64,1.4.3,BSD License,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
@@ -2749,8 +2749,8 @@ pygments,2.20.0,BSD-2-Clause,services/agent,python,lockfile,services/agent/uv.lo
 pygments,2.20.0,BSD-2-Clause,services/vios,python,lockfile,services/vios/test/bdd_tests/poetry.lock,runtime,no,no,no,declared-manifest,None
 pygments,2.21.0,UNKNOWN,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
 PyGObject,3.48.2,GNU Lesser General Public License v2 or later (LGPLv2+),services/rtvi/rt-vlm,python,container,services/rtvi/rt-vlm/docker/Dockerfile,runtime,no,no,yes,container-pip,Medium
-PyGObject,UNKNOWN,UNKNOWN,services/rtvi/rt-embed,python,usage,services/rtvi/rt-embed/src/server/rtvi_embed_server.py,runtime,no,no,no,imported-only,Unknown
-PyGObject,UNKNOWN,UNKNOWN,services/rtvi/rt-vlm,python,usage,services/rtvi/rt-vlm/src/server/alert_verification_server.py,runtime,no,no,no,imported-only,Unknown
+PyGObject,UNKNOWN,GNU Lesser General Public License v2 or later (LGPLv2+),services/rtvi/rt-embed,python,usage,services/rtvi/rt-embed/src/server/rtvi_embed_server.py,runtime,no,no,no,imported-only,Medium
+PyGObject,UNKNOWN,GNU Lesser General Public License v2 or later (LGPLv2+),services/rtvi/rt-vlm,python,usage,services/rtvi/rt-vlm/src/server/alert_verification_server.py,runtime,no,no,no,imported-only,Medium
 pyhanko,0.35.2,MIT,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
 pyhanko-certvalidator,0.31.1,MIT,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
 pyjwt,2.13.0,MIT,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
@@ -2823,11 +2823,11 @@ python-dotenv,1.0.1,BSD-3-Clause,libs/analytics/spatialai-data-utils,python,lock
 python-dotenv,1.0.1,BSD-3-Clause,services/configurators/vss-configurator,python,lockfile,services/configurators/vss-configurator/uv.lock,runtime,no,no,no,declared-manifest,None
 python-dotenv,1.2.2,BSD-3-Clause,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
 python-dotenv,1.2.2,BSD-3-Clause,services/vios,python,lockfile,services/vios/test/bdd_tests/poetry.lock,runtime,no,no,no,declared-manifest,None
-python-dotenv,1.2.3,UNKNOWN,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
+python-dotenv,1.2.3,BSD-3-Clause,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 python-dotenv,UNKNOWN,BSD-3-Clause,skills/benchmarking,python,manifest,skills/benchmarking/benchmark-video-summarization/scripts/requirements.txt,runtime,no,no,no,declared-manifest,None
 python-gi-dev,UNKNOWN,UNKNOWN,services/rtvi/rt-vlm,deb,container,services/rtvi/rt-vlm/docker/Dockerfile,runtime,no,no,yes,container-apt,Unknown
-python-multipart,0.0.30,UNKNOWN,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/pyproject.toml;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
-python-multipart,0.0.30,UNKNOWN,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pyproject.toml;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
+python-multipart,0.0.30,Apache-2.0,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/pyproject.toml;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
+python-multipart,0.0.30,Apache-2.0,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pyproject.toml;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 python-multipart,0.0.32,Apache-2.0,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
 python-multipart,0.0.32,Apache-2.0,services/vios,python,lockfile,services/vios/test/bdd_tests/poetry.lock,runtime,no,no,no,declared-manifest,None
 python-rapidjson,1.23,MIT,services/analytics/behavior-analytics,python,lockfile,services/analytics/behavior-analytics/Pipfile.lock,runtime,no,no,no,declared-manifest,None
@@ -3107,7 +3107,7 @@ set-blocking,2.0.0,ISC,services/analytics/video-analytics-api,node,lockfile,serv
 setprototypeof,1.2.0,ISC,services/analytics/video-analytics-api,node,lockfile,services/analytics/video-analytics-api/src/app/package-lock.json;services/analytics/video-analytics-api/test/package-lock.json,runtime,no,no,no,declared-manifest,None
 setuptools,78.1.1,MIT,services/rtvi/rt-cv,python,container,services/rtvi/rt-cv/docker/Dockerfile,runtime,no,no,yes,container-pip,None
 setuptools,78.1.1,MIT,services/sdrc,python,container,services/sdrc/envoy/Dockerfile.wdm-router,runtime,no,no,yes,container-pip,None
-setuptools,79.0.1,UNKNOWN,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
+setuptools,79.0.1,MIT,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 setuptools,80.10.2,MIT,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 setuptools,80.10.2,MIT,services/sdrc,python,lockfile,services/sdrc/uv.lock,runtime,no,no,no,declared-manifest,None
 setuptools,82.0.1,MIT,libs/analytics/spatialai-data-utils,python,container,libs/analytics/spatialai-data-utils/docker/Dockerfile,runtime,no,no,yes,container-pip,None
@@ -3198,7 +3198,7 @@ starlette,1.3.1,BSD-3-Clause,services/agent,python,lockfile,services/agent/uv.lo
 starlette,1.3.1,BSD-3-Clause,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/pyproject.toml;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 starlette,1.3.1,BSD-3-Clause,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pyproject.toml;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 starlette,1.3.1,BSD-3-Clause,services/vios,python,lockfile,services/vios/test/bdd_tests/poetry.lock,runtime,no,no,no,declared-manifest,None
-starlette,UNKNOWN,UNKNOWN,services/video-summarization,python,usage,services/video-summarization/src/lvs_mcp.py,runtime,no,no,no,imported-only,Unknown
+starlette,UNKNOWN,BSD-3-Clause,services/video-summarization,python,usage,services/video-summarization/src/lvs_mcp.py,runtime,no,no,no,imported-only,None
 stat-mode,1.0.0,MIT,services/vios,node,lockfile,services/vios/ui/vios-ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 statuses,2.0.2,MIT,services/analytics/video-analytics-api,node,lockfile,services/analytics/video-analytics-api/src/app/package-lock.json;services/analytics/video-analytics-api/test/package-lock.json,runtime,no,no,no,declared-manifest,None
 store2,2.14.4,MIT,services/vios,node,lockfile,services/vios/ui/vios-ui/package-lock.json,runtime,no,no,no,declared-manifest,None
@@ -3291,9 +3291,9 @@ threadpoolctl,3.6.0,BSD-3-Clause,services/agent,python,lockfile,services/agent/u
 threadpoolctl,3.6.0,BSD-3-Clause,services/configurators/vss-configurator,python,lockfile,services/configurators/vss-configurator/uv.lock,runtime,no,no,no,declared-manifest,None
 threadpoolctl,3.6.0,BSD-3-Clause,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 through,2.3.8,MIT,services/ui,node,lockfile,services/ui/package-lock.json,runtime,no,no,no,declared-manifest,None
-tiktoken,0.11.0,UNKNOWN,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
+tiktoken,0.11.0,MIT License,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 tiktoken,0.13.0,MIT License,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
-tiktoken,0.14.0,UNKNOWN,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
+tiktoken,0.14.0,MIT License,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 time-span,5.1.0,MIT,services/ui,node,lockfile,services/ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 tiny-async-pool,1.3.0,MIT,services/vios,node,lockfile,services/vios/ui/vios-ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 tiny-case,1.0.3,MIT,services/vios,node,lockfile,services/vios/ui/vios-ui/package-lock.json,runtime,no,no,no,declared-manifest,None
@@ -3319,7 +3319,7 @@ tokenizers,0.22.2,Apache Software License,services/agent,python,lockfile,service
 tokenizers,0.22.2,Apache Software License,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 tokenizers,0.23.0rc0,Apache Software License,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 tomli,2.3.0,MIT,services/vios,python,lockfile,services/vios/test/bdd_tests/poetry.lock,runtime,no,no,no,declared-manifest,None
-tomli,UNKNOWN,UNKNOWN,.github,python,usage,.github/skill-eval/envs/brev_env.py,runtime,no,no,no,imported-only,Unknown
+tomli,UNKNOWN,MIT,.github,python,usage,.github/skill-eval/envs/brev_env.py,runtime,no,no,no,imported-only,None
 toolz,1.1.0,BSD-3-Clause,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
 toposort,2.0.2,MIT,services/vios,node,lockfile,services/vios/ui/vios-ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 torch,2.10.0+cpu,Apache-2.0 AND Apache-2.0 WITH LLVM-exception AND BSD-2-Clause AND BSD-3-Clause AND BSL-1.0 AND MIT,libs/analytics/spatialai-data-utils,python,container,libs/analytics/spatialai-data-utils/docker/Dockerfile,runtime,no,no,yes,container-pip,Unknown
@@ -3393,7 +3393,7 @@ typedarray,0.0.6,MIT,services/analytics/video-analytics-api,node,lockfile,servic
 typedarray-to-buffer,3.1.5,MIT,services/analytics/video-analytics-api,node,lockfile,services/analytics/video-analytics-api/test/package-lock.json,runtime,no,no,no,declared-manifest,None
 typedoc,0.28.20,Apache-2.0,services/vios,node,lockfile,services/vios/ui/streaming-lib/package-lock.json,runtime,no,no,no,declared-manifest,None
 typer,0.27.0,MIT,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
-typer,0.27.1,UNKNOWN,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
+typer,0.27.1,MIT,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 typescript,5.5.4,Apache-2.0,services/vios,node,lockfile,services/vios/ui/streaming-lib/package-lock.json,runtime,no,no,no,declared-manifest,None
 typescript,5.9.3,Apache-2.0,services/ui,node,lockfile,services/ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 typescript,5.9.3,Apache-2.0,services/vios,node,lockfile,services/vios/ui/vios-ui/package-lock.json,runtime,no,no,no,declared-manifest,None
@@ -3411,7 +3411,7 @@ typing-inspection,0.4.2,MIT,services/analytics/behavior-analytics,python,lockfil
 typing-inspection,0.4.2,MIT,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 typing-inspection,0.4.2,MIT,services/vios,python,lockfile,services/vios/test/bdd_tests/poetry.lock,runtime,no,no,no,declared-manifest,None
 typing-inspection,0.4.2,MIT,tools/sdg-postprocessing,python,manifest,tools/sdg-postprocessing/requirements.txt,runtime,no,no,no,declared-manifest,None
-typing-inspection,0.4.4,UNKNOWN,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
+typing-inspection,0.4.4,MIT,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 typing_extensions,4.15.0,PSF-2.0,tools/sdg-postprocessing,python,manifest,tools/sdg-postprocessing/requirements.txt,runtime,no,no,no,declared-manifest,None
 tzdata,2025.3,Apache-2.0,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
 tzdata,2026.2,Apache-2.0,libs/analytics/spatialai-data-utils,python,lockfile,libs/analytics/spatialai-data-utils/Pipfile.lock,runtime,no,no,no,declared-manifest,None
@@ -3484,7 +3484,7 @@ uvicorn,UNKNOWN,BSD-3-Clause,services/alert,python,manifest,services/alert/requi
 uvicorn,UNKNOWN,BSD-3-Clause,services/video-summarization,python,usage,services/video-summarization/src/lvs_mcp.py,runtime,no,no,no,imported-only,None
 uvicorn,UNKNOWN,BSD-3-Clause,skills/operations,python,manifest,skills/operations/vss-manage-alerts/scripts/alert-notify/requirements.txt,runtime,no,no,no,declared-manifest,None
 uvloop,0.22.1,MIT License,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
-uvloop,UNKNOWN,UNKNOWN,services/rtvi/rt-vlm,python,usage,services/rtvi/rt-vlm/docker/rtvi_vlm/patches/evs_vllm_public_files/entrypoints/openai/api_server.py,runtime,no,no,no,imported-only,Unknown
+uvloop,UNKNOWN,MIT License,services/rtvi/rt-vlm,python,usage,services/rtvi/rt-vlm/docker/rtvi_vlm/patches/evs_vllm_public_files/entrypoints/openai/api_server.py,runtime,no,no,no,imported-only,None
 v4l-utils,UNKNOWN,UNKNOWN,services/vios,deb,container,services/vios/cicd_files/aarch64/Dockerfile.base,runtime,no,no,yes,container-apt,Unknown
 v8-to-istanbul,9.3.0,ISC,services/ui,node,lockfile,services/ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 validators,0.35.0,MIT License,services/rtvi/rt-embed,python,lockfile;manifest,services/rtvi/rt-embed/docker/py_deps/pdm.lock;services/rtvi/rt-embed/docker/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
@@ -3581,7 +3581,7 @@ xml-name-validator,5.0.0,Apache-2.0,services/ui,node,lockfile,services/ui/packag
 xmlbuilder,15.1.1,MIT,services/vios,node,lockfile,services/vios/ui/vios-ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 xmlchars,2.2.0,MIT,services/ui,node,lockfile,services/ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 xxhash,3.8.1,BSD-2-Clause,services/agent,python,lockfile,services/agent/uv.lock,runtime,no,no,no,declared-manifest,None
-xxhash,4.0.1,UNKNOWN,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,Unknown
+xxhash,4.0.1,BSD-2-Clause,services/rtvi/rt-vlm,python,lockfile;manifest,services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock;services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/requirements.txt,runtime,no,no,no,declared-manifest,None
 xz-utils,UNKNOWN,UNKNOWN,deploy,deb,container,deploy/docker/services/infra/Dockerfiles/elasticsearch-gpu.Dockerfile,runtime,no,no,yes,container-apt,Unknown
 y18n,4.0.3,ISC,services/analytics/video-analytics-api,node,lockfile,services/analytics/video-analytics-api/test/package-lock.json,runtime,no,no,no,declared-manifest,None
 y18n,5.0.8,ISC,services/analytics/video-analytics-api,node,lockfile,services/analytics/video-analytics-api/src/app/package-lock.json;services/analytics/video-analytics-api/src/web-api-core/package-lock.json;services/analytics/video-analytics-api/test/package-lock.json,runtime,no,no,no,declared-manifest,None
@@ -3589,7 +3589,7 @@ y18n,5.0.8,ISC,services/ui,node,lockfile,services/ui/package-lock.json,runtime,n
 y18n,5.0.8,ISC,services/vios,node,lockfile,services/vios/ui/vios-ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 yacs,0.1.8,Apache-2.0,libs/analytics/spatialai-data-utils,python,lockfile,libs/analytics/spatialai-data-utils/Pipfile.lock,runtime,no,no,no,declared-manifest,None
 yacs,0.1.8,Apache-2.0,services/configurators/vss-configurator,python,lockfile,services/configurators/vss-configurator/uv.lock,runtime,no,no,no,declared-manifest,None
-yacs,UNKNOWN,UNKNOWN,deploy,python,usage,deploy/docker/services/rtvi/reid-embed/convert_clipreid_to_onnx.py,runtime,no,no,no,imported-only,Unknown
+yacs,UNKNOWN,Apache-2.0,deploy,python,usage,deploy/docker/services/rtvi/reid-embed/convert_clipreid_to_onnx.py,runtime,no,no,no,imported-only,None
 yallist,3.1.1,ISC,services/analytics/video-analytics-api,node,lockfile,services/analytics/video-analytics-api/test/package-lock.json,runtime,no,no,no,declared-manifest,None
 yallist,3.1.1,ISC,services/ui,node,lockfile,services/ui/package-lock.json,runtime,no,no,no,declared-manifest,None
 yallist,4.0.0,ISC,services/vios,node,lockfile,services/vios/ui/vios-ui/package-lock.json,runtime,no,no,no,declared-manifest,None

--- a/.github/osrb/osrb_agent.py
+++ b/.github/osrb/osrb_agent.py
@@ -498,9 +498,16 @@ Hard rules:
     evidence_url and DISCARDS your verdict when the licence is not in the
     document, so pick the URL that shows it (the registry JSON or the LICENSE
     file itself).
-  - permissive=true only for a single unambiguous permissive licence (MIT,
-    BSD, Apache-2.0, ISC, ...). Composite expressions (AND/OR/WITH), copyleft,
-    unknown, or ambiguous metadata => permissive=false, needs_osrb=true.
+  - permissive=true when every licence the expression names is permissive
+    (MIT, BSD, Apache-2.0, ISC, MPL-2.0, LGPL-2.1, BlueOak-1.0.0, ...).
+    "A OR B" is dual licensing and is permissive when either branch is;
+    "A AND B" is permissive only when both are. So "Apache-2.0 OR
+    BSD-3-Clause" and "MIT AND PSF-2.0" are permissive=true, needs_osrb=false.
+  - permissive=false, needs_osrb=true for a copyleft operand (GPL, AGPL,
+    LGPL-3.0), a WITH exception, a source-available licence (Elastic, SSPL,
+    BUSL), unknown metadata, or prose you cannot resolve to licence names.
+    Report the licence exactly as the evidence states it; do not simplify a
+    composite down to one operand.
 
 Output format — JSON ONLY:
 Your final message must be EXACTLY ONE fenced ```json code block containing a
@@ -1153,6 +1160,7 @@ def build_comment(
     }
 
     nvidia_owned_skipped: set[str] = set()
+    permissive_agent_verdicts: set[str] = set()
 
     def _osrb_skip_nvidia(package: str) -> bool:
         """Skip NVIDIA's own components, unless OSRB has ruled on them."""
@@ -1250,6 +1258,15 @@ def build_comment(
     for verdict in flagged:
         if _osrb_skip_nvidia(verdict.get("package", "")):
             continue
+        # The agent may report a licence the repo's own gate already clears --
+        # "Apache-2.0 OR BSD-3-Clause", "MIT AND PSF-2.0". Its prompt used to
+        # call every composite reviewable, which is what put cryptography,
+        # greenlet, numpy and packaging in front of OSRB on #2101. Judge the
+        # licence it found with the same rule everything else is judged by,
+        # rather than trusting the model to have applied it.
+        if is_permissive(verdict.get("license", ""), verdict.get("package", "")):
+            permissive_agent_verdicts.add(verdict.get("package", ""))
+            continue
         osrb_rows.append([
             verdict.get("package", ""),
             verdict.get("version", ""),
@@ -1257,17 +1274,15 @@ def build_comment(
             f"agent flagged for OSRB: {verdict.get('reasoning', '') or 'needs review'}",
             verdict.get("evidence_url", ""),
         ])
-    for entry in not_triaged:
-        row, why = entry["row"], entry["reason"]
-        if _osrb_skip_nvidia(row.get("package", "")):
-            continue
-        osrb_rows.append([
-            row.get("package", ""),
-            row.get("new_version", "") or row.get("version", ""),
-            row.get("module", ""),
-            f"not triaged this run ({why})",
-            "",
-        ])
+    # Rows the agent never looked at are NOT listed here. "over the
+    # --max-unknowns bound" is the tool describing its own budget, and putting
+    # it under a heading that means "a human must act" made eleven such rows on
+    # #2101 read as OSRB findings. They are reported below the table instead,
+    # so the gap is visible without being mistaken for a verdict.
+    untriaged_rows = [
+        entry for entry in not_triaged
+        if not _osrb_skip_nvidia(entry["row"].get("package", ""))
+    ]
 
     lines.append("## OSRB review required")
     lines.append("")
@@ -1280,6 +1295,32 @@ def build_comment(
             "conditional package is touched, every new dependency is "
             "permissively licensed, no licence change moves a risk band, and "
             "no usage drift was detected."
+        )
+    if permissive_agent_verdicts:
+        names = ", ".join(f"`{n}`" for n in sorted(permissive_agent_verdicts)[:6])
+        more = len(permissive_agent_verdicts) - 6
+        lines.append("")
+        lines.append(
+            f"_{len(permissive_agent_verdicts)} package(s) the agent raised "
+            f"({names}{f' and {more} more' if more > 0 else ''}) resolve to a "
+            "permissive licence under the repository's own rule, so they are "
+            "not listed. A composite is permissive when every branch it can "
+            "land on is._"
+        )
+    if untriaged_rows:
+        names = ", ".join(
+            f"`{e['row'].get('package', '')}`" for e in untriaged_rows[:6]
+        )
+        more = len(untriaged_rows) - 6
+        why = untriaged_rows[0]["reason"]
+        lines.append("")
+        lines.append(
+            f"_{len(untriaged_rows)} unknown licence(s) were not researched "
+            f"this run ({why}): {names}"
+            f"{f' and {more} more' if more > 0 else ''}. "
+            "This is a triage gap, not a verdict -- nobody has judged them "
+            "yet. They stay UNKNOWN in `inventory.csv` and come back next "
+            "run._"
         )
     if nvidia_owned_skipped:
         names = ", ".join(f"`{n}`" for n in sorted(nvidia_owned_skipped)[:6])

--- a/.github/osrb/osrb_agent.py
+++ b/.github/osrb/osrb_agent.py
@@ -399,7 +399,8 @@ def research_rows(triage: dict[str, list]) -> list[dict[str, str]]:
     """The agent's work list: new unknowns + licence changes, deduplicated.
 
     Order is deterministic (new_unknowns first, then license_changes, each in
-    delta order) so --max-unknowns cuts the same rows on every rerun.
+    delta order) so an explicit --max-unknowns cuts the same rows on every
+    rerun. There is no bound by default.
     """
     seen: set[tuple[str, str, str]] = set()
     out: list[dict[str, str]] = []
@@ -1522,9 +1523,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--verdicts-out", help="where to write triage-verdicts.json")
     parser.add_argument("--skip-agent", action="store_true",
                         help="deterministic pre-pass + comment only, no model")
-    parser.add_argument("--max-unknowns", type=int, default=25,
-                        help="bound on rows handed to the agent; overflow rows "
-                             "go to the OSRB section as 'not triaged this run'")
+    parser.add_argument("--max-unknowns", type=int, default=0,
+                        help="bound on rows handed to the agent; 0 (the "
+                             "default) means no bound. A licence nobody "
+                             "researched is the one worth researching, so "
+                             "leaving rows untriaged is not a saving")
     parser.add_argument("--check-inventory-diff", nargs=2,
                         metavar=("OLD", "NEW"),
                         help="standalone guard mode: verify NEW differs from "
@@ -1559,13 +1562,24 @@ def main(argv: list[str] | None = None) -> int:
 
     triage = build_triage_input(delta_rows, compliance_rows, conditions)
     work = research_rows(triage)
-    overflow = work[args.max_unknowns:]
-    work = work[:args.max_unknowns]
+    # No bound by default. The work list is the unknowns THIS change
+    # introduces, so it is already bounded by the size of the change, and a
+    # default of 25 quietly left the rest unexamined -- on #2101, eleven rows
+    # the agent never looked at. The flag stays for a run that needs to be
+    # capped deliberately, and the overflow is still reported rather than
+    # dropped.
+    overflow: list[dict[str, str]] = []
+    if args.max_unknowns > 0:
+        overflow = work[args.max_unknowns:]
+        work = work[:args.max_unknowns]
 
     results: dict = {
         "validated": [], "rejected": [], "flagged": [], "unverifiable": [],
-        "not_triaged": [{"row": row, "reason": "over --max-unknowns bound"}
-                        for row in overflow],
+        "not_triaged": [
+            {"row": row,
+             "reason": f"over the --max-unknowns bound of {args.max_unknowns}"}
+            for row in overflow
+        ],
         "skip_agent": False, "agent_note": "",
     }
 

--- a/.github/osrb/osrb_inventory.py
+++ b/.github/osrb/osrb_inventory.py
@@ -799,6 +799,25 @@ def previous_licenses(path: str) -> dict[tuple[str, str], str]:
     return out
 
 
+def previous_licenses_by_language(path: str) -> dict[tuple[str, str], set[str]]:
+    """{(name, language): {licences}} from a previously committed inventory.
+
+    Language is in the key because a package name is only unique inside its
+    ecosystem: `regex` on PyPI is "Apache-2.0 AND CNRI-Python" and `regex` on
+    npm is MIT. Keyed on the name alone, one would answer for the other.
+    """
+    out: dict[tuple[str, str], set[str]] = {}
+    with open(path, newline="", encoding="utf-8") as handle:
+        for row in csv.DictReader(handle):
+            license_expr = (row.get("license") or "").strip()
+            package = (row.get("package") or "").strip()
+            language = (row.get("language") or "").strip()
+            if not package or not license_expr or license_expr == UNKNOWN:
+                continue
+            out.setdefault((package.lower(), language), set()).add(license_expr)
+    return out
+
+
 def unanimous_parser_licenses(entries: list[_Entry]) -> dict[tuple[str, str], str]:
     """{(name, version): license} for releases every parser in the tree agrees on.
 
@@ -823,11 +842,58 @@ def unanimous_parser_licenses(entries: list[_Entry]) -> dict[tuple[str, str], st
     return {key: next(iter(values)) for key, values in candidates.items() if len(values) == 1}
 
 
+def unanimous_package_licenses(
+    entries: list[_Entry],
+    previous_by_language: dict[tuple[str, str], set[str]] | None = None,
+) -> dict[tuple[str, str], str]:
+    """{(name, language): license} for packages every KNOWN VERSION agrees on.
+
+    Every other tier matches an exact (name, version). That is right when a
+    release can be looked up, and wrong the moment a version moves: relocating
+    a library into its own module re-resolves the lockfile, so cryptography
+    goes 50.0.0 -> 50.0.1 and its licence -- recorded three times elsewhere in
+    this same tree -- stops being found at all. The row lands UNKNOWN, the
+    agent has to research a licence the repository already knows, and past
+    --max-unknowns it is reported as needing OSRB review.
+
+    A licence is a property of the package far more often than of the release,
+    so when every version this repository knows about agrees, that answer
+    carries to a version none of them names.
+
+    Language is in the key: `regex` on PyPI is "Apache-2.0 AND CNRI-Python"
+    and `regex` on npm is MIT, and a name-only key would let one answer for
+    the other. Attribution files do not feed this tier for the same reason --
+    they are keyed by module rather than ecosystem, so they cannot say which
+    `regex` they mean.
+
+    Unanimity is the whole safeguard, and it is what makes a relicence safe:
+    a package that was MIT at 1.0 and GPL-3.0 at 2.0 disagrees, gets no
+    fallback, and goes to the agent and then to a human -- which is the
+    outcome that matters. This is the last tier, so it can only ever fill a
+    row that would otherwise be UNKNOWN.
+    """
+    candidates: dict[tuple[str, str], set[str]] = {}
+    for entry in entries:
+        for licence in entry.licenses:
+            if licence and licence != UNKNOWN:
+                candidates.setdefault(
+                    (entry.package.lower(), entry.language), set()
+                ).add(licence)
+    for key, licences in (previous_by_language or {}).items():
+        candidates.setdefault(key, set()).update(licences)
+    return {
+        key: next(iter(values))
+        for key, values in candidates.items()
+        if len(values) == 1
+    }
+
+
 def resolve_license(
     entry: _Entry,
     attribution: dict[tuple[str, str, str], str],
     previous: dict[tuple[str, str], str],
     in_tree: dict[tuple[str, str], str] | None = None,
+    across_versions: dict[tuple[str, str], str] | None = None,
 ) -> tuple[str, str]:
     """Pick a licence for one entry, or UNKNOWN. Never guesses.
 
@@ -861,6 +927,9 @@ def resolve_license(
     carried = previous.get((name, entry.version))
     if carried:
         return carried, "carried-forward"
+    across = (across_versions or {}).get((name, entry.language))
+    if across:
+        return across, "another-version"
     return UNKNOWN, "unresolved"
 
 
@@ -935,11 +1004,17 @@ def build(
 
     entries = inventory.entries()
     in_tree = unanimous_parser_licenses(entries)
+    across_versions = unanimous_package_licenses(
+        entries,
+        previous_licenses_by_language(previous_path) if previous_path else {},
+    )
 
     rows: list[dict[str, str]] = []
     provenance: dict[str, int] = {}
     for entry in entries:
-        license_expr, source = resolve_license(entry, attribution, previous, in_tree)
+        license_expr, source = resolve_license(
+            entry, attribution, previous, in_tree, across_versions
+        )
         provenance[source] = provenance.get(source, 0) + 1
         rows.append(row_for(entry, license_expr))
     rows.sort(key=sort_key)
@@ -955,6 +1030,7 @@ def build(
         "license_from_attribution_file": provenance.get("attribution", 0),
         "license_from_another_parser_in_tree": provenance.get("another-parser", 0),
         "license_carried_forward": provenance.get("carried-forward", 0),
+        "license_from_another_version": provenance.get("another-version", 0),
         "license_unknown": provenance.get("unresolved", 0),
     }
     return rows, counters

--- a/.github/osrb/test_osrb_agent.py
+++ b/.github/osrb/test_osrb_agent.py
@@ -526,7 +526,14 @@ class CommentTests(unittest.TestCase):
         self.assertIn("Nothing in this change requires OSRB review", comment)
         self.assertIn("None.", comment)  # empty licence-change / drift sections
 
-    def test_overflow_rows_land_in_osrb_section_never_dropped(self) -> None:
+    def test_overflow_rows_are_named_but_are_not_osrb_findings(self) -> None:
+        """Never dropped, never presented as a verdict.
+
+        "over the --max-unknowns bound" is the tool describing its own budget.
+        Listed in the findings table it reads as "OSRB must act on this" -- on
+        #2101 eleven rows did exactly that. It has to stay visible, because a
+        licence nobody looked at is worth knowing about, but as a gap.
+        """
         row = delta_row(package="overflow-pkg", new_license="UNKNOWN")
         triage = agent.build_triage_input([row], [], [])
         comment = agent.build_comment(
@@ -536,8 +543,12 @@ class CommentTests(unittest.TestCase):
         )
         osrb = comment[comment.index("## OSRB review required")
                        :comment.index("## New dependencies")]
-        self.assertIn("overflow-pkg", osrb)
-        self.assertIn("not triaged this run", osrb)
+        self.assertIn("overflow-pkg", osrb)          # never dropped
+        self.assertIn("over --max-unknowns bound", osrb)
+        self.assertIn("triage gap, not a verdict", osrb)
+        # ...and not in the findings table
+        self.assertNotIn("| overflow-pkg |", osrb)
+        self.assertIn("Nothing in this change requires OSRB review", osrb)
 
     def test_unverifiable_verdicts_named_in_osrb_section(self) -> None:
         row = delta_row(package="shady", new_license="UNKNOWN")
@@ -610,7 +621,9 @@ class CliTests(unittest.TestCase):
             text = comment.read_text(encoding="utf-8")
             self.assertTrue(text.startswith(agent.MARKER))
             self.assertIn("mystery", text)
-            self.assertIn("not triaged this run", text)
+            # the skipped rows stay named, as a triage gap rather than a finding
+            self.assertIn("were not researched this run", text)
+            self.assertIn("agent skipped", text)
             doc = json.loads(verdicts.read_text(encoding="utf-8"))
             self.assertTrue(doc["skip_agent"])
             self.assertEqual(doc["validated"], [])
@@ -982,6 +995,46 @@ class RepoStateSectionTest(unittest.TestCase):
         # the agent row for the SAME conditioned package must survive the guard
         self.assertIn("agent flagged for OSRB", comment)
         self.assertNotIn("NVIDIA-published component", comment)
+
+    def test_a_permissive_composite_the_agent_raised_is_not_a_finding(self) -> None:
+        """The repo's own rule outranks the model's opinion.
+
+        The prompt used to call every composite reviewable, so the agent put
+        cryptography (Apache-2.0 OR BSD-3-Clause), greenlet (MIT AND PSF-2.0),
+        numpy and packaging in front of OSRB on #2101 -- all expressions
+        license_passes already clears. Judging the licence it found with the
+        same rule everything else uses does not depend on the model obeying a
+        reworded prompt.
+        """
+        flagged = [
+            {"package": "cryptography", "version": "50.0.1",
+             "license": "Apache-2.0 OR BSD-3-Clause",
+             "reasoning": "composite requires OSRB", "evidence_url": "u"},
+            {"package": "greenlet", "version": "3.5.5",
+             "license": "MIT AND PSF-2.0",
+             "reasoning": "composite requires OSRB", "evidence_url": "u"},
+        ]
+        comment = agent.build_comment(
+            {"new_deps": [], "license_changes": [], "usage_drift": [],
+             "new_unknowns": [], "refused_or_conditional": [], "removed": []},
+            {"validated": [], "rejected": [], "unverifiable": [],
+             "not_triaged": [], "flagged": flagged})
+        self.assertIn("Nothing in this change requires OSRB review", comment)
+        self.assertNotIn("agent flagged for OSRB", comment)
+        self.assertIn("resolve to a permissive licence", comment)
+        self.assertIn("`cryptography`", comment)
+
+    def test_a_copyleft_composite_the_agent_raised_still_is_a_finding(self) -> None:
+        comment = agent.build_comment(
+            {"new_deps": [], "license_changes": [], "usage_drift": [],
+             "new_unknowns": [], "refused_or_conditional": [], "removed": []},
+            {"validated": [], "rejected": [], "unverifiable": [],
+             "not_triaged": [],
+             "flagged": [{"package": "copyleft-dep", "version": "1.0",
+                          "license": "MIT AND GPL-3.0",
+                          "reasoning": "copyleft operand", "evidence_url": "u"}]})
+        self.assertIn("agent flagged for OSRB", comment)
+        self.assertIn("copyleft-dep", comment)
 
     def test_no_repo_state_means_no_section(self) -> None:
         comment = agent.build_comment({"new_deps": [], "license_changes": [],

--- a/.github/osrb/test_osrb_agent.py
+++ b/.github/osrb/test_osrb_agent.py
@@ -587,6 +587,81 @@ class CliTests(unittest.TestCase):
             writer.writeheader()
             writer.writerows(rows)
 
+    def test_no_unknown_is_left_untriaged_by_default(self) -> None:
+        """More unknowns than the old default of 25, none reported as skipped.
+
+        The bound used to be 25, so a change introducing more than that left
+        the rest unexamined and listed them as untriaged -- eleven such rows on
+        #2101. Driven through the CLI because the default lives on the parser
+        inside main(), which is the thing that actually has to change.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            delta = tmp_path / "license-diff.csv"
+            compliance = tmp_path / "osrb-compliance.csv"
+            comment = tmp_path / "triage-comment.md"
+            verdicts = tmp_path / "triage-verdicts.json"
+            self.write_csv(delta, [
+                delta_row(package=f"unknown-{i:02d}", new_license="UNKNOWN")
+                for i in range(40)
+            ])
+            self.write_csv(compliance, [{
+                "verdict": "", "package": "", "version": "", "module": "",
+                "source_file": "", "notes": "",
+            }])
+            rc = agent.main([
+                "--delta", str(delta),
+                "--compliance", str(compliance),
+                "--inventory", str(DIRECTORY / "inventory.csv"),
+                "--approved", str(DIRECTORY / "approved.csv"),
+                "--conditions", str(DIRECTORY / "conditions.csv"),
+                "--comment-out", str(comment),
+                "--verdicts-out", str(verdicts),
+                "--skip-agent",
+            ])
+            self.assertEqual(rc, 0)
+            doc = json.loads(verdicts.read_text(encoding="utf-8"))
+            bounded = [r for r in doc["not_triaged"]
+                       if "max-unknowns" in r.get("reason", "")]
+            self.assertEqual([], bounded,
+                             "no row may be withheld for a bound that is off")
+            self.assertNotIn("--max-unknowns bound",
+                             comment.read_text(encoding="utf-8"))
+
+    def test_an_explicit_bound_still_caps_and_still_reports(self) -> None:
+        """The flag still works when a run is capped on purpose."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            delta = tmp_path / "license-diff.csv"
+            compliance = tmp_path / "osrb-compliance.csv"
+            comment = tmp_path / "triage-comment.md"
+            verdicts = tmp_path / "triage-verdicts.json"
+            self.write_csv(delta, [
+                delta_row(package=f"unknown-{i:02d}", new_license="UNKNOWN")
+                for i in range(5)
+            ])
+            self.write_csv(compliance, [{
+                "verdict": "", "package": "", "version": "", "module": "",
+                "source_file": "", "notes": "",
+            }])
+            agent.main([
+                "--delta", str(delta),
+                "--compliance", str(compliance),
+                "--inventory", str(DIRECTORY / "inventory.csv"),
+                "--approved", str(DIRECTORY / "approved.csv"),
+                "--conditions", str(DIRECTORY / "conditions.csv"),
+                "--comment-out", str(comment),
+                "--verdicts-out", str(verdicts),
+                "--skip-agent", "--max-unknowns", "2",
+            ])
+            doc = json.loads(verdicts.read_text(encoding="utf-8"))
+            bounded = [r for r in doc["not_triaged"]
+                       if "max-unknowns bound of 2" in r.get("reason", "")]
+            self.assertEqual(3, len(bounded))
+            # capped rows are still named, as a gap rather than a finding
+            self.assertIn("were not researched this run",
+                          comment.read_text(encoding="utf-8"))
+
     def test_skip_agent_end_to_end(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)

--- a/.github/osrb/test_osrb_inventory.py
+++ b/.github/osrb/test_osrb_inventory.py
@@ -664,5 +664,74 @@ class DeterminismTest(unittest.TestCase):
             self.assertGreater(Path(outputs[0]).stat().st_size, 0)
 
 
+
+class LicenseAcrossVersionsTest(unittest.TestCase):
+    """The last tier: a licence known for other versions of the same package.
+
+    Every other tier matches an exact (name, version), which breaks the moment
+    a version moves. #2101 relocated the CLI into libs/vss, the new lockfile
+    re-resolved cryptography 50.0.0 -> 50.0.1, and the licence recorded three
+    times elsewhere in the same tree stopped being found.
+    """
+
+    def _entry(self, package, version, licenses=(), module="m", language="python"):
+        return osrb_inventory._Entry(
+            package=package, version=version, module=module,
+            language=language, licenses=set(licenses),
+        )
+
+    def test_unanimous_license_carries_to_an_unseen_version(self) -> None:
+        entries = [
+            self._entry("cryptography", "50.0.0", ["Apache-2.0 OR BSD-3-Clause"]),
+            self._entry("cryptography", "48.0.0", ["Apache-2.0 OR BSD-3-Clause"]),
+        ]
+        across = osrb_inventory.unanimous_package_licenses(entries)
+        self.assertEqual("Apache-2.0 OR BSD-3-Clause",
+                         across[("cryptography", "python")])
+
+    def test_a_relicence_gets_no_fallback(self) -> None:
+        """MIT at 1.0 and GPL-3.0 at 2.0 must NOT silently pick one."""
+        entries = [
+            self._entry("shifty", "1.0", ["MIT"]),
+            self._entry("shifty", "2.0", ["GPL-3.0"]),
+        ]
+        across = osrb_inventory.unanimous_package_licenses(entries)
+        self.assertNotIn(("shifty", "python"), across)
+
+    def test_the_previous_inventory_also_feeds_it(self) -> None:
+        across = osrb_inventory.unanimous_package_licenses(
+            [], {("typer", "python"): {"MIT"}})
+        self.assertEqual("MIT", across[("typer", "python")])
+
+    def test_unknown_in_the_previous_inventory_is_not_an_answer(self) -> None:
+        across = osrb_inventory.unanimous_package_licenses(
+            [self._entry("mystery", "1.0", [osrb_inventory.UNKNOWN])])
+        self.assertNotIn(("mystery", "python"), across)
+
+    def test_the_same_name_in_two_ecosystems_never_answers_for_the_other(self) -> None:
+        """`regex` is Apache-2.0 AND CNRI-Python on PyPI and MIT on npm."""
+        entries = [
+            self._entry("regex", "2026.7.10", ["Apache-2.0 AND CNRI-Python"]),
+            self._entry("regex", "6.1.0", ["MIT"], language="node"),
+        ]
+        across = osrb_inventory.unanimous_package_licenses(entries)
+        self.assertEqual("Apache-2.0 AND CNRI-Python", across[("regex", "python")])
+        self.assertEqual("MIT", across[("regex", "node")])
+
+    def test_it_is_the_last_tier_and_never_overrides_an_exact_match(self) -> None:
+        entry = self._entry("pkg", "2.0")
+        licence, source = osrb_inventory.resolve_license(
+            entry,
+            {("m", "pkg", "2.0"): "BSD-3-Clause"},   # exact attribution wins
+            {},
+            None,
+            {("pkg", "python"): "MIT"},
+        )
+        self.assertEqual(("BSD-3-Clause", "attribution"), (licence, source))
+        # with no exact match, the fallback fills what would be UNKNOWN
+        licence, source = osrb_inventory.resolve_license(
+            entry, {}, {}, None, {("pkg", "python"): "MIT"})
+        self.assertEqual(("MIT", "another-version"), (licence, source))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

[#2101](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/2101) moves the CLI library into `libs/vss`. The dependencies didn't change — but the triage comment asked OSRB to review **16 rows** for a relocation.

They're not literally "just moved": the new lockfile re-resolved them.

| package | `services/agent` | `libs/vss` |
|---|---|---|
| cryptography | 50.0.0 | **50.0.1** → UNKNOWN |
| greenlet | 3.5.4 | **3.5.5** → UNKNOWN |
| typer | 0.27.0 | **0.27.2** → UNKNOWN |

Three separate faults turned that into OSRB findings.

## 1. Every licence tier required an exact version

```python
attribution.get((module, name, version))   # miss
in_tree.get((name, version))               # miss — tree has 50.0.0
previous.get((name, version))              # miss — carry-forward has 50.0.0
→ UNKNOWN
```

`cryptography` resolved UNKNOWN while `Apache-2.0 OR BSD-3-Clause` for 50.0.0 sat **three times in the same tree**. A patch bump discarded a licence we already had.

Added a **last** tier that answers from other versions of the same package when every version the repo knows about agrees.

- **Unanimity is the safeguard** — MIT at 1.0 and GPL-3.0 at 2.0 disagree, get no fallback, and go to a human.
- **Last tier only** — it can only fill a row that would otherwise be UNKNOWN. Across the tree it fills **47** and changes **0** existing answers (verified by diff).
- **Keyed on (name, language)** — `regex` is `Apache-2.0 AND CNRI-Python` on PyPI and `MIT` on npm. A name-only key let one answer for the other; that was a bug in the first draft of this fix, caught by checking the packages that still didn't resolve. Attribution files stay out of this tier for the same reason: keyed by module, they can't say which ecosystem they mean.

## 2. Budget exhaustion was reported as a finding

Eleven rows said *"not triaged this run (over --max-unknowns bound)"* under **OSRB review required**. That's the tool describing its own budget. They're reported below the table now — still named, because a licence nobody looked at is worth knowing, but as a **gap, not a verdict**.

## 3. The agent's prompt contradicted the code

The prompt declared every composite reviewable, which flagged `cryptography` (`Apache-2.0 OR BSD-3-Clause`), `greenlet` (`MIT AND PSF-2.0`), `numpy` and `packaging`. But `license_passes` — which the rest of the pipeline uses — already clears those: `OR` is dual licensing, `AND` clears when both branches are permissive.

Reworded the prompt **and** judge whatever licence the agent reports with that same rule, rather than trusting the model to have applied it. The validator guarding writes to `inventory.csv` stays strict about composites — *"may a bot commit this unattended"* is a different question.

## Verification

- **442 tests pass**; inventory reaches a fixpoint.
- Checked against #2101's exact package list: **10 of 15** now resolve (`cryptography`, `greenlet`, `packaging`, `pydantic`, `setuptools`, `starlette`, `typer`, `pyarrow`, `pybase64`, `pydantic-core`). The rest genuinely disagree across versions and still go to review — which is the point.
- Mutation-tested, 4 for 4: dropping unanimity, jumping the tier order, removing the agent-verdict gate, and putting untriaged rows back in the table each fail their test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)