### PR TITLE
fix(helm): register LVS cameras with RT-VLM

### DIFF
--- a/deploy/helm/developer-profiles/dev-profile-lvs/README.md
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/README.md
@@ -100,10 +100,11 @@ Choose the `nims.gpuType` matching the cluster GPU. Capacity and available NIM p
 
 ## RTVI-VLM integration (always on)
 
-The LVS profile always deploys **`vss-rtvi-vlm`**. VLM calls from both clients are routed through this in-cluster service:
+The LVS profile always deploys **`vss-rtvi-vlm`**. VLM calls from both HTTP clients are routed through this in-cluster service, and VIOS registers cameras with it on VST lifecycle events:
 
 - **`vss-agent`**: `video_understanding` picks the `rtvi_vlm` LLM profile (`configs/vss-agent/config.yml`) because `VLM_MODEL_TYPE=rtvi`. `RTVI_VLM_BASE_URL` resolves to the in-cluster `vss-rtvi-vlm` Service via `agent.vss-agent.rtviVlmServiceName` (default `vss-rtvi-vlm`).
 - **`vss-summarization`**: receives `RTVI_VLM_URL=http://vss-rtvi-vlm:8000` by default (`http://<release>-vss-rtvi-vlm:8000` only when `global.useReleaseNamePrefix=true`), plus `RTVI_VLM_URL_PASSTHROUGH=true` via `vss-summarization.extraEnv` — LVS backend forwards `/generate_captions` to the RTVI pod.
+- **VIOS** (sensor and stream-processing): `global.vios.notificationConfig` enables `camera_add` / `camera_streaming` / `camera_remove` webhooks to `http://<rtvi>/v1/stream/add` and `/v1/stream/remove`, matching Compose. The usable stream URL arrives on `camera_streaming`; `camera_add` may have an empty URL.
 
 Key values (see `values.yaml` for defaults and the full `rtvi.vss-rtvi-vlm.env` list):
 
