### PR TITLE
fix(agent): trust the generated plan instead of re-asserting a report step

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
@@ -377,7 +377,7 @@ workflow:
     For summaries of named media, plan `vst_video_list` first, then exactly one summary tool based only on its result: `rtsp` → `lvs_stream_understanding`; `video` → `lvs_video_understanding`. Never choose the summary tool from duration.
     Treat "until now" and "till now" as `end_time=0` for `lvs_stream_understanding`; never replace them with the stream duration returned by `vst_video_list`.
     A non-empty name supplied in the request is the sensor_id. For example, in "Generate a report for warehouse_sample", the sensor_id is "warehouse_sample"; this request is complete and MUST NOT trigger a clarifying question.
-    If the user explicitly requests long video summarization or LVS in a report, the plan MUST first call `lvs_video_understanding` with the exact sensor_id and requested time range, then call `report_agent` with the same inputs and the original request as user_query.
+    If the user explicitly requests long video summarization, long video understanding, or LVS in a report, the plan MUST first call `lvs_video_understanding` with the exact sensor_id and requested time range, then call `report_agent` with the same inputs and the original request as user_query. The `report_agent` step is never optional: it is the only tool that writes the PDF and Markdown artifacts, so a plan that stops at the analysis step answers with prose and no downloads.
     For every other named report request, the plan MUST contain exactly one action: call `report_agent` directly with that exact name as sensor_id and the original request as user_query. Do not verify the name or media type first.
     Ask which video or camera the user means only when the request contains no name and the conversation provides no usable name.
     Only use tools from the available tools list. Never invent or assume tools that are not listed.
@@ -387,6 +387,9 @@ workflow:
     Example plan for "Generate a report using long video summarization for warehouse_sample":
     1. Call `lvs_video_understanding` with sensor_id="warehouse_sample".
     2. Call `report_agent` with sensor_id="warehouse_sample" and user_query="Generate a report using long video summarization for warehouse_sample", then present the generated report.
+    Example plan for "Generate a report for warehouse_sample using long video understanding":
+    1. Call `lvs_video_understanding` with sensor_id="warehouse_sample".
+    2. Call `report_agent` with sensor_id="warehouse_sample" and user_query="Generate a report for warehouse_sample using long video understanding", then present the generated report.
 
   prompt: |
     You are a routing agent for a video surveillance system. Your job is to route requests to the correct tool.

--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
@@ -377,7 +377,7 @@ workflow:
     For summaries of named media, plan `vst_video_list` first, then exactly one summary tool based only on its result: `rtsp` → `lvs_stream_understanding`; `video` → `lvs_video_understanding`. Never choose the summary tool from duration.
     Treat "until now" and "till now" as `end_time=0` for `lvs_stream_understanding`; never replace them with the stream duration returned by `vst_video_list`.
     A non-empty name supplied in the request is the sensor_id. For example, in "Generate a report for warehouse_sample", the sensor_id is "warehouse_sample"; this request is complete and MUST NOT trigger a clarifying question.
-    If the user explicitly requests long video summarization or LVS in a report, the plan MUST first call `lvs_video_understanding` with the exact sensor_id and requested time range, then call `report_agent` with the same inputs and the original request as user_query.
+    If the user explicitly requests long video summarization, long video understanding, or LVS in a report, the plan MUST first call `lvs_video_understanding` with the exact sensor_id and requested time range, then call `report_agent` with the same inputs and the original request as user_query. The `report_agent` step is never optional: it is the only tool that writes the PDF and Markdown artifacts, so a plan that stops at the analysis step answers with prose and no downloads.
     For every other named report request, the plan MUST contain exactly one action: call `report_agent` directly with that exact name as sensor_id and the original request as user_query. Do not verify the name or media type first.
     Ask which video or camera the user means only when the request contains no name and the conversation provides no usable name.
     Only use tools from the available tools list. Never invent or assume tools that are not listed.
