### PR TITLE
fix(rtvi-vlm): stabilize CR3 combo kernel selection

### DIFF
--- a/services/rtvi/rt-vlm/src/models/vllm_compatible/vllm_compatible_model.py
+++ b/services/rtvi/rt-vlm/src/models/vllm_compatible/vllm_compatible_model.py
@@ -258,13 +258,29 @@ def _get_num_preprocess_workers() -> int:
     return num_workers
 
 
-def _get_vllm_compilation_config(model_architecture: str) -> dict[str, object] | None:
+def _get_vllm_compilation_config(
+    model_architecture: str,
+    vlm_model_type: str = "",
+    enforce_eager: bool = False,
+) -> dict[str, object] | None:
     raw_mode = (_get_rtvi_vllm_env("VLLM_CUDAGRAPH_MODE", "") or "").strip()
+    stabilize_cr3 = (
+        not enforce_eager
+        and vlm_model_type == "cosmos-reason3"
+        and model_architecture in _QWEN3VL_ARCHS
+    )
     if not raw_mode:
         if _is_cosmos3_edge_arch(model_architecture):
             return {
                 "mode": "VLLM_COMPILE",
                 "cudagraph_mode": "PIECEWISE",
+            }
+        if stabilize_cr3:
+            return {
+                "inductor_compile_config": {
+                    "combo_kernels": True,
+                    "benchmark_combo_kernel": False,
+                },
             }
         return None
     cudagraph_mode = raw_mode.upper()
@@ -277,6 +293,11 @@ def _get_vllm_compilation_config(model_architecture: str) -> dict[str, object] |
         "mode": "VLLM_COMPILE",
         "cudagraph_mode": cudagraph_mode,
     }
+    if stabilize_cr3:
+        config["inductor_compile_config"] = {
+            "combo_kernels": True,
+            "benchmark_combo_kernel": False,
+        }
     return config
 
 
@@ -1571,7 +1592,11 @@ class VllmCompatible(BaseVlmModel):
                     if enforce_eager:
                         logger.info("VLLM enforce_eager enabled via VLLM_ENFORCE_EAGER")
 
-                compilation_config = _get_vllm_compilation_config(self._model_architecture)
+                compilation_config = _get_vllm_compilation_config(
+                    self._model_architecture,
+                    self._vlm_model_type,
+                    enforce_eager,
+                )
                 if compilation_config:
                     if enforce_eager:
                         raise ValueError(

--- a/services/rtvi/rt-vlm/tests/model/vllm_compatible/test_input_error_handling.py
+++ b/services/rtvi/rt-vlm/tests/model/vllm_compatible/test_input_error_handling.py
@@ -679,6 +679,48 @@ def test_vllm_compilation_config_defaults_edge_to_compiled_execution(monkeypatch
     }
 
 
+@pytest.mark.parametrize("cudagraph_mode", (None, "FULL"))
+def test_vllm_compilation_config_stabilizes_cosmos_reason3_qwen3vl(
+    monkeypatch, cudagraph_mode
+):
+    monkeypatch.delenv("VLLM_CUDAGRAPH_MODE", raising=False)
+    monkeypatch.delenv("RTVI_VLLM_CUDAGRAPH_MODE", raising=False)
+    if cudagraph_mode:
+        monkeypatch.setenv("VLLM_CUDAGRAPH_MODE", cudagraph_mode)
+
+    expected = {
+        "inductor_compile_config": {
+            "combo_kernels": True,
+            "benchmark_combo_kernel": False,
+        }
+    }
+    if cudagraph_mode:
+        expected.update(
+            {
+                "mode": "VLLM_COMPILE",
+                "cudagraph_mode": cudagraph_mode,
+            }
+        )
+
+    assert vllm_compatible_model._get_vllm_compilation_config(
+        "Qwen3VLForConditionalGeneration", "cosmos-reason3"
+    ) == expected
+
+
+def test_vllm_compilation_config_honors_explicit_eager_mode(monkeypatch):
+    monkeypatch.delenv("VLLM_CUDAGRAPH_MODE", raising=False)
+    monkeypatch.delenv("RTVI_VLLM_CUDAGRAPH_MODE", raising=False)
+
+    assert (
+        vllm_compatible_model._get_vllm_compilation_config(
+            "Qwen3VLForConditionalGeneration",
+            "cosmos-reason3",
+            enforce_eager=True,
+        )
+        is None
+    )
+
+
 def test_vllm_compilation_config_rejects_unknown_cudagraph_mode(monkeypatch):
     monkeypatch.delenv("RTVI_VLLM_CUDAGRAPH_MODE", raising=False)
     monkeypatch.setenv("VLLM_CUDAGRAPH_MODE", "invalid")


### PR DESCRIPTION
## Summary

- Stabilize the CR3 Qwen3-VL Inductor path by retaining combo kernels while disabling cold-start combo-kernel benchmarking.
- Preserve explicit eager-mode and CUDAGRAPH behavior.
- Cover default, explicit CUDAGRAPH, and eager-mode configuration paths.

## Why

Fresh H100 cold starts produced deterministic but different first-token outputs for a close-margin VANTAGE case despite identical model inputs. The selected configuration removes timing-based compiler-arm selection.

## Validation

- `124 passed` in the focused pinned-image test file.
- `python3 -m py_compile` on the changed Python files.
- `git diff --check`.
- H100 VANTAGE validation: `99/163` valid and correct on two same-service passes, with zero answer, input-hash, or prompt-token mismatches.

## Caveat

Clip 96 is deterministic with this configuration but remains label-wrong. The selected arm was retained because it is repeatable and outperformed the alternative across the full VANTAGE set. No decoder or polling change is included.