### PR TITLE
fix(rtvi-vlm): restore AAC decoder dependency

### DIFF
--- a/services/rtvi/rt-embed/src/scripts/install_codecs_nonroot.sh
+++ b/services/rtvi/rt-embed/src/scripts/install_codecs_nonroot.sh
@@ -142,6 +142,7 @@ PACKAGES=(
     libmbedcrypto7t64
     libhwy1t64
     libcjson1
+    libsodium23
 )
 
 if [ "$DEB_ARCH" = "amd64" ]; then
@@ -263,6 +264,50 @@ export PYTHONPATH=${PYTHON_CODEC_DIR}\${PYTHONPATH:+:\$PYTHONPATH}
 export LD_LIBRARY_PATH=${PYTHON_CODEC_DIR}/PyNvVideoCodec:${LIB_DIR}\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}
 export PATH=${INSTALL_DIR}/usr/bin\${PATH:+:\$PATH}
 EOF
+
+# Do not record a successful installation merely because the packages were
+# extracted. GStreamer silently blacklists plugins with unresolved shared
+# libraries, which makes the libav package appear installed while avdec_aac is
+# unavailable at runtime. Use a fresh registry so a previous blacklist cannot
+# influence this check.
+LIBAV_PLUGIN="$GST_PLUGIN_DIR/libgstlibav.so"
+if [ ! -s "$LIBAV_PLUGIN" ]; then
+    echo "ERROR: GStreamer libav plugin is missing at $LIBAV_PLUGIN" >&2
+    exit 1
+fi
+
+if ! LDD_OUTPUT=$(
+    LD_LIBRARY_PATH="${PYTHON_CODEC_DIR}/PyNvVideoCodec:${LIB_DIR}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+        ldd "$LIBAV_PLUGIN"
+); then
+    echo "ERROR: Failed to inspect GStreamer libav runtime dependencies" >&2
+    exit 1
+fi
+MISSING_LIBRARIES=$(awk '/not found/ { print $1 }' <<< "$LDD_OUTPUT")
+if [ -n "$MISSING_LIBRARIES" ]; then
+    echo "ERROR: GStreamer libav plugin has unresolved runtime dependencies:" >&2
+    sed 's/^/  /' <<< "$MISSING_LIBRARIES" >&2
+    exit 1
+fi
+
+if ! env \
+    GST_PLUGIN_PATH="${GST_PLUGIN_DIR}${GST_PLUGIN_PATH:+:$GST_PLUGIN_PATH}" \
+    LD_LIBRARY_PATH="${PYTHON_CODEC_DIR}/PyNvVideoCodec:${LIB_DIR}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+    GST_REGISTRY="$DEBS_DIR/gstreamer-registry.bin" \
+    python3 - <<'PY'
+import gi
+
+gi.require_version("Gst", "1.0")
+from gi.repository import Gst
+
+Gst.init(None)
+if Gst.ElementFactory.find("avdec_aac") is None:
+    raise SystemExit("avdec_aac element factory is unavailable")
+PY
+then
+    echo "ERROR: GStreamer could not load the avdec_aac decoder from $LIBAV_PLUGIN" >&2
+    exit 1
+fi
 
 touch "$INSTALL_DIR/.installed"
 echo "Codec installation complete. Env written to $INSTALL_DIR/codec_env.sh"

--- a/services/rtvi/rt-vlm/src/scripts/install_codecs_nonroot.sh
+++ b/services/rtvi/rt-vlm/src/scripts/install_codecs_nonroot.sh
@@ -142,6 +142,7 @@ PACKAGES=(
     libmbedcrypto7t64
     libhwy1t64
     libcjson1
+    libsodium23
 )
 
 if [ "$DEB_ARCH" = "amd64" ]; then
@@ -263,6 +264,50 @@ export PYTHONPATH=${PYTHON_CODEC_DIR}\${PYTHONPATH:+:\$PYTHONPATH}
 export LD_LIBRARY_PATH=${PYTHON_CODEC_DIR}/PyNvVideoCodec:${LIB_DIR}\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}
 export PATH=${INSTALL_DIR}/usr/bin\${PATH:+:\$PATH}
 EOF