@@ -387,6 +387,9 @@ workflow:
     Example plan for "Generate a report using long video summarization for warehouse_sample":
     1. Call `lvs_video_understanding` with sensor_id="warehouse_sample".
     2. Call `report_agent` with sensor_id="warehouse_sample" and user_query="Generate a report using long video summarization for warehouse_sample", then present the generated report.
+    Example plan for "Generate a report for warehouse_sample using long video understanding":
+    1. Call `lvs_video_understanding` with sensor_id="warehouse_sample".
+    2. Call `report_agent` with sensor_id="warehouse_sample" and user_query="Generate a report for warehouse_sample using long video understanding", then present the generated report.
 
   prompt: |
     You are a routing agent for a video surveillance system. Your job is to route requests to the correct tool.

--- a/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
@@ -900,31 +900,6 @@ class TopAgent(AsyncMixin):
             )
             logger.warning("Corrected LVS report plan that omitted lvs_video_understanding")
 
-        # `report_agent` is the only tool that writes the PDF and Markdown artifacts, so a report
-        # plan that stops at the analysis step answers with prose and no downloads. The profile
-        # prompts already declare that a report request routes to `report_agent`; re-assert it here
-        # rather than trusting the planner to keep the step it was told to plan.
-        if (
-            "report" in lowered_question
-            and "report_agent" in self.tools_dict
-            and "report_agent" not in plan_text
-            and not plan_text.strip().startswith(PLAN_CLARIFY_PREFIX)
-        ):
-            report_step = (
-                "Call `report_agent` with every media name from the user's request (as a single list when the "
-                "request names more than one) and the original request as `user_query`, then present the "
-                "generated report."
-            )
-            planned_steps = [int(match.group(1)) for match in re.finditer(r"(?:^|\s)(\d+)\.\s", plan_text)]
-            if planned_steps:
-                plan_text = f"{plan_text.rstrip()}\n{max(planned_steps) + 1}. {report_step}"
-            else:
-                # No numbered step at all means the planner returned prose rather than a plan, and
-                # prose such as "route to the appropriate tools" steers the execution agent into a
-                # summary tool. Replace it instead of appending the report step underneath it.
-                plan_text = f"1. {report_step}"
-            logger.warning("Added the missing `report_agent` step to a report plan")
-
         # Check if the planner wants to ask the user for clarification
         if plan_text.strip().startswith(PLAN_CLARIFY_PREFIX):
             clarification = plan_text.strip()[len(PLAN_CLARIFY_PREFIX) :].strip()

--- a/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
@@ -870,8 +870,8 @@ class TestRequestOptionsContext:
         assert result.plan == ordinary_plan
 
     @pytest.mark.asyncio
-    async def test_plan_node_adds_report_agent_to_an_analysis_only_report_plan(self, monkeypatch):
-        """Without `report_agent` the run answers with prose and writes no PDF/Markdown artifacts."""
+    async def test_plan_node_keeps_an_analysis_only_report_plan(self, monkeypatch):
+        """The planner's plan is the plan. No `report_agent` step is appended to it."""
         monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
 
         agent = self._agent_with_search_tool()
@@ -897,43 +897,47 @@ class TestRequestOptionsContext:
 
         result = await agent._plan_node(state)
 
-        assert result.plan.startswith(analysis_only_plan)
-        assert result.plan.index("lvs_video_understanding") < result.plan.index("report_agent")
-        assert "3. Call `report_agent`" in result.plan
+        assert result.plan == analysis_only_plan
+        assert "3. Call `report_agent`" not in result.plan
 
     @pytest.mark.asyncio
