### PR TITLE
docs: fix semantic labeling tool path

### DIFF
--- a/docs/warehouse-docs/Semantic-Label-Setup.mdx
+++ b/docs/warehouse-docs/Semantic-Label-Setup.mdx
@@ -5,10 +5,10 @@ position: 3
 ---
 Label the relevant objects so Ground Truth (GT) data can be generated for your targets. If the asset scene is SimReady, you can reuse its existing semantic labels for SDG. Otherwise, follow the steps below to add semantic labels.
 
-Navigate to the `sdg/semantic_labeling` path:
+Navigate to the `tools/sdg-postprocessing/semantic_labeling` path:
 
 ```bash
-cd $MDX_SAMPLE_APPS_DIR/deploy-warehouse-compose/modules/sdg/semantic_labeling/
+cd /path/to/video-search-and-summarization/tools/sdg-postprocessing/semantic_labeling
 ```
 
 - Using boxes in the scene as an example, first find the prim paths of the boxes to label by searching with keywords such as `box`. See `box_check.py` for details.


### PR DESCRIPTION
Fix tool path under doc: semantic labeling setup section 