### PR TITLE
updated(config): removed calib_mode from warehouse 3D app configuration

### DIFF
--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/deepstream/configs/config.yaml
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/deepstream/configs/config.yaml
@@ -29,7 +29,6 @@ interval: 0 # Number of consecutive batches to be skipped for inference
 # Calibration Properties
 calib_file_path: /opt/data/ds-configurator/calibration.json # Calibration file path
 bev_group_name: bev-sensor-1 # BEV group name
-calib_mode: synthetic # Calibration mode
 use_camera_groups: True # Groups cameras for multi-view fusion in synthetic mode
 recentering: True # Recalculates camera coordinates from a reference point
 


### PR DESCRIPTION
Removed the 'calib_mode' setting from the config.yaml file for the warehouse-3D application to streamline the calibration properties.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
