### PR TITLE
fix(rtvi-vlm): preserve Parakeet patch across EVS overlay

### DIFF
--- a/services/rtvi/rt-vlm/docker/Dockerfile
+++ b/services/rtvi/rt-vlm/docker/Dockerfile
@@ -346,11 +346,6 @@ COPY src/scripts/install_codecs_nonroot.sh /opt/nvidia/rtvi/
 RUN --mount=type=bind,source=docker,target=/tmp/rtvi-src/docker \
     python3 /tmp/rtvi-src/docker/rtvi_vlm/patches/apply_vllm_arch_patch.py
 
-# Transformers 5 makes Parakeet's base configuration a dataclass. vLLM's
-# positional required subclass fields must be keyword-only to remain valid.
-RUN --mount=type=bind,source=docker,target=/tmp/rtvi-src/docker \
-    python3 /tmp/rtvi-src/docker/rtvi_vlm/patches/apply_vllm_parakeet_transformers5_patch.py
-
 # Qwen3-Omni's nightly processor incorrectly assumes every video item has
 # use_audio_in_video, including video-only requests.
 RUN --mount=type=bind,source=docker,target=/tmp/rtvi-src/docker \
@@ -364,10 +359,12 @@ RUN set -eu; \
     cp -a /tmp/evs-public-overlay/. "$vllm_root"/; \
     rm -rf /tmp/evs-public-overlay
 
-# Apply the remaining public compatibility patches after the overlay. The
-# protected serving module imports VideoClipAddRequest from the protocol.
+# Apply compatibility patches after the overlay so overlay-owned files cannot
+# replace their patched versions. The protected serving module imports
+# VideoClipAddRequest from the protocol.
 RUN --mount=type=bind,source=docker,target=/tmp/rtvi-src/docker \
-    python3 /tmp/rtvi-src/docker/rtvi_vlm/patches/apply_vllm_evs_protocol_patch.py \
+    python3 /tmp/rtvi-src/docker/rtvi_vlm/patches/apply_vllm_parakeet_transformers5_patch.py \
+    && python3 /tmp/rtvi-src/docker/rtvi_vlm/patches/apply_vllm_evs_protocol_patch.py \
     && python3 /tmp/rtvi-src/docker/rtvi_vlm/patches/apply_vllm_tensor_ipc_patch.py
 
 # Patch FlashInfer CUDA runtime discovery for the non-eager compile path.
@@ -399,7 +396,7 @@ RUN set -eu; \
 # compatibility types are not a coherent set. The SBSA build environment does
 # not mount the Tegra driver, which vLLM imports during this check.
 RUN if [ "$TARGETARCH" != "arm64" ] || [ "$ARM_PLATFORM" != "sbsa" ]; then \
-        python3 -c 'from vllm.entrypoints.openai.serving_video_sessions import OpenAIServingVideoSessions'; \
+        python3 -c 'from vllm.entrypoints.openai.serving_video_sessions import OpenAIServingVideoSessions; from vllm.model_executor.models.nano_nemotron_vl import NemotronH_Nano_VL_V2'; \
     fi
 
 # Remove unneeded media libraries shipped under /usr and DALI-bundled FFmpeg

--- a/services/rtvi/rt-vlm/docker/rtvi_vlm/patches/evs_vllm_public_files/transformers_utils/configs/parakeet.py
+++ b/services/rtvi/rt-vlm/docker/rtvi_vlm/patches/evs_vllm_public_files/transformers_utils/configs/parakeet.py
@@ -1,16 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from transformers import ParakeetEncoderConfig, PretrainedConfig
 
 
 class ParakeetConfig(ParakeetEncoderConfig):
-    llm_hidden_size: int
-    projection_hidden_size: int
-    projection_bias: bool
+    llm_hidden_size: int = field(kw_only=True)
+    projection_hidden_size: int = field(kw_only=True)
+    projection_bias: bool = field(kw_only=True)
     projection_eps: float = 1e-5
