### PR TITLE
fix(ci): tell downstream infrastructure failure apart from code failure

### DIFF
--- a/.github/scripts/poll-downstream-pipeline.py
+++ b/.github/scripts/poll-downstream-pipeline.py
@@ -32,6 +32,23 @@ failed and was retried into a pass is not held against the pipeline.
 The check still goes red for any job that is genuinely failed or
 canceled once the pipeline is done.
 
+Not every blocking failure is the pull request's fault, though, and the
+report used to render them identically: a 15-second git abort in
+``get_sources`` on a dirty runner and a genuine product assertion both
+came out as ``FAIL: <job>``, with the downstream URL masked so the
+author could not click through and see which. So the terminal snapshot
+classifies each blocking failure (see ``infra_failure_cause``):
+
+* **Infrastructure** - the downstream CI system could not run the job.
+  Reported as ``DOWNSTREAM_INFRA``, in words that say plainly this is
+  not a verdict on the pull request, and *not* fatal on its own. A
+  non-secret triage handle is printed so a maintainer can find the run.
+* **Product** - everything else. Still a hard red.
+
+Classification has to prove infrastructure; anything unproven stays a
+product failure. A false green hides a regression, a false red costs a
+retry.
+
 Resolving the exit code is non-trivial: many downstream API versions
 do NOT include ``exit_code`` in either the pipeline-jobs listing or
 the per-job detail endpoint, so we fall back to fetching the job's
@@ -41,9 +58,10 @@ cached for the lifetime of the poller.
 
 Exit codes:
 
-* ``0`` - pipeline finished with no failures.
-* ``1`` - the finished pipeline had a failing / canceled job, or the
-  poller timed out (see ``MAX_POLL_DURATION_SECONDS``).
+* ``0`` - pipeline finished with no failures, or its only blocking
+  failures were classified as downstream infrastructure.
+* ``1`` - the finished pipeline had a product failure or a canceled
+  job, or the poller timed out (see ``MAX_POLL_DURATION_SECONDS``).
 
 Retried jobs are handled by de-duping on ``name`` and keeping only
 the latest attempt (highest ``id``).
@@ -206,6 +224,14 @@ def _job_exit_code(job: dict[str, Any]) -> int | None:
         return None
 
 
