### PR TITLE
fix(lvs): Improve summarization reliability at scale

### DIFF
--- a/deploy/docker/services/video-summarization/compose.yml
+++ b/deploy/docker/services/video-summarization/compose.yml
@@ -24,6 +24,13 @@ services:
       - ${BACKEND_HOST_PORT:-38111}:${BACKEND_PORT:-38111}
       - ${LVS_MCP_HOST_PORT:-38112}:${LVS_MCP_PORT:-38112}
 
+    # The process-based ContextManager pool can exceed Docker's default
+    # descriptor limit under sustained concurrency.
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
+
     # Volume mounts
     volumes:
       # Mount config.yaml and set CA_RAG_CONFIG_PATH to this location
@@ -107,6 +114,7 @@ services:
       # to avoid host-port collisions in multi-profile deployments.
       - LVS_ENABLE_MCP=${LVS_ENABLE_MCP:-false}
       - VSS_LOG_LEVEL=${VSS_LOG_LEVEL:-INFO}
+      - VSS_EXTRA_ARGS=${VSS_EXTRA_ARGS:-}
       - VLM_SYSTEM_PROMPT=""
 
       # RTVI-VLM integration (routes VLM calls to the RTVI container /generate_captions)

--- a/deploy/docker/services/video-summarization/configs/config.yaml
+++ b/deploy/docker/services/video-summarization/configs/config.yaml
@@ -30,7 +30,8 @@ tools:
     params:
       host: !ENV ${ES_HOST}
       port: !ENV ${ES_PORT}
-      kafka_consumer_settle_secs: 5.0
+      kafka_consumer_wait_timeout_secs: 90.0
+      kafka_consumer_poll_interval_secs: 0.5
       collection_name: lvs-events
     tools:
       embedding: nvidia_embedding

--- a/deploy/docker/services/video-summarization/lvs.env
+++ b/deploy/docker/services/video-summarization/lvs.env
@@ -73,6 +73,9 @@ NGC_MODEL_CACHE=/opt/models/ # path to download the model
 
 # Logging and Debug
 VSS_LOG_LEVEL=INFO
+# Optional capacity overrides. Keep the 256-manager default and scale out the
+# summarization service for higher concurrency; a busy replica returns 503.
+VSS_EXTRA_ARGS=
 
 # LLM Configuration
 # Update these to point to your external LLM NIM services

--- a/deploy/helm/developer-profiles/dev-profile-lvs/README.md
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/README.md
@@ -271,6 +271,7 @@ Use the table below for additional keys. Order follows **`values.yaml`**. **`ngc
 | **`vssIngress.kibanaPort`** | **`5601`** | Kibana **Service** port when Kibana is enabled. |
 | **`vssIngress.phoenixPort`** | **`6006`** | Phoenix **Service** port when Phoenix is enabled. |
 | **`vss-summarization.enabled`** | **`true`** | Set **`false`** to disable the **LVS** summarization service. |
+| **`vss-summarization.replicas`** | **`1`** | Use one summarization replica per two **RTVI-VLM** replicas. Set **`2`** for 3X/4X VLM scale tests instead of increasing the per-process ContextManager limit. |
 | **`vss-summarization.elasticsearchHost`** | **`""`** | Elasticsearch hostname for **vss-summarization** **`ES_HOST`**. When empty, defaults to **`<release>-elasticsearch`**. |
 | **`vss-summarization.elasticsearchPort`** | **`9200`** | Elasticsearch HTTP port (**`ES_PORT`**). |
 | **`vss-summarization.llmService`** | **`nemotron-35-lightning-30b-a3b`** | NIM subchart **name segment** used to build **`LVS_LLM_BASE_URL`** as **`http://<release>-<value>:8000/v1`** when **`global.llmBaseUrl`** and **`vss-summarization.llmBaseUrl`** are empty. Keep it aligned with the enabled LLM NIM. |

--- a/deploy/helm/developer-profiles/dev-profile-lvs/README.md
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/README.md
@@ -281,9 +281,12 @@ Use the table below for additional keys. Order follows **`values.yaml`**. **`ngc
 | **`vss-summarization.llmName`** | **`""`** | Optional **LVS-only** override of **`global.llmName`** (**`LVS_LLM_MODEL_NAME`**). |
 | **`vss-summarization.vlmName`** | **`""`** | Optional **LVS-only** override of **`global.vlmName`** (**`VIA_VLM_OPENAI_MODEL_DEPLOYMENT_NAME`**). |
 | **`infra.elasticsearch.enabled`** | **`true`** | Set **`false`** to disable the in-cluster **Elasticsearch** deployment. |
+| **`infra.elasticsearch.replicas`** | **4** | Elasticsearch data nodes. The validated sizing rule is one node per 10X VLM scale; reduce this only for developer validation. Multi-node discovery is configured automatically whenever this value is greater than one. |
+| **`infra.elasticsearch.env.ES_JAVA_OPTS`** | **`-Xms4g -Xmx4g`** | Heap per Elasticsearch node. Keep the pod memory request and limit above the heap size. |
+| **`infra.elasticsearch.resources`** | **2 CPU / 6Gi requested; 8Gi memory limit** | Per-node scheduling envelope for the 4Gi heap. CPU is intentionally not limited so indexing bursts can use available capacity. |
 | **`infra.elasticsearch.persistence.data.size`** | **10Gi** | PVC size for Elasticsearch **data** volume. |
 | **`infra.elasticsearch.persistence.logs.size`** | **5Gi** | PVC size for Elasticsearch **logs** volume (LVS chart exposes both **data** and **logs** sizes). |
-| **`infra.elasticsearch.persistence.storageClass`** | **`""`** | **StorageClass** for Elasticsearch PVCs; leave empty to inherit **`global.storageClass`**, or set explicitly. |
+| **`infra.elasticsearch.persistence.storageClass`** | **`""`** | **StorageClass** for Elasticsearch PVCs; leave empty to inherit **`global.storageClass`**, or set explicitly. Production scale requires fast block storage capable of at least 5K IOPS and 30 Mbps writes. |
 | **`infra.kibana.enabled`** | **`true`** | Set **`false`** to disable the in-cluster **Kibana** deployment. |
 | **`infra.kibana.elasticsearchHosts`** | **`""`** | Elasticsearch URL list **Kibana** connects to. When empty, defaults to **`http://<release>-elasticsearch:9200`**. |
 | **`infra.kibana.kibanaPublicUrl`** | **`""`** | Browser-facing **Kibana** base URL. When empty, templates use **`global.kibanaPublicUrl`** if set, else **`http://<release>-kibana:5601`**. |

--- a/deploy/helm/developer-profiles/dev-profile-lvs/values-lvs.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/values-lvs.yaml
@@ -59,6 +59,9 @@ vios:
 # Remote endpoints: use global.llmBaseUrl / global.vlmBaseUrl.
 # LVS backend routes VLM calls through vss-rtvi-vlm by default (RTVI_VLM_URL set in values.yaml extraEnv). Override only to bypass RTVI.
 vss-summarization:
+  # Size at one summarization replica per two RTVI-VLM replicas. Keep the
+  # default for the single-VLM profile; use 2 for 3X/4X scale testing.
+  replicas: 1
   vlmService: "vss-rtvi-vlm"
 
 # LVS always enables vss-rtvi-vlm (integrated checkpoint, Kafka enabled in values.yaml). Override here only when

--- a/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
@@ -74,11 +74,26 @@ infra:
       mountPath: /config.yml
   elasticsearch:
     enabled: true
+    # NVBug 6661431: the single 1 GiB node saturates at >=20X VLM scale.
+    # Four 4 GiB-heap data nodes sustain the measured 40X topology. Scale at
+    # one Elasticsearch data node per 10X VLM for larger deployments.
+    replicas: 4
+    env:
+      ES_JAVA_OPTS: "-Xms4g -Xmx4g"
+    resources:
+      requests:
+        cpu: "2"
+        memory: 6Gi
+      limits:
+        memory: 8Gi
     persistence:
       data:
         size: 10Gi
       logs:
         size: 5Gi
+      # Production scale requires fast block storage (>=5K IOPS and
+      # >=30 Mbps writes). Leave empty only when global.storageClass already
+      # selects a class with those characteristics.
       storageClass: ''
     init:
       enabled: true

--- a/deploy/helm/services/infra/charts/elasticsearch/templates/statefulset.yaml
+++ b/deploy/helm/services/infra/charts/elasticsearch/templates/statefulset.yaml
@@ -11,6 +11,10 @@ metadata:
 spec:
   replicas: {{ .Values.replicas }}
   serviceName: {{ include "elasticsearch.fullname" . }}-headless
+  # Keep the bootstrap node deterministic. Pod 0 forms the cluster with the
+  # single initial-master entry below, then the remaining pods join through
+  # the headless Service.
+  podManagementPolicy: OrderedReady
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: Delete
     whenScaled: Retain
@@ -58,8 +62,19 @@ spec:
           env:
             - name: ES_JAVA_OPTS
               value: {{ index .Values.env "ES_JAVA_OPTS" | default "-Xmx1024m -Xms256m" | quote }}
+            {{- if gt (int .Values.replicas) 1 }}
+            - name: node.name
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: discovery.seed_hosts
+              value: {{ printf "%s-headless" (include "elasticsearch.fullname" .) | quote }}
+            - name: cluster.initial_master_nodes
+              value: {{ printf "%s-0" (include "elasticsearch.fullname" .) | quote }}
+            {{- else }}
             - name: discovery.type
               value: {{ index .Values.env "discovery.type" | default "single-node" | quote }}
+            {{- end }}
             {{- if .Values.gpu.enabled }}
             - name: NVIDIA_VISIBLE_DEVICES
               value: "all"
@@ -98,7 +113,7 @@ spec:
             failureThreshold: 5
           readinessProbe:
             httpGet:
-              path: /_cluster/health
+              path: /_cluster/health?wait_for_status=yellow&timeout=5s
               port: http
             initialDelaySeconds: 30
             periodSeconds: 15