@@ -117,6 +118,7 @@ Key values (see `values.yaml` for defaults and the full `rtvi.vss-rtvi-vlm.env` 
 | `rtvi.vss-rtvi-vlm.waitForKafka.enabled` | `true` | The RTVI-VLM init container waits for Kafka and required RTVI topics before startup. |
 | `rtvi.vss-rtvi-vlm.env` | full list | Replaces the subchart default `env`. Override individual values (e.g. edge `VLM_INPUT_*`) by editing the list in your overlay. |
 | `vss-summarization.extraEnv` | 2 RTVI vars | `RTVI_VLM_URL`, `RTVI_VLM_URL_PASSTHROUGH`. `RTVI_VLM_URL` is rendered with `tpl`, so it picks up `{{ .Release.Name }}` when `global.useReleaseNamePrefix` is true. |
+| `global.vios.notificationConfig` | LVS webhook JSON | Shared by `vss-vios-sensor` and `vss-vios-streamprocessing`. Empty on those subcharts uses the chart file default (webhooks off); this profile override registers VST cameras with RT-VLM. |
 | `agent.vss-agent.rtviVlmEnabled` / `rtviVlmServiceName` | `true` / `vss-rtvi-vlm` | Parity flags; `RTVI_VLM_BASE_URL` in the `env` list reads `rtviVlmServiceName`. |
 | `agent.vss-agent.env` → `VLM_MODEL_TYPE` | `rtvi` | Flip to `nim` only to bypass RTVI for the agent (video_understanding will then hit the VLM NIM directly). |
 

--- a/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
@@ -51,6 +51,67 @@ global:
   # Mirrors docker dev-profile-lvs/.env: VST_USE_SDRC=true, VST_NGINX_MODE=vst-sdrc.
   vios:
     useSdrc: true
+    # Register direct VST camera additions with RT-VLM before caption generation.
+    # Both the sensor and streamprocessing charts consume this shared config.
+    notificationConfig: |-
+      {
+        "message_broker": {
+          "enable_notification": true,
+          "enable_notification_consumer": true,
+          "use_message_broker_consumer": "kafka",
+          "message_broker_topic_consumer": "mdx-raw",
+          "use_message_broker": "redis",
+          "message_broker_payload_key": "sensor.id",
+          "message_broker_topic": "vst.event",
+          "message_broker_metadata_topic": "mdx-raw",
+          "redis_server_env_var": "__REDIS_ADDRESS__",
+          "kafka_server_address": "__KAFKA_ADDRESS__",
+          "mqtt_broker_address": "__MQTT_BROKER_ADDRESS__"
+        },
+        "webhooks": {
+          "enabled": true,
+          "items": [
+            {
+              "enabled": true,
+              "camera_status_change": "camera_add",
+              "request": [{
+                "url": "http://__RTVI_VLM_ADDRESS__/v1/stream/add",
+                "method": "POST",
+                "headers": {"Content-Type": "application/json", "x-stream-id": "{{event.camera_id}}"},
+                "query_params": {"change": "{{event.change}}"},
+                "camera_type": ["rtsp", "file"],
+                "timeout_ms": 5000,
+                "retry": {"max_attempts": 3, "backoff_ms": [1000, 5000, 15000], "retry_on_status": [408, 429, 500, 502, 503, 504]}
+              }]
+            },
+            {
+              "enabled": true,
+              "camera_status_change": "camera_streaming",
+              "request": [{
+                "url": "http://__RTVI_VLM_ADDRESS__/v1/stream/add",
+                "method": "POST",
+                "headers": {"Content-Type": "application/json", "x-stream-id": "{{event.camera_id}}"},
+                "query_params": {"change": "{{event.change}}"},
+                "camera_type": ["rtsp", "file"],
+                "timeout_ms": 5000,
+                "retry": {"max_attempts": 3, "backoff_ms": [1000, 5000, 15000], "retry_on_status": [408, 429, 500, 502, 503, 504]}
+              }]
+            },
+            {
+              "enabled": true,
+              "camera_status_change": "camera_remove",
+              "request": [{
+                "url": "http://__RTVI_VLM_ADDRESS__/v1/stream/remove",
+                "method": "POST",
+                "headers": {"accept": "application/json", "Content-Type": "application/json", "x-stream-id": "{{event.camera_id}}"},
+                "camera_type": ["rtsp", "file"],
+                "timeout_ms": 600000,
+                "retry": {"max_attempts": 3, "backoff_ms": [1000, 5000, 15000], "retry_on_status": [408, 429, 500, 502, 503, 504]}
+              }]
+            }
+          ]
+        }
+      }
 
 # Set global.external* and optional global.kibanaPublicUrl in values-lvs.yaml. Images/replicas: charts/<name>/values.yaml.
 

--- a/deploy/helm/services/ui/values.yaml
+++ b/deploy/helm/services/ui/values.yaml
@@ -30,7 +30,7 @@ service:
 # the browser fetches agent and VST APIs from these URLs. Use in-cluster URLs (default) when
 # the UI is reached via Ingress/LoadBalancer that proxies to the same cluster. For local
 # port-forward, set to 127.0.0.1 and run three port-forwards (UI 3000, agent 8000, vst-ingress 30888);
-# see helm_dp/vss/values-local-portforward.example.yaml. Chat tab needs chatCompletionUrl and websocketChatUrl (agent serves /chat/stream and /websocket, not /api/chat).
+# see helm_dp/vss/values-local-portforward.example.yaml. Chat tab needs chatCompletionUrl and websocketChatUrl (agent serves /v1/chat/stream and /websocket, not /api/chat).
 # Parent developer-profile sets these (e.g. dev-profile-base, dev-profile-lvs, dev-profile-alerts, dev-profile-search).
 # Set global.externalHost to the browser-reachable host (e.g. vss-search.<ip>.nip.io). Trailing NEXT_PUBLIC_* URLs are derived from {scheme}://{externalHost} (and wss/ws for websockets).
 # If externalHost is vss-search.<ip>.nip.io, the Dashboard Kibana base defaults to http://kibana.<ip>.nip.io{kibanaNipPathSuffix} unless global.kibanaPublicUrl or dashboardKibanaBaseUrl is set.

--- a/deploy/helm/services/vios/charts/vios-sensor/templates/configmap.yaml
+++ b/deploy/helm/services/vios/charts/vios-sensor/templates/configmap.yaml
@@ -30,6 +30,10 @@ data:
 {{- $esH := ternary (printf "%s-elasticsearch" .Release.Name) "elasticsearch" $pfx }}
 {{- $redisAddr := .Values.redisServerAddress | default (printf "%s:6379" $redisH) }}
 {{- $kafkaAddr := .Values.kafkaServerAddress | default (printf "%s:9092" $kafkaH) }}
+{{- $rtviVlmH := ternary (printf "%s-vss-rtvi-vlm" .Release.Name) "vss-rtvi-vlm" $pfx }}
+{{- $rtviVlmAddr := .Values.rtviVlmServerAddress | default (printf "%s:8000" $rtviVlmH) }}
+{{- $viosGlobal := index $g "vios" | default dict }}
+{{- $notificationConfig := .Values.notificationConfig | default (index $viosGlobal "notificationConfig" | default "") | default (.Files.Get "configs/notification_config.json") }}
 {{- $videoMeta := .Values.videoMetadataServerUrl | default (printf "%s:9200/mdx-raw*" $esH) }}
 {{- $cloudStorage := .Values.cloudStorageEndpoint | default "http://127.0.0.1:9000" }}
 {{- $mqttHost := ternary (printf "%s-mosquitto" .Release.Name) "mosquitto" $pfx }}
@@ -49,7 +53,7 @@ data:
 {{- end }}
 {{ .Files.Get "configs/vst_config.json" | replace "__VIDEO_METADATA_SERVER__" $videoMeta | replace "__CLOUD_STORAGE_ENDPOINT__" $cloudStorage | replace "__ANALYTICS_SERVER_ADDRESS__" $analyticsAddr | replace "__STATIC_TURNURL_LIST__" ($turnUrls | toJson) | indent 4 }}
   notification_config.json: |
-{{ .Files.Get "configs/notification_config.json" | replace "__REDIS_ADDRESS__" $redisAddr | replace "__KAFKA_ADDRESS__" $kafkaAddr | replace "__MQTT_BROKER_ADDRESS__" $mqttAddr | indent 4 }}
+{{ $notificationConfig | replace "__REDIS_ADDRESS__" $redisAddr | replace "__KAFKA_ADDRESS__" $kafkaAddr | replace "__MQTT_BROKER_ADDRESS__" $mqttAddr | replace "__RTVI_VLM_ADDRESS__" $rtviVlmAddr | indent 4 }}
   adaptor_config.json: |
 {{ .Files.Get "configs/adaptor_config.json" | indent 4 }}
   vst_storage.json: |

--- a/deploy/helm/services/vios/charts/vios-sensor/values.yaml
+++ b/deploy/helm/services/vios/charts/vios-sensor/values.yaml
@@ -48,6 +48,8 @@ vstIngressEndpoint: ""        # full URL with scheme. When global.vlmBaseUrl and
 redisServerAddress: ""
 # Kafka and MQTT use notification_config.json placeholders; video metadata and cloud storage remain in vst_config.json. Empty = release-based or Compose default.
 kafkaServerAddress: ""
+# RT-VLM webhook target (__RTVI_VLM_ADDRESS__). Empty = vss-rtvi-vlm:8000, or
+# <Release.Name>-vss-rtvi-vlm:8000 when global.useReleaseNamePrefix is true.
 rtviVlmServerAddress: ""
 # Optional complete notification_config.json. Empty uses the chart default;
 # global.vios.notificationConfig provides one shared config to sensor and streamprocessing.

--- a/deploy/helm/services/vios/charts/vios-sensor/values.yaml
+++ b/deploy/helm/services/vios/charts/vios-sensor/values.yaml
@@ -48,6 +48,10 @@ vstIngressEndpoint: ""        # full URL with scheme. When global.vlmBaseUrl and
 redisServerAddress: ""
 # Kafka and MQTT use notification_config.json placeholders; video metadata and cloud storage remain in vst_config.json. Empty = release-based or Compose default.
 kafkaServerAddress: ""
+rtviVlmServerAddress: ""
+# Optional complete notification_config.json. Empty uses the chart default;
+# global.vios.notificationConfig provides one shared config to sensor and streamprocessing.
+notificationConfig: ""
 videoMetadataServerUrl: ""
 cloudStorageEndpoint: ""
 mqttBrokerAddress: ""

--- a/deploy/helm/services/vios/charts/vios-streamprocessing/templates/configmap.yaml
+++ b/deploy/helm/services/vios/charts/vios-streamprocessing/templates/configmap.yaml
@@ -30,6 +30,10 @@ data:
 {{- $esH := ternary (printf "%s-elasticsearch" .Release.Name) "elasticsearch" $pfx }}
 {{- $redisAddr := .Values.redisServerAddress | default (printf "%s:6379" $redisH) }}
 {{- $kafkaAddr := .Values.kafkaServerAddress | default (printf "%s:9092" $kafkaH) }}
+{{- $rtviVlmH := ternary (printf "%s-vss-rtvi-vlm" .Release.Name) "vss-rtvi-vlm" $pfx }}
+{{- $rtviVlmAddr := .Values.rtviVlmServerAddress | default (printf "%s:8000" $rtviVlmH) }}
+{{- $viosGlobal := index $g "vios" | default dict }}
+{{- $notificationConfig := .Values.notificationConfig | default (index $viosGlobal "notificationConfig" | default "") | default (.Files.Get "configs/notification_config.json") }}
 {{- $videoMeta := .Values.videoMetadataServerUrl | default (printf "%s:9200/mdx-raw*" $esH) }}
 {{- $cloudStorage := .Values.cloudStorageEndpoint | default "http://127.0.0.1:9000" }}
 {{- $mqttHost := ternary (printf "%s-mosquitto" .Release.Name) "mosquitto" $pfx }}
@@ -52,7 +56,7 @@ data:
 {{- end }}
 {{ .Files.Get "configs/vst_config.json" | replace "__VIDEO_METADATA_SERVER__" $videoMeta | replace "__CLOUD_STORAGE_ENDPOINT__" $cloudStorage | replace "__ANALYTICS_SERVER_ADDRESS__" $analyticsAddr | replace "__CALIBRATION_FILE_ENDPOINT__" $calibEp | replace "__FLOORMAP_IMAGE_ENDPOINT__" $floorEp | replace "__USE_SOFTWARE_PATH__" ($softwarePath | toString) | replace "__STATIC_TURNURL_LIST__" ($turnUrls | toJson) | indent 4 }}
   notification_config.json: |
-{{ .Files.Get "configs/notification_config.json" | replace "__REDIS_ADDRESS__" $redisAddr | replace "__KAFKA_ADDRESS__" $kafkaAddr | replace "__MQTT_BROKER_ADDRESS__" $mqttAddr |  indent 4 }}
+{{ $notificationConfig | replace "__REDIS_ADDRESS__" $redisAddr | replace "__KAFKA_ADDRESS__" $kafkaAddr | replace "__MQTT_BROKER_ADDRESS__" $mqttAddr | replace "__RTVI_VLM_ADDRESS__" $rtviVlmAddr | indent 4 }}
   adaptor_config.json: |
 {{ .Files.Get "configs/adaptor_config.json" | indent 4 }}
   vst_storage.json: |

--- a/deploy/helm/services/vios/charts/vios-streamprocessing/values.yaml
+++ b/deploy/helm/services/vios/charts/vios-streamprocessing/values.yaml
@@ -55,6 +55,10 @@ vstIngressEndpoint: ""   # default: <Release>-vss-vios-ingress:30888/vst (host:p
 redisServerAddress: ""
 # Kafka and MQTT use notification_config.json placeholders; video metadata and cloud storage remain in vst_config.json. Empty = release-based or Compose default.
 kafkaServerAddress: ""
+rtviVlmServerAddress: ""
+# Optional complete notification_config.json. Empty uses the chart default;
+# global.vios.notificationConfig provides one shared config to sensor and streamprocessing.
+notificationConfig: ""
 videoMetadataServerUrl: ""
 cloudStorageEndpoint: ""
 mqttBrokerAddress: ""

--- a/deploy/helm/services/vios/charts/vios-streamprocessing/values.yaml
+++ b/deploy/helm/services/vios/charts/vios-streamprocessing/values.yaml
@@ -55,6 +55,8 @@ vstIngressEndpoint: ""   # default: <Release>-vss-vios-ingress:30888/vst (host:p
 redisServerAddress: ""
 # Kafka and MQTT use notification_config.json placeholders; video metadata and cloud storage remain in vst_config.json. Empty = release-based or Compose default.
 kafkaServerAddress: ""
+# RT-VLM webhook target (__RTVI_VLM_ADDRESS__). Empty = vss-rtvi-vlm:8000, or
+# <Release.Name>-vss-rtvi-vlm:8000 when global.useReleaseNamePrefix is true.
 rtviVlmServerAddress: ""
 # Optional complete notification_config.json. Empty uses the chart default;
 # global.vios.notificationConfig provides one shared config to sensor and streamprocessing.

--- a/deploy/tests/test_helm_lvs_rtvi_registration.py
+++ b/deploy/tests/test_helm_lvs_rtvi_registration.py
@@ -48,8 +48,8 @@ def _notification_configs(release_prefix: bool = False) -> dict[str, dict]:
     for doc in yaml.safe_load_all(_run(cmd)):
         if not doc or doc.get("kind") != "ConfigMap":
             continue
-        component = doc.get("metadata", {}).get("labels", {}).get(
-            "app.kubernetes.io/name"
+        component = (
+            doc.get("metadata", {}).get("labels", {}).get("app.kubernetes.io/name")
         )
         if component in VIOS_COMPONENTS:
             configs[component] = json.loads(doc["data"]["notification_config.json"])
@@ -87,25 +87,29 @@ class LvsRtviRegistrationTests(unittest.TestCase):
                 )
 
     def test_release_prefix_is_applied_to_rtvi_webhook_target(self):
-        for component, config in _notification_configs(True).items():
+        configs = _notification_configs(True)
+        self.assertEqual(set(configs), VIOS_COMPONENTS)
+        expected = {
+            "http://vss-vss-rtvi-vlm:8000/v1/stream/add",
+            "http://vss-vss-rtvi-vlm:8000/v1/stream/remove",
+        }
+        for component, config in configs.items():
             with self.subTest(component=component):
-                urls = [
+                urls = {
                     request["url"]
                     for item in config["webhooks"]["items"]
                     for request in item["request"]
-                ]
-                self.assertTrue(
-                    all(url.startswith("http://vss-vss-rtvi-vlm:8000/") for url in urls)
-                )
+                }
+                self.assertEqual(urls, expected)
 
     def test_cluster_message_broker_addresses_are_rendered(self):
         for component, config in _notification_configs().items():
             with self.subTest(component=component):
                 broker = config["message_broker"]
                 self.assertEqual(broker["redis_server_env_var"], "redis:6379")
-                self.assertEqual(
-                    broker["kafka_server_address"], "kafka-kafka:9092"
-                )
-                self.assertEqual(
-                    broker["mqtt_broker_address"], "tcp://mosquitto:1883"
-                )
+                self.assertEqual(broker["kafka_server_address"], "kafka-kafka:9092")
+                self.assertEqual(broker["mqtt_broker_address"], "tcp://mosquitto:1883")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/tests/test_helm_lvs_rtvi_registration.py
+++ b/deploy/tests/test_helm_lvs_rtvi_registration.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Helm LVS registers direct VST camera additions with RT-VLM."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import unittest
+from functools import cache
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROFILES_DIR = REPO_ROOT / "helm" / "developer-profiles"
+PROFILE = "dev-profile-lvs"
+VIOS_COMPONENTS = {"vss-vios-sensor", "vss-vios-streamprocessing"}
+
+helm_required = unittest.skipUnless(
+    shutil.which("helm"), "helm is not installed; chart rendering cannot be checked"
+)
+
+
+def _run(cmd: list[str]) -> str:
+    out = subprocess.run(
+        cmd, cwd=PROFILES_DIR, capture_output=True, text=True, check=False
+    )
+    if out.returncode != 0:
+        raise AssertionError(f"{' '.join(cmd)} failed:\n{out.stderr}")
+    return out.stdout
+
+
+def setUpModule() -> None:
+    """The profile renders only with its file:// dependencies unpacked."""
+    if shutil.which("helm") and not (PROFILES_DIR / PROFILE / "charts").is_dir():
+        _run(["helm", "dependency", "build", PROFILE])
+
+
+@cache
+def _notification_configs(release_prefix: bool = False) -> dict[str, dict]:
+    cmd = ["helm", "template", "vss", f"./{PROFILE}"]
+    if release_prefix:
+        cmd.extend(["--set", "global.useReleaseNamePrefix=true"])
+
+    configs = {}
+    for doc in yaml.safe_load_all(_run(cmd)):
+        if not doc or doc.get("kind") != "ConfigMap":
+            continue
+        component = doc.get("metadata", {}).get("labels", {}).get(
+            "app.kubernetes.io/name"
+        )
+        if component in VIOS_COMPONENTS:
+            configs[component] = json.loads(doc["data"]["notification_config.json"])
+    return configs
+
+
+@helm_required
+class LvsRtviRegistrationTests(unittest.TestCase):
+    def test_sensor_and_streamprocessing_share_rtvi_lifecycle_webhooks(self):
+        configs = _notification_configs()
+        self.assertEqual(set(configs), VIOS_COMPONENTS)
+
+        for component, config in configs.items():
+            with self.subTest(component=component):
+                self.assertTrue(config["webhooks"]["enabled"])
+                events = {
+                    item["camera_status_change"]: item
+                    for item in config["webhooks"]["items"]
+                    if item["enabled"]
+                }
+                self.assertEqual(
+                    set(events), {"camera_add", "camera_streaming", "camera_remove"}
+                )
+                self.assertEqual(
+                    events["camera_add"]["request"][0]["url"],
+                    "http://vss-rtvi-vlm:8000/v1/stream/add",
+                )
+                self.assertEqual(
+                    events["camera_streaming"]["request"][0]["url"],
+                    "http://vss-rtvi-vlm:8000/v1/stream/add",
+                )
+                self.assertEqual(
+                    events["camera_remove"]["request"][0]["url"],
+                    "http://vss-rtvi-vlm:8000/v1/stream/remove",
+                )
+
+    def test_release_prefix_is_applied_to_rtvi_webhook_target(self):
+        for component, config in _notification_configs(True).items():
+            with self.subTest(component=component):
+                urls = [
+                    request["url"]
+                    for item in config["webhooks"]["items"]
+                    for request in item["request"]
+                ]
+                self.assertTrue(
+                    all(url.startswith("http://vss-vss-rtvi-vlm:8000/") for url in urls)
+                )
+
+    def test_cluster_message_broker_addresses_are_rendered(self):
+        for component, config in _notification_configs().items():
+            with self.subTest(component=component):
+                broker = config["message_broker"]
+                self.assertEqual(broker["redis_server_env_var"], "redis:6379")
+                self.assertEqual(
+                    broker["kafka_server_address"], "kafka-kafka:9092"
+                )
+                self.assertEqual(
+                    broker["mqtt_broker_address"], "tcp://mosquitto:1883"
+                )


### PR DESCRIPTION
## What this does now

Makes the Helm LVS profile register cameras with RT-VLM when they are added directly through VST, matching the Docker Compose profile.

The LVS UI e2e path calls VST `sensor/add` directly. Docker mounts an LVS-specific `notification_config.json` into VIOS, so `camera_add` and `camera_streaming` events call RT-VLM `/v1/stream/add` before `/v1/generate_captions` is requested. Helm was still rendering the generic VIOS config with webhooks disabled, so VST returned a camera UUID that RT-VLM did not know and caption generation failed with `400 No such resource`.

This PR:

- supplies the LVS lifecycle notification config to both Helm VIOS sensor and stream-processing workloads;
- renders cluster-local Redis, Kafka, MQTT, and RT-VLM addresses, including release-name prefixes;
- registers on `camera_add` and `camera_streaming`, and unregisters on `camera_remove`;
- adds focused Helm render tests for both workloads and address modes;
- corrects the remaining stale Helm UI comment to name `/v1/chat/stream`.

## Compose/Helm gap

PR #2107 already changed both Docker and Helm UI chat defaults to `/v1/chat/stream` and added the UI HITL response proxy/modal. The remaining Helm gap came from the subsequent Docker LVS camera notification change: Compose had the RT-VLM webhook configuration, while the Helm LVS profile retained webhook-disabled generic VIOS defaults.

## State after merge

- **Immediate behavior:** a camera added through the Helm LVS VST/UI path is registered with RT-VLM before caption generation, preventing the observed missing-resource path when webhook delivery succeeds.
- **Unchanged fallback/defaults:** non-LVS profiles keep their existing VIOS notification config; the shared VIOS chart defaults remain webhook-disabled unless a profile supplies an override.
- **External prerequisites:** VIOS must be able to resolve and reach the deployed `vss-rtvi-vlm` Service.
- **Failure behavior:** VST retries configured transient webhook failures three times; a persistent RT-VLM/network failure can still leave caption generation without a registered resource.
- **Rollback:** revert this PR to restore the previous Helm webhook-disabled behavior.

The separate `ci-vss-oss` hardcoded `/chat/stream` test-harness route is outside this GitHub repository and still needs its GitLab-side `/v1/chat/stream` update (tracked in GitLab CI !538). That route issue is distinct from the Sept 10 `No such resource` failure fixed here.

## Validation

- `python3 -m pytest deploy/tests/test_helm_lvs_rtvi_registration.py deploy/tests/test_helm_llm_route.py -q` — 16 passed, 46 subtests passed
- `helm lint ./dev-profile-lvs` — 1 chart linted, 0 failed
- `helm template vss ./dev-profile-lvs` — rendered successfully
- `git diff --check` — clean
