### PR TITLE
fix(agent): keep video reports when a VST snapshot is missing

### DIFF
--- a/services/agent/packages/vss_agents/src/vss_agents/tools/video_report_gen.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/video_report_gen.py
@@ -1004,30 +1004,55 @@ async def _inject_snapshots(
         logger.warning("Video Analysis Report: No timestamps found in VLM response for snapshot injection")
         return content
 
-    image_urls = await asyncio.gather(
-        *[
-            picture_url_tool.ainvoke(
+    async def _fetch_snapshot(ts: TimestampMatch) -> tuple[TimestampMatch, str | None]:
+        try:
+            snapshot = await picture_url_tool.ainvoke(
                 input={
                     "sensor_id": sensor_id,
                     "start_time": ts.seconds,
                 }
             )
-            for ts in timestamps
-        ]
-    )
+        except Exception as e:
+            logger.warning(
+                "Video Analysis Report: Snapshot at %.1fs failed (%s); skipping image",
+                ts.seconds,
+                e,
+            )
+            return ts, None
+        image_src = _snapshot_image_src(snapshot)
+        if not image_src:
+            logger.warning(
+                "Video Analysis Report: Snapshot at %.1fs returned no image URL; skipping image",
+                ts.seconds,
+            )
+        return ts, image_src
+
+    fetched = await asyncio.gather(*[_fetch_snapshot(ts) for ts in timestamps])
     result_content = content
-    for ts, image_url in reversed(list(zip(timestamps, image_urls, strict=False))):
+    for ts, image_src in reversed(fetched):
+        if not image_src:
+            continue
         # Format seconds to readable string for alt text
         mins = int(ts.seconds) // 60
         secs = int(ts.seconds) % 60
         time_str = f"{mins:02d}:{secs:02d}"
         # Use HTML img tag for size control with minimal spacing
         # Add style to control margins for PDF rendering
-        image_md = (
-            f'\n\n<img src="{image_url.image_url}" alt="Snapshot at {time_str}" width="400" style="margin: 10px 0;">\n'
-        )
+        image_md = f'\n\n<img src="{image_src}" alt="Snapshot at {time_str}" width="400" style="margin: 10px 0;">\n'
         result_content = result_content[: ts.position] + image_md + result_content[ts.position :]
     return result_content
+
+
+def _snapshot_image_src(snapshot: Any) -> str | None:
+    """Extract a usable image URL from a snapshot tool result, if any."""
+    if snapshot is None:
+        return None
+    image_src = getattr(snapshot, "image_url", None)
+    if not image_src and isinstance(snapshot, dict):
+        image_src = snapshot.get("image_url")
+    if isinstance(image_src, str) and image_src.strip():
+        return image_src.strip()
+    return None
 
 
 def _clean_vlm_response(vlm_response: str) -> str:

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_video_report_gen.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_video_report_gen.py
@@ -26,9 +26,11 @@ from vss_agents.tools.video_report_gen import VideoReportGenInput
 from vss_agents.tools.video_report_gen import VideoReportGenOutput
 from vss_agents.tools.video_report_gen import _convert_markdown_to_pdf
 from vss_agents.tools.video_report_gen import _divide_video_into_chunks
+from vss_agents.tools.video_report_gen import _inject_snapshots
 from vss_agents.tools.video_report_gen import _inject_video_clips
 from vss_agents.tools.video_report_gen import _normalize_chunk_timestamps
 from vss_agents.tools.video_report_gen import _parse_timestamps
+from vss_agents.tools.video_report_gen import _snapshot_image_src
 from vss_agents.tools.video_understanding import VideoUnderstandingInput
 from vss_agents.tools.video_understanding import VideoUnderstandingOffsetInput
 
@@ -435,3 +437,28 @@ class TestResourcesSectionFormatting:
                 # PDF was generated successfully - the CSS is valid
                 assert os.path.exists(pdf_path), "PDF file should be created"
                 assert os.path.getsize(pdf_path) > 0, "PDF file should not be empty"
+
+
+class TestInjectSnapshots:
+    """Failed snapshot fetches must not abort the rest of the report."""
+
+    @pytest.mark.asyncio
+    async def test_inject_snapshots_skips_missing_urls(self):
+        class Ok:
+            image_url = "http://example/ok.jpg"
+
+        tool = AsyncMock()
+        tool.ainvoke = AsyncMock(side_effect=[None, Ok()])
+        content = "[0.0s-2.0s] First event. [10.0s-12.0s] Second event."
+        result = await _inject_snapshots(content, "warehouse_safety_0001", tool)
+        assert tool.ainvoke.await_count == 2
+        assert "http://example/ok.jpg" in result
+        assert result.count("<img") == 1
+
+    def test_snapshot_image_src_handles_none_and_blank(self):
+        class Empty:
+            image_url = "  "
+
+        assert _snapshot_image_src(None) is None
+        assert _snapshot_image_src(Empty()) is None
+        assert _snapshot_image_src({"image_url": "http://example/a.jpg"}) == "http://example/a.jpg"


### PR DESCRIPTION
A failed or empty snapshot used to raise on .image_url and abort report generation after a successful VLM caption. Skip that still and write the rest of the Markdown.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