--- a/deploy/helm/services/infra/charts/elasticsearch/templates/tests/test-cluster.yaml
+++ b/deploy/helm/services/infra/charts/elasticsearch/templates/tests/test-cluster.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "elasticsearch.fullname" . }}-test-cluster
+  labels:
+    {{- include "elasticsearch.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: cluster-health
+      image: {{ .Values.volumeInit.image }}:{{ .Values.volumeInit.tag }}
+      command:
+        - sh
+        - -ec
+        - |
+          expected={{ .Values.replicas }}
+          health_url="http://{{ include "elasticsearch.fullname" . }}:{{ .Values.service.port }}/_cluster/health?wait_for_nodes=%3E%3D${expected}&wait_for_status=yellow&timeout=120s"
+          response="$(wget -qO- "${health_url}")"
+          nodes="$(printf '%s' "${response}" | sed -n 's/.*"number_of_nodes":\([0-9][0-9]*\).*/\1/p')"
+          status="$(printf '%s' "${response}" | sed -n 's/.*"status":"\([^"]*\)".*/\1/p')"
+          test -n "${nodes}"
+          test "${nodes}" -ge "${expected}"
+          test "${status}" = green -o "${status}" = yellow
+{{- end }}

--- a/deploy/helm/services/infra/charts/elasticsearch/tests/README.md
+++ b/deploy/helm/services/infra/charts/elasticsearch/tests/README.md
@@ -1,0 +1,16 @@
+# Elasticsearch scale acceptance test
+
+`scale_e2e.py` reproduces the Elasticsearch portion of the NVBug 6661431
+40X workload. By default it runs two waves of 1,280 per-stream indices and
+80 raw-event documents per stream (102,400 indexing operations per wave).
+
+Run it against the HTTP endpoint of a deployed four-node chart:
+
+```bash
+python3 scale_e2e.py --url http://127.0.0.1:9200
+```
+
+The test passes only when all documents are searchable, every primary shard
+is `STARTED` and distributed across all four nodes, the write-rejection delta
+is zero, and maximum JVM heap remains below 80%. Test indices and the temporary
+index template use unique names and are removed at the end of the run.

--- a/deploy/helm/services/infra/charts/elasticsearch/tests/scale_e2e.py
+++ b/deploy/helm/services/infra/charts/elasticsearch/tests/scale_e2e.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exercise Elasticsearch with the NVBug 6661431 high-scale workload shape."""
+
+import argparse
+import concurrent.futures
+import json
+import os
+import re
+import sys
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+def request(base_url, method, path, body=None, timeout=180):
+    data = None if body is None else json.dumps(body).encode()
+    req = urllib.request.Request(
+        f"{base_url.rstrip('/')}/{path.lstrip('/')}",
+        data=data,
+        method=method,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            payload = response.read()
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace")
+        raise RuntimeError(f"{method} {path} returned {exc.code}: {detail}") from exc
+    return json.loads(payload) if payload else {}
+
+
+def write_rejections(stats):
+    total = 0
+    for node in stats.get("nodes", {}).values():
+        pools = node.get("thread_pool", {})
+        for pool_name in ("write", "write_coordination"):
+            total += pools.get(pool_name, {}).get("rejected", 0)
+    return total
+
+
+def max_heap_percent(stats):
+    return max(
+        (
+            node.get("jvm", {}).get("mem", {}).get("heap_used_percent", 0)
+            for node in stats.get("nodes", {}).values()
+        ),
+        default=0,
+    )
+
+
+def bulk_payload(index_name, documents):
+    lines = []
+    for doc_id in range(documents):
+        lines.append(json.dumps({"index": {"_index": index_name, "_id": doc_id}}))
+        lines.append(
+            json.dumps(
+                {
+                    "text": f"Synthetic raw event {doc_id} for {index_name}",
+                    "metadata": {
+                        "content_metadata": {
+                            "uuid": index_name,
+                            "doc_type": "raw_events",
+                            "chunkIdx": doc_id,
+                        }
+                    },
+                }
+            )
+        )
+    return ("\n".join(lines) + "\n").encode()
+
+
+def write_stream(base_url, index_name, documents, timeout):
+    req = urllib.request.Request(
+        f"{base_url.rstrip('/')}/_bulk?wait_for_active_shards=1",
+        data=bulk_payload(index_name, documents),
+        method="POST",
+        headers={"Content-Type": "application/x-ndjson"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            result = json.loads(response.read())
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace")
+        raise RuntimeError(
+            f"bulk write for {index_name} returned {exc.code}: {detail}"
+        ) from exc
+    if result.get("errors"):
+        failures = [
+            item
+            for item in result.get("items", [])
+            if next(iter(item.values())).get("status", 500) >= 300
+        ]
+        raise RuntimeError(
+            f"bulk write for {index_name} had {len(failures)} failed items"
+        )
+
+
+def wait_for_cluster(base_url, nodes, timeout):
+    query = urllib.parse.urlencode(
+        {
+            "wait_for_nodes": f">={nodes}",
+            "wait_for_status": "yellow",
+            "wait_for_no_initializing_shards": "true",
+            "wait_for_no_relocating_shards": "true",
+            "timeout": f"{timeout}s",
+        }
+    )
+    health = request(base_url, "GET", f"_cluster/health?{query}", timeout=timeout + 10)
+    if health.get("timed_out"):
+        raise RuntimeError(f"cluster did not settle: {health}")
+    if health.get("number_of_nodes", 0) < nodes:
+        raise RuntimeError(f"expected at least {nodes} nodes: {health}")
+    return health
+
+
+def monitor_cluster(base_url, stop, sample):
+    while not stop.wait(0.5):
+        try:
+            stats = request(base_url, "GET", "_nodes/stats/thread_pool,jvm", timeout=10)
+            sample["max_heap_percent"] = max(
+                sample["max_heap_percent"], max_heap_percent(stats)
+            )
+            sample["max_write_rejections"] = max(
+                sample["max_write_rejections"], write_rejections(stats)
+            )
+        except Exception as exc:  # preserve monitoring failures for the main thread
+            sample["errors"].append(str(exc))
+
+
+def run_wave(args, prefix, wave):
+    pattern = f"{prefix}-w{wave}-*"
+    indices = [f"{prefix}-w{wave}-s{stream:04d}" for stream in range(args.streams)]
+    before = request(args.url, "GET", "_nodes/stats/thread_pool,jvm")
+    rejected_before = write_rejections(before)
+    sample = {
+        "max_heap_percent": max_heap_percent(before),
+        "max_write_rejections": rejected_before,
+        "errors": [],
+    }
+    monitor_stop = threading.Event()
+    monitor = threading.Thread(
+        target=monitor_cluster,
+        args=(args.url, monitor_stop, sample),
+        daemon=True,
+    )
+
+    failures = []
+    started = time.monotonic()
+    monitor.start()
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+            futures = {
+                pool.submit(
+                    write_stream,
+                    args.url,
+                    index_name,
+                    args.documents,
+                    args.timeout,
+                ): index_name
+                for index_name in indices
+            }
+            for completed, future in enumerate(
+                concurrent.futures.as_completed(futures), 1
+            ):
+                try:
+                    future.result()
+                except Exception as exc:  # collect all failures before reporting
+                    failures.append({"index": futures[future], "error": str(exc)})
+                if completed % 128 == 0 or completed == args.streams:
+                    print(
+                        f"wave {wave}: {completed}/{args.streams} streams written",
+                        flush=True,
+                    )
+    finally:
+        monitor_stop.set()
+        monitor.join(timeout=15)
+    if monitor.is_alive():
+        raise RuntimeError(f"wave {wave}: cluster monitor did not stop")
+    if sample["errors"]:
+        raise RuntimeError(
+            f"wave {wave}: cluster monitoring failed: {sample['errors'][:10]}"
+        )
+    if failures:
+        raise RuntimeError(
+            f"wave {wave} had failed writes: {json.dumps(failures[:10])}"
+        )
+
+    health = wait_for_cluster(args.url, args.nodes, args.timeout)
+    encoded_pattern = urllib.parse.quote(pattern, safe="*-_")
+    request(args.url, "POST", f"{encoded_pattern}/_refresh")
+    count = request(args.url, "GET", f"{encoded_pattern}/_count").get("count", -1)
+    expected = args.streams * args.documents
+    if count != expected:
+        raise RuntimeError(f"wave {wave}: expected {expected} documents, found {count}")
+
+    shards = request(
+        args.url,
+        "GET",
+        f"_cat/shards/{encoded_pattern}?format=json&h=index,prirep,state,node",
+    )
+    primaries = [shard for shard in shards if shard.get("prirep") == "p"]
+    if len(primaries) != args.streams:
+        raise RuntimeError(
+            f"wave {wave}: expected {args.streams} primary shards, found {len(primaries)}"
+        )
+    not_started = [shard for shard in primaries if shard.get("state") != "STARTED"]
+    if not_started:
+        raise RuntimeError(
+            f"wave {wave}: {len(not_started)} primary shards are not STARTED"
+        )
+    shard_nodes = {shard.get("node") for shard in primaries if shard.get("node")}
+    if len(shard_nodes) < args.nodes:
+        raise RuntimeError(f"wave {wave}: shards use only {len(shard_nodes)} nodes")
+
+    after = request(args.url, "GET", "_nodes/stats/thread_pool,jvm")
+    rejected_delta = max(
+        write_rejections(after), sample["max_write_rejections"]
+    ) - rejected_before
+    heap = max(max_heap_percent(after), sample["max_heap_percent"])
+    if rejected_delta:
+        raise RuntimeError(
+            f"wave {wave}: Elasticsearch rejected {rejected_delta} writes"
+        )
+    if heap >= args.max_heap_percent:
+        raise RuntimeError(
+            f"wave {wave}: heap reached {heap}%, limit is <{args.max_heap_percent}%"
+        )
+
+    result = {
+        "wave": wave,
+        "streams": args.streams,
+        "documents": count,
+        "duration_seconds": round(time.monotonic() - started, 3),
+        "nodes": health.get("number_of_nodes"),
+        "shard_nodes": sorted(shard_nodes),
+        "write_rejections": rejected_delta,
+        "max_heap_percent": heap,
+    }
+    print(json.dumps(result, sort_keys=True), flush=True)
+    return result, indices
+
+
+def delete_indices(base_url, indices):
+    # Elasticsearch disables wildcard deletes in the shipped configuration.
+    # Use bounded batches of exact test-created names to keep request URLs
+    # below common proxy limits without weakening that safety setting.
+    for offset in range(0, len(indices), 50):
+        encoded = urllib.parse.quote(",".join(indices[offset : offset + 50]), safe=",-_")
+        request(base_url, "DELETE", f"{encoded}?ignore_unavailable=true")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--url", default="http://127.0.0.1:9200")
+    parser.add_argument("--nodes", type=int, default=4)
+    parser.add_argument("--waves", type=int, default=2)
+    parser.add_argument("--streams", type=int, default=1280)
+    parser.add_argument("--documents", type=int, default=80)
+    parser.add_argument("--concurrency", type=int, default=1280)
+    parser.add_argument("--timeout", type=int, default=180)
+    parser.add_argument("--max-heap-percent", type=int, default=80)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    if min(args.nodes, args.waves, args.streams, args.documents, args.concurrency) < 1:
+        raise SystemExit(
+            "nodes, waves, streams, documents, and concurrency must be positive"
+        )
+
+    unique = f"{int(time.time())}-{os.getpid()}"
+    prefix = f"default_nvbug6661431_{unique}"
+    if not re.fullmatch(r"[a-z0-9_-]+", prefix):
+        raise SystemExit(f"unsafe test index prefix: {prefix}")
+    template_name = f"nvbug6661431-e2e-{unique}"
+    pattern = f"{prefix}-*"
+    results = []
+    created_indices = []
+
+    wait_for_cluster(args.url, args.nodes, args.timeout)
+    request(
+        args.url,
+        "PUT",
+        f"_index_template/{template_name}",
+        {
+            "index_patterns": [pattern],
+            "priority": 500,
+            "template": {
+                "settings": {"number_of_shards": 1, "number_of_replicas": 0}
+            },
+        },
+    )
+    try:
+        for wave in range(1, args.waves + 1):
+            wave_indices = [
+                f"{prefix}-w{wave}-s{stream:04d}" for stream in range(args.streams)
+            ]
+            created_indices.extend(wave_indices)
+            result, _ = run_wave(args, prefix, wave)
+            results.append(result)
+            delete_indices(args.url, wave_indices)
+            wait_for_cluster(args.url, args.nodes, args.timeout)
+    finally:
+        if created_indices:
+            try:
+                delete_indices(args.url, created_indices)
+            except RuntimeError as exc:
+                print(f"cleanup warning: {exc}", file=sys.stderr)
+        try:
+            request(args.url, "DELETE", f"_index_template/{template_name}")
+        except RuntimeError as exc:
+            print(f"cleanup warning: {exc}", file=sys.stderr)
+
+    print(json.dumps({"status": "passed", "waves": results}, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/helm/services/infra/charts/elasticsearch/tests/scale_e2e.py
+++ b/deploy/helm/services/infra/charts/elasticsearch/tests/scale_e2e.py
@@ -9,12 +9,32 @@ import concurrent.futures
 import json
 import os
 import re
+import resource
 import sys
 import threading
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
+
+
+def ensure_file_limit(concurrency):
+    """Reserve enough descriptors for concurrent writers and monitoring."""
+    required = max(4096, concurrency + 512)
+    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    if soft < required:
+        target = required if hard == resource.RLIM_INFINITY else min(required, hard)
+        try:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (target, hard))
+        except (OSError, ValueError) as exc:
+            raise SystemExit(
+                f"file descriptor limit {soft} is below required {required}: {exc}"
+            ) from exc
+        soft, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
+    if soft < required:
+        raise SystemExit(
+            f"file descriptor limit {soft} is below required {required}"
+        )
 
 
 def request(base_url, method, path, body=None, timeout=180):
@@ -273,6 +293,7 @@ def main():
         raise SystemExit(
             "nodes, waves, streams, documents, and concurrency must be positive"
         )
+    ensure_file_limit(args.concurrency)
 
     unique = f"{int(time.time())}-{os.getpid()}"
     prefix = f"default_nvbug6661431_{unique}"

--- a/deploy/helm/services/video-summarization/configs/config.yaml
+++ b/deploy/helm/services/video-summarization/configs/config.yaml
@@ -30,7 +30,8 @@ tools:
     params:
       host: !ENV ${ES_HOST}
       port: !ENV ${ES_PORT}
-      kafka_consumer_settle_secs: 5.0
+      kafka_consumer_wait_timeout_secs: 90.0
+      kafka_consumer_poll_interval_secs: 0.5
       collection_name: lvs-events
     tools:
       embedding: nvidia_embedding

--- a/deploy/helm/services/video-summarization/values.yaml
+++ b/deploy/helm/services/video-summarization/values.yaml
@@ -19,6 +19,8 @@ image:
   repository: ghcr.io/nvidia-ai-blueprints/vss/vss-video-summarization
   tag: "develop-latest"
   pullPolicy: IfNotPresent
+# Each replica owns an independent 256-ContextManager pool. Use at least one
+# summarization replica per two VLM replicas instead of raising that cap.
 replicas: 1
 # Backend (API), MCP ports — match Compose
 service:
@@ -130,6 +132,8 @@ env:
     value: ""
   - name: VSS_LOG_LEVEL
     value: INFO
+  - name: VSS_EXTRA_ARGS
+    value: ""
 
 # extraEnv: appended after the computed env block. Each value is rendered with `tpl`, so expressions like
 # `http://{{ .Release.Name }}-vss-rtvi-vlm:8000` are supported. Use this for LVS -> RTVI-VLM wiring

--- a/services/video-summarization/README.md
+++ b/services/video-summarization/README.md
@@ -195,6 +195,10 @@ export KAFKA_ENABLED=false                       # Enable Kafka streaming pipeli
 export ENABLE_AUDIO=false                        # Enable audio transcription
 export VIA_DEV_API=true                          # Enable /files and /generate_vlm_captions dev routes
 export DISABLE_CA_RAG=false                      # Disable CA-RAG aggregation
+# Optional: tune independent CA-RAG and HTTP worker limits. Keep the defaults
+# for normal deployments; scale out instead of raising the per-process cap.
+export VSS_EXTRA_ARGS="--max-context-managers 256 --max-async-workers 320"
+# The provided Compose deployment raises the descriptor limit for this pool.
 
 # Optional — Elasticsearch tuning
 export ES_MAX_SHARDS_PER_NODE=2000   # Raise for retain-mode workloads
@@ -217,6 +221,27 @@ RT-VLM credential fallback.
 The runtime environment variables above do not log Docker into `nvcr.io`. If Docker
 needs to pull private NGC images, authenticate the Docker client with an NGC credential
 before running `docker compose up`.
+
+### Scaling concurrent summarization
+
+Each service replica has an independent pool of 256 CA-RAG ContextManager
+processes. When that pool is exhausted, the replica returns HTTP 503 with the
+`ServerBusy` code at admission so callers can retry another replica; excess
+requests do not wait for a ContextManager lease.
+
+Use one `vss-summarization` replica for up to two VLM replicas. Deploy at least
+two summarization replicas when running more than two VLM replicas:
+
+```bash
+helm upgrade --install <RELEASE_NAME> <CHART> \
+  --set vss-summarization.replicas=2
+```
+
+Do not raise `--max-context-managers` to absorb sustained concurrency. Every
+manager creates a process and supporting threads inside the same Python
+service; scaling replicas spreads that CPU and file-descriptor load. Clients
+should use a bounded request timeout and retry transient `ServerBusy`
+responses. Let one benchmark wave drain before starting the next.
 
 ### Data directory prerequisites for repo-level Compose
 
@@ -541,7 +566,7 @@ http://<host>:38112/sse
 | 422 | Unprocessable | Extra unknown field, wrong type, value out of range |
 | 429 | Rate Limited | Too many concurrent requests |
 | 500 | Server Error | VLM inference failure, GPU OOM, internal error |
-| 503 | Server Busy | Processing another file/stream — retry with backoff |
+| 503 | Server Busy | ContextManager capacity exhausted — retry another replica with backoff |
 
 ## Important Notes
 

--- a/services/video-summarization/config/config.yaml
+++ b/services/video-summarization/config/config.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,7 +30,8 @@ tools:
     params:
       host: !ENV ${ES_HOST}
       port: !ENV ${ES_PORT}
-      kafka_consumer_settle_secs: 5.0
+      kafka_consumer_wait_timeout_secs: 90.0
+      kafka_consumer_poll_interval_secs: 0.5
       collection_name: lvs-events
     tools:
       embedding: nvidia_embedding

--- a/services/video-summarization/docker/Dockerfile
+++ b/services/video-summarization/docker/Dockerfile
@@ -69,6 +69,13 @@ RUN uv pip install \
     --extra-index-url https://pypi.nvidia.com/ \
     --python-version 3.13 --target /tmp/packages
 
+# Apply a downstream patch to retry transient Elasticsearch primary-shard
+# failures until the behavior is available in an upstream release.
+RUN --mount=type=bind,source=docker/patches/context-aware-rag,target=/tmp/context-aware-rag-patches \
+    cd /tmp/packages \
+    && git apply --no-index --unidiff-zero -p2 \
+        /tmp/context-aware-rag-patches/elasticsearch-shard-readiness.patch
+
 # Ubuntu builder: shell-based operations only — user creation, config/source copy scripts
 FROM jammy-builder-base AS app-builder
 

--- a/services/video-summarization/docker/package_file_list.txt
+++ b/services/video-summarization/docker/package_file_list.txt
@@ -1,5 +1,6 @@
 __init__.py
 chunk_info.py
+elasticsearch_shard_retry.py
 kafka_producer.py
 lvs_errors.py
 protos/__init__.py

--- a/services/video-summarization/docker/patches/context-aware-rag/elasticsearch-shard-readiness.patch
+++ b/services/video-summarization/docker/patches/context-aware-rag/elasticsearch-shard-readiness.patch
@@ -1,0 +1,30 @@
+diff --git a/src/vss_ctx_rag/tools/storage/elasticsearch_db.py b/src/vss_ctx_rag/tools/storage/elasticsearch_db.py
+index e6a0895..c6f395e 100644
+--- a/src/vss_ctx_rag/tools/storage/elasticsearch_db.py
++++ b/src/vss_ctx_rag/tools/storage/elasticsearch_db.py
+@@ -23,0 +24 @@ from langchain_elasticsearch.vectorstores import ElasticsearchStore
++from elasticsearch_shard_retry import retry_shard_operation, wait_for_primary_shard
+@@ -522,4 +523,14 @@ class ElasticsearchDBTool(VectorStorageTool):
+-            response = es_client.search(
+-                index=self.index_name,
+-                body=query,
+-                size=10000,
++
++            def search_when_ready():
++                wait_for_primary_shard(es_client, self.index_name)
++                return es_client.search(
++                    index=self.index_name,
++                    body=query,
++                    size=10000,
++                )
++
++            response = retry_shard_operation(
++                search_when_ready,
++                operation_name="retrieve_docs",
++                index_name=self.index_name,
++                logger=logger,
+@@ -546,2 +557,2 @@ class ElasticsearchDBTool(VectorStorageTool):
+-            logger.warning(f"Error retrieving docs: {e}")
+-            return []
++            logger.error(f"Error retrieving docs: {e}")
++            raise

--- a/services/video-summarization/src/elasticsearch_shard_retry.py
+++ b/services/video-summarization/src/elasticsearch_shard_retry.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Retry helpers for transient Elasticsearch shard-allocation races."""
+
+import os
+import time
+from collections.abc import Callable
+from typing import Any
+
+_SHARD_UNAVAILABLE_MARKERS = (
+    "noshardavailableactionexception",
+    "no_shard_available_action_exception",
+    "no shard available",
+    "all shards failed",
+    "primary shard is not active",
+)
+
+
+class PrimaryShardUnavailable(RuntimeError):
+    """An Elasticsearch primary shard did not become active in time."""
+
+    status_code = 503
+
+
+def is_shard_unavailable_error(error: BaseException) -> bool:
+    """Return whether an Elasticsearch error represents an unavailable shard."""
+    message = str(error).lower()
+    return any(marker in message for marker in _SHARD_UNAVAILABLE_MARKERS)
+
+
+def _retry_settings() -> tuple[int, float]:
+    try:
+        attempts = int(os.environ.get("VSS_CTX_RAG_ES_SHARD_RETRY_ATTEMPTS", "5"))
+    except (TypeError, ValueError):
+        attempts = 5
+    try:
+        backoff = float(os.environ.get("VSS_CTX_RAG_ES_SHARD_RETRY_BACKOFF_SECS", "0.1"))
+    except (TypeError, ValueError):
+        backoff = 0.1
+    return max(1, attempts), max(0.0, backoff)
+
+
+def retry_shard_operation(
+    operation: Callable[[], Any],
+    *,
+    operation_name: str,
+    index_name: str,
+    logger,
+    sleep: Callable[[float], None] = time.sleep,
+):
+    """Retry only transient shard-unavailable failures with bounded backoff."""
+    attempts, delay = _retry_settings()
+    for attempt in range(1, attempts + 1):
+        try:
+            return operation()
+        except Exception as error:
+            if not is_shard_unavailable_error(error) or attempt == attempts:
+                raise
+            logger.warning(
+                "Elasticsearch %s for index '%s' hit an unavailable shard "
+                "(attempt %d/%d); retrying in %.3fs: %s",
+                operation_name,
+                index_name,
+                attempt,
+                attempts,
+                delay,
+                error,
+            )
+            sleep(delay)
+            delay = min(delay * 2, 1.0)
+
+
+def wait_for_primary_shard(es_client, index_name: str) -> None:
+    """Wait briefly until the index has one active primary shard."""
+    try:
+        health = es_client.cluster.health(
+            index=index_name,
+            wait_for_status="yellow",
+            wait_for_active_shards="1",
+            timeout="1s",
+        )
+    except Exception as error:
+        # Elasticsearch 9 reports a timed-out cluster-health wait as HTTP 408,
+        # so the Python client raises before returning the response body.
+        status = getattr(error, "status_code", None)
+        if status is None:
+            status = getattr(getattr(error, "meta", None), "status", None)
+        if status == 408:
+            raise PrimaryShardUnavailable(
+                f"primary shard is not active for index '{index_name}'"
+            ) from error
+        raise
+    if health.get("timed_out"):
+        raise PrimaryShardUnavailable(f"primary shard is not active for index '{index_name}'")

--- a/services/video-summarization/src/lvs_errors.py
+++ b/services/video-summarization/src/lvs_errors.py
@@ -36,6 +36,8 @@ from __future__ import annotations
 import logging
 from typing import Tuple
 
+from elasticsearch_shard_retry import is_shard_unavailable_error
+
 logger = logging.getLogger(__name__)
 
 
@@ -110,6 +112,11 @@ def _looks_like_shard_cap(exc: BaseException) -> bool:
     return False
 
 
+def _looks_like_unavailable_shard(exc: BaseException) -> bool:
+    """Identify a transient search failure caused by an inactive shard."""
+    return any(is_shard_unavailable_error(link) for link in _walk_causes(exc))
+
+
 def classify_es_error(exc: BaseException) -> Tuple[int, str]:
     """Map an Elasticsearch / Logstash dependency exception to an HTTP
     response shape suitable for surfacing through ``/v1/summarize`` and
@@ -139,6 +146,9 @@ def classify_es_error(exc: BaseException) -> Tuple[int, str]:
 
     if _looks_like_shard_cap(exc):
         return 503, _SHARD_LIMIT_USER_MESSAGE
+
+    if _looks_like_unavailable_shard(exc):
+        return 503, _GENERIC_ES_USER_MESSAGE.format(status=503)
 
     if isinstance(status, int) and 400 <= status < 600:
         return 503, _GENERIC_ES_USER_MESSAGE.format(status=status)

--- a/services/video-summarization/src/via_server.py
+++ b/services/video-summarization/src/via_server.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -165,7 +165,7 @@ class ViaServer:
         self._args = args
 
         self._async_executor = ThreadPoolExecutor(
-            max_workers=args.max_live_streams, thread_name_prefix="vss-async-worker"
+            max_workers=args.max_async_workers, thread_name_prefix="vss-async-worker"
         )
 
         # Use FastAPI to implement the REST API
@@ -229,6 +229,26 @@ class ViaServer:
         self._server = None
 
         self._stream_settings_cache = StreamSettingsCache(logger=logger)
+
+    async def _wait_for_request_done(self, request_id: str) -> None:
+        """Wait without occupying an HTTP offload worker."""
+        try:
+            while not self._stream_handler.is_request_done(request_id):
+                await asyncio.sleep(0.1)
+        except asyncio.CancelledError:
+            # A non-streaming client disconnected. Mark the request for
+            # deferred removal once its processing thread reaches safety.
+            self._stream_handler.check_status_remove_req_id(request_id)
+            raise
+
+    async def _cleanup_sse_generator(self, generator, source_id: str, request_id: str):
+        """Record cleanup on normal completion and client disconnect."""
+        try:
+            async for message in generator:
+                yield message
+        finally:
+            self._sse_active_clients.pop(source_id, None)
+            self._stream_handler.check_status_remove_req_id(request_id)
 
     def run(self):
         from via_stream_handler import ViaStreamHandler
@@ -795,15 +815,15 @@ class ViaServer:
                         except ViaException:
                             pass
                     yield "[DONE]"
-                    self._sse_active_clients.pop(videoId, None)
-                    self._stream_handler.check_status_remove_req_id(request_id)
 
-                return EventSourceResponse(message_generator(), send_timeout=5, ping=1)
+                return EventSourceResponse(
+                    self._cleanup_sse_generator(message_generator(), videoId, request_id),
+                    send_timeout=5,
+                    ping=1,
+                )
             else:
                 # Non-streaming output. Wait for request to be completed.
-                await loop.run_in_executor(
-                    self._async_executor, self._stream_handler.wait_for_request_done, request_id
-                )
+                await self._wait_for_request_done(request_id)
                 req_info, resp_list = self._stream_handler.get_response(request_id)
                 self._stream_handler.check_status_remove_req_id(request_id)
                 if req_info.status == RequestInfo.Status.FAILED:
@@ -1146,11 +1166,7 @@ class ViaServer:
                 stream_id,
             )
 
-            await loop.run_in_executor(
-                self._async_executor,
-                self._stream_handler.wait_for_request_done,
-                request_id,
-            )
+            await self._wait_for_request_done(request_id)
             req_info, resp_list = self._stream_handler.get_response(request_id)
             self._stream_handler.check_status_remove_req_id(request_id)
 
@@ -1609,15 +1625,15 @@ class ViaServer:
                         except ViaException:
                             pass
                     yield "[DONE]"
-                    self._sse_active_clients.pop(videoId, None)
-                    self._stream_handler.check_status_remove_req_id(request_id)
 
-                return EventSourceResponse(message_generator(), send_timeout=5, ping=1)
+                return EventSourceResponse(
+                    self._cleanup_sse_generator(message_generator(), videoId, request_id),
+                    send_timeout=5,
+                    ping=1,
+                )
             else:
                 # Non-streaming output. Wait for request to be completed.
-                await loop.run_in_executor(
-                    self._async_executor, self._stream_handler.wait_for_request_done, request_id
-                )
+                await self._wait_for_request_done(request_id)
                 req_info, resp_list = self._stream_handler.get_response(request_id)
                 self._stream_handler.check_status_remove_req_id(request_id)
                 if req_info.status == RequestInfo.Status.FAILED:
@@ -1948,4 +1964,3 @@ if __name__ == "__main__":
 
     server = ViaServer(args)
     server.run()
-

--- a/services/video-summarization/src/via_stream_handler.py
+++ b/services/video-summarization/src/via_stream_handler.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,7 +32,7 @@ from threading import Event, RLock, Thread
 
 import json_repair
 import prometheus_client as prom
-import requests.exceptions
+import requests
 from pyaml_env import parse_config
 
 from chunk_info import ChunkInfo, RequestSource, get_timestamp_str
@@ -94,6 +94,12 @@ MAX_MILVUS_STRING_LEN = 65535
 # response, which surfaces to the caller as HTTP 200 with total_events=0 and
 # video_summary="". Override with LVS_AGGREGATION_EMPTY_RETRIES; 0 disables.
 DEFAULT_AGGREGATION_EMPTY_RETRIES = 2
+
+
+class KafkaIngestionTimeout(RuntimeError):
+    """Kafka-to-Elasticsearch ingestion did not finish before aggregation."""
+
+    status_code = 503
 
 
 class RequestInfo:
@@ -3488,15 +3494,9 @@ This is very important and you must follow this strictly.
                                 "Elastic DB (LVS_CAPTION_SOURCE=db)",
                                 req_info.source_id,
                             )
-                            settle_secs = self._kafka_settle_secs()
-                            if settle_secs > 0:
-                                logger.info(
-                                    "Waiting %.3fs for Kafka -> Logstash -> ES "
-                                    "raw_events flush before aggregating %s",
-                                    settle_secs,
-                                    req_info.source_id,
-                                )
-                                time.sleep(settle_secs)
+                            self._wait_for_kafka_raw_events(
+                                req_info.source_id, len(chunk_responses)
+                            )
                             sum_state: dict = {"uuids": [str(req_info.source_id)]}
                             _start_ts = getattr(req_info, "start_timestamp", None)
                             _end_ts = getattr(req_info, "end_timestamp", None)
@@ -3972,7 +3972,8 @@ This is very important and you must follow this strictly.
             via SSE (``start_index / end_index``).
           * ``db`` — aggregation retrieves captions from Elastic DB
             populated by the Kafka -> Logstash -> ES pipeline
-            (``uuids``).  Requires a settle delay so Logstash can flush.
+            (``uuids``). The read starts only after all expected raw-event
+            documents become searchable.
 
         Requires both server-level ``KAFKA_ENABLED`` (env) and config-level
         ``functions.summarization.params.kafka_enabled`` (CA-RAG YAML).
@@ -3984,22 +3985,98 @@ This is very important and you must follow this strictly.
         summ = (self._ca_rag_config or {}).get("functions", {}).get("summarization", {})
         return bool(summ.get("params", {}).get("kafka_enabled", False))
 
-    def _kafka_settle_secs(self) -> float:
-        """Seconds to sleep after RTVI SSE ``[DONE]`` in file-path Kafka mode.
-
-        Reads ``tools.<db>.params.kafka_consumer_settle_secs`` from the
-        parsed CA-RAG config; falls back to env override
-        ``LVS_KAFKA_CONSUMER_SETTLE_SECS`` when the YAML key is absent;
-        defaults to ``5.0``. Used so the Kafka -> Logstash -> ES pipeline
-        has time to flush raw_events into the DB before the aggregator
-        (running with ``kafka_enabled=true``) reads them at acall time.
-        """
+    def _kafka_wait_value(self, key: str, env_name: str, default: float) -> float:
+        """Read a positive Kafka-ingestion wait setting."""
         db_name = self._get_db_tool_name(self._ca_rag_config) or "elasticsearch_db"
         tools = (self._ca_rag_config or {}).get("tools", {})
-        val = tools.get(db_name, {}).get("params", {}).get("kafka_consumer_settle_secs")
+        val = tools.get(db_name, {}).get("params", {}).get(key)
         if val is None:
-            val = os.environ.get("LVS_KAFKA_CONSUMER_SETTLE_SECS", "5.0")
+            val = os.environ.get(env_name, str(default))
         try:
-            return float(val)
+            parsed = float(val)
         except (TypeError, ValueError):
-            return 5.0
+            parsed = default
+        if parsed <= 0:
+            logger.warning("Invalid %s=%r; using %.3f", key, val, default)
+            return default
+        return parsed
+
+    def _wait_for_kafka_raw_events(self, source_id, expected_docs: int) -> None:
+        """Wait until Kafka/Logstash makes every video chunk searchable.
+
+        The RTVI SSE ``[DONE]`` marker only means caption generation has
+        finished. It does not guarantee that the independent Kafka consumer
+        has drained its backlog or that Elasticsearch has refreshed the
+        writes. Polling the request's raw-event count closes that race without
+        imposing a fixed delay on requests whose data is already available.
+        """
+        if expected_docs <= 0:
+            return
+
+        db_name = self._get_db_tool_name(self._ca_rag_config) or "elasticsearch_db"
+        params = (self._ca_rag_config or {}).get("tools", {}).get(db_name, {}).get("params", {})
+        host = params.get("host") or os.environ.get("ES_HOST")
+        port = params.get("port") or os.environ.get("ES_PORT", "9200")
+        if not host:
+            raise KafkaIngestionTimeout(
+                "Elasticsearch host is unavailable while waiting for Kafka ingestion"
+            )
+        base_url = str(host).rstrip("/")
+        if not base_url.startswith(("http://", "https://")):
+            base_url = f"http://{base_url}:{port}"
+
+        timeout = self._kafka_wait_value(
+            "kafka_consumer_wait_timeout_secs",
+            "LVS_KAFKA_CONSUMER_WAIT_TIMEOUT_SECS",
+            90.0,
+        )
+        poll_interval = self._kafka_wait_value(
+            "kafka_consumer_poll_interval_secs",
+            "LVS_KAFKA_CONSUMER_POLL_INTERVAL_SECS",
+            0.5,
+        )
+        index_name = requests.utils.quote(_safe_collection_name(source_id), safe="")
+        count_url = f"{base_url}/{index_name}/_count"
+        count_query = {"query": {"term": {"metadata.content_metadata.doc_type": "raw_events"}}}
+        started = time.monotonic()
+        deadline = started + timeout
+        last_count = 0
+        last_error = None
+
+        while True:
+            remaining = max(0.0, deadline - time.monotonic())
+            try:
+                response = requests.post(
+                    count_url,
+                    json=count_query,
+                    timeout=min(5.0, max(1.0, remaining)),
+                )
+                if response.status_code == 404:
+                    last_count = 0
+                elif response.status_code >= 500 or response.status_code == 429:
+                    last_error = f"Elasticsearch returned HTTP {response.status_code}"
+                else:
+                    response.raise_for_status()
+                    last_count = int(response.json().get("count", 0))
+                    last_error = None
+                    if last_count >= expected_docs:
+                        logger.info(
+                            "Kafka -> Logstash -> ES ingestion ready for %s: "
+                            "%d/%d raw_events after %.3fs",
+                            source_id,
+                            last_count,
+                            expected_docs,
+                            time.monotonic() - started,
+                        )
+                        return
+            except (requests.exceptions.RequestException, TypeError, ValueError) as ex:
+                last_error = str(ex)
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                detail = f"; last error: {last_error}" if last_error else ""
+                raise KafkaIngestionTimeout(
+                    "Timed out waiting for Kafka ingestion for "
+                    f"{source_id}: {last_count}/{expected_docs} raw_events{detail}"
+                )
+            time.sleep(min(poll_interval, remaining))

--- a/services/video-summarization/src/via_stream_handler.py
+++ b/services/video-summarization/src/via_stream_handler.py
@@ -214,6 +214,10 @@ class RequestInfo:
         self.rtvi_status_code = None
         self.rtvi_error_code = None
         self.rtvi_error_message = None
+        # RTVI assigns a distinct ID to each caption-generation run. Keep it
+        # separate from the reusable source ID so Kafka readiness checks cannot
+        # be satisfied by raw events left over from an earlier run.
+        self.rtvi_request_id = None
         self.enable_qa = False
         self._qa_ctx_mgr = None
 
@@ -1623,6 +1627,20 @@ class ViaStreamHandler:
                 api_type=getattr(req_info, "api_type", None),
                 mm_processor_kwargs=getattr(req_info, "mm_processor_kwargs", None),
             ):
+                rtvi_request_id = sse_chunk.get("id")
+                if rtvi_request_id:
+                    rtvi_request_id = str(rtvi_request_id)
+                    if (
+                        req_info.rtvi_request_id
+                        and req_info.rtvi_request_id != rtvi_request_id
+                    ):
+                        raise RtviError(
+                            502,
+                            "DependencyError",
+                            "RTVI returned inconsistent request IDs for one caption run",
+                        )
+                    req_info.rtvi_request_id = rtvi_request_id
+
                 chunk_responses = sse_chunk.get("chunk_responses", [])
                 if not chunk_responses:
                     continue
@@ -3156,10 +3174,15 @@ This is very important and you must follow this strictly.
             )
             if not req_info.is_live:
                 try:
-                    self.drop_collection_for_asset(req_info.source_id, force_legacy=True)
+                    result = ctx_mgr.drop_collection()
+                    logger.info(
+                        "post-summarize drop_collection for source_id=%s -> %s",
+                        req_info.source_id,
+                        result,
+                    )
                 except Exception as drop_ex:
                     logger.warning(
-                        "post-summarize drop_collection_for_asset failed for %s: %s",
+                        "post-summarize drop_collection failed for %s: %s",
                         req_info.source_id,
                         drop_ex,
                     )
@@ -3582,7 +3605,9 @@ This is very important and you must follow this strictly.
                                 req_info.source_id,
                             )
                             self._wait_for_kafka_raw_events(
-                                req_info.source_id, len(chunk_responses)
+                                req_info.source_id,
+                                len(chunk_responses),
+                                req_info.rtvi_request_id,
                             )
                             sum_state: dict = {"uuids": [str(req_info.source_id)]}
                             _start_ts = getattr(req_info, "start_timestamp", None)
@@ -4103,7 +4128,9 @@ This is very important and you must follow this strictly.
             return default
         return parsed
 
-    def _wait_for_kafka_raw_events(self, source_id, expected_docs: int) -> None:
+    def _wait_for_kafka_raw_events(
+        self, source_id, expected_docs: int, rtvi_request_id: str | None
+    ) -> None:
         """Wait until Kafka/Logstash makes every video chunk searchable.
 
         The RTVI SSE ``[DONE]`` marker only means caption generation has
@@ -4114,6 +4141,10 @@ This is very important and you must follow this strictly.
         """
         if expected_docs <= 0:
             return
+        if not rtvi_request_id:
+            raise KafkaIngestionTimeout(
+                "RTVI request ID is unavailable while waiting for Kafka ingestion"
+            )
 
         db_name = self._get_db_tool_name(self._ca_rag_config) or "elasticsearch_db"
         params = (self._ca_rag_config or {}).get("tools", {}).get(db_name, {}).get("params", {})
@@ -4139,7 +4170,24 @@ This is very important and you must follow this strictly.
         )
         index_name = requests.utils.quote(_safe_collection_name(source_id), safe="")
         count_url = f"{base_url}/{index_name}/_count"
-        count_query = {"query": {"term": {"metadata.content_metadata.doc_type": "raw_events"}}}
+        count_query = {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "term": {
+                                "metadata.content_metadata.doc_type.keyword": "raw_events"
+                            }
+                        },
+                        {
+                            "term": {
+                                "metadata.content_metadata.requestId.keyword": rtvi_request_id
+                            }
+                        },
+                    ]
+                }
+            }
+        }
         started = time.monotonic()
         deadline = started + timeout
         last_count = 0

--- a/services/video-summarization/src/via_stream_handler.py
+++ b/services/video-summarization/src/via_stream_handler.py
@@ -202,6 +202,9 @@ class RequestInfo:
         self.custom_metadata = None
         self.delete_external_collection = False
         self.error_message = ""
+        # Set when an HTTP/SSE consumer disconnects before processing reaches
+        # a terminal state. The processing path performs deferred cleanup.
+        self.cleanup_requested = False
         self.schema = None
         self.batch_response_method = None
         self.scenario = None
@@ -398,6 +401,23 @@ class ViaStreamHandler:
                 "vlm_latency_seconds_latest", "Latest VLM processing latency in seconds"
             )
 
+            self.context_managers_created = prom.Gauge(
+                "context_managers_created",
+                "Number of CA-RAG context-manager processes created by this replica",
+            )
+            self.context_managers_available = prom.Gauge(
+                "context_managers_available",
+                "Number of CA-RAG context managers available for new requests",
+            )
+            self.context_managers_in_use = prom.Gauge(
+                "context_managers_in_use",
+                "Number of CA-RAG context managers currently leased",
+            )
+            self.context_manager_rejections = prom.Counter(
+                "context_manager_rejections_total",
+                "Requests rejected because the CA-RAG context-manager pool is exhausted",
+            )
+
         def unregister(self):
             prom.REGISTRY.unregister(self.queries_processed)
             prom.REGISTRY.unregister(self.queries_pending)
@@ -414,6 +434,10 @@ class ViaStreamHandler:
             prom.REGISTRY.unregister(self.ca_rag_latency_latest)
             prom.REGISTRY.unregister(self.e2e_latency_latest)
             prom.REGISTRY.unregister(self.vlm_pipeline_latency_latest)
+            prom.REGISTRY.unregister(self.context_managers_created)
+            prom.REGISTRY.unregister(self.context_managers_available)
+            prom.REGISTRY.unregister(self.context_managers_in_use)
+            prom.REGISTRY.unregister(self.context_manager_rejections)
 
     def __init__(self, args) -> None:
         """Initialize the VIA Stream Handler"""
@@ -450,7 +474,18 @@ class ViaStreamHandler:
         self.NUM_CA_RAG_PROCESSES_LAUNCH = 10
         self.num_ctx_mgr = 0
         self.num_qa_ctx_mgr = 0
-        self.MAX_STREAMS = self._args.max_live_streams
+        self.MAX_CONTEXT_MANAGERS = self._args.max_context_managers
+        # Reset work can block on CA-RAG/DB teardown. Keep it off request and
+        # output threads while bounding the number of concurrent cleanups.
+        self._context_cleanup_executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=max(1, min(8, self.MAX_CONTEXT_MANAGERS)),
+            thread_name_prefix="vss-context-cleanup",
+        )
+        self._metrics.context_managers_created.set_function(lambda: self.num_ctx_mgr)
+        self._metrics.context_managers_available.set_function(lambda: len(self._ctx_mgr_pool))
+        self._metrics.context_managers_in_use.set_function(
+            lambda: max(0, self.num_ctx_mgr - len(self._ctx_mgr_pool))
+        )
 
         self._vlm_pipeline = RtviVlmClient(args)
         logger.info(
@@ -553,13 +588,8 @@ class ViaStreamHandler:
             # Create ctx mgr pool only if the pool is empty
             if len(self._ctx_mgr_pool) > 0:
                 return
-            if self.num_ctx_mgr >= self.MAX_STREAMS:
-                raise ViaException(
-                    "Server is already processing maximum number of live streams"
-                    f" ({self._args.max_live_streams})",
-                    "ServerBusy",
-                    503,
-                )
+            if self.num_ctx_mgr >= self.MAX_CONTEXT_MANAGERS:
+                return
             logger.info(  # noqa: BLK100
                 f"Context Manager Process Pool is empty,"
                 f" adding new processes from index {self.num_ctx_mgr}"
@@ -570,8 +600,38 @@ class ViaStreamHandler:
                 )
                 os.environ["CA_RAG_ENABLE_WARMUP"] = "false"
                 self.num_ctx_mgr = self.num_ctx_mgr + 1
-                if self.num_ctx_mgr >= self.MAX_STREAMS:
+                if self.num_ctx_mgr >= self.MAX_CONTEXT_MANAGERS:
                     return
+
+    def _acquire_ctx_mgr(self, config, *, record_rejection=True):
+        """Borrow a context manager or reject excess work immediately."""
+        with self._lock:
+            self._create_ctx_mgr_pool(config)
+            if self._ctx_mgr_pool:
+                return self._ctx_mgr_pool.pop()
+
+        if record_rejection:
+            self._metrics.context_manager_rejections.inc()
+        raise ViaException(
+            "Server is already processing the maximum number of concurrent "
+            f"summarization requests ({self.MAX_CONTEXT_MANAGERS} context managers)",
+            "ServerBusy",
+            503,
+        )
+
+    def _release_ctx_mgr(self, ctx_mgr) -> None:
+        """Return a context-manager lease to this replica's pool."""
+        if ctx_mgr is None:
+            return
+        with self._lock:
+            self._ctx_mgr_pool.append(ctx_mgr)
+
+    def _release_qa_ctx_mgr(self, ctx_mgr) -> None:
+        """Return a QA context-manager lease to its separate pool."""
+        if ctx_mgr is None:
+            return
+        with self._lock:
+            self._qa_ctx_mgr_pool.append(ctx_mgr)
 
     def _create_qa_ctx_mgr_pool(self, config):
         """Create a pool of ContextManagers configured only for QA (ingestion + retriever)."""
@@ -597,7 +657,7 @@ class ViaStreamHandler:
                 )
                 os.environ["CA_RAG_ENABLE_WARMUP"] = "false"
                 self.num_qa_ctx_mgr += 1
-                if self.num_qa_ctx_mgr >= self.MAX_STREAMS:
+                if self.num_qa_ctx_mgr >= self.MAX_CONTEXT_MANAGERS:
                     return
 
     @staticmethod
@@ -703,6 +763,9 @@ class ViaStreamHandler:
                 self._update_completion_metrics(req_info, chunk_responses)
         else:
             if req_info.status == RequestInfo.Status.FAILED:
+                req_info.progress = 100
+                if req_info.end_time is None:
+                    req_info.end_time = time.time()
                 logger.info(
                     "Summary generation failed for video file request %s", req_info.request_id
                 )
@@ -722,13 +785,19 @@ class ViaStreamHandler:
 
             self._metrics.queries_processed.inc()
             self._metrics.queries_pending.dec()
-        req_info.status_event.set()
         # For live streams _process_output runs per intermediate chunk
         # (is_live_stream_ended=False) and once at end-of-stream (True). Only end
         # the E2E span on the final call so the live span isn't truncated to the
         # first chunk. File requests are never live, so the span always ends here.
-        if not req_info.is_live or is_live_stream_ended:
+        request_finished = not req_info.is_live or is_live_stream_ended
+        if request_finished:
             self._end_e2e_span(req_info)
+            # Response metadata stays available for the HTTP/SSE consumer,
+            # but its process leases can be detached and reset independently.
+            self._release_request_contexts(req_info)
+        req_info.status_event.set()
+        if req_info.cleanup_requested:
+            self.check_status_remove_req_id(req_info.request_id)
 
     def _get_cv_metadata_for_chunk(self, json_file, frame_times):
         cv_meta = []
@@ -1676,7 +1745,10 @@ class ViaStreamHandler:
             self._end_vlm_pipeline_span(req_info)
             # This error exit returns before _process_output runs, so end the E2E span here too.
             self._end_e2e_span(req_info)
+            self._release_request_contexts(req_info)
             req_info.status_event.set()
+            if req_info.cleanup_requested:
+                self.check_status_remove_req_id(req_info.request_id)
             return
         except Exception as ex:
             logger.error("RTVI query %s failed: %s", req_info.request_id, ex)
@@ -1694,7 +1766,10 @@ class ViaStreamHandler:
             self._end_vlm_pipeline_span(req_info)
             # This error exit returns before _process_output runs, so end the E2E span here too.
             self._end_e2e_span(req_info)
+            self._release_request_contexts(req_info)
             req_info.status_event.set()
+            if req_info.cleanup_requested:
+                self.check_status_remove_req_id(req_info.request_id)
             return
 
         req_info.chunk_count = chunk_idx
@@ -1876,15 +1951,13 @@ class ViaStreamHandler:
 
         ctx_mgr = None
         try:
-            with self._lock:
-                self._create_ctx_mgr_pool(self._ca_rag_config)
-                if not self._ctx_mgr_pool:
-                    logger.warning(
-                        "_store_event_prompt_in_db: no ctx_mgr available for %s",
-                        asset_id,
-                    )
-                    return
-                ctx_mgr = self._ctx_mgr_pool.pop()
+            try:
+                ctx_mgr = self._acquire_ctx_mgr(
+                    self._ca_rag_config, record_rejection=False
+                )
+            except ViaException as ex:
+                logger.warning("_store_event_prompt_in_db: %s", ex)
+                return
 
             config = deepcopy(self._ca_rag_config)
             config["context_manager"]["uuid"] = asset_id
@@ -1954,8 +2027,7 @@ class ViaStreamHandler:
             )
         finally:
             if ctx_mgr is not None:
-                with self._lock:
-                    self._ctx_mgr_pool.append(ctx_mgr)
+                self._release_ctx_mgr(ctx_mgr)
 
     def summarize_stream(self, request: StreamSummarizeRequest, trace_context=None):
         """Summarize a live stream by aggregating captions from Elasticsearch via CA-RAG.
@@ -2029,15 +2101,7 @@ class ViaStreamHandler:
 
         ctx_mgr = None
         try:
-            with self._lock:
-                self._create_ctx_mgr_pool(self._ca_rag_config)
-                if not self._ctx_mgr_pool:
-                    raise ViaException(
-                        "No context manager available in pool",
-                        "InternalServerError",
-                        500,
-                    )
-                ctx_mgr = self._ctx_mgr_pool.pop()
+            ctx_mgr = self._acquire_ctx_mgr(self._ca_rag_config)
 
             config = deepcopy(self._ca_rag_config)
             config["context_manager"]["uuid"] = req_info.source_id
@@ -2130,8 +2194,7 @@ class ViaStreamHandler:
                         )
                     finally:
                         if qa_ctx is not None:
-                            with self._lock:
-                                self._qa_ctx_mgr_pool.append(qa_ctx)
+                            self._release_qa_ctx_mgr(qa_ctx)
 
                 req_info.response = [
                     RequestInfo.Response(
@@ -2164,7 +2227,7 @@ class ViaStreamHandler:
                                 req_info.source_id,
                                 reset_ex,
                             )
-                    self._ctx_mgr_pool.append(ctx_mgr)
+                    self._release_ctx_mgr(ctx_mgr)
 
         req_info.end_time = time.time()
         req_info.progress = 100
@@ -2276,8 +2339,7 @@ class ViaStreamHandler:
             ) from ex
         finally:
             if qa_ctx is not None:
-                with self._lock:
-                    self._qa_ctx_mgr_pool.append(qa_ctx)
+                self._release_qa_ctx_mgr(qa_ctx)
 
     def _publish_aggregate_to_kafka(
         self,
@@ -2453,11 +2515,12 @@ class ViaStreamHandler:
 
         ctx_mgr = None
         try:
-            with self._lock:
-                self._create_ctx_mgr_pool(self._ca_rag_config)
-                if not self._ctx_mgr_pool:
-                    return {"error": "no context manager available in pool"}
-                ctx_mgr = self._ctx_mgr_pool.pop()
+            try:
+                ctx_mgr = self._acquire_ctx_mgr(
+                    self._ca_rag_config, record_rejection=False
+                )
+            except ViaException as ex:
+                return {"error": str(ex)}
 
             config = deepcopy(self._ca_rag_config)
             config["context_manager"]["uuid"] = asset_id
@@ -2470,27 +2533,12 @@ class ViaStreamHandler:
             return {"error": str(ex)}
         finally:
             if ctx_mgr is not None:
-                with self._lock:
-                    self._ctx_mgr_pool.append(ctx_mgr)
+                self._release_ctx_mgr(ctx_mgr)
 
-    def get_ctx_mgr(self, source_id: str) -> None:
-        """
-        Return a ContextManager associated with the given source_id.
-        """
-        with self._lock:
-            for _, request_info in self._request_info_map.items():
-                if request_info.source_id == source_id:
-                    # Remove old data for the same source
-                    if request_info.summarize:
-                        request_info._ctx_mgr.reset(
-                            {
-                                "summarization": {"uuid": request_info.source_id},
-                            }
-                        )
-                    return request_info._ctx_mgr
-            # If ctx mgr not found in request info map
-            logger.info(f"Getting new Context Manager for {source_id}")
-            return self._ctx_mgr_pool.pop()
+    def get_ctx_mgr(self, source_id: str):
+        """Return a dedicated ContextManager lease for ``source_id``."""
+        logger.info("Getting new Context Manager for %s", source_id)
+        return self._acquire_ctx_mgr(self._ca_rag_config)
 
     def remove_request_id(self, request_id: str) -> None:
         """Remove request info for a single request ID"""
@@ -2637,9 +2685,7 @@ class ViaStreamHandler:
         req_info.objects_of_interest = query.objects_of_interest
         req_info.enable_qa = getattr(query, "enable_qa", False)
         if not self._args.disable_ca_rag and not skip_ca_rag:
-            with self._lock:
-                self._create_ctx_mgr_pool(self._ca_rag_config)
-                req_info._ctx_mgr = self.get_ctx_mgr(req_info.source_id)
+            req_info._ctx_mgr = self.get_ctx_mgr(req_info.source_id)
             try:
                 config = deepcopy(self._ca_rag_config)
                 config["context_manager"]["uuid"] = req_info.source_id
@@ -2648,9 +2694,8 @@ class ViaStreamHandler:
                 logger.error(traceback.format_exc())
                 logger.error("Query failed for %s - %s", req_info.request_id, str(ex))
                 if req_info._ctx_mgr is not None:
-                    with self._lock:
-                        self._ctx_mgr_pool.append(req_info._ctx_mgr)
-                        req_info._ctx_mgr = None
+                    self._release_ctx_mgr(req_info._ctx_mgr)
+                    req_info._ctx_mgr = None
                 return req_info.request_id
             # Reset the context manager for the first time
             if self.first_init and os.environ.get(
@@ -2685,9 +2730,15 @@ class ViaStreamHandler:
                     req_info._qa_ctx_mgr.configure(config=qa_config)
                     logger.info("Borrowed QA ctx_mgr for source_id=%s", req_info.source_id)
                 except ViaException:
+                    self._release_qa_ctx_mgr(req_info._qa_ctx_mgr)
+                    req_info._qa_ctx_mgr = None
+                    self._release_ctx_mgr(req_info._ctx_mgr)
+                    req_info._ctx_mgr = None
                     raise
                 except Exception as ex:
                     logger.error("Failed to configure QA ctx_mgr: %s", ex)
+                    self._release_qa_ctx_mgr(req_info._qa_ctx_mgr)
+                    req_info._qa_ctx_mgr = None
 
         req_info.summarize_top_p = query.summarize_top_p
         req_info.summarize_temperature = query.summarize_temperature
@@ -2988,11 +3039,10 @@ This is very important and you must follow this strictly.
                     ex,
                 )
             finally:
-                with self._lock:
-                    logger.info(
-                        f"Adding Context Manager no.: {ctx_mgr._process_index} back to process pool."
-                    )
-                    self._ctx_mgr_pool.append(ctx_mgr)
+                logger.info(
+                    f"Adding Context Manager no.: {ctx_mgr._process_index} back to process pool."
+                )
+                self._release_ctx_mgr(ctx_mgr)
         try:
             shutil.rmtree(f"/tmp/via/cached_frames/{source_id}")
         except FileNotFoundError:
@@ -3016,6 +3066,10 @@ This is very important and you must follow this strictly.
             except Exception as ex:
                 logger.warning("Error closing Kafka producer: %s", ex)
             self._kafka_producer = None
+
+        cleanup_executor = getattr(self, "_context_cleanup_executor", None)
+        if cleanup_executor is not None:
+            cleanup_executor.shutdown(wait=not force, cancel_futures=force)
 
         self._metrics.unregister()
 
@@ -3091,6 +3145,70 @@ This is very important and you must follow this strictly.
             req_info.response = req_info.response[chunk_response_size:]
         return req_info, response
 
+    def _reset_and_release_ctx_mgr(self, ctx_mgr, req_info: RequestInfo) -> None:
+        """Reset one detached lease, then make it available for reuse."""
+        try:
+            ctx_mgr.reset(
+                {
+                    "summarization": {"uuid": req_info.source_id},
+                    "delete_external_collection": req_info.delete_external_collection,
+                }
+            )
+            if not req_info.is_live:
+                try:
+                    self.drop_collection_for_asset(req_info.source_id, force_legacy=True)
+                except Exception as drop_ex:
+                    logger.warning(
+                        "post-summarize drop_collection_for_asset failed for %s: %s",
+                        req_info.source_id,
+                        drop_ex,
+                    )
+        except Exception as reset_ex:
+            logger.warning(
+                "ctx_mgr.reset failed during request cleanup for source_id=%s: %s",
+                req_info.source_id,
+                reset_ex,
+            )
+        finally:
+            self._release_ctx_mgr(ctx_mgr)
+            logger.info(
+                "Returning Context Manager Process%s to process pool",
+                ctx_mgr._process_index,
+            )
+
+    def _release_request_contexts(self, req_info: RequestInfo) -> None:
+        """Detach a request's process leases exactly once and recycle them."""
+        with self._lock:
+            ctx_mgr = req_info._ctx_mgr
+            qa_ctx_mgr = req_info._qa_ctx_mgr
+            req_info._ctx_mgr = None
+            req_info._qa_ctx_mgr = None
+
+        if ctx_mgr is not None:
+            reset_on_done = os.environ.get(
+                "LVS_DISABLE_DB_RESET_ON_REQUEST_DONE", "false"
+            ).lower() not in ("true", "1")
+            if reset_on_done:
+                executor = getattr(self, "_context_cleanup_executor", None)
+                if executor is None:
+                    self._reset_and_release_ctx_mgr(ctx_mgr, req_info)
+                else:
+                    try:
+                        executor.submit(self._reset_and_release_ctx_mgr, ctx_mgr, req_info)
+                    except RuntimeError:
+                        # Shutdown raced with terminal request cleanup. Avoid
+                        # leaking the detached process lease.
+                        self._reset_and_release_ctx_mgr(ctx_mgr, req_info)
+            else:
+                self._release_ctx_mgr(ctx_mgr)
+
+        if qa_ctx_mgr is not None:
+            self._release_qa_ctx_mgr(qa_ctx_mgr)
+            logger.info(
+                "Returning QA Context Manager Process%s to QA pool",
+                qa_ctx_mgr._process_index,
+            )
+
     def check_status_remove_req_id(self, request_id):
         with self._lock:
             req_info = self._request_info_map.get(request_id, None)
@@ -3098,7 +3216,7 @@ This is very important and you must follow this strictly.
                 return
             # If request for file summarization has completed
             lsinfo = self._live_stream_info_map.get(req_info.source_id)
-            if (
+            cleanup_ready = (
                 (not req_info.is_live and req_info.progress == 100)
                 or (
                     req_info.is_live
@@ -3107,56 +3225,25 @@ This is very important and you must follow this strictly.
                     and len(req_info.response) == 0
                 )
                 or (req_info.is_live and lsinfo is None)
-            ):
-                # Remove only this specific request, not all requests for the same asset
-                # This allows concurrent processing of the same asset by multiple requests
-                self.remove_request_id(request_id)
-                if req_info._ctx_mgr:
-                    if not os.environ.get(
-                        "LVS_DISABLE_DB_RESET_ON_REQUEST_DONE", "false"
-                    ).lower() in [
-                        "true",
-                        "1",
-                    ]:  # noqa: E501
-                        req_info._ctx_mgr.reset(
-                            {
-                                "summarization": {"uuid": req_info.source_id},
-                                "delete_external_collection": req_info.delete_external_collection,
-                            }
-                        )
-                        # Drop the per-file Elasticsearch
-                        # index after the summarize completes so the
-                        # cluster shard pool drains as fast as it fills.
-                        # Strictly file-path only; live-stream summarize
-                        # completion never triggers this drop because
-                        # streams reuse the same source_id across multiple
-                        # /v1/stream_summarize calls. force_legacy=True
-                        # bypasses drop_collection_for_asset's KAFKA_ENABLED
-                        # guard so the legacy in-process file path also
-                        # benefits — both paths create per-file indices.
-                        if not req_info.is_live:
-                            try:
-                                self.drop_collection_for_asset(
-                                    req_info.source_id, force_legacy=True
-                                )
-                            except Exception as drop_ex:
-                                logger.warning(
-                                    "post-summarize drop_collection_for_asset" " failed for %s: %s",
-                                    req_info.source_id,
-                                    drop_ex,
-                                )
-                    self._ctx_mgr_pool.append(req_info._ctx_mgr)
-                    logger.info(
-                        f"Returning Context Manager Process"
-                        f"{req_info._ctx_mgr._process_index} to process pool"
-                    )
-                if req_info._qa_ctx_mgr:
-                    self._qa_ctx_mgr_pool.append(req_info._qa_ctx_mgr)
-                    logger.info(
-                        "Returning QA Context Manager Process%s to QA pool",
-                        req_info._qa_ctx_mgr._process_index,
-                    )
-                    req_info._qa_ctx_mgr = None
+            )
+            if not cleanup_ready:
+                req_info.cleanup_requested = True
+                return
+
+            # Remove this request only; concurrent requests may share an asset ID.
+            self._request_info_map.pop(request_id, None)
+
+        # Usually already detached by the terminal processing path. This also
+        # covers legacy callers that mark progress without _process_output.
+        self._release_request_contexts(req_info)
+
+    def is_request_done(self, request_id):
+        """Return whether a request has completed or failed."""
+        with self._lock:
+            if request_id not in self._request_info_map:
+                raise ViaException(f"No such request-id {request_id}", "InvalidParameterValue", 400)
+            req_info = self._request_info_map[request_id]
+            return req_info.status in [RequestInfo.Status.FAILED, RequestInfo.Status.SUCCESSFUL]
 
     def wait_for_request_done(self, request_id):
         """Wait for request to either complete or fail."""
@@ -3692,6 +3779,21 @@ This is very important and you must follow this strictly.
         """Add VIA Stream Handler arguments to the argument parser"""
 
         parser.add_argument("--max-live-streams", type=int, default=256)
+        parser.add_argument(
+            "--max-context-managers",
+            type=int,
+            default=256,
+            help="Maximum CA-RAG ContextManager processes per service replica",
+        )
+        parser.add_argument(
+            "--max-async-workers",
+            type=int,
+            default=320,
+            help=(
+                "Maximum HTTP offload workers; includes admission headroom above "
+                "the ContextManager limit"
+            ),
+        )
         parser.add_argument("--enable-audio", action="store_true", default=False)
 
         parser.add_argument(

--- a/services/video-summarization/tests/unit/test_elasticsearch_shard_retry.py
+++ b/services/video-summarization/tests/unit/test_elasticsearch_shard_retry.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for transient Elasticsearch shard-allocation retries."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from elasticsearch_shard_retry import (
+    PrimaryShardUnavailable,
+    is_shard_unavailable_error,
+    retry_shard_operation,
+    wait_for_primary_shard,
+)
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "NoShardAvailableActionException: all shards failed",
+        "no_shard_available_action_exception",
+        "primary shard is not active",
+    ],
+)
+def test_identifies_shard_unavailable_errors(message):
+    assert is_shard_unavailable_error(RuntimeError(message))
+
+
+def test_retries_until_shard_operation_succeeds(monkeypatch):
+    monkeypatch.setenv("VSS_CTX_RAG_ES_SHARD_RETRY_ATTEMPTS", "4")
+    monkeypatch.setenv("VSS_CTX_RAG_ES_SHARD_RETRY_BACKOFF_SECS", "0.25")
+    operation = MagicMock(
+        side_effect=[
+            RuntimeError("NoShardAvailableActionException"),
+            RuntimeError("all shards failed"),
+            {"hits": []},
+        ]
+    )
+    sleep = MagicMock()
+
+    result = retry_shard_operation(
+        operation,
+        operation_name="retrieve_docs",
+        index_name="default_video_1",
+        logger=MagicMock(),
+        sleep=sleep,
+    )
+
+    assert result == {"hits": []}
+    assert operation.call_count == 3
+    assert [call.args[0] for call in sleep.call_args_list] == [0.25, 0.5]
+
+
+def test_surfaces_shard_error_after_bounded_attempts(monkeypatch):
+    monkeypatch.setenv("VSS_CTX_RAG_ES_SHARD_RETRY_ATTEMPTS", "3")
+    operation = MagicMock(side_effect=RuntimeError("all shards failed"))
+
+    with pytest.raises(RuntimeError, match="all shards failed"):
+        retry_shard_operation(
+            operation,
+            operation_name="retrieve_docs",
+            index_name="default_video_1",
+            logger=MagicMock(),
+            sleep=MagicMock(),
+        )
+
+    assert operation.call_count == 3
+
+
+def test_does_not_retry_non_shard_error(monkeypatch):
+    monkeypatch.setenv("VSS_CTX_RAG_ES_SHARD_RETRY_ATTEMPTS", "5")
+    operation = MagicMock(side_effect=ValueError("invalid query"))
+
+    with pytest.raises(ValueError, match="invalid query"):
+        retry_shard_operation(
+            operation,
+            operation_name="retrieve_docs",
+            index_name="default_video_1",
+            logger=MagicMock(),
+            sleep=MagicMock(),
+        )
+
+    operation.assert_called_once_with()
+
+
+def test_waits_for_yellow_index_health():
+    es_client = MagicMock()
+    es_client.cluster.health.return_value = {"timed_out": False, "status": "yellow"}
+
+    wait_for_primary_shard(es_client, "default_video_1")
+
+    es_client.cluster.health.assert_called_once_with(
+        index="default_video_1",
+        wait_for_status="yellow",
+        wait_for_active_shards="1",
+        timeout="1s",
+    )
+
+
+def test_primary_shard_timeout_is_503():
+    es_client = MagicMock()
+    es_client.cluster.health.return_value = {"timed_out": True}
+
+    with pytest.raises(PrimaryShardUnavailable) as exc_info:
+        wait_for_primary_shard(es_client, "default_video_1")
+
+    assert exc_info.value.status_code == 503
+
+
+@pytest.mark.parametrize("status_location", ["status_code", "meta"])
+def test_http_408_cluster_health_timeout_is_503(status_location):
+    class ClusterHealthTimeout(Exception):
+        pass
+
+    error = ClusterHealthTimeout("cluster health wait timed out")
+    if status_location == "status_code":
+        error.status_code = 408
+    else:
+        error.meta = type("Meta", (), {"status": 408})()
+    es_client = MagicMock()
+    es_client.cluster.health.side_effect = error
+
+    with pytest.raises(PrimaryShardUnavailable) as exc_info:
+        wait_for_primary_shard(es_client, "default_video_1")
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.__cause__ is error
+
+
+def test_non_timeout_cluster_health_error_is_not_reclassified():
+    error = RuntimeError("authentication failed")
+    error.status_code = 401
+    es_client = MagicMock()
+    es_client.cluster.health.side_effect = error
+
+    with pytest.raises(RuntimeError, match="authentication failed"):
+        wait_for_primary_shard(es_client, "default_video_1")

