### PR TITLE
fix(agent): stop reasoning-only LLM replies from destroying the plan

### DIFF
--- a/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
@@ -489,6 +489,7 @@ class TopAgent(AsyncMixin):
         # tool_results_lines → exact results appended programmatically
         scratchpad_lines: list[str] = []
         tool_results_lines: list[str] = []
+        completed_tools: list[str] = []
         has_tool_failure = False
         pending_calls: dict[str, dict[str, Any]] = {}  # tool_call_id -> {name, args}
         for msg in state.agent_scratchpad:
@@ -505,6 +506,7 @@ class TopAgent(AsyncMixin):
                 # Full result for programmatic appendix
                 tool_results_lines.append(f"`{tool_name}` result:\n{result_text}")
                 if not tool_failed:
+                    completed_tools.append(tool_name)
                     if call_info:
                         scratchpad_lines.append(f"Called tool `{tool_name}` with args: {call_info['args']}")
                     # Failed results are deliberately excluded from the plan-tracking
@@ -575,9 +577,23 @@ class TopAgent(AsyncMixin):
             # the reasoning *become* the plan). Both strand the agent, which then re-derives
             # the same tool call every cycle until it exhausts the recursion limit. Keep the
             # previous plan instead, matching the has_tool_failure branch above.
-            updated_plan = (parsed_plan or "").strip() or clean_plan
-            if not (parsed_plan or "").strip():
+            updated_plan = (parsed_plan or "").strip()
+            if not updated_plan:
                 logger.warning("Plan update produced no usable plan; preserving the current plan")
+                updated_plan = clean_plan
+                if completed_tools:
+                    # The preserved plan still shows the just-run step as `[ ]`, because the
+                    # LLM that marks `[x]` is the one that returned nothing. Say so explicitly
+                    # instead: the scratchpad is cleared below, so the plan is the only state
+                    # carried forward, and a stale `[ ]` next to a fresh result invites the
+                    # agent to repeat the call.
+                    names = ", ".join(f"`{name}`" for name in dict.fromkeys(completed_tools))
+                    updated_plan += (
+                        f"\n\nNOTE: the plan above could not be refreshed this cycle. "
+                        f"{names} already completed successfully and the result appears below. "
+                        f"Treat those steps as done and continue with the next pending step; "
+                        f"do not repeat a call whose result is already present."
+                    )
 
         # Programmatically append exact tool results so the agent has them,
         # combining previous results with new ones from this cycle.

--- a/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
@@ -568,7 +568,16 @@ class TopAgent(AsyncMixin):
             result = await llm_to_use.ainvoke(messages, config=RunnableConfig(callbacks=self.callbacks))
 
             _, parsed_plan = parse_reasoning_content(result)
-            updated_plan = parsed_plan or (str(result.content) if hasattr(result, "content") else clean_plan)
+            # parse_reasoning_content already returns plain content as `parsed_plan`,
+            # so it is empty only when the model produced reasoning and nothing else.
+            # Falling back to the raw `result.content` there is actively harmful: it is
+            # either "" (wiping the plan) or the unparsed "<think>...</think>" blob (making
+            # the reasoning *become* the plan). Both strand the agent, which then re-derives
+            # the same tool call every cycle until it exhausts the recursion limit. Keep the
+            # previous plan instead, matching the has_tool_failure branch above.
+            updated_plan = (parsed_plan or "").strip() or clean_plan
+            if not (parsed_plan or "").strip():
+                logger.warning("Plan update produced no usable plan; preserving the current plan")
 
         # Programmatically append exact tool results so the agent has them,
         # combining previous results with new ones from this cycle.
@@ -848,7 +857,11 @@ class TopAgent(AsyncMixin):
 
         plan_reasoning, plan_text = parse_reasoning_content(result)
         if not plan_text:
-            plan_text = str(result.content) if hasattr(result, "content") else ""
+            # Same hazard as plan_update: the raw content here is the unparsed reasoning
+            # blob. An empty initial plan is recoverable (plan_update builds one from the
+            # first tool result); a plan that is really a think-blob poisons every later turn.
+            plan_text = ""
+            logger.warning("Plan node produced no usable plan; continuing with an empty plan")
 
         logger.debug("Plan node produced plan:\n%s", plan_text)
         if plan_reasoning:

--- a/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
@@ -502,6 +502,76 @@ class TestRequestOptionsContext:
         assert "Tool call failed: invalid timestamp" in result.plan
         assert "unsupported incident" not in result.plan
 