+def _job_id(job: dict[str, Any]) -> int | None:
+    raw = job.get("id")
+    try:
+        return int(raw) if raw is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
 def fetch_job_detail(
     base_url: str,
     token: str,
@@ -234,6 +260,30 @@ def fetch_job_detail(
 _TRACE_EXIT_CODE_RE = re.compile(r"Job failed: exit code (\d+)")
 
 
+def fetch_job_trace(
+    base_url: str,
+    token: str,
+    project_id: int,
+    job_id: int,
+) -> str | None:
+    """Fetch a job's raw text trace, or ``None`` if it is unavailable."""
+    url = f"{base_url}/projects/{project_id}/jobs/{job_id}/trace"
+    request = Request(
+        url,
+        headers={
+            "PRIVATE-TOKEN": token,
+            "Accept": "text/plain",
+            "User-Agent": "poll-downstream-pipeline",
+        },
+    )
+    try:
+        with urlopen(request, timeout=30) as response:
+            return response.read().decode("utf-8", errors="replace")
+    except (HTTPError, URLError, ContentTooShortError) as exc:
+        emit_warning(f"Job trace lookup failed: {exc}")
+        return None
+
+
 def fetch_job_trace_exit_code(
     base_url: str,
     token: str,
@@ -248,20 +298,8 @@ def fetch_job_trace_exit_code(
     ``failed + allow_failure: true`` jobs and cache the result, so the
     extra request cost is bounded.
     """
-    url = f"{base_url}/projects/{project_id}/jobs/{job_id}/trace"
-    request = Request(
-        url,
-        headers={
-            "PRIVATE-TOKEN": token,
-            "Accept": "text/plain",
-            "User-Agent": "poll-downstream-pipeline",
-        },
-    )
-    try:
-        with urlopen(request, timeout=30) as response:
-            payload = response.read().decode("utf-8", errors="replace")
-    except (HTTPError, URLError, ContentTooShortError) as exc:
-        emit_warning(f"Job trace lookup failed: {exc}")
+    payload = fetch_job_trace(base_url, token, project_id, job_id)
+    if payload is None:
         return None
 
     # The runner always prints this near the end. Use the LAST match
@@ -298,11 +336,7 @@ def resolve_exit_code(
     if direct is not None:
         return direct
 
-    raw_id = job.get("id")
-    try:
-        job_id = int(raw_id) if raw_id is not None else None
-    except (TypeError, ValueError):
-        job_id = None
+    job_id = _job_id(job)
     if job_id is None:
         return None
 
@@ -355,6 +389,129 @@ def blocking_jobs(
         elif status == "canceled":
             canceled.append(job)
     return failed, canceled
+
+
+# Failure reasons the downstream API attributes to its own runners rather
+# than to the job's script. Deliberately excludes `job_execution_timeout`:
+# a job that ran to its wall clock may well have been hung by the product.
+INFRA_FAILURE_REASONS = frozenset({"runner_system_failure", "stuck_or_timeout_failure"})
+
+# A `preflight` job that dies this fast never reached the product: those
+# jobs resolve credentials and check out sources, so a sub-minute-and-a-half
+# failure is environment, not code.
+PREFLIGHT_INFRA_MAX_SECONDS = 90
+
+# The runner brackets each phase of a job with a marker it writes into the
+# trace: `section_start:<unix ts>:<section name>`. `step_script` is the
+# section that runs the job's own `script:`, so a finished trace without it
+# proves the job died in the runner's own setup (get_sources, restore_cache,
+# artifact download) before a single line of product code ran.
+_STEP_SCRIPT_SECTION_RE = re.compile(r"section_start:\d+:step_script")
+
+
+def failed_before_step_script(
+    job: dict[str, Any],
+    base_url: str,
+    token: str,
+    project_id: int,
+    cache: dict[int, bool],
+) -> bool:
+    """Whether the job's trace shows it never entered ``step_script``.
+
+    Returns ``False`` when the trace cannot be fetched or read, so an API
+    problem can never upgrade a product failure into an infra failure.
+    """
+    job_id = _job_id(job)
+    if job_id is None:
+        return False
+    if job_id in cache:
+        return cache[job_id]
+    trace = fetch_job_trace(base_url, token, project_id, job_id)
+    # An empty trace is not evidence of anything: the runner may simply
+    # have failed to upload it.
+    verdict = bool(trace) and not _STEP_SCRIPT_SECTION_RE.search(trace or "")
+    cache[job_id] = verdict
+    return verdict
+
+
+def infra_failure_cause(
+    job: dict[str, Any],
+    base_url: str,
+    token: str,
+    project_id: int,
+    cache: dict[int, bool],
+) -> str | None:
+    """Why a failed job looks like downstream infrastructure rather than
+    the product under test, or ``None`` if it does not.
+
+    Conservative by construction: every branch here has to *prove*
+    infrastructure, and anything unproven stays a product failure and
+    keeps the check red. A false green hides a real regression; a false
+    red costs a retry.
+    """
+    reason = str(job.get("failure_reason") or "").strip().lower()
+    if reason in INFRA_FAILURE_REASONS:
+        # `describe_job` already prints the reason, so name the consequence.
+        return "reported by the downstream CI system, not by the job's script"
+    if reason != "script_failure":
+        return None
+
+    duration = job.get("duration")
+    stage = str(job.get("stage") or "").strip().lower()
+    if (
+        "preflight" in stage
+        and isinstance(duration, (int, float))
+        and not isinstance(duration, bool)
+        and duration < PREFLIGHT_INFRA_MAX_SECONDS
+    ):
+        return f"{reason} after {_format_hms(duration)} in stage {stage}"
+
+    if failed_before_step_script(job, base_url, token, project_id, cache):
+        return "failed before step_script, so no product code ran"
+    return None
+
+
+def partition_infra_failures(
+    failed: list[dict[str, Any]],
+    base_url: str,
+    token: str,
+    project_id: int,
+    cache: dict[int, bool],
+) -> tuple[list[tuple[dict[str, Any], str]], list[dict[str, Any]]]:
+    """Split blocking failures into ``(infra, product)``.
+
+    ``infra`` pairs each job with the cause string that classified it.
+    """
+    infra: list[tuple[dict[str, Any], str]] = []
+    product: list[dict[str, Any]] = []
+    for job in failed:
+        cause = infra_failure_cause(job, base_url, token, project_id, cache)
+        if cause:
+            infra.append((job, cause))
+        else:
+            product.append(job)
+    return infra, product
+
+
+def triage_handle(pipeline_id: int, pipeline: dict[str, Any]) -> str:
+    """A non-secret identifier a human can use to find the downstream run.
+
+    The downstream host and project path are masked, so the author cannot
+    click through. These identifiers are not secrets: the pipeline IID is
+    already printed by the trigger step, and the GitHub run id / attempt
+    are the prefix of the ``VSS_TRIGGER_CORRELATION_ID`` sent with the
+    trigger, which is what a maintainer greps for downstream.
+    """
+    iid = pipeline.get("iid") or pipeline_id
+    parts = [f"downstream pipeline IID {iid}"]
+    correlation = os.environ.get("VSS_TRIGGER_CORRELATION_ID", "").strip()
+    if not correlation:
+        run_id = os.environ.get("GITHUB_RUN_ID", "").strip()
+        attempt = os.environ.get("GITHUB_RUN_ATTEMPT", "1").strip() or "1"
+        correlation = f"gh-{run_id}-{attempt}-*" if run_id else ""
+    if correlation:
+        parts.append(f"VSS_TRIGGER_CORRELATION_ID {correlation}")
+    return ", ".join(parts)
 
 
 def describe_job(job: dict[str, Any]) -> str:
@@ -449,18 +606,27 @@ def report_terminal_pipeline(
     seen_success: set[str],
     seen_skipped: set[str],
     seen_allowed_failure: set[str],
+    pipeline: dict[str, Any],
+    base_url: str,
+    token: str,
+    project_id: int,
+    trace_cache: dict[int, bool],
 ) -> int:
     """Decide the check's verdict from a terminal pipeline snapshot."""
     failed, canceled = blocking_jobs(jobs)
+    infra, product = partition_infra_failures(failed, base_url, token, project_id, trace_cache)
+    handle = triage_handle(pipeline_id, pipeline)
 
-    if failed or canceled:
-        for job in failed:
+    if product or canceled:
+        for job in product:
             emit_error(f"Downstream job failed: {describe_job(job)}")
+        for job, cause in infra:
+            emit_warning(f"Downstream infrastructure failure (not a product failure): {describe_job(job)} - {cause}")
         for job in canceled:
             emit_error(f"Downstream job canceled: {describe_job(job)}")
         print(
             f"Downstream pipeline #{pipeline_id} finished '{pipeline_status}': "
-            f"{len(failed)} failed, {len(canceled)} canceled, "
+            f"{len(product)} failed, {len(infra)} infrastructure, {len(canceled)} canceled, "
             f"{len(seen_success)} succeeded, "
             f"{len(seen_skipped)} skipped, "
             f"{len(seen_allowed_failure)} allowed failures"
@@ -470,9 +636,12 @@ def report_terminal_pipeline(
             "",
             f"- **Outcome:** {pipeline_status}",
         ]
-        if failed:
-            summary.append(f"- **Failed jobs:** {len(failed)}")
-            summary.extend(f"  - `{describe_job(job)}`" for job in failed)
+        if product:
+            summary.append(f"- **Failed jobs:** {len(product)}")
+            summary.extend(f"  - `{describe_job(job)}`" for job in product)
+        if infra:
+            summary.append(f"- **Infrastructure failures (not product failures):** {len(infra)}")
+            summary.extend(f"  - `{describe_job(job)}` - {cause}" for job, cause in infra)
         if canceled:
             summary.append(f"- **Canceled jobs:** {len(canceled)}")
             summary.extend(f"  - `{describe_job(job)}`" for job in canceled)
@@ -481,8 +650,41 @@ def report_terminal_pipeline(
             summary.append(f"- **Skipped jobs (exit {GATE_SKIP_EXIT_CODE}):** {len(seen_skipped)}")
         if seen_allowed_failure:
             summary.append(f"- **Allowed failures:** {len(seen_allowed_failure)}")
+        summary.append(f"- **Triage handle:** {handle}")
         write_summary(summary)
         return 1
+
+    if infra:
+        # Every blocking failure was the downstream CI system failing to run
+        # the job, not the job finding a problem. Say so in words a PR author
+        # can act on, and do not paint the check red for it: a red here reads
+        # as "your change is broken", which is exactly what this was not.
+        print(f"DOWNSTREAM_INFRA: {len(infra)} job(s) could not be run by the downstream CI system.")
+        print(
+            "This is NOT a verdict on this pull request - no product code failed. "
+            "Any FAIL lines above are these infrastructure failures."
+        )
+        for job, cause in infra:
+            print(f"DOWNSTREAM_INFRA: {describe_job(job)} - {cause}")
+        print(f"Ask a CI maintainer to retry the downstream pipeline: {handle}")
+        emit_warning(
+            f"Downstream pipeline could not run {len(infra)} job(s) for infrastructure reasons; "
+            f"this is not a verdict on this pull request ({handle})"
+        )
+        write_summary(
+            [
+                "### Downstream pipeline result",
+                "",
+                "- **Outcome:** infrastructure failure, not a product failure",
+                "- The downstream CI system could not run the job(s) below. Nothing here says",
+                "  this pull request is broken; the work simply did not run.",
+                f"- **Jobs not run:** {len(infra)}",
+                *(f"  - `{describe_job(job)}` - {cause}" for job, cause in infra),
+                f"- **Succeeded jobs:** {len(seen_success)}",
+                f"- **Triage handle:** {handle}",
+            ]
+        )
+        return 0
 
     if pipeline_status == "success":
         print(
@@ -581,6 +783,9 @@ def main() -> int:
     # payload doesn't carry `exit_code` (the listing endpoint never
     # does, but the per-job endpoint does).
     exit_code_cache: dict[int, int | None] = {}
+    # Per-job "did it reach step_script" cache, populated only on the
+    # terminal snapshot when a blocking failure needs classifying.
+    trace_cache: dict[int, bool] = {}
     start = time.monotonic()
     tick = 0
 
@@ -653,6 +858,11 @@ def main() -> int:
                 seen_success,
                 seen_skipped,
                 seen_allowed_failure,
+                pipeline,
+                base_url,
+                token,
+                project_id,
+                trace_cache,
             )
 
         if time.monotonic() - start > max_duration:

--- a/.github/scripts/test_poll_downstream_pipeline.py
+++ b/.github/scripts/test_poll_downstream_pipeline.py
@@ -63,13 +63,27 @@ class Run:
         self.ticks_read = ticks_read
 
 
-def drive(ticks: list[tuple[list[dict[str, Any]], str]], *, env: dict[str, str] | None = None) -> Run:
+def drive(
+    ticks: list[tuple[list[dict[str, Any]], str]],
+    *,
+    env: dict[str, str] | None = None,
+    traces: dict[str, str] | None = None,
+    pipeline_iid: str = "",
+) -> Run:
     """Run ``main()`` against ``ticks``, a list of ``(jobs, pipeline_status)``.
 
     The last tick repeats forever, which is what lets a test assert the
     timeout path without waiting for it.
+
+    ``traces`` maps job name to that job's trace text. Names absent from
+    it have no trace available, which is the conservative default the
+    classifier has to fall back on.
     """
     reads = {"n": 0, "current": 0}
+    by_id = {j["id"]: j["name"] for jobs, _ in ticks for j in jobs}
+
+    def fake_fetch_job_trace(_base, _token, _project, job_id):
+        return (traces or {}).get(by_id.get(job_id, ""))
 
     def fake_fetch_all_jobs(*_args, **_kwargs):
         # main() fetches jobs first, then the pipeline, once per tick.
@@ -79,7 +93,10 @@ def drive(ticks: list[tuple[list[dict[str, Any]], str]], *, env: dict[str, str] 
         return list(ticks[reads["current"]][0])
 
     def fake_fetch_pipeline(*_args, **_kwargs):
-        return {"status": ticks[reads["current"]][1]}
+        pipeline = {"status": ticks[reads["current"]][1]}
+        if pipeline_iid:
+            pipeline["iid"] = pipeline_iid
+        return pipeline
 
     # Advance the clock by the poll interval on each sleep so a test that
     # never reaches a terminal state still hits MAX_POLL_DURATION_SECONDS.
@@ -96,6 +113,7 @@ def drive(ticks: list[tuple[list[dict[str, Any]], str]], *, env: dict[str, str] 
             mock.patch.dict(os.environ, full_env, clear=False),
             mock.patch.object(module, "fetch_all_jobs", fake_fetch_all_jobs),
             mock.patch.object(module, "fetch_pipeline", fake_fetch_pipeline),
+            mock.patch.object(module, "fetch_job_trace", fake_fetch_job_trace),
             mock.patch.object(module.time, "sleep", fake_sleep),
             mock.patch.object(module.time, "monotonic", lambda: clock["t"]),
             contextlib.redirect_stdout(out),
@@ -113,6 +131,10 @@ class AbortOnFirstFailureRegressionTest(unittest.TestCase):
     in ``get_sources`` on a dirty runner while every other job was still
     running. The poller used to return at that first tick, two minutes in,
     discarding the ~46 minutes of product testing that then passed.
+
+    No trace is available for the failing job in these ticks, so the infra
+    classifier cannot prove infrastructure and the failure stays red. That
+    fail-closed default is asserted on its own in ``InfraClassificationTest``.
     """
 
     TICKS: ClassVar[list[tuple[list[dict[str, Any]], str]]] = [
@@ -342,6 +364,229 @@ class BlockingJobsTest(unittest.TestCase):
     def test_status_case_is_ignored(self):
         failed, _ = module.blocking_jobs([job("a", "FAILED")])
         self.assertEqual([j["name"] for j in failed], ["a"])
+
+
+# A runner brackets every phase it runs with a `section_start` marker. A
+# trace that stops after `get_sources` never reached the job's own script.
+TRACE_NO_STEP_SCRIPT = (
+    "section_start:1757600000:resolve_secrets\r\x1b[0K"
+    "section_end:1757600002:resolve_secrets\r\x1b[0K"
+    "section_start:1757600002:get_sources\r\x1b[0K"
+    "fatal: could not read Username for 'https://gitlab.example': No such device or address\n"
+    "section_end:1757600019:get_sources\r\x1b[0K"
+    "ERROR: Job failed: exit code 1\n"
+)
+TRACE_WITH_STEP_SCRIPT = (
+    "section_start:1757600002:get_sources\r\x1b[0K"
+    "section_end:1757600019:get_sources\r\x1b[0K"
+    "section_start:1757600020:step_script\r\x1b[0K"
+    "$ pytest tests/\nE   assert 3 == 4\n"
+    "section_end:1757603120:step_script\r\x1b[0K"
+    "ERROR: Job failed: exit code 1\n"
+)
+
+
+class InfraClassificationTest(unittest.TestCase):
+    """A downstream failure the CI system caused must not read as a
+    verdict on the pull request.
+
+    Motivating pair: GitLab pipelines 67253826 and 67393139 emitted the
+    same ``FAIL: <job>`` shape as run 34573793808 (a genuine product
+    failure) for a 17-second git plumbing error where no product code ran.
+    With the downstream URL masked as a secret, the author had nothing to
+    tell them apart.
+    """
+
+    def _run(self, failing, *, traces=None, extra=()):
+        return drive(
+            [([failing, *extra, job("test-base", "success", duration=713)], "failed")],
+            traces=traces,
+            pipeline_iid="67253826",
+        )
+
+    def test_runner_system_failure_is_not_a_product_failure(self):
+        run = self._run(job("test-search", "failed", duration=8, failure_reason="runner_system_failure"))
+        self.assertEqual(run.exit_code, 0)
+        self.assertIn("DOWNSTREAM_INFRA", run.stdout)
+        self.assertIn("runner_system_failure", run.stdout)
+
+    def test_stuck_or_timeout_failure_is_not_a_product_failure(self):
+        run = self._run(job("test-search", "failed", duration=3600, failure_reason="stuck_or_timeout_failure"))
+        self.assertEqual(run.exit_code, 0)
+        self.assertIn("DOWNSTREAM_INFRA", run.stdout)
+
+    def test_fast_preflight_script_failure_is_infra(self):
+        run = self._run(
+            job("fetch_vault_creds", "failed", duration=17, stage="preflight", failure_reason="script_failure")
+        )
+        self.assertEqual(run.exit_code, 0)
+        self.assertIn("DOWNSTREAM_INFRA", run.stdout)
+        self.assertIn("fetch_vault_creds", run.stdout)
+
+    def test_slow_preflight_script_failure_stays_red(self):
+        # Long enough that it may well have run something real.
+        run = self._run(
+            job("lint_eval_scripts", "failed", duration=240, stage="preflight", failure_reason="script_failure")
+        )
+        self.assertEqual(run.exit_code, 1)
+        self.assertIn("lint_eval_scripts", run.stderr)
+
+    def test_failure_before_step_script_is_infra(self):
+        # The 17s get_sources abort: the trace proves no product code ran.
+        failing = job(
+            "eval-warehouse-bp-wh-2d",
+            "failed",
+            job_id=901,
+            duration=17,
+            stage="blueprint eval docker-compose",
+            failure_reason="script_failure",
+        )
+        run = self._run(failing, traces={"eval-warehouse-bp-wh-2d": TRACE_NO_STEP_SCRIPT})
+        self.assertEqual(run.exit_code, 0)
+        self.assertIn("DOWNSTREAM_INFRA", run.stdout)
+        self.assertIn("no product code ran", run.stdout)
+
+    def test_failure_after_step_script_stays_red(self):
+        failing = job(
+            "test-search",
+            "failed",
+            job_id=902,
+            duration=3113,
+            stage="blueprint eval docker-compose",
+            failure_reason="script_failure",
+        )
+        run = self._run(failing, traces={"test-search": TRACE_WITH_STEP_SCRIPT})
+        self.assertEqual(run.exit_code, 1)
+        self.assertNotIn("DOWNSTREAM_INFRA", run.stdout)
+        self.assertIn("test-search", run.stderr)
+
+    def test_unavailable_trace_fails_closed(self):
+        # An API problem must never upgrade a product failure into infra.
+        run = self._run(job("test-search", "failed", duration=17, failure_reason="script_failure"))
+        self.assertEqual(run.exit_code, 1)
+
+    def test_job_execution_timeout_stays_red(self):
+        # An 80-minute job that hit its wall clock may have been hung by
+        # the product, so this is not classified as infrastructure.
+        run = self._run(job("test-search", "failed", duration=4800, failure_reason="job_execution_timeout"))
+        self.assertEqual(run.exit_code, 1)
+        self.assertIn("job_execution_timeout", run.stderr)
+
+    def test_infra_alongside_a_product_failure_is_still_red(self):
+        run = self._run(
+            job("fetch_vault_creds", "failed", duration=17, stage="preflight", failure_reason="script_failure"),
+            extra=[job("test-search", "failed", duration=3113, failure_reason="job_execution_timeout")],
+        )
+        self.assertEqual(run.exit_code, 1)
+        self.assertIn("1 failed, 1 infrastructure", run.stdout)
+        # The infra job is still surfaced, just not as the verdict.
+        self.assertIn("fetch_vault_creds", run.stderr)
+        self.assertIn("not a product failure", run.stderr)
+
+    def test_infra_alongside_a_canceled_job_is_still_red(self):
+        run = self._run(
+            job("fetch_vault_creds", "failed", duration=17, stage="preflight", failure_reason="script_failure"),
+            extra=[job("test-base-2", "canceled", duration=5)],
+        )
+        self.assertEqual(run.exit_code, 1)
+
+    def test_infra_report_says_it_is_not_a_verdict_on_the_pr(self):
+        run = self._run(job("test-search", "failed", duration=8, failure_reason="runner_system_failure"))
+        self.assertIn("NOT a verdict on this pull request", run.stdout)
+        self.assertIn("not a product failure", run.summary)
+
+    def test_infra_report_carries_a_non_secret_triage_handle(self):
+        run = drive(
+            [([job("test-search", "failed", duration=8, failure_reason="runner_system_failure")], "failed")],
+            env={"GITHUB_RUN_ID": "34573793808", "GITHUB_RUN_ATTEMPT": "1"},
+            pipeline_iid="67253826",
+        )
+        self.assertIn("67253826", run.stdout)
+        self.assertIn("gh-34573793808-1", run.stdout)
+        self.assertIn("67253826", run.summary)
+        # The handle itself carries no masked value: a masked string is
+        # redacted in the runner log, which would defeat the purpose.
+        handle = module.triage_handle(66683019, {"iid": "67253826"})
+        for key in ("DOWNSTREAM_CI_URL", "DOWNSTREAM_PROJECT_PATH", "DOWNSTREAM_CI_TOKEN"):
+            self.assertNotIn(BASE_ENV[key], handle)
+
+    def test_allowed_failures_are_untouched_by_classification(self):
+        gate = job("brev-script-base", "failed", allow_failure=True, duration=3, failure_reason="script_failure")
+        with mock.patch.object(module, "resolve_exit_code", lambda *_a, **_k: 75):
+            run = drive([([gate, job("test-base", "success", duration=713)], "success")])
+        self.assertEqual(run.exit_code, 0)
+        self.assertIn("SKIPPED: brev-script-base", run.stdout)
+        self.assertNotIn("DOWNSTREAM_INFRA", run.stdout)
+
+
+class InfraFailureCauseTest(unittest.TestCase):
+    """``infra_failure_cause`` in isolation, with no trace available."""
+
+    def cause(self, j, trace=None):
+        with mock.patch.object(module, "fetch_job_trace", lambda *_a, **_k: trace):
+            return module.infra_failure_cause(j, "https://gitlab.example", "token", 1, {})
+
+    def test_runner_system_failure(self):
+        cause = self.cause(job("a", "failed", failure_reason="runner_system_failure"))
+        self.assertIn("not by the job's script", cause or "")
+
+    def test_reason_matching_is_case_insensitive(self):
+        self.assertIsNotNone(self.cause(job("a", "failed", failure_reason="RUNNER_SYSTEM_FAILURE")))
+
+    def test_missing_failure_reason_is_not_infra(self):
+        self.assertIsNone(self.cause(job("a", "failed")))
+        self.assertIsNone(self.cause({}))
+
+    def test_preflight_boundary_is_exclusive(self):
+        at_limit = job("a", "failed", stage="preflight", failure_reason="script_failure", duration=90)
+        under = job("a", "failed", stage="preflight", failure_reason="script_failure", duration=89)
+        self.assertIsNone(self.cause(at_limit))
+        self.assertIsNotNone(self.cause(under))
+
+    def test_preflight_without_a_duration_is_not_infra(self):
+        self.assertIsNone(self.cause(job("a", "failed", stage="preflight", failure_reason="script_failure")))
+
+    def test_empty_trace_is_not_evidence(self):
+        # A runner that failed to upload its trace tells us nothing.
+        j = job("a", "failed", failure_reason="script_failure", duration=17)
+        self.assertIsNone(self.cause(j, trace=""))
+
+    def test_trace_is_fetched_once_per_job(self):
+        calls = {"n": 0}
+
+        def counting_fetch(*_a, **_k):
+            calls["n"] += 1
+            return TRACE_NO_STEP_SCRIPT
+
+        j = job("a", "failed", job_id=7, failure_reason="script_failure", duration=17)
+        cache: dict[int, bool] = {}
+        with mock.patch.object(module, "fetch_job_trace", counting_fetch):
+            for _ in range(3):
+                module.infra_failure_cause(j, "https://gitlab.example", "token", 1, cache)
+        self.assertEqual(calls["n"], 1)
+
+
+class PartitionInfraFailuresTest(unittest.TestCase):
+    def test_splits_infra_from_product(self):
+        infra_job = job("a", "failed", failure_reason="runner_system_failure")
+        product_job = job("b", "failed", failure_reason="script_failure", duration=3113)
+        with mock.patch.object(module, "fetch_job_trace", lambda *_a, **_k: None):
+            infra, product = module.partition_infra_failures(
+                [infra_job, product_job], "https://gitlab.example", "token", 1, {}
+            )
+        self.assertEqual([j["name"] for j, _ in infra], ["a"])
+        self.assertEqual([j["name"] for j in product], ["b"])
+
+    def test_pairs_each_infra_job_with_its_cause(self):
+        with mock.patch.object(module, "fetch_job_trace", lambda *_a, **_k: None):
+            infra, _ = module.partition_infra_failures(
+                [job("a", "failed", failure_reason="stuck_or_timeout_failure")],
+                "https://gitlab.example",
+                "token",
+                1,
+                {},
+            )
+        self.assertIn("not by the job's script", infra[0][1])
 
 
 class DescribeJobTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

The downstream-pipeline GitHub check renders a 17-second git plumbing error and a genuine product assertion failure identically, with the downstream URL masked as a secret. A PR author cannot tell whether a red gate means "your change is broken" or "the CI system had a bad day", so the only rational response is to ask a maintainer, every time.

This teaches the poller to classify each blocking failure, and to report an infrastructure failure as such instead of as a verdict on the pull request.

## Problem

`blocking_jobs` in `.github/scripts/poll-downstream-pipeline.py` fails the check for any job with `status == "failed" and not allow_failure`, plus any `canceled` job, **without ever consulting `failure_reason`**. A `runner_system_failure`, a `get_sources` git abort, an 80-minute `job_execution_timeout` and a real product failure all come out as the same three lines.

`describe_job` already carried the stage, duration and `failure_reason` that separate these cases. Only the verdict logic ignored them.

## Evidence

Verbatim, from GitHub run 34573793808 (job 103272481086), on commit `47c9ee91` where every native GitHub check passed:

```
FAIL: test-base
FAIL: test-search
##[error]Downstream job failed: test-search (stage blueprint eval docker-compose, 51m53s, script_failure)
Downstream pipeline #67368057 finished 'failed': 2 failed, 0 canceled, 14 succeeded, 0 skipped, 1 allowed failures
```

In that run the failures were real. GitLab pipelines `67253826` and `67393139` emitted the **same message shape** for a 17-second git abort in `get_sources`, where no product code ran at all. The downstream host, project path and pipeline URL are all masked, so the author cannot click through and tell them apart either.

## Change

The terminal snapshot now classifies each blocking failure (`infra_failure_cause`):

**Infrastructure** — reported as `DOWNSTREAM_INFRA`, non-blocking, in words that say plainly the downstream pipeline could not run the job and that this is not a verdict on the PR:

- `failure_reason` in `runner_system_failure` / `stuck_or_timeout_failure`
- a `script_failure` under 90s in a `preflight` stage
- a job whose trace never reached the runner's `step_script` section, which proves it died in `get_sources` / `restore_cache` / artifact download before running anything

**Product** — everything else. Still a hard red.

Classification has to *prove* infrastructure. Anything it cannot prove stays a product failure, so an unavailable trace, an empty trace, a missing `failure_reason`, a slow `preflight` job, and `job_execution_timeout` (a job that ran to its wall clock may have been hung by the product) all keep the check red. A false green hides a regression; a false red costs a retry.

Infrastructure failures are still printed when the check goes red for another reason — as warnings rather than as the verdict — so they are never silently dropped.

The report carries a triage handle built only from non-secret values: the downstream pipeline IID and the GitHub run id / attempt that prefix the `VSS_TRIGGER_CORRELATION_ID` sent with the trigger. Nothing new is masked, because a masked handle would be redacted in the log and therefore useless.

`fetch_job_trace_exit_code` was split so the new classifier reuses its trace fetch rather than duplicating it. The trace is fetched at most once per job and only on the terminal snapshot, so the added API cost is bounded by the number of blocking failures.

## Checks run

- `python3 .github/scripts/test_poll_downstream_pipeline.py` — 47 tests, OK. This is the repo's own check for this path (`.github/workflows/ci.yml`). 20 of them are new, one per classification branch.
- `python3 .github/scripts/test_trigger_downstream_pipeline.py`, `python3 .github/scripts/test_cancel_downstream_pipeline.py` — OK, for the shared trace-fetch refactor.
- `python3 .github/scripts/check_copyright_headers.py` — OK.
- `uv run ruff check` on both touched files — identical findings before and after this branch, so no new lint debt. (`.github/scripts` is outside the configured ruff scope.)

## Out of scope

- `trigger_downstream_pipeline.py` re-run behaviour — a separate concern.
- Exporting the full `VSS_TRIGGER_CORRELATION_ID` as a trigger step output. It is generated inside the trigger and not written to `$GITHUB_OUTPUT`, so the handle names its `gh-<run id>-<attempt>-` prefix rather than the exact id. Wiring the output through would make the handle exact, and would touch `trigger_downstream_pipeline.py`.
- The per-tick `FAIL: <job>` announcements are unchanged. Classifying mid-flight would mean fetching traces that are still being written; the final report explicitly retracts those lines when everything turned out to be infrastructure.
- Unmasking the downstream pipeline URL.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] Every commit on this PR is DCO sign-off'd.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes (the module docstring documents the classification and the new exit-code meaning).
- [x] No secrets, API keys, or credentials committed.