--- a/services/video-summarization/tests/unit/test_rtvi_dependency_down.py
+++ b/services/video-summarization/tests/unit/test_rtvi_dependency_down.py
@@ -172,6 +172,40 @@ class TestStartStreamCaptionsRtviDown:
 
 @pytest.mark.unit
 class TestTriggerQueryRtviDown:
+    def test_records_rtvi_request_id_from_sse(self):
+        handler = _make_handler()
+        handler._vlm_pipeline.generate_captions_stream.return_value = iter(
+            [{"id": "rtvi-request-1", "chunk_responses": []}]
+        )
+
+        req_info = _make_req_info()
+        handler._request_info_map[req_info.request_id] = req_info
+
+        with patch.dict(os.environ, {"ENABLE_DENSE_CAPTION": ""}):
+            handler._trigger_query(req_info)
+
+        assert req_info.rtvi_request_id == "rtvi-request-1"
+
+    def test_rejects_inconsistent_rtvi_request_ids(self):
+        handler = _make_handler()
+        handler._vlm_pipeline.generate_captions_stream.return_value = iter(
+            [
+                {"id": "rtvi-request-1", "chunk_responses": []},
+                {"id": "rtvi-request-2", "chunk_responses": []},
+            ]
+        )
+
+        req_info = _make_req_info()
+        handler._request_info_map[req_info.request_id] = req_info
+
+        with patch.dict(os.environ, {"ENABLE_DENSE_CAPTION": ""}):
+            handler._trigger_query(req_info)
+
+        assert req_info.status == RequestInfo.Status.FAILED
+        assert req_info.rtvi_status_code == 502
+        assert req_info.rtvi_error_code == "DependencyError"
+        assert "inconsistent request IDs" in req_info.error_message
+
     @pytest.mark.parametrize("exc", CONNECTION_ERRORS, ids=["ConnectionError", "Timeout"])
     def test_request_info_marked_failed_503(self, exc):
         handler = _make_handler()

