### PR TITLE
fix(lvs): cap shared RT-VLM memory on RTX Pro 6000

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-lvs/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/overrides.env
@@ -187,8 +187,9 @@ SDR_CONTROLLER_CONFIG_PATH=${VSS_APPS_DIR}/developer-profiles/dev-profile-lvs/sd
 RTVI_VLM_ENDPOINT=''
 # Alerts/LVS remote VLM uses openai-compat; local RT-VLM uses cosmos-reason3.
 RTVI_VLM_MODEL_TO_USE=cosmos-reason3
-# Set per hardware/mode for local RT-VLM; THOR edge can pass host env override.
-RTVI_VLLM_GPU_MEMORY_UTILIZATION=''
+# Safe default for the stock H100/RTX PRO 6000 shared-GPU layout. The profile
+# generator rewrites this for other hardware and dedicated-GPU deployments.
+RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.4
 # Keep the MM processor cache off: vLLM unlinks its shm cache only from
 # __del__, so a SIGKILL leaks a 1 GiB object into the host tmpfs because
 # rtvi-vlm runs ipc: host. Opting in also needs


### PR DESCRIPTION
## Summary

Fix the LVS `local_shared` deployment on RTX PRO 6000 Blackwell by preventing the RT-VLM
  from consuming excessive GPU memory and blocking Nemotron initialization.

## Plan

  - Set a safe default RT-VLM GPU-memory utilization for the stock shared-GPU configuration.
  - Confirm the original failure using the previous `0.7` fallback.
  - Confirm both models initialize successfully with the new `0.4` value.

## Related Issue

https://nvbugspro.nvidia.com/bug/6762617

## Changes

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.