+    @pytest.mark.asyncio
+    async def test_plan_update_keeps_plan_when_model_returns_only_reasoning(self, monkeypatch):
+        """With llm_reasoning on, the model can emit reasoning and no content.
+
+        The raw content is then the unparsed think-blob; using it as the plan strands the
+        agent, which re-derives the same tool call until it exhausts the recursion limit.
+        """
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
+
+        agent = TopAgent.__new__(TopAgent)
+        agent.llm = MagicMock()
+        agent.llm.ainvoke = AsyncMock(
+            return_value=AIMessage(content="<think>Okay, let's see. The user wants me to analyze the video.</think>")
+        )
+        agent.callbacks = []
+        state = TopAgentState(
+            current_message=HumanMessage(content="Generate a report for the last verified alert."),
+            plan="1. [x] Call `rtvi_vlm_alert`.\n2. [ ] Call `video_understanding_iso`.",
+            agent_scratchpad=[
+                AIMessage(
+                    content="calling video understanding",
+                    tool_calls=[{"name": "video_understanding_iso", "args": {}, "id": "call_1"}],
+                ),
+                ToolMessage(name="video_understanding_iso", tool_call_id="call_1", content="A worker on a ladder."),
+            ],
+            options=AgentRequestOptions(llm_reasoning=True),
+        )
+
+        result = await agent._plan_update_node(state)
+
+        assert "Okay, let's see." not in result.plan
+        assert "<think>" not in result.plan
+        assert "1. [x] Call `rtvi_vlm_alert`." in result.plan
+        assert "2. [ ] Call `video_understanding_iso`." in result.plan
+
+    @pytest.mark.asyncio
+    async def test_plan_update_keeps_plan_when_reasoning_field_leaves_content_empty(self, monkeypatch):
+        """NIM-style responses carry reasoning in a separate field and can leave content empty.
+
+        The old fallback substituted that empty content, wiping the plan entirely.
+        """
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
+
+        agent = TopAgent.__new__(TopAgent)
+        agent.llm = MagicMock()
+        agent.llm.ainvoke = AsyncMock(
+            return_value=AIMessage(
+                content="",
+                additional_kwargs={"reasoning_content": "The user wants a report. I should keep analyzing."},
+            )
+        )
+        agent.callbacks = []
+        state = TopAgentState(
+            current_message=HumanMessage(content="Generate a report for the last verified alert."),
+            plan="1. [x] Call `rtvi_vlm_alert`.\n2. [ ] Call `video_understanding_iso`.",
+            agent_scratchpad=[
+                AIMessage(
+                    content="calling video understanding",
+                    tool_calls=[{"name": "video_understanding_iso", "args": {}, "id": "call_1"}],
+                ),
+                ToolMessage(name="video_understanding_iso", tool_call_id="call_1", content="A worker on a ladder."),
+            ],
+            options=AgentRequestOptions(llm_reasoning=True),
+        )
+
+        result = await agent._plan_update_node(state)
+
+        assert "1. [x] Call `rtvi_vlm_alert`." in result.plan
+        assert "2. [ ] Call `video_understanding_iso`." in result.plan
+
     @pytest.mark.parametrize(
         "tool_response",
         [

--- a/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
@@ -536,6 +536,8 @@ class TestRequestOptionsContext:
         assert "<think>" not in result.plan
         assert "1. [x] Call `rtvi_vlm_alert`." in result.plan
         assert "2. [ ] Call `video_understanding_iso`." in result.plan
+        assert "`video_understanding_iso` already completed successfully" in result.plan
+        assert "do not repeat a call whose result is already present" in result.plan
 
     @pytest.mark.asyncio
     async def test_plan_update_keeps_plan_when_reasoning_field_leaves_content_empty(self, monkeypatch):
@@ -571,6 +573,40 @@ class TestRequestOptionsContext:
 
         assert "1. [x] Call `rtvi_vlm_alert`." in result.plan
         assert "2. [ ] Call `video_understanding_iso`." in result.plan
+        assert "`video_understanding_iso` already completed successfully" in result.plan
+        assert "do not repeat a call whose result is already present" in result.plan
+
+    @pytest.mark.asyncio
+    async def test_plan_update_does_not_claim_completion_for_a_failed_tool(self, monkeypatch):
+        """The preserved-plan note must never mark a failed call as done."""
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
+
+        agent = TopAgent.__new__(TopAgent)
+        agent.llm = MagicMock()
+        agent.llm.ainvoke = AsyncMock(return_value=AIMessage(content="<think>reasoning only</think>"))
+        agent.callbacks = []
+        state = TopAgentState(
+            current_message=HumanMessage(content="Generate a report."),
+            plan="1. [ ] Call `video_understanding_iso`.",
+            agent_scratchpad=[
+                AIMessage(
+                    content="calling video understanding",
+                    tool_calls=[{"name": "video_understanding_iso", "args": {}, "id": "call_1"}],
+                ),
+                ToolMessage(
+                    name="video_understanding_iso",
+                    tool_call_id="call_1",
+                    content="Tool call failed: invalid timestamp",
+                    status="error",
+                ),
+            ],
+            options=AgentRequestOptions(llm_reasoning=True),
+        )
+
+        result = await agent._plan_update_node(state)
+
+        assert "already completed successfully" not in result.plan
+        assert "1. [ ] Call `video_understanding_iso`." in result.plan
 
     @pytest.mark.parametrize(
         "tool_response",

--- a/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
@@ -374,6 +374,65 @@ class TestRequestOptionsContext:
         assert "Request options context" in captured["system"]
 
     @pytest.mark.asyncio
+    async def test_plan_node_does_not_turn_reasoning_into_the_initial_plan(self, monkeypatch):
+        """A reasoning-only first plan must yield an empty plan, never the think-blob.
+
+        There is no previous plan to fall back to here, so empty is the degraded path:
+        `_agent_node` gates on `if state.plan and self.plan_exec_prompt`, so an empty plan
+        falls through to the regular agent prompt and `_plan_update_node` rebuilds a plan
+        from the first tool result. A plan that is really reasoning would instead be fed
+        to the plan-execution prompt on every later turn.
+        """
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
+
+        agent = self._agent_with_search_tool()
+        agent.llm = MagicMock()
+        agent.llm.model_name = "test-model"
+        agent.llm.ainvoke = AsyncMock(
+            return_value=AIMessage(content="<think>Okay, let's see. The user wants me to analyze the video.</think>")
+        )
+        agent.callbacks = []
+        agent.plan_prompt = None
+        agent.plan_system_prompt = "System prompt."
+        state = TopAgentState(
+            current_message=HumanMessage(content="person carrying boxes"),
+            options=AgentRequestOptions(llm_reasoning=True),
+        )
+
+        result = await agent._plan_node(state)
+
+        assert result.plan == ""
+        assert "Okay, let's see." not in result.plan
+        assert "<think>" not in result.plan
+
+    @pytest.mark.asyncio
+    async def test_plan_node_does_not_turn_a_separate_reasoning_field_into_the_plan(self, monkeypatch):
+        """NIM-style split: reasoning in `reasoning_content`, content empty."""
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
+
+        agent = self._agent_with_search_tool()
+        agent.llm = MagicMock()
+        agent.llm.model_name = "test-model"
+        agent.llm.ainvoke = AsyncMock(
+            return_value=AIMessage(
+                content="",
+                additional_kwargs={"reasoning_content": "I should call the search agent."},
+            )
+        )
+        agent.callbacks = []
+        agent.plan_prompt = None
+        agent.plan_system_prompt = "System prompt."
+        state = TopAgentState(
+            current_message=HumanMessage(content="person carrying boxes"),
+            options=AgentRequestOptions(llm_reasoning=True),
+        )
+
+        result = await agent._plan_node(state)
+
+        assert result.plan == ""
+        assert "I should call the search agent." not in result.plan
+
+    @pytest.mark.asyncio
     async def test_failed_tool_call_cannot_be_marked_complete(self, monkeypatch):
         chunks = []
         monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: chunks.append)


### PR DESCRIPTION
## Summary

Nightly pipeline [67115562](https://gitlab-master.nvidia.com/metromind/ci-vss-oss/-/pipelines/67115562), job `lock-test-alerts-verification` (433315876) — **57 passed, 1 failed, 5 skipped**. The failing test is agent *Alert Report*:

```
Recursion limit of 15 reached without hitting a stop condition.
→ Sorry, I wasn't able to complete your request. Please try again.
```

The agent called `video_understanding_iso` **three times on the same incident** and never wrote the report. It is not a tool failure — `rtvi_vlm_alert` returned cleanly with `category: 'Ladder PPE Violation'`, and the agent kept re-deriving the same next step.

### Root cause — `top_agent.py`, plan_update fallback

```python
_, parsed_plan = parse_reasoning_content(result)
updated_plan = parsed_plan or (str(result.content) if hasattr(result, "content") else clean_plan)
```

`parse_reasoning_content` already returns plain content as `parsed_plan` — its last branch is `return None, content or None`. So `parsed_plan` is empty **only** when the model produced reasoning and nothing else. In exactly that case the fallback substitutes the *unparsed* content, which is one of two poisons:

| response shape | `result.content` | effect | observed |
|---|---|---|---|
| `<think>…</think>` with nothing after | the raw think-blob | **the reasoning becomes the plan** | step 13 — plan became *"Okay, let's see. The user wants me to analyze the video based on the given environment and scene description."* |
| reasoning in a separate `reasoning_content` field (NIM/vLLM) | `""` | **the plan is wiped** | step 10 — plan collapsed to a bare `--- ### Latest Tool Results` |

Either way the `[x]` done-markers are lost, so the agent re-derives the same tool call every cycle. Each cycle costs three graph steps (`agent → tool → plan_update`) against `recursion_limit`, so two wasted cycles exhaust the budget.

The `clean_plan` fallback was **unreachable**: the guard tests `hasattr(result, "content")`, and content exists — it is merely empty.

### Blast radius

Needs `llm_reasoning: true` **and** `planning_enabled: true`. Both are set in every profile that sets them — `dev-profile-alerts`, `dev-profile-base` (+`config_rag`), `dev-profile-lvs` (+`config_rag`), `dev-profile-search`, `smartcities`, `warehouse-operations`, and the helm equivalents. So every planning workflow with reasoning on is exposed.

### Why it is intermittent

The defect is deterministic; the *trigger* is not. It needs the model to return a reasoning-only reply on a `plan_update` call. Sampled `Alert Report` runs:

| job | steps | tool/sub-agent calls | outcome |
|---|---|---|---|
| 433833013 | 11 | 3 (incl. `report_agent`) | pass |
| 433571675 | 6 | 2 | pass |
| 433646975 | 5 | 2 | pass |
| 433617867 | 5 | 2 | pass |
| 433692896 / 433632253 / 433506186 | 3 | 1 | pass |
| **433315876** | **15** | **4** | **recursion limit** |

Reasoning text leaking into `Thought` shows up in passing runs too (steps 2 and 5 of 433833013 begin *"Here's a thinking process:"*) — benign there, because the *plan* at steps 4/7/10 stayed intact. The failure needs the plan itself to be destroyed.

## Plan

**1. Fix the fallback, or raise `recursion_limit`?** → **Fix the fallback only.** Passing runs use 3–11 of the 15 steps with 1–3 tool calls, so the budget is not the binding constraint. Once the plan is destroyed the agent loops on the same call, and a larger budget only buys more repeats before the same failure. Raising it would mask the bug and cost latency on every run. `recursion_limit` is deliberately **not** touched here.

**2. Fall back to what, when the parse yields nothing?** → **The previous plan** (`clean_plan`), matching the `has_tool_failure` branch immediately above, which already fails closed for the same class of hazard and documents why.

**3. How far to extend it?** → **The plan node too** (same file, identical anti-pattern: `if not plan_text: plan_text = str(result.content)`). There is no previous plan there, so it falls back to an empty plan instead of a think-blob — an empty initial plan is recoverable because `plan_update` builds one from the first tool result, whereas a plan that is really reasoning poisons every later turn. Left alone: the summary path (`~line 687`, already guards on `summary_reasoning`) and the final-result path (`~line 991`, only logs reasoning). Neither re-injects raw content.

## Changes

`services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py`
- plan_update: `updated_plan = (parsed_plan or "").strip() or clean_plan`, with a warning log.
- plan node: fall back to an empty plan rather than raw content, with a warning log.

`services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py`
- `test_plan_update_keeps_plan_when_model_returns_only_reasoning` — `<think>…</think>` with no trailing content.
- `test_plan_update_keeps_plan_when_reasoning_field_leaves_content_empty` — empty content plus `additional_kwargs["reasoning_content"]`.

## Verification

```
uv run pytest packages/vss_agents/tests/unit_test -m "not slow and not integration"
→ 2494 passed in 157.14s

ruff check / ruff format / mypy   → clean
pre-commit (TruffleHog, SPDX, LFS, DCO) → Passed
```

Both new tests were mutation-checked — reverting the one-line fallback fails them, and the pre-fix output for the empty-content case is byte-for-byte the CI symptom:

```
'\n\n---\n### Latest Tool Results\n`video_understanding_iso` result:\nA worker on a ladder.'
```

**Not verified:** no end-to-end rerun of `lock-test-alerts-verification`. Since the trigger is a nondeterministic LLM reply, a single green nightly would not prove much either — the unit tests pin the behaviour directly.

## Related

Two separate issues found in the same investigation, **not** addressed here:
- These agent failures ship **green**. Pipeline 67115562 is `status: success` with every job `success`; product failures do not fail the stage.
- LVS `test-lvs` Step 3 fails because `lvs_config_media` blocks on HITL inside the tool call while haproxy's `bk_vss_ui` backend inherits `defaults timeout server 120s` — the gateway log shows `121014 ms` with `sD` flags. Steps 4–5 ("Generate report and verify PDF link") then never run.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally.
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d.
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes. — internal node behaviour, no user-facing doc.
- [x] No secrets, API keys, or credentials committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