--- a/services/video-summarization/tests/unit/test_rtvi_dependency_down.py
+++ b/services/video-summarization/tests/unit/test_rtvi_dependency_down.py
@@ -69,7 +69,7 @@ def _make_handler():
         handler.default_caption_prompt = "Summarize"
         handler.NUM_CA_RAG_PROCESSES_LAUNCH = 10
         handler.num_ctx_mgr = 0
-        handler.MAX_STREAMS = 4
+        handler.MAX_CONTEXT_MANAGERS = 4
         handler._start_time = time.time()
         handler._kafka_enabled = False
         return handler

--- a/services/video-summarization/tests/unit/test_via_server.py
+++ b/services/video-summarization/tests/unit/test_via_server.py
@@ -155,6 +155,7 @@ def _make_mock_args(**overrides):
         port="8000",
         max_asset_storage_size=None,
         max_live_streams=2,
+        max_async_workers=4,
         log_level="info",
         disable_ca_rag=True,
         summarization_query="Summarize",
@@ -201,6 +202,45 @@ class TestViaServerInit:
 
     def test_sse_active_clients_empty(self, mock_via_server):
         assert mock_via_server._sse_active_clients == {}
+
+    def test_async_workers_are_independent_of_live_stream_limit(self, mock_via_server):
+        assert mock_via_server._async_executor._max_workers == 4
+
+
+@pytest.mark.unit
+class TestSseCleanup:
+    def test_generator_close_requests_cleanup(self, mock_via_server):
+        async def messages():
+            yield "first"
+            yield "second"
+
+        async def close_after_first():
+            wrapped = mock_via_server._cleanup_sse_generator(messages(), "source-1", "request-1")
+            assert await anext(wrapped) == "first"
+            await wrapped.aclose()
+
+        mock_via_server._sse_active_clients["source-1"] = 1
+        asyncio.run(close_after_first())
+
+        assert "source-1" not in mock_via_server._sse_active_clients
+        mock_via_server._stream_handler.check_status_remove_req_id.assert_called_once_with(
+            "request-1"
+        )
+
+    def test_cancelled_non_stream_wait_requests_cleanup(self, mock_via_server):
+        async def cancel_wait():
+            mock_via_server._stream_handler.is_request_done.return_value = False
+            task = asyncio.create_task(mock_via_server._wait_for_request_done("request-2"))
+            await asyncio.sleep(0)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        asyncio.run(cancel_wait())
+
+        mock_via_server._stream_handler.check_status_remove_req_id.assert_called_once_with(
+            "request-2"
+        )
 
 
 @pytest.mark.unit