+
+# Do not record a successful installation merely because the packages were
+# extracted. GStreamer silently blacklists plugins with unresolved shared
+# libraries, which makes the libav package appear installed while avdec_aac is
+# unavailable at runtime. Use a fresh registry so a previous blacklist cannot
+# influence this check.
+LIBAV_PLUGIN="$GST_PLUGIN_DIR/libgstlibav.so"
+if [ ! -s "$LIBAV_PLUGIN" ]; then
+    echo "ERROR: GStreamer libav plugin is missing at $LIBAV_PLUGIN" >&2
+    exit 1
+fi
+
+if ! LDD_OUTPUT=$(
+    LD_LIBRARY_PATH="${PYTHON_CODEC_DIR}/PyNvVideoCodec:${LIB_DIR}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+        ldd "$LIBAV_PLUGIN"
+); then
+    echo "ERROR: Failed to inspect GStreamer libav runtime dependencies" >&2
+    exit 1
+fi
+MISSING_LIBRARIES=$(awk '/not found/ { print $1 }' <<< "$LDD_OUTPUT")
+if [ -n "$MISSING_LIBRARIES" ]; then
+    echo "ERROR: GStreamer libav plugin has unresolved runtime dependencies:" >&2
+    sed 's/^/  /' <<< "$MISSING_LIBRARIES" >&2
+    exit 1
+fi
+
+if ! env \
+    GST_PLUGIN_PATH="${GST_PLUGIN_DIR}${GST_PLUGIN_PATH:+:$GST_PLUGIN_PATH}" \
+    LD_LIBRARY_PATH="${PYTHON_CODEC_DIR}/PyNvVideoCodec:${LIB_DIR}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+    GST_REGISTRY="$DEBS_DIR/gstreamer-registry.bin" \
+    python3 - <<'PY'
+import gi
+
+gi.require_version("Gst", "1.0")
+from gi.repository import Gst
+
+Gst.init(None)
+if Gst.ElementFactory.find("avdec_aac") is None:
+    raise SystemExit("avdec_aac element factory is unavailable")
+PY
+then
+    echo "ERROR: GStreamer could not load the avdec_aac decoder from $LIBAV_PLUGIN" >&2
+    exit 1
+fi
 
 touch "$INSTALL_DIR/.installed"
 echo "Codec installation complete. Env written to $INSTALL_DIR/codec_env.sh"

--- a/services/rtvi/rt-vlm/tests/test_install_codecs_nonroot.py
+++ b/services/rtvi/rt-vlm/tests/test_install_codecs_nonroot.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import subprocess
+from pathlib import Path
+
+
+INSTALLER = Path(__file__).parents[1] / "src" / "scripts" / "install_codecs_nonroot.sh"
+
+
+def _installer_text() -> str:
+    return INSTALLER.read_text(encoding="utf-8")
+
+
+def test_installer_shell_syntax() -> None:
+    subprocess.run(["bash", "-n", str(INSTALLER)], check=True)
+
+
+def test_libav_runtime_dependency_is_downloaded() -> None:
+    text = _installer_text()
+    package_block = re.search(r"PACKAGES=\(\n(?P<body>.*?)\n\)", text, re.DOTALL)
+
+    assert package_block is not None
+    packages = {
+        line.strip()
+        for line in package_block.group("body").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+    assert "gstreamer1.0-libav" in packages
+    assert "libsodium23" in packages
+
+
+def test_aac_decoder_is_verified_before_success_marker() -> None:
+    text = _installer_text()
+
+    verify_plugin = text.index('ldd "$LIBAV_PLUGIN"')
+    verify_factory = text.index('Gst.ElementFactory.find("avdec_aac")')
+    success_marker = text.index('touch "$INSTALL_DIR/.installed"')
+
+    assert verify_plugin < success_marker
+    assert verify_factory < success_marker

--- a/services/rtvi/rt-vlm/tests/test_install_codecs_nonroot.py
+++ b/services/rtvi/rt-vlm/tests/test_install_codecs_nonroot.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -23,6 +24,97 @@ INSTALLER = Path(__file__).parents[1] / "src" / "scripts" / "install_codecs_nonr
 
 def _installer_text() -> str:
     return INSTALLER.read_text(encoding="utf-8")
+
+
+def _write_executable(path: Path, contents: str) -> None:
+    path.write_text(contents, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _run_installer(
+    tmp_path: Path, *, ldd_output: str = "", gst_exit: int = 0, create_libav: bool = True
+) -> tuple[subprocess.CompletedProcess[str], Path, str]:
+    fake_bin = tmp_path / "bin"
+    install_dir = tmp_path / "codecs"
+    call_log = tmp_path / "calls.log"
+    fake_bin.mkdir()
+
+    _write_executable(
+        fake_bin / "apt-get",
+        """#!/usr/bin/env bash
+set -eu
+downloading=false
+index=0
+for argument in "$@"; do
+    if [ "$downloading" = true ]; then
+        : > "fake-${index}.deb"
+        index=$((index + 1))
+    elif [ "$argument" = download ]; then
+        downloading=true
+    fi
+done
+""",
+    )
+    _write_executable(
+        fake_bin / "dpkg",
+        """#!/usr/bin/env bash
+set -eu
+if [ "${1:-}" = --print-architecture ]; then
+    echo amd64
+    exit 0
+fi
+if [ "${1:-}" = -x ] && [ "${FAKE_CREATE_LIBAV:-true}" = true ]; then
+    plugin_dir="$3/usr/lib/x86_64-linux-gnu/gstreamer-1.0"
+    mkdir -p "$plugin_dir"
+    printf plugin > "$plugin_dir/libgstlibav.so"
+fi
+""",
+    )
+    _write_executable(
+        fake_bin / "ldd",
+        """#!/usr/bin/env bash
+set -eu
+printf 'ldd:%s\n' "$1" >> "$FAKE_CALL_LOG"
+printf '%s\n' "${FAKE_LDD_OUTPUT:-}"
+""",
+    )
+    _write_executable(
+        fake_bin / "python3",
+        """#!/usr/bin/env bash
+set -eu
+if [ "${1:-}" = -m ]; then
+    printf 'pip\n' >> "$FAKE_CALL_LOG"
+    exit 0
+fi
+payload=$(cat)
+printf 'gstreamer\n' >> "$FAKE_CALL_LOG"
+grep -F 'Gst.ElementFactory.find("avdec_aac")' <<< "$payload" >/dev/null
+exit "${FAKE_GST_EXIT:-0}"
+""",
+    )
+
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "CODEC_INSTALL_DIR": str(install_dir),
+            "FAKE_CALL_LOG": str(call_log),
+            "FAKE_CREATE_LIBAV": str(create_libav).lower(),
+            "FAKE_GST_EXIT": str(gst_exit),
+            "FAKE_LDD_OUTPUT": ldd_output,
+            "HOME": str(tmp_path / "home"),
+            "PATH": f"{fake_bin}:{environment['PATH']}",
+        }
+    )
+    result = subprocess.run(
+        ["bash", str(INSTALLER)],
+        capture_output=True,
+        check=False,
+        env=environment,
+        text=True,
+        timeout=30,
+    )
+    calls = call_log.read_text(encoding="utf-8") if call_log.exists() else ""
+    return result, install_dir, calls
 
 
 def test_installer_shell_syntax() -> None:
@@ -43,12 +135,47 @@ def test_libav_runtime_dependency_is_downloaded() -> None:
     assert "libsodium23" in packages
 
 
-def test_aac_decoder_is_verified_before_success_marker() -> None:
-    text = _installer_text()
+def test_installer_rejects_missing_libav_plugin(tmp_path: Path) -> None:
+    result, install_dir, calls = _run_installer(tmp_path, create_libav=False)
+    call_lines = calls.splitlines()
 
-    verify_plugin = text.index('ldd "$LIBAV_PLUGIN"')
-    verify_factory = text.index('Gst.ElementFactory.find("avdec_aac")')
-    success_marker = text.index('touch "$INSTALL_DIR/.installed"')
+    assert result.returncode != 0
+    assert "GStreamer libav plugin is missing" in result.stderr
+    assert not (install_dir / ".installed").exists()
+    assert "ldd:" not in calls
+    assert "gstreamer" not in call_lines
 
