### PR TITLE
fix(video-summarization): serialize CA-RAG installs

### DIFF
--- a/services/video-summarization/docker/Dockerfile
+++ b/services/video-summarization/docker/Dockerfile
@@ -65,6 +65,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends git ca-certific
 
 RUN uv pip install \
     "vss-ctx-rag @ git+https://github.com/NVIDIA/context-aware-rag.git@3.1.0" \
+    --extra-index-url https://pypi.nvidia.com/ \
+    --python-version 3.13 --target /tmp/packages
+
+RUN uv pip install \
     "vss-ctx-rag-arango @ git+https://github.com/NVIDIA/context-aware-rag.git@3.1.0#subdirectory=packages/vss_ctx_rag_arango" \
     --extra-index-url https://pypi.nvidia.com/ \
     --python-version 3.13 --target /tmp/packages


### PR DESCRIPTION
## Summary

Prevent the video-summarization image build from repeatedly timing out on the uv Git cache lock while installing CA-RAG packages.

Both `vss-ctx-rag` and `vss-ctx-rag-arango` were installed in one `uv pip install` command from the same Git repository. uv attempted concurrent access to the same repository cache and timed out after 300 seconds.

## Plan

Install the two CA-RAG packages in separate Docker build steps so their Git operations execute serially.

## Related Issue

None — CI build reliability fix.

## Changes

- Install `vss-ctx-rag` first.
- Install `vss-ctx-rag-arango` in a subsequent Docker layer.
- Preserve the existing `3.1.0` references, NVIDIA package index, Python version, and installation target.
- Avoid concurrent access to the same uv Git lock.

## Validation

- Built the `pkg-installer` Docker target successfully.
- Ran `.github/osrb/test_osrb_sources.py`: 45 passed.
- Ran `.github/osrb/test_osrb_inventory.py`: 47 passed.
- Verified the commit includes a DCO `Signed-off-by` trailer.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTR
## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