--- a/services/video-summarization/tests/unit/test_via_stream_handler.py
+++ b/services/video-summarization/tests/unit/test_via_stream_handler.py
@@ -48,6 +48,7 @@ class TestRequestInfo:
         assert ri.progress == 0
         assert ri.response == []
         assert ri.enable_audio is False
+        assert ri.cleanup_requested is False
 
     def test_status_enum_values(self):
         from via_stream_handler import RequestInfo
@@ -261,7 +262,7 @@ def _make_mock_stream_handler():
         handler.default_caption_prompt = "Summarize"
         handler.NUM_CA_RAG_PROCESSES_LAUNCH = 10
         handler.num_ctx_mgr = 0
-        handler.MAX_STREAMS = 4
+        handler.MAX_CONTEXT_MANAGERS = 4
         handler._start_time = time.time()
         # Bypass real __init__; empty-guard needs this (0 => single attempt).
         handler._aggregation_empty_retries = 0
@@ -490,6 +491,7 @@ class TestCheckStatusRemoveReqId:
 
         handler.check_status_remove_req_id(ri.request_id)
         assert ri.request_id in handler._request_info_map
+        assert ri.cleanup_requested is True
 
     def test_ctx_mgr_reset_and_returned_to_pool_when_removed(self):
         from via_stream_handler import RequestInfo
