### PR TITLE
tune(warehouse): adjust 3d per-class detection thresholds

### DIFF
--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/deepstream/label/labels-real.txt
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/deepstream/label/labels-real.txt
@@ -1,1 +1,1 @@
-Person:0.5;Fourier_GR1_T2_Humanoid:0.5;Agility_Digit_Humanoid:0.5;Nova_Carter:0.5;Transporter:0.5;Forklift:0.3;Forklift:0.3;
+Person:0.6;Fourier_GR1_T2_Humanoid:0.5;Agility_Digit_Humanoid:0.5;Nova_Carter:0.5;Transporter:0.5;Forklift:0.3;Forklift:0.3;

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/deepstream/label/labels-synthetic.txt
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/deepstream/label/labels-synthetic.txt
@@ -1,1 +1,1 @@
-Person:0.85;Fourier_GR1_T2_Humanoid:0.85;Agility_Digit_Humanoid:0.85;Nova_Carter:0.9;Transporter:0.9;Forklift:0.75;Forklift:0.75;
+Person:0.75;Fourier_GR1_T2_Humanoid:0.75;Agility_Digit_Humanoid:0.75;Nova_Carter:0.75;Transporter:0.75;Forklift:0.5;Forklift:0.5;


### PR DESCRIPTION
The sparse4d labels file carries a confidence threshold per class, selected by DATASET_TYPE, and the two variants are tuned independently because the real and synthetic datasets do not behave alike.

Real: raise Person from 0.5 to 0.6. Every other class is unchanged.

Synthetic: lower the whole set -- Person, both humanoids from 0.85 to 0.75, Nova_Carter and Transporter from 0.9 to 0.75, and Forklift from 0.75 to 0.5.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