-    async def test_plan_node_replaces_a_prose_report_plan_with_a_report_step(self, monkeypatch):
-        """Prose without numbered steps is not a plan; appending under it leaves the prose in charge."""
+    async def test_plan_node_does_not_inject_report_agent_into_an_incident_plan(self, monkeypatch):
+        """The alerts profile forbids `report_agent` for incidents.
+
+        The word "report" appears in every incident-report request, so a post-hoc
+        rewrite keyed on it cannot tell an uploaded-video report from an incident
+        one and used to override the profile's own instruction.
+        """
         monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
 
         agent = self._agent_with_search_tool()
-        report_tool = MagicMock()
-        report_tool.name = "report_agent"
-        report_tool.description = "Run report_agent."
-        agent.tools_dict["report_agent"] = report_tool
+        for tool_name in ("rtvi_vlm_alert", "video_understanding_iso", "report_agent"):
+            tool = MagicMock()
+            tool.name = tool_name
+            tool.description = f"Run {tool_name}."
+            agent.tools_dict[tool_name] = tool
+        incident_plan = (
+            '1. Call `rtvi_vlm_alert` with action="get_incidents" and max_count=1. '
+            "2. Call `video_understanding_iso` with the incident time range +/-30s. "
+            "3. Present the incident metadata with the analysis."
+        )
         agent.llm = MagicMock()
         agent.llm.model_name = "test-model"
-        agent.llm.ainvoke = AsyncMock(
-            return_value=AIMessage(
-                content=(
-                    "The user wants to generate reports for two uploaded videos. I need to first check the "
-                    "available media to confirm their types, then route to the appropriate tools."
-                )
-            )
-        )
+        agent.llm.ainvoke = AsyncMock(return_value=AIMessage(content=incident_plan))
         agent.callbacks = []
         agent.plan_prompt = None
         agent.plan_system_prompt = "System prompt."
         state = TopAgentState(
-            current_message=HumanMessage(content="Generate reports for video honest1 and honest2."),
+            current_message=HumanMessage(
+                content="Generate a report for the last verified alert of sensor vss-sample-warehouse-4min"
+            ),
             options=AgentRequestOptions(),
         )
 
         result = await agent._plan_node(state)
 
-        assert result.plan.startswith("1. Call `report_agent`")
-        assert "route to the appropriate tools" not in result.plan
-        assert "single list" in result.plan
+        assert result.plan == incident_plan
+        assert "report_agent" not in result.plan
 
     @pytest.mark.asyncio
     async def test_plan_node_keeps_camera_clarification_for_uploaded_video_report(self, monkeypatch):


### PR DESCRIPTION
## Summary

`_plan_node` rewrote the planner's output whenever the user's question contained the word "report":

```python
if ("report" in lowered_question
    and "report_agent" in self.tools_dict
    and "report_agent" not in plan_text
    and not plan_text.strip().startswith(PLAN_CLARIFY_PREFIX)):
    plan_text = f"{plan_text.rstrip()}\n{max(planned_steps) + 1}. {report_step}"
    logger.warning("Added the missing `report_agent` step to a report plan")
```

`self.tools_dict` is built from `subagents_plus_tools` (`top_agent.py:452`), so `report_agent` is always present where the profile offers it, and "report" appears in every report request. The rewrite therefore cannot distinguish **"the planner forgot the step"** from **"the planner deliberately left it out"**.

On the alerts profile it is always the second. `dev-profile-alerts` forbids `report_agent` for incidents in two places:

- rule 5 — *"For INCIDENT reports/analysis → DO NOT use report_agent"*
- WORKFLOW 5 — *"⚠️ IMPORTANT: DO NOT use report_agent for incidents! report_agent is ONLY for uploaded video files."*

The planner correctly omits it, and this code appends it anyway — **deterministically, on every incident report**. Reported from the alerts nightly by Amy Li; visible in ci-vss-oss job 433833013, where step 9 of a *passing* run is `Sub-Agent Call: report_agent`. It also spends one of roughly four tool calls the recursion limit allows, so it makes the `GRAPH_RECURSION_LIMIT` failure more likely without being its root cause.

More prompt text cannot fix this: there are already two prohibitions, and this runs *after* the LLM and overwrites its output.

## Plan

**1. Scope the rewrite to exclude incidents, or remove it?** → **Remove it.** A post-hoc rewrite that overrides a correct plan is the wrong shape; an exclusion list would need extending for every future profile whose prompt disagrees with it. The planner should be trusted to follow instructions it was given, and corrected at the prompt when it does not.

**2. What about the LVS bug it was added for?** → **Fix it at the source.** `e92f6dc28` (2026-09-08) added the rewrite for a real gap: the LVS planner drops the report step for *"report … using long video understanding"*, a phrasing the `dev-profile-lvs` `plan_prompt` two-step rule did not match because it only named *"long video summarization or LVS"*. That rule now also names **"long video understanding"**, states the `report_agent` step is never optional and why, and carries a worked example for that phrasing.

**3. Is the rewrite otherwise load-bearing?** → **No.** Both plan prompts already mandate the step for requests that need it — `dev-profile-base`: *"the plan MUST contain exactly one action: call `report_agent` directly"*; `dev-profile-lvs`: the same plus the two-step rule and two worked examples. The post-condition was largely restating what the planner is already told, while overriding it in the one case where the planner was right.

## Changes

`services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py`
- Remove the `report_agent` plan rewrite (−25 lines).

`dev-profile-lvs` `plan_prompt` (docker + helm)
- The two-step rule now also triggers on "long video understanding".
- States that the `report_agent` step is never optional, and why — it is the only tool that writes the PDF and Markdown artifacts, so a plan that stops at analysis answers with prose and no downloads.
- Adds a worked example for the phrasing that `e92f6dc28` found failing.

Tests
- `test_plan_node_adds_report_agent_to_an_analysis_only_report_plan` → `test_plan_node_keeps_an_analysis_only_report_plan` (plan returned verbatim).
- `test_plan_node_replaces_a_prose_report_plan_with_a_report_step` → `test_plan_node_does_not_inject_report_agent_into_an_incident_plan` (the alerts case, encoding Amy's bug).

## Verification

```
uv run pytest packages/vss_agents/tests/unit_test -m "not slow and not integration"
→ 2497 passed

ruff check / ruff format / mypy → clean
pre-commit (TruffleHog, SPDX, LFS, DCO) → Passed
```

Both new tests mutation-checked: restoring the rewrite fails both, with `Added the missing report_agent step to a report plan` in the captured log.

**Not verified, and this is the risk to weigh:** the LVS behaviour is now carried by prompt text rather than by code, and I have not run a live LVS report. `e92f6dc28` was verified on a live deployment precisely because the prompt alone had not held. A `test-lvs` run should confirm all three report rows still produce PDF + Markdown before this lands.

## One protection genuinely lost

The removed block had a second branch: when the planner returned prose with no numbered steps at all, it replaced the prose with a `report_agent` step, on the grounds that *"prose such as 'route to the appropriate tools' steers the execution agent into a summary tool"*. That is a different concern from the missing-step case — it is about the planner not returning a plan at all — and it goes away with the rest.

If we want it back it belongs as plan-output validation (reject a plan with no numbered steps, whatever the question) rather than as a report-specific rewrite. Not included here; say the word and I will add it.

## Related

From the same alerts nightly report, **not** addressed here:
- Mark `video_understanding_iso` complete deterministically after a successful result — #2149 covers only the variant where the plan is wiped entirely.
- Prevent duplicate tool calls with identical arguments — the robust fix for the repeat-call loop; deferred from #2149 review as belonging in the tool node.
- Capture vss-agent logs when report generation times out — ci-vss-oss side; the DGX Spark 300s is `eval/scripts/_lib/_http.py:18`, the harness client timeout, not a gateway one.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally.
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d.
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes. — internal planning behaviour, no user-facing doc.
- [x] No secrets, API keys, or credentials committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