@@ -510,6 +512,25 @@ class TestCheckStatusRemoveReqId:
 
         mock_ctx.reset.assert_called_once()
         assert mock_ctx in handler._ctx_mgr_pool
+
+    def test_reset_is_detached_and_scheduled_off_request_path(self):
+        from via_stream_handler import RequestInfo
+
+        handler = _make_mock_stream_handler()
+        handler._context_cleanup_executor = MagicMock()
+        ri = RequestInfo()
+        ri.source_id = "test-stream"
+        mock_ctx = MagicMock()
+        ri._ctx_mgr = mock_ctx
+
+        with patch.dict(os.environ, {"LVS_DISABLE_DB_RESET_ON_REQUEST_DONE": "false"}):
+            handler._release_request_contexts(ri)
+
+        assert ri._ctx_mgr is None
+        assert mock_ctx not in handler._ctx_mgr_pool
+        handler._context_cleanup_executor.submit.assert_called_once_with(
+            handler._reset_and_release_ctx_mgr, mock_ctx, ri
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1188,11 +1209,25 @@ class TestPopulateArgumentParser:
         ViaStreamHandler.populate_argument_parser(parser)
         add_calls = [c[0][0] for c in parser.add_argument.call_args_list]
         assert "--max-live-streams" in add_calls
+        assert "--max-context-managers" in add_calls
+        assert "--max-async-workers" in add_calls
         assert "--enable-audio" in add_calls
         assert "--enable-dev-dc-gen" in add_calls
         assert "--max-file-duration" in add_calls
         assert "--disable-ca-rag" in add_calls
         assert "--ca-rag-config" in add_calls
+
+    def test_worker_default_preserves_admission_headroom(self):
+        from argparse import ArgumentParser
+
+        from via_stream_handler import ViaStreamHandler
+
+        parser = ArgumentParser()
+        ViaStreamHandler.populate_argument_parser(parser)
+        args = parser.parse_args([])
+
+        assert args.max_context_managers == 256
+        assert args.max_async_workers == 320
 
 
 # ---------------------------------------------------------------------------
@@ -2084,6 +2119,26 @@ class TestProcessOutputAdditional:
         # Exception is caught internally; status should be FAILED for non-live
         assert ri.status == RequestInfo.Status.FAILED
 
+    def test_terminal_processing_releases_context_before_response_cleanup(self):
+        from via_stream_handler import RequestInfo
+
+        handler = self._make_handler()
+        handler._ctx_mgr_pool = []
+        handler._qa_ctx_mgr_pool = []
+        ri = RequestInfo()
+        ri.status = RequestInfo.Status.FAILED
+        ri.is_live = False
+        ri.source_id = "file-1"
+        ri.start_time = time.time()
+        mock_ctx = MagicMock()
+        ri._ctx_mgr = mock_ctx
+
+        with patch.dict(os.environ, {"LVS_DISABLE_DB_RESET_ON_REQUEST_DONE": "true"}):
+            handler._process_output(ri, False, [])
+
+        assert ri._ctx_mgr is None
+        assert mock_ctx in handler._ctx_mgr_pool
+
 
 # ---------------------------------------------------------------------------
 # _create_ctx_mgr_pool
@@ -2101,9 +2156,8 @@ class TestCreateCtxMgrPool:
         handler._lock = RLock()
         handler._ctx_mgr_pool = []
         handler._args = MagicMock()
-        handler._args.max_live_streams = 4
         handler.num_ctx_mgr = 0
-        handler.MAX_STREAMS = 4
+        handler.MAX_CONTEXT_MANAGERS = 4
         handler.NUM_CA_RAG_PROCESSES_LAUNCH = 2
         return handler
 
@@ -2130,14 +2184,33 @@ class TestCreateCtxMgrPool:
         # ContextManager should never have been called
         assert len(handler._ctx_mgr_pool) == 1  # unchanged
 
-    def test_raises_when_num_ctx_mgr_at_max_streams(self):
-        from via_stream_handler import ViaException
+    def test_does_not_create_when_num_ctx_mgr_at_capacity(self):
+        handler = self._make_handler()
+        handler.num_ctx_mgr = 4  # equal to MAX_CONTEXT_MANAGERS
+        with self._ctx_rag_patch():
+            handler._create_ctx_mgr_pool(config={})
+        assert handler._ctx_mgr_pool == []
+
+    def test_acquire_returns_fast_503_at_capacity(self):
+        from via_exception import ViaException
 
         handler = self._make_handler()
-        handler.num_ctx_mgr = 4  # equal to MAX_STREAMS
+        handler._metrics = MagicMock()
+        handler.num_ctx_mgr = 4
+        with self._ctx_rag_patch(), pytest.raises(ViaException) as exc_info:
+            handler._acquire_ctx_mgr(config={})
+        assert exc_info.value.code == "ServerBusy"
+        assert exc_info.value.status_code == 503
+        assert "summarization requests" in exc_info.value.message
+        assert "context managers" in exc_info.value.message
+        handler._metrics.context_manager_rejections.inc.assert_called_once()
+
+    def test_acquire_returns_available_context_manager(self):
+        handler = self._make_handler()
+        expected = MagicMock()
+        handler._ctx_mgr_pool = [expected]
         with self._ctx_rag_patch():
-            with pytest.raises(ViaException):
-                handler._create_ctx_mgr_pool(config={})
+            assert handler._acquire_ctx_mgr(config={}) is expected
 
     def test_creates_context_managers_up_to_launch_count(self):
         import sys
@@ -2161,7 +2234,7 @@ class TestCreateCtxMgrPool:
         import sys
 
         handler = self._make_handler()
-        handler.num_ctx_mgr = 3  # 1 away from MAX_STREAMS=4
+        handler.num_ctx_mgr = 3  # 1 away from MAX_CONTEXT_MANAGERS=4
         handler.NUM_CA_RAG_PROCESSES_LAUNCH = 5  # would add 5, but stops at MAX
         mock_cm_mod = MagicMock()
         mock_cm_mod.ContextManager.return_value = MagicMock()

--- a/services/video-summarization/tests/unit/test_via_stream_handler.py
+++ b/services/video-summarization/tests/unit/test_via_stream_handler.py
@@ -1436,7 +1436,7 @@ class TestUpdateCaRagConfigBranches:
 
 @pytest.mark.unit
 class TestGetAggregatedSummary:
-    def test_file_kafka_db_mode_waits_for_logstash_flush_before_aggregation(self):
+    def test_file_kafka_db_mode_waits_for_expected_raw_events(self):
         from via_stream_handler import RequestInfo
 
         handler = _make_mock_stream_handler()
@@ -1450,7 +1450,7 @@ class TestGetAggregatedSummary:
                     "tools": {"db": "elasticsearch_db"},
                 }
             },