-    assert verify_plugin < success_marker
-    assert verify_factory < success_marker
+
+def test_installer_rejects_unresolved_libav_dependency(tmp_path: Path) -> None:
+    result, install_dir, calls = _run_installer(
+        tmp_path, ldd_output="libsodium.so.23 => not found"
+    )
+    call_lines = calls.splitlines()
+
+    assert result.returncode != 0
+    assert "unresolved runtime dependencies" in result.stderr
+    assert "libsodium.so.23" in result.stderr
+    assert not (install_dir / ".installed").exists()
+    assert "ldd:" in calls
+    assert "gstreamer" not in call_lines
+
+
+def test_installer_rejects_unavailable_aac_factory(tmp_path: Path) -> None:
+    result, install_dir, calls = _run_installer(tmp_path, gst_exit=1)
+    call_lines = calls.splitlines()
+
+    assert result.returncode != 0
+    assert "could not load the avdec_aac decoder" in result.stderr
+    assert not (install_dir / ".installed").exists()
+    assert "ldd:" in calls
+    assert "gstreamer" in call_lines
+
+
+def test_installer_marks_success_after_runtime_checks(tmp_path: Path) -> None:
+    result, install_dir, calls = _run_installer(tmp_path)
+    call_lines = calls.splitlines()
+
+    assert result.returncode == 0, result.stderr
+    assert (install_dir / ".installed").is_file()
+    assert "ldd:" in calls
+    assert "gstreamer" in call_lines


### PR DESCRIPTION
## Summary

Fix RT-VLM audio-enabled caption generation for MP4 media containing H.264 video and AAC-LC audio when `INSTALL_PROPRIETARY_CODECS=true`.

The proprietary codec overlay extracted `gstreamer1.0-libav`, but did not include `libsodium23`. As a result, GStreamer could not load `libgstlibav.so` (`libsodium.so.23` was missing), `avdec_aac` was unavailable, and AAC requests failed with HTTP 500 even though RT-VLM remained healthy.

This change adds the missing runtime dependency and makes codec installation fail before writing `.installed` unless:

- `libgstlibav.so` was extracted;
- all of its shared-library dependencies resolve; and
- a fresh GStreamer registry can load the `avdec_aac` element.

## Verification

Built the multi-architecture RT-VLM image and tested it on an H100 with the actual `Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8` model.

| Configuration | H.264 + AAC-LC warehouse video | H.264 + Opus Jensen Artifactory video |
|---|---|---|
| `INSTALL_PROPRIETARY_CODECS` unset | HTTP 500 in 1.89 s (expected opt-out behavior) | HTTP 200 in 22.97 s; 27/27 chunks |
| `INSTALL_PROPRIETARY_CODECS=true` | HTTP 200 in 13.81 s; 21/21 chunks | HTTP 200 in 20.91 s; 27/27 chunks |

Additional checks with codecs enabled:

- `avdec_aac` and `opusdec` were both discoverable by GStreamer.
- `ldd` reported no unresolved dependencies for `libgstlibav.so`.
- RT-VLM readiness remained HTTP 200 after both requests.
- Logs contained no missing-AAC-decoder, decode-retry, or `libgstlibav.so` load failures.
- Signed codec package resolution succeeded for amd64 (62 artifacts) and arm64 (61 artifacts).
- Codec installer regression tests: 3 passed.
- `bash -n` and `git diff --check` passed.

## Related Issue

- [NVBug 6753003](https://nvbugspro.nvidia.com/bug/6753003)

## Changes

- Add `libsodium23` to the proprietary codec overlay package set.
- Validate the extracted libav plugin and its shared-library dependencies.
- Verify `avdec_aac` availability using a fresh GStreamer registry before marking installation complete.
- Add regression tests for package inclusion and installer validation ordering.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/develop/CONTRIBUTING.md).
- [x] I have installed and run the pre-commit hooks.
- [x] I have signed my commits with DCO.
- [x] Tests cover the changes.
- [x] Documentation is current; no user-facing documentation change is required.
- [x] No secrets or credentials are included.
