### PR TITLE
enhance Kafka initializer to support dynamic stream type

### DIFF
--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/deepstream/configs/config.yaml
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/deepstream/configs/config.yaml
@@ -29,7 +29,6 @@ interval: 0 # Number of consecutive batches to be skipped for inference
 # Calibration Properties
 calib_file_path: /opt/data/ds-configurator/calibration.json # Calibration file path
 bev_group_name: bev-sensor-1 # BEV group name
-calib_mode: synthetic # Calibration mode
 use_camera_groups: True # Groups cameras for multi-view fusion in synthetic mode
 recentering: True # Recalculates camera coordinates from a reference point
 

--- a/services/analytics/video-analytics-api/src/app/initializers/kafka.js
+++ b/services/analytics/video-analytics-api/src/app/initializers/kafka.js
@@ -20,10 +20,11 @@
 const mdx = require("@nvidia-mdx/web-api-core");
 const cache = require('./cache');
 const config = cache.get("bootstrap-config");
+const streamType = process.env.STREAM_TYPE || "kafka";
 
 let kafka = null;
 
-if(config.kafka.brokers!=null && config.kafka.brokers.length!=0){
+if(streamType === "kafka" && config.kafka.brokers!=null && config.kafka.brokers.length!=0){
     let kafkaConfigMap = new Map();
 
     // Custom log creator for KafkaJS to format logs with timestamp first

--- a/services/analytics/video-analytics-api/test/unit-test/app/initializers/kafka.test.js
+++ b/services/analytics/video-analytics-api/test/unit-test/app/initializers/kafka.test.js
@@ -1,0 +1,103 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const { expect } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire').noCallThru().noPreserveCache();
+
+describe('Kafka Initializer', () => {
+    const kafkaInitializerPath = '../../../../src/app/initializers/kafka';
+    let originalStreamType;
+
+    beforeEach(() => {
+        originalStreamType = process.env.STREAM_TYPE;
+    });
+
+    afterEach(() => {
+        if (originalStreamType === undefined) {
+            delete process.env.STREAM_TYPE;
+        } else {
+            process.env.STREAM_TYPE = originalStreamType;
+        }
+    });
+
+    const loadKafkaInitializer = ({ streamType, brokers }) => {
+        if (streamType === undefined) {
+            delete process.env.STREAM_TYPE;
+        } else {
+            process.env.STREAM_TYPE = streamType;
+        }
+
+        const kafkaInstance = {};
+        const kafkaConstructor = sinon.stub().returns(kafkaInstance);
+        const cache = {
+            get: sinon.stub().withArgs('bootstrap-config').returns({
+                kafka: {
+                    brokers,
+                    retries: 15
+                }
+            })
+        };
+
+        const kafka = proxyquire(kafkaInitializerPath, {
+            './cache': cache,
+            '@nvidia-mdx/web-api-core': {
+                Utils: {
+                    Kafka: kafkaConstructor
+                }
+            }
+        });
+
+        return { kafka, kafkaConstructor, kafkaInstance };
+    };
+
+    it('should not create a Kafka client in Redis mode when brokers are configured', () => {
+        const { kafka, kafkaConstructor } = loadKafkaInitializer({
+            streamType: 'redis',
+            brokers: ['kafka:29092']
+        });
+
+        expect(kafka).to.be.null;
+        expect(kafkaConstructor.notCalled).to.be.true;
+    });
+
+    it('should create a Kafka client in Kafka mode when brokers are configured', () => {
+        const { kafka, kafkaConstructor, kafkaInstance } = loadKafkaInitializer({
+            streamType: 'kafka',
+            brokers: ['kafka:29092']
+        });
+
+        expect(kafka).to.equal(kafkaInstance);
+        expect(kafkaConstructor.calledOnce).to.be.true;
+        expect(kafkaConstructor.firstCall.args[0]).to.deep.include({
+            brokers: ['kafka:29092'],
+            retry: { retries: 15 }
+        });
+    });
+
+    it('should default to Kafka mode when STREAM_TYPE is unset', () => {
+        const { kafka, kafkaConstructor, kafkaInstance } = loadKafkaInitializer({
+            streamType: undefined,
+            brokers: ['kafka:29092']
+        });
+
+        expect(kafka).to.equal(kafkaInstance);
+        expect(kafkaConstructor.calledOnce).to.be.true;
+    });
+});


### PR DESCRIPTION
## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