-            "tools": {"elasticsearch_db": {"params": {"kafka_consumer_settle_secs": 2.5}}},
+            "tools": {"elasticsearch_db": {"params": {"host": "elasticsearch", "port": 9200}}},
         }
         handler._publish_aggregate_to_kafka = MagicMock()
 
@@ -1485,11 +1485,127 @@ class TestGetAggregatedSummary:
             vlm_stats={},
         )
 
-        with patch("via_stream_handler.time.sleep") as sleep_mock:
+        with patch.object(handler, "_wait_for_kafka_raw_events") as wait_mock:
             handler._get_aggregated_summary(req_info, [chunk_response])
 
-        sleep_mock.assert_called_once_with(2.5)
+        wait_mock.assert_called_once_with("source-1", 1)
         req_info._ctx_mgr.call.assert_called_once_with({"summarization": {"uuids": ["source-1"]}})
+
+
+# ---------------------------------------------------------------------------
+# Kafka -> Logstash -> Elasticsearch readiness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestKafkaRawEventsReadiness:
+    @staticmethod
+    def _handler(timeout=1.0, poll_interval=0.001):
+        handler = _make_mock_stream_handler()
+        handler._ca_rag_config = {
+            "functions": {
+                "summarization": {
+                    "params": {"kafka_enabled": True},
+                    "tools": {"db": "elasticsearch_db"},
+                }
+            },
+            "tools": {
+                "elasticsearch_db": {
+                    "params": {
+                        "host": "elasticsearch",
+                        "port": 9200,
+                        "kafka_consumer_wait_timeout_secs": timeout,
+                        "kafka_consumer_poll_interval_secs": poll_interval,
+                    }
+                }
+            },
+        }
+        return handler
+
+    @staticmethod
+    def _count_response(count, status_code=200):
+        response = MagicMock()
+        response.status_code = status_code
+        response.json.return_value = {"count": count}
+        return response
+
+    def test_polls_until_expected_count_is_searchable(self):
+        handler = self._handler()
+        responses = [
+            self._count_response(0, status_code=404),
+            self._count_response(1),
+            self._count_response(3),
+        ]
+
+        with (
+            patch("via_stream_handler.requests.post", side_effect=responses) as post_mock,
+            patch("via_stream_handler.time.sleep") as sleep_mock,
+        ):
+            handler._wait_for_kafka_raw_events("source-1", 3)
+
+        assert post_mock.call_count == 3
+        assert sleep_mock.call_count == 2
+        request = post_mock.call_args
+        assert request.args[0] == "http://elasticsearch:9200/default_source_1/_count"
+        assert request.kwargs["json"] == {
+            "query": {"term": {"metadata.content_metadata.doc_type": "raw_events"}}
+        }
+
+    def test_timeout_has_service_unavailable_status(self):
+        from via_stream_handler import KafkaIngestionTimeout
+
+        handler = self._handler(timeout=0.001, poll_interval=0.001)
+        missing_index = self._count_response(0, status_code=404)
+
+        with patch("via_stream_handler.requests.post", return_value=missing_index):
+            with pytest.raises(KafkaIngestionTimeout) as exc_info:
+                handler._wait_for_kafka_raw_events("source-1", 2)
+
+        assert exc_info.value.status_code == 503
+        assert "0/2 raw_events" in str(exc_info.value)
+
+    def test_timeout_is_returned_as_dependency_failure(self):
+        from via_exception import ViaException
+        from via_stream_handler import KafkaIngestionTimeout, RequestInfo
+
+        handler = self._handler()
+        handler._args.enable_dev_dc_gen = False
+        handler._kafka_enabled = True
+        handler._caption_source = "db"
+
+        req_info = RequestInfo()
+        req_info.file = "/tmp/video.mp4"
+        req_info.source_id = "source-1"
+        req_info.request_id = "request-1"
+        req_info.enable_audio = False
+        req_info.is_live = False
+        req_info.summarize = True
+        req_info.camera_id = "default"
+        req_info._ctx_mgr = MagicMock()
+        chunk = SimpleNamespace(
+            chunkIdx=0,
+            start_pts=0,
+            end_pts=10_000_000_000,
+            start_ntp="1970-01-01T00:00:00.000Z",
+            end_ntp="1970-01-01T00:00:10.000Z",
+        )
+        chunk_response = SimpleNamespace(
+            chunk=chunk,
+            vlm_response='{"events":[]}',
+            vlm_stats={},
+        )
+
+        with patch.object(
+            handler,
+            "_wait_for_kafka_raw_events",
+            side_effect=KafkaIngestionTimeout("ingestion timed out"),
+        ):
+            with pytest.raises(ViaException) as exc_info:
+                handler._get_aggregated_summary(req_info, [chunk_response])
+
+        assert exc_info.value.status_code == 503
+        assert req_info.status == RequestInfo.Status.FAILED
+        req_info._ctx_mgr.call.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/services/video-summarization/tests/unit/test_via_stream_handler.py
+++ b/services/video-summarization/tests/unit/test_via_stream_handler.py
@@ -2740,6 +2740,26 @@ class TestClassifyEsError:
         assert status == 503
         assert message == self._SHARD_MESSAGE
 
