### PR TITLE
fix(agent): treat duplicate LVS RT-VLM stream registration as success

### DIFF
--- a/services/agent/packages/vss_agents/src/vss_agents/api/rtsp_ingest.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/api/rtsp_ingest.py
@@ -378,6 +378,15 @@ async def add_to_rtvi_vlm(
                 errors = result.get("errors") if isinstance(result, dict) else None
                 results = result.get("results", []) if isinstance(result, dict) else []
                 if errors and not results:
+                    if all(
+                        isinstance(error, dict) and error.get("error_code") == "DuplicateStreamId" for error in errors
+                    ):
+                        logger.info(
+                            "RTVI-VLM stream already registered: rtvi_stream_id=%s (vst_sensor_id=%s)",
+                            sensor_id,
+                            sensor_id,
+                        )
+                        return True, "Already registered", sensor_id
                     return False, f"RTVI-VLM returned errors: {errors}", None
 
                 rtvi_stream_id = (results[0].get("id") if results else None) or sensor_id

--- a/services/agent/packages/vss_agents/tests/unit_test/api/test_rtsp_ingest.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/api/test_rtsp_ingest.py
@@ -635,6 +635,51 @@ class TestAddToRtviVlm:
 
     @pytest.mark.asyncio
     @patch("vss_agents.api.rtsp_ingest.create_retry_strategy")
+    async def test_duplicate_stream_is_idempotent_success(self, mock_retry):
+        mock_client = MagicMock()
+        config = ServiceConfig(vst_internal_url="http://vst:30888", rtvi_vlm_base_url="http://rtvi-vlm:8018")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b'{"results": [], "errors": [{"error_code": "DuplicateStreamId"}]}'
+        mock_response.json = MagicMock(
+            return_value={"results": [], "errors": [{"error_code": "DuplicateStreamId", "status_code": 409}]}
+        )
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_retry.return_value = _single_attempt_retry()
+
+        success, msg, stream_id = await add_to_rtvi_vlm(
+            mock_client, config, "sensor-123", "camera-1", "rtsp://vst:554/sensor-123"
+        )
+
+        assert success is True
+        assert msg == "Already registered"
+        assert stream_id == "sensor-123"
+
+    @pytest.mark.asyncio
+    @patch("vss_agents.api.rtsp_ingest.create_retry_strategy")
+    async def test_non_duplicate_error_still_fails(self, mock_retry):
+        mock_client = MagicMock()
+        config = ServiceConfig(vst_internal_url="http://vst:30888", rtvi_vlm_base_url="http://rtvi-vlm:8018")
+
+        error = {"error_code": "InvalidStreamUrl", "status_code": 400}
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b'{"results": [], "errors": [{"error_code": "InvalidStreamUrl"}]}'
+        mock_response.json = MagicMock(return_value={"results": [], "errors": [error]})
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_retry.return_value = _single_attempt_retry()
+
+        success, msg, stream_id = await add_to_rtvi_vlm(
+            mock_client, config, "sensor-123", "camera-1", "rtsp://vst:554/sensor-123"
+        )
+
+        assert success is False
+        assert "InvalidStreamUrl" in msg
+        assert stream_id is None
+
+    @pytest.mark.asyncio
+    @patch("vss_agents.api.rtsp_ingest.create_retry_strategy")
     async def test_downstream_url_is_never_rewritten(self, mock_retry):
         """rtvi-vlm gets VST's ``/live/<uuid>`` URL verbatim; audio opt-in happens upstream."""
         mock_client = MagicMock()


### PR DESCRIPTION
## Summary
- VST's LVS webhook can register a sensor with RT-VLM before the agent's transactional RTSP ingest reaches the same service.
- Treat an RT-VLM `add` response whose errors are all `DuplicateStreamId` as idempotent success, and keep failing on any other error.
- Cover both the duplicate-success path and a non-duplicate error path in `test_rtsp_ingest.py`.

## Test plan
- [ ] Agent unit tests for `add_to_rtvi_vlm` (`test_duplicate_stream_is_idempotent_success`, `test_non_duplicate_error_still_fails`)
- [ ] GitHub copy-PR CI via `/ok to test` on the pinned head SHA
- [ ] Confirm other RT-VLM error codes still fail ingest