-    sampling_rate: int
+    sampling_rate: int = field(kw_only=True)
 
     @staticmethod
     def from_hf_config(

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_vllm_parakeet_transformers5_patch.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_vllm_parakeet_transformers5_patch.py
@@ -25,6 +25,10 @@ PATCH_PATH = (
     Path(__file__).parents[2]
     / "docker/rtvi_vlm/patches/apply_vllm_parakeet_transformers5_patch.py"
 )
+OVERLAY_PATH = (
+    Path(__file__).parents[2]
+    / "docker/rtvi_vlm/patches/evs_vllm_public_files/transformers_utils/configs/parakeet.py"
+)
 
 
 def _load_patch_module():
@@ -63,3 +67,16 @@ def test_parakeet_patch_makes_subclass_fields_keyword_only(tmp_path, monkeypatch
         "    projection_eps: float = 1e-5\n"
         "    sampling_rate: int = field(kw_only=True)\n"
     )
+
+
+def test_evs_overlay_keeps_parakeet_subclass_fields_keyword_only():
+    content = OVERLAY_PATH.read_text(encoding="utf-8")
+
+    assert "from dataclasses import dataclass, field" in content
+    for name, annotation in (
+        ("llm_hidden_size", "int"),
+        ("projection_hidden_size", "int"),
+        ("projection_bias", "bool"),
+        ("sampling_rate", "int"),
+    ):
+        assert f"    {name}: {annotation} = field(kw_only=True)" in content


### PR DESCRIPTION
## Summary

Fixes an RT-VLM startup failure when loading `NemotronH_Nano_Omni_Reasoning_V3` with Transformers 5 and the EVS++ vLLM overlay.

Transformers 5 converts `ParakeetEncoderConfig` subclasses into dataclasses. The EVS++ overlay restored required positional `ParakeetConfig` fields after inherited default fields, causing `TypeError: non-default argument 'llm_hidden_size' follows default argument` during vLLM model architecture inspection. The existing compatibility patch also ran before the overlay, allowing the overlay to replace the patched file.

Related: [NVBug 6710950](https://nvbugspro.nvidia.com/bug/6710950)

## Changes

- Make the four required EVS++ `ParakeetConfig` fields keyword-only for Transformers 5 dataclass compatibility.
- Apply the Parakeet compatibility patch after installing the EVS++ overlay.
- Add a build-time import check for the protected EVS++ serving module and the Nemotron architecture.
- Add regression coverage that verifies both the patch behavior and the checked-in EVS++ overlay.

## Testing

- Reproduced the original import failure with `nvcr.io/nvstaging/vss-core/vss-rt-vlm:nightly-20260907` and a local pre-fix image.
- Built the patched RT-VLM image successfully; the build-time EVS++ and Nemotron import gate passed.
- Ran both focused Parakeet/EVS++ overlay regression tests successfully.
- Real GPU validation on NVIDIA H100 NVL:
  - Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8 initialized successfully, including CUDA graph capture and the native sound encoder.
  - Readiness returned HTTP 200.
  - The supplied Jensen RTSP source was verified as H.264 video plus 48 kHz mono Opus audio.
  - Native audio/video inference returned four consecutive 10-second captions containing both correct stage visuals and spoken content.
- Cosmos Reason3 FP8 regression on NVIDIA H100 NVL with the same patched image and Jensen RTSP stream:
  - EVS++ disabled: readiness returned HTTP 200 and three captured 10-second captions completed successfully.
  - EVS++ enabled: EVS session creation was confirmed, readiness returned HTTP 200, and four captured 10-second captions completed successfully.
  - Both modes completed with valid frame counts and latency metrics and no fatal errors, tracebacks, architecture-inspection failures, or VLM-load failures.

## Checklist

- [x] I have read and followed the contribution guidelines.
- [x] The commit includes the required DCO sign-off.
- [x] New regression coverage was added and exercised.
- [x] The image was built and validated with real GPU inference.
- [x] No unrelated workspace files or credentials are included.