+    @pytest.mark.parametrize(
+        "detail",
+        [
+            "NoShardAvailableActionException: all shards failed",
+            "no_shard_available_action_exception",
+            "primary shard is not active for index default_video_1",
+        ],
+    )
+    def test_unavailable_shard_text_returns_503(self, detail):
+        from lvs_errors import classify_es_error
+
+        status, message = classify_es_error(Exception(detail))
+
+        assert status == 503
+        assert message == (
+            "Service temporarily unavailable: Elasticsearch dependency error (503). "
+            "See server logs for details."
+        )
+        assert detail not in message
+
     def test_generic_es_4xx_returns_sanitised_message(self):
         from lvs_errors import classify_es_error
 

--- a/services/video-summarization/tests/unit/test_via_stream_handler.py
+++ b/services/video-summarization/tests/unit/test_via_stream_handler.py
@@ -1493,6 +1493,7 @@ class TestGetAggregatedSummary:
         req_info.file = "/tmp/video.mp4"
         req_info.source_id = "source-1"
         req_info.request_id = "request-1"
+        req_info.rtvi_request_id = "rtvi-request-1"
         req_info.enable_audio = False
         req_info.is_live = False
         req_info.summarize = True
@@ -1523,7 +1524,7 @@ class TestGetAggregatedSummary:
         with patch.object(handler, "_wait_for_kafka_raw_events") as wait_mock:
             handler._get_aggregated_summary(req_info, [chunk_response])
 
-        wait_mock.assert_called_once_with("source-1", 1)
+        wait_mock.assert_called_once_with("source-1", 1, "rtvi-request-1")
         req_info._ctx_mgr.call.assert_called_once_with({"summarization": {"uuids": ["source-1"]}})
 
 
@@ -1576,15 +1577,38 @@ class TestKafkaRawEventsReadiness:
             patch("via_stream_handler.requests.post", side_effect=responses) as post_mock,
             patch("via_stream_handler.time.sleep") as sleep_mock,
         ):
-            handler._wait_for_kafka_raw_events("source-1", 3)
+            handler._wait_for_kafka_raw_events("source-1", 3, "rtvi-request-1")
 
         assert post_mock.call_count == 3
         assert sleep_mock.call_count == 2
         request = post_mock.call_args
         assert request.args[0] == "http://elasticsearch:9200/default_source_1/_count"
         assert request.kwargs["json"] == {
-            "query": {"term": {"metadata.content_metadata.doc_type": "raw_events"}}
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "term": {
+                                "metadata.content_metadata.doc_type.keyword": "raw_events"
+                            }
+                        },
+                        {
+                            "term": {
+                                "metadata.content_metadata.requestId.keyword": "rtvi-request-1"
+                            }
+                        },
+                    ]
+                }
+            }
         }
+
+    def test_requires_current_rtvi_request_id(self):
+        from via_stream_handler import KafkaIngestionTimeout
+
+        handler = self._handler()
+
+        with pytest.raises(KafkaIngestionTimeout, match="RTVI request ID is unavailable"):
+            handler._wait_for_kafka_raw_events("source-1", 1, None)
 
     def test_timeout_has_service_unavailable_status(self):
         from via_stream_handler import KafkaIngestionTimeout
@@ -1594,7 +1618,7 @@ class TestKafkaRawEventsReadiness:
 
         with patch("via_stream_handler.requests.post", return_value=missing_index):
             with pytest.raises(KafkaIngestionTimeout) as exc_info:
-                handler._wait_for_kafka_raw_events("source-1", 2)
+                handler._wait_for_kafka_raw_events("source-1", 2, "rtvi-request-1")
 
         assert exc_info.value.status_code == 503
         assert "0/2 raw_events" in str(exc_info.value)
@@ -2912,9 +2936,9 @@ class TestClassifyEsError:
 
 @pytest.mark.unit
 class TestCheckStatusRemoveReqIdDropsIndex:
-    """``check_status_remove_req_id`` should call
-    ``drop_collection_for_asset(force_legacy=True)`` after a file
-    summarize completes, but ONLY when:
+    """``check_status_remove_req_id`` should drop the collection through
+    the request's leased context manager after a file summarize completes,
+    but ONLY when:
 
       * ``LVS_DISABLE_DB_RESET_ON_REQUEST_DONE`` is unset / "false"
       * ``req_info.is_live`` is False (live-stream completions reuse
@@ -2941,22 +2965,21 @@ class TestCheckStatusRemoveReqIdDropsIndex:
         return handler, ri, mock_ctx
 
     def test_drops_index_when_gate_unset(self):
-        handler, ri, _ = self._make_completed_file_request()
-        handler.drop_collection_for_asset = MagicMock(return_value={"ok": True})
+        handler, ri, mock_ctx = self._make_completed_file_request()
+        mock_ctx.drop_collection.return_value = {"ok": True}
 
         with patch.dict(os.environ, {"LVS_DISABLE_DB_RESET_ON_REQUEST_DONE": "false"}):
             handler.check_status_remove_req_id(ri.request_id)
 
-        handler.drop_collection_for_asset.assert_called_once_with(ri.source_id, force_legacy=True)
+        mock_ctx.drop_collection.assert_called_once_with()
 
     def test_skips_drop_when_gate_true(self):
-        handler, ri, _ = self._make_completed_file_request()
-        handler.drop_collection_for_asset = MagicMock(return_value={"ok": True})
+        handler, ri, mock_ctx = self._make_completed_file_request()
 
         with patch.dict(os.environ, {"LVS_DISABLE_DB_RESET_ON_REQUEST_DONE": "true"}):
             handler.check_status_remove_req_id(ri.request_id)
 
-        handler.drop_collection_for_asset.assert_not_called()
+        mock_ctx.drop_collection.assert_not_called()
 
     def test_skips_drop_for_live_stream_completion(self):
         from via_stream_handler import LiveStreamInfo, RequestInfo
@@ -2976,25 +2999,37 @@ class TestCheckStatusRemoveReqIdDropsIndex:
         lsi = LiveStreamInfo()
         lsi.live_stream_ended = True
         handler._live_stream_info_map[ri.source_id] = lsi
-        handler.drop_collection_for_asset = MagicMock(return_value={"ok": True})
 
         with patch.dict(os.environ, {"LVS_DISABLE_DB_RESET_ON_REQUEST_DONE": "false"}):
             handler.check_status_remove_req_id(ri.request_id)
 
-        handler.drop_collection_for_asset.assert_not_called()
+        mock_ctx.drop_collection.assert_not_called()
 
     def test_drop_failure_does_not_break_pool_return(self):
-        """If drop_collection_for_asset raises (transient ES blip during
-        cleanup), the ctx_mgr must still be returned to the pool.
+        """If drop_collection raises during cleanup, the ctx_mgr must still
+        be returned to the pool.
         """
         handler, ri, mock_ctx = self._make_completed_file_request()
-        handler.drop_collection_for_asset = MagicMock(
-            side_effect=Exception("transient ES failure during cleanup")
+        mock_ctx.drop_collection.side_effect = Exception("transient ES failure during cleanup")
+
+        with patch.dict(os.environ, {"LVS_DISABLE_DB_RESET_ON_REQUEST_DONE": "false"}):
+            handler.check_status_remove_req_id(ri.request_id)
+
+        assert mock_ctx in handler._ctx_mgr_pool
+
+    def test_drop_does_not_acquire_second_manager_at_capacity(self):
+        handler, ri, mock_ctx = self._make_completed_file_request()
+        handler._ctx_mgr_pool = []
+        handler.num_ctx_mgr = handler.MAX_CONTEXT_MANAGERS
+        handler._acquire_ctx_mgr = MagicMock(
+            side_effect=AssertionError("cleanup must not acquire another manager")
         )
 
         with patch.dict(os.environ, {"LVS_DISABLE_DB_RESET_ON_REQUEST_DONE": "false"}):
             handler.check_status_remove_req_id(ri.request_id)
 
+        mock_ctx.drop_collection.assert_called_once_with()
+        handler._acquire_ctx_mgr.assert_not_called()
         assert mock_ctx in handler._ctx_mgr_pool
 
 


### PR DESCRIPTION
## Summary

Improve video summarization reliability and scalability under Kafka ingestion
delays, transient Elasticsearch shard unavailability, and high request
concurrency.

The changes also scale the LVS Elasticsearch deployment for high-volume
ingestion and add acceptance coverage for the multi-node configuration.

## Plan

- Wait for expected Kafka events to become searchable before starting
  aggregation.
- Retry transient Elasticsearch primary-shard failures with bounded backoff.
- Return HTTP 503 when dependent services remain unavailable instead of
  returning a misleading empty summary.
- Separate request admission, ContextManager, cleanup, and HTTP worker
  capacities to prevent pool starvation.
- Ensure ContextManager leases are returned exactly once after completion,
  failure, or client disconnection.
- Scale the LVS Elasticsearch deployment to four nodes with explicit heap and
  resource settings.
- Add Helm rendering, cluster health, and high-scale Elasticsearch acceptance
  coverage.

## Related Issue

- [NVBug 6667632](https://nvbugspro.nvidia.com/bug/6667632)
- [NVBug 6668209](https://nvbugspro.nvidia.com/bug/6668209)
- [NVBug 6661234](https://nvbugspro.nvidia.com/bug/6661234)
- [NVBug 6661431](https://nvbugspro.nvidia.com/bug/6661431)

## Changes

### Kafka ingestion visibility

- Replace the fixed post-caption delay with a per-video Elasticsearch
  visibility check.
- Wait until the expected number of `raw_events` documents is searchable.
- Retry missing indices, connection failures, HTTP 429 responses, and
  transient server errors within a configurable timeout.
- Return HTTP 503 when the ingestion wait expires.

### Elasticsearch shard readiness

- Add a bounded retry helper for transient primary-shard failures.
- Wait for an active primary shard before CA-RAG retrieval.
- Preserve unrelated Elasticsearch failures instead of retrying them.
- Handle Elasticsearch 9 cluster-health timeout exceptions as retryable.
- Apply the shard-readiness behavior to the pinned CA-RAG 3.1.0 dependency
  during the image build.
- Return HTTP 503 when the retry budget is exhausted.

### Summarization request capacity

- Separate live-stream admission, ContextManager, HTTP offload, and cleanup
  worker limits.
- Reject excess summarization requests promptly with HTTP 503.
- Replace blocking completion waits with asynchronous polling.
- Release ContextManager leases after terminal processing.
- Perform optional reset work in a bounded cleanup executor.
- Clean up abandoned SSE and non-streaming requests after client disconnects.
- Add capacity overrides, lease metrics, and deployment sizing guidance.

### Elasticsearch Helm deployment

- Scale the LVS Elasticsearch StatefulSet to four nodes.
- Configure 4 GiB JVM heaps and explicit resource reservations.
- Configure multi-node discovery while retaining the chart's single-node
  deployment path.
- Add deterministic initial master-node bootstrap configuration.
- Use yellow cluster health for readiness so replicas can initialize while
  shards are being assigned.
- Add Helm tests for node count, cluster health, shard distribution, ingestion,
  and cleanup.
- Raise the scale-test file-descriptor limit before launching 1,280 concurrent
  writers and fail preflight when the host hard limit is insufficient.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
