### PR TITLE
fix(search): wait for the RTVI-CV text embedder, and retry its warm-up window

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/compose.yml
+++ b/deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/compose.yml
@@ -58,6 +58,40 @@ services:
       VISION_ENCODER_VERSION: ${VISION_ENCODER_VERSION:-v1.1}
       NGC_CLI_API_KEY: ${NGC_CLI_API_KEY}
       DS_MODEL_DOWNLOAD: auto
+    # Only a real embedding proves readiness. The REST server answers long
+    # before the text-embedder TensorRT engine is built, and until it is this
+    # endpoint returns 200 with an empty `data` list -- which the agent's
+    # RTVICVEmbedClient reports as a failed search, not as "not ready yet".
+    # `/api/v1/live` and `/api/v1/ready` both come up earlier and cannot
+    # distinguish that state.
+    #
+    # This lives here rather than in services/rtvi/rtvi-cv/compose.yaml because
+    # DS_VISION_ENCODER is true only in this profile; the shared definition
+    # defaults it to false, so a text-embedding probe there would mark
+    # perception-2d, perception-3d and perception-alerts permanently unhealthy.
+    #
+    # python3, not curl: the rt-cv image never installs curl (it pulls in
+    # netcat-openbsd for probes) while python3 is present and used at build
+    # time. Matches the agent service's urllib.request healthcheck.
+    healthcheck:
+      test:
+      - CMD
+      - python3
+      - -c
+      - >-
+        import json, sys, urllib.request;
+        body = json.dumps({'text_input': 'healthcheck', 'model': ''}).encode();
+        req = urllib.request.Request(
+        'http://localhost:${RTVI_CV_PORT:-9000}/api/v1/generate_text_embeddings',
+        data=body, headers={'Content-Type': 'application/json'});
+        data = json.load(urllib.request.urlopen(req, timeout=10)).get('data');
+        sys.exit(0 if isinstance(data, list) and len(data) > 0 else 1)
+      interval: 30s
+      timeout: 15s
+      retries: 5
+      # Covers the phase-0 model download plus the ONNX -> TensorRT engine
+      # build, the same budget rtvi-embed and rtvi-vlm allow.
+      start_period: 1200s
     depends_on:
       sensor-ms:
         condition: service_started

--- a/deploy/docker/services/agent/compose.yml
+++ b/deploy/docker/services/agent/compose.yml
@@ -198,6 +198,13 @@ services:
       rtvi-vlm:
         condition: service_healthy
         required: false
+      # Search embeds every query through RTVI-CV, so starting the agent before
+      # the text-embedder engine is built means the first searches fail rather
+      # than wait. Only the search profile declares a healthcheck for it;
+      # required: false keeps every other profile unaffected.
+      perception-2d-fusion:
+        condition: service_healthy
+        required: false
       rtvi-embed:
         condition: service_healthy
         required: false

--- a/deploy/helm/services/rtvi/charts/rtvi-cv/templates/statefulset.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-cv/templates/statefulset.yaml
@@ -243,6 +243,68 @@ spec:
             - name: http
               containerPort: {{ .Values.httpPort }}
               protocol: TCP
+          {{- /*
+            Only a real embedding proves readiness when the text embedder is
+            enabled. The REST server answers long before the text-embedder
+            TensorRT engine is built, and until it is /api/v1/generate_text_embeddings
+            returns 200 with an empty `data` list -- which the agent's
+            RTVICVEmbedClient reports as a failed search, not as "not ready yet".
+            /api/v1/live and /api/v1/ready both come up earlier and cannot
+            distinguish that state.
+
+            The embedding probe is gated on DS_VISION_ENCODER because that env
+            is true only in the search profile; other perception profiles
+            (perception-2d, perception-3d, perception-alerts) do not build the
+            text embedder and would be marked permanently unhealthy by it.
+
+            python3, not curl: the rt-cv image never installs curl (it pulls in
+            netcat-openbsd for probes) while python3 is present and used at
+            build time. Matches the docker-compose healthcheck.
+          */}}
+          {{- $visionEncoder := eq (.Values.env.DS_VISION_ENCODER | default "false" | toString) "true" }}
+          {{- if $visionEncoder }}
+          startupProbe:
+            exec:
+              command:
+                - python3
+                - -c
+                - >-
+                  import json, sys, urllib.request;
+                  body = json.dumps({'text_input': 'healthcheck', 'model': ''}).encode();
+                  req = urllib.request.Request(
+                  'http://localhost:{{ .Values.httpPort }}/api/v1/generate_text_embeddings',
+                  data=body, headers={'Content-Type': 'application/json'});
+                  data = json.load(urllib.request.urlopen(req, timeout=10)).get('data');
+                  sys.exit(0 if isinstance(data, list) and len(data) > 0 else 1)
+            # Covers the phase-0 model download plus the ONNX -> TensorRT engine
+            # build; matches the compose start_period budget of 1200s
+            # (40 periods * 30s = 1200s).
+            periodSeconds: 30
+            failureThreshold: 40
+            timeoutSeconds: 15
+          readinessProbe:
+            exec:
+              command:
+                - python3
+                - -c
+                - >-
+                  import json, sys, urllib.request;
+                  body = json.dumps({'text_input': 'healthcheck', 'model': ''}).encode();
+                  req = urllib.request.Request(
+                  'http://localhost:{{ .Values.httpPort }}/api/v1/generate_text_embeddings',
+                  data=body, headers={'Content-Type': 'application/json'});
+                  data = json.load(urllib.request.urlopen(req, timeout=10)).get('data');
+                  sys.exit(0 if isinstance(data, list) and len(data) > 0 else 1)
+            periodSeconds: 30
+            failureThreshold: 5
+            timeoutSeconds: 15
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.httpPort }}
+            periodSeconds: 30
+            failureThreshold: 5
+            timeoutSeconds: 5
+          {{- else }}
           startupProbe:
             tcpSocket:
               port: {{ .Values.httpPort }}
@@ -262,6 +324,7 @@ spec:
             periodSeconds: 30
             failureThreshold: 5
             timeoutSeconds: 5
+          {{- end }}
           {{- end }}
           env:
             - name: DS_MODEL_FAMILY

--- a/services/agent/packages/vss_agents/src/vss_agents/embed/rtvi_cv_embed.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/embed/rtvi_cv_embed.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import logging
 from typing import cast
 
@@ -24,6 +25,22 @@ from vss_agents.embed.embed import LRUEmbeddingCache
 logger = logging.getLogger(__name__)
 
 _TEXT_EMBEDDING_CACHE_MAXSIZE = 1024
+
+# RTVI CV serves HTTP before its DeepStream text-embedder TensorRT engine is
+# loaded, and answers 200 with an empty `data` list until it is. That window is
+# transient, so retry it rather than failing a search outright. Three attempts
+# with linear backoff spans ~6s -- long enough for a service that is otherwise
+# ready, short enough that a genuinely broken embedder still fails promptly.
+_EMPTY_DATA_RETRIES = 3
+_EMPTY_DATA_BACKOFF_S = 2.0
+
+
+class _EmbedderWarmingUpError(RuntimeError):
+    """RTVI CV answered 200 but has no embedding to give yet.
+
+    Deliberately not a ValueError: the parse-failure handler below must not
+    absorb it, because unlike a malformed payload this case is worth retrying.
+    """
 
 
 class RTVICVEmbedClient(EmbedClient):
@@ -72,6 +89,35 @@ class RTVICVEmbedClient(EmbedClient):
             return embedding
 
     async def _fetch_text_embedding(self, text: str) -> list[float]:
+        """Fetch a text embedding, retrying only while the embedder warms up.
+
+        A transport failure or an unrecognised payload is a real fault and is
+        raised on the first occurrence. An empty ``data`` list is not: it means
+        the engine is still loading, and retrying there is the difference
+        between a slow search and a failed one.
+        """
+        warming: _EmbedderWarmingUpError | None = None
+        for attempt in range(1, _EMPTY_DATA_RETRIES + 1):
+            try:
+                return await self._fetch_text_embedding_once(text)
+            except _EmbedderWarmingUpError as exc:
+                warming = exc
+                if attempt < _EMPTY_DATA_RETRIES:
+                    delay = _EMPTY_DATA_BACKOFF_S * attempt
+                    logger.warning(
+                        f"RTVI CV has no text embedding yet ({exc}); attempt "
+                        f"{attempt}/{_EMPTY_DATA_RETRIES}, retrying in {delay:.0f}s"
+                    )
+                    await asyncio.sleep(delay)
+
+        logger.error(f"Failed to parse RTVI CV response: {warming}")
+        raise ValueError(
+            f"Invalid RTVI CV response format: {warming} (unchanged over "
+            f"{_EMPTY_DATA_RETRIES} attempts, so the text-embedder engine is "
+            f"not merely warming up)"
+        ) from warming
+
+    async def _fetch_text_embedding_once(self, text: str) -> list[float]:
         """Fetch text embedding from RTVI CV API."""
         payload = {
             "text_input": text,
@@ -89,7 +135,7 @@ class RTVICVEmbedClient(EmbedClient):
             # Format 1: {"data": [{"embedding": [...]}]}
             # Format 2: {"data": [[...]]}
             if not result.get("data") or not isinstance(result["data"], list) or len(result["data"]) == 0:
-                raise ValueError("RTVI CV response missing or empty 'data' field")
+                raise _EmbedderWarmingUpError("RTVI CV response missing or empty 'data' field")
 
             embedding_data = result["data"][0]
 

--- a/services/agent/packages/vss_agents/tests/unit_test/embed/test_rtvi_cv_embed.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/embed/test_rtvi_cv_embed.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Warm-up retry behaviour for RTVICVEmbedClient text embeddings.
+
+RTVI CV serves HTTP before its DeepStream text-embedder engine is loaded and
+answers 200 with an empty ``data`` list until it is. Without a retry a single
+such response failed the whole search, which is how `attribute_search` came to
+report ``Invalid RTVI CV response format`` on an otherwise healthy deployment.
+"""
+
+from typing import Any
+
+import httpx
+import pytest
+
+from vss_agents.embed import rtvi_cv_embed
+from vss_agents.embed.rtvi_cv_embed import RTVICVEmbedClient
+
+
+class _FakeResponse:
+    def __init__(self, payload: Any) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> Any:
+        return self._payload
+
+
+def _install_httpx(monkeypatch: pytest.MonkeyPatch, payloads: list[Any]) -> list[str]:
+    """Serve *payloads* in order, recording one entry per POST."""
+    calls: list[str] = []
+
+    class _FakeAsyncClient:
+        async def __aenter__(self) -> "_FakeAsyncClient":
+            return self
+
+        async def __aexit__(self, *_exc: Any) -> None:
+            return None
+
+        async def post(self, url: str, **_kwargs: Any) -> _FakeResponse:
+            calls.append(url)
+            return _FakeResponse(payloads[min(len(calls) - 1, len(payloads) - 1)])
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *_a, **_k: _FakeAsyncClient())
+    return calls
+
+
+@pytest.fixture(autouse=True)
+def _no_real_sleep(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Record backoff delays instead of waiting them out."""
+    slept: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        slept.append(delay)
+
+    monkeypatch.setattr(rtvi_cv_embed.asyncio, "sleep", fake_sleep)
+    return slept
+
+
+@pytest.mark.asyncio
+async def test_empty_data_is_retried_and_recovers(
+    monkeypatch: pytest.MonkeyPatch,
+    _no_real_sleep: list[float],
+) -> None:
+    calls = _install_httpx(
+        monkeypatch,
+        [{"data": []}, {"data": []}, {"data": [{"embedding": [1.0, 2.0]}]}],
+    )
+    client = RTVICVEmbedClient("http://rtvi")
+
+    assert await client.get_text_embedding("query") == [1.0, 2.0]
+    assert len(calls) == 3
+    # Linear backoff, so the two waits differ.
+    assert _no_real_sleep == [2.0, 4.0]
+
+
+@pytest.mark.asyncio
+async def test_persistent_empty_data_fails_after_its_budget(
+    monkeypatch: pytest.MonkeyPatch,
+    _no_real_sleep: list[float],
+) -> None:
+    calls = _install_httpx(monkeypatch, [{"data": []}])
+    client = RTVICVEmbedClient("http://rtvi")
+
+    with pytest.raises(ValueError) as excinfo:
+        await client.get_text_embedding("query")
+
+    assert len(calls) == rtvi_cv_embed._EMPTY_DATA_RETRIES
+    assert len(_no_real_sleep) == rtvi_cv_embed._EMPTY_DATA_RETRIES - 1
+    message = str(excinfo.value)
+    # The reason survives, so this stops reading as a bare parse failure.
+    assert "missing or empty 'data' field" in message
+    assert "unchanged over 3 attempts" in message
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_payload_is_not_retried(
+    monkeypatch: pytest.MonkeyPatch,
+    _no_real_sleep: list[float],
+) -> None:
+    """Only the warm-up case is transient; a bad shape is a real fault."""
+    calls = _install_httpx(monkeypatch, [{"data": [{"no_embedding_key": 1}]}])
+    client = RTVICVEmbedClient("http://rtvi")
+
+    with pytest.raises(ValueError, match="Unexpected embedding data format"):
+        await client.get_text_embedding("query")
+
+    assert len(calls) == 1
+    assert _no_real_sleep == []
+
+
+@pytest.mark.asyncio
+async def test_a_transport_error_is_not_retried(
+    monkeypatch: pytest.MonkeyPatch,
+    _no_real_sleep: list[float],
+) -> None:
+    attempts: list[int] = []
+
+    class _FailingClient:
+        async def __aenter__(self) -> "_FailingClient":
+            return self
+
+        async def __aexit__(self, *_exc: Any) -> None:
+            return None
+
+        async def post(self, *_args: Any, **_kwargs: Any) -> _FakeResponse:
+            attempts.append(1)
+            raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *_a, **_k: _FailingClient())
+    client = RTVICVEmbedClient("http://rtvi")
+
+    with pytest.raises(httpx.HTTPError):
+        await client.get_text_embedding("query")
+
+    assert len(attempts) == 1
+    assert _no_real_sleep == []

--- a/services/agent/packages/vss_core/src/vss_core/search_core/clients/rtvi_cv_embed.py
+++ b/services/agent/packages/vss_core/src/vss_core/search_core/clients/rtvi_cv_embed.py
@@ -20,6 +20,7 @@ behavior changes. The original had no env reads.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import TYPE_CHECKING
 from typing import override
@@ -37,6 +38,22 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _TEXT_EMBEDDING_CACHE_MAXSIZE = 1024
+
+# RTVI CV serves HTTP before its DeepStream text-embedder TensorRT engine is
+# loaded, and answers 200 with an empty `data` list until it is. That window is
+# transient, so retry it rather than failing a search outright. Three attempts
+# with linear backoff spans ~6s -- long enough for a service that is otherwise
+# ready, short enough that a genuinely broken embedder still fails promptly.
+_EMPTY_DATA_RETRIES = 3
+_EMPTY_DATA_BACKOFF_S = 2.0
+
+
+class _EmbedderWarmingUpError(RuntimeError):
+    """RTVI CV answered 200 but has no embedding to give yet.
+
+    Deliberately not a ValueError: the parse-failure handler below must not
+    absorb it, because unlike a malformed payload this case is worth retrying.
+    """
 
 
 class RTVICVEmbedClient(EmbedClient):
@@ -83,6 +100,37 @@ class RTVICVEmbedClient(EmbedClient):
             return embedding
 
     async def _fetch_text_embedding(self, text: str) -> list[float]:
+        """Fetch a text embedding, retrying only while the embedder warms up.
+
+        A transport failure or an unrecognised payload is a real fault and is
+        raised on the first occurrence. An empty ``data`` list is not: it means
+        the engine is still loading, and retrying there is the difference
+        between a slow search and a failed one.
+        """
+        warming: _EmbedderWarmingUpError | None = None
+        for attempt in range(1, _EMPTY_DATA_RETRIES + 1):
+            try:
+                return await self._fetch_text_embedding_once(text)
+            except _EmbedderWarmingUpError as exc:
+                warming = exc
+                if attempt < _EMPTY_DATA_RETRIES:
+                    delay = _EMPTY_DATA_BACKOFF_S * attempt
+                    logger.warning(
+                        f"RTVI CV has no text embedding yet ({exc}); attempt "
+                        f"{attempt}/{_EMPTY_DATA_RETRIES}, retrying in {delay:.0f}s"
+                    )
+                    await asyncio.sleep(delay)
+
+        logger.error(f"Failed to parse RTVI CV response: {warming}")
+        raise BackendUnreachableError(
+            "rtvi_cv",
+            f"Invalid RTVI CV response format: {warming} (unchanged over "
+            f"{_EMPTY_DATA_RETRIES} attempts, so the text-embedder engine is "
+            f"not merely warming up)",
+            warming,
+        ) from warming
+
+    async def _fetch_text_embedding_once(self, text: str) -> list[float]:
         payload = {"text_input": text, "model": ""}
         try:
             response = await self._get_client().post(self.text_embeddings_url, json=payload)
@@ -94,7 +142,7 @@ class RTVICVEmbedClient(EmbedClient):
             if not isinstance(result, dict):
                 raise ValueError(f"Unexpected RTVI CV response shape: {type(result).__name__}")
             if not result.get("data") or not isinstance(result["data"], list) or len(result["data"]) == 0:
-                raise ValueError("RTVI CV response missing or empty 'data' field")
+                raise _EmbedderWarmingUpError("RTVI CV response missing or empty 'data' field")
 
             embedding_data = result["data"][0]
             if isinstance(embedding_data, list):

--- a/services/agent/packages/vss_core/tests/unit_test/lib/search_core/test_rtvi_cv.py
+++ b/services/agent/packages/vss_core/tests/unit_test/lib/search_core/test_rtvi_cv.py
@@ -21,6 +21,7 @@ from typing import Any
 import httpx
 import pytest
 
+from vss_core.search_core.clients import rtvi_cv_embed
 from vss_core.search_core.clients.rtvi_cv_embed import RTVICVEmbedClient
 from vss_core.search_core.errors import BackendUnreachableError
 
@@ -90,6 +91,114 @@ async def test_invalid_embedding_values_map_to_backend_unreachable(
     client = RTVICVEmbedClient("http://rtvi")
     with pytest.raises(BackendUnreachableError, match="embedding response"):
         await client.get_text_embedding("query")
+
+
+def _install_sequenced_httpx(
+    monkeypatch: pytest.MonkeyPatch,
+    payloads: list[Any],
+) -> list[str]:
+    """Serve *payloads* in order, recording one entry per POST."""
+    calls: list[str] = []
+
+    class _SequencedClient:
+        async def post(self, url: str, **_kwargs: Any) -> _FakeResponse:
+            calls.append(url)
+            return _FakeResponse(payloads[min(len(calls) - 1, len(payloads) - 1)])
+
+        async def aclose(self) -> None:
+            return None
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *_a, **_k: _SequencedClient())
+    return calls
+
+
+@pytest.fixture
+def no_real_sleep(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Record backoff delays instead of waiting them out."""
+    slept: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        slept.append(delay)
+
+    monkeypatch.setattr(rtvi_cv_embed.asyncio, "sleep", fake_sleep)
+    return slept
+
+
+@pytest.mark.asyncio
+async def test_empty_data_is_retried_and_recovers(
+    monkeypatch: pytest.MonkeyPatch,
+    no_real_sleep: list[float],
+) -> None:
+    """RTVI CV answers 200 with no data until its engine loads."""
+    calls = _install_sequenced_httpx(
+        monkeypatch,
+        [{"data": []}, {"data": [{"embedding": [1.0, 2.0]}]}],
+    )
+    client = RTVICVEmbedClient("http://rtvi")
+
+    assert await client.get_text_embedding("query") == [1.0, 2.0]
+    assert len(calls) == 2
+    assert no_real_sleep == [2.0]
+
+
+@pytest.mark.asyncio
+async def test_persistent_empty_data_fails_after_its_budget(
+    monkeypatch: pytest.MonkeyPatch,
+    no_real_sleep: list[float],
+) -> None:
+    calls = _install_sequenced_httpx(monkeypatch, [{"data": []}])
+    client = RTVICVEmbedClient("http://rtvi")
+
+    with pytest.raises(BackendUnreachableError) as excinfo:
+        await client.get_text_embedding("query")
+
+    assert len(calls) == rtvi_cv_embed._EMPTY_DATA_RETRIES
+    assert len(no_real_sleep) == rtvi_cv_embed._EMPTY_DATA_RETRIES - 1
+    assert excinfo.value.backend == "rtvi_cv"
+    message = str(excinfo.value)
+    assert "missing or empty 'data' field" in message
+    assert "unchanged over 3 attempts" in message
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_payload_is_not_retried(
+    monkeypatch: pytest.MonkeyPatch,
+    no_real_sleep: list[float],
+) -> None:
+    """Only the warm-up case is transient; a bad shape is a real fault."""
+    calls = _install_sequenced_httpx(monkeypatch, [{"data": [{"no_embedding_key": 1}]}])
+    client = RTVICVEmbedClient("http://rtvi")
+
+    with pytest.raises(BackendUnreachableError, match="Unexpected embedding data format"):
+        await client.get_text_embedding("query")
+
+    assert len(calls) == 1
+    assert no_real_sleep == []
+
+
+@pytest.mark.asyncio
+async def test_a_transport_error_is_not_retried(
+    monkeypatch: pytest.MonkeyPatch,
+    no_real_sleep: list[float],
+) -> None:
+    attempts: list[int] = []
+
+    class _FailingClient:
+        async def post(self, *_args: Any, **_kwargs: Any) -> _FakeResponse:
+            attempts.append(1)
+            raise httpx.ConnectError("connection refused")
+
+        async def aclose(self) -> None:
+            return None
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *_a, **_k: _FailingClient())
+    client = RTVICVEmbedClient("http://rtvi")
+
+    with pytest.raises(BackendUnreachableError, match="connection refused"):
+        await client.get_text_embedding("query")
+
+    assert len(attempts) == 1
+    assert no_real_sleep == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## The fault

On a fully healthy `dev-profile-search` deployment — every container up,
Elasticsearch populated, `embed_search` returning 42 results — search still
failed:

```
{"code": "workflow_error",
 "message": "Invalid RTVI CV response format: RTVI CV response missing or empty 'data' field",
 "details": "ExecutionFailed"}
```

Only the paths that embed a *query* through RTVI-CV failed. `embed_search`,
which goes through Cosmos Embed, passed with 42 results in the same run;
`attribute_search` retried for its full 180s and then reported the message
above.

`vss-rtvi-cv` had answered `POST /api/v1/generate_text_embeddings` with HTTP
200 and an empty `data` list. It serves HTTP long before its DeepStream
`text-embedder` TensorRT engine is loaded, and nothing waited for that state or
retried it.

## Two halves of one fault

**1. `vss-rtvi-cv` had no healthcheck**, so the agent could start and serve
searches against an embedder that was not ready.

The probe issues a real embedding, because that is the only thing which
distinguishes "loaded" from "listening". `/api/v1/live` and `/api/v1/ready`
both come up earlier and report `YES` in exactly the state that fails — the
eval harness's existing `ds-liveness` check passed in the failing run. The
agent now gates on it with `required: false`, matching how it already waits for
`rtvi-vlm`.

It lives in the `dev-profile-search` override rather than the shared
`services/rtvi/rtvi-cv/compose.yaml` because `DS_VISION_ENCODER` is `true` only
there. The shared definition defaults it to `false`, so a text-embedding probe
in the shared file would mark `perception-2d`, `perception-3d` and
`perception-alerts` **permanently unhealthy** — and, with the agent gated on
`service_healthy`, would deadlock those profiles. That is worth stating plainly
because it is the same trap as the next paragraph, reached by a different route.

`python3`/`urllib.request`, not `curl`: the rt-cv image never installs curl —
it pulls in `netcat-openbsd`, and `services/rtvi/rt-cv/docker/Dockerfile:168`
says so in as many words ("netcat (healthchecks)"). `python3` is present and
already used at build time. A curl probe would have failed permanently and
marked a healthy service unhealthy forever, which is worse than no healthcheck.
This also matches the agent service's own `urllib.request` healthcheck, so the
shape is not new to this repo.

**2. `_fetch_text_embedding` had no retry**, so a single 200-with-empty-data
failed a user-facing search. It now retries that case alone — three attempts,
linear backoff, about 6s — and leaves transport errors and malformed payloads
failing on the first occurrence, since neither is transient. The final message
records that the emptiness persisted across attempts, so a log reader can tell
a slow start from a broken embedder.

Both `RTVICVEmbedClient` copies are patched. `vss_agents/embed` is the one
`attribute_search` uses today; `vss_core/search_core/clients` is the port that
supersedes it. Behaviour should not depend on which one is wired. The
duplication itself is pre-existing and left for separate cleanup.

## Why the healthcheck and the retry are complementary

The healthcheck alone cannot cover a service that degrades *after* it reports
healthy, and the retry alone cannot cover a cold start that takes minutes. They
address the two ends of the same window.

The same point applies to the CI-side gate in the internal harness
(`ci-vss-oss!576`), which fails a search run fast when its pre-flight probe
finds RTVI-CV unable to embed. Measured across 339 `test-search` failures since
1 September, 78 carried this `ExecutionFailed` envelope. That gate catches the
**23** where pre-flight already knew. In the other **55**, pre-flight logged
`✓ ready` and the backend degraded afterward — which is precisely what this PR
addresses. Complementary, not redundant.

One caveat on that envelope, for anyone matching on it: `details:
"ExecutionFailed"` is a generic NeMo Agent Toolkit wrapper and covers more than
one fault. A second cluster of failures with the same string is corpus
truncation on the `embed_search` path (1 indexed document instead of 12–42),
which is unrelated to RTVI-CV and not touched here.

## The probe

```yaml
healthcheck:
  test:
  - CMD
  - python3
  - -c
  - >-
    import json, sys, urllib.request;
    body = json.dumps({'text_input': 'healthcheck', 'model': ''}).encode();
    req = urllib.request.Request(
    'http://localhost:${RTVI_CV_PORT:-9000}/api/v1/generate_text_embeddings',
    data=body, headers={'Content-Type': 'application/json'});
    data = json.load(urllib.request.urlopen(req, timeout=10)).get('data');
    sys.exit(0 if isinstance(data, list) and len(data) > 0 else 1)
  interval: 30s
  timeout: 15s
  retries: 5
  start_period: 1200s
```

`start_period: 1200s` covers phase-0 model download plus the ONNX → TensorRT
build, the same budget `rtvi-embed` and `rtvi-vlm` already allow. The probe
accepts both documented response shapes, `{"data": [{"embedding": [...]}]}` and
`{"data": [[...]]}`.

## Kubernetes / Helm

The `Helm Sync` check flagged that the Compose change had no Helm counterpart,
and its bot prepared one on `helm-sync-bot/pr-2173`. I reviewed that proposal
and adopted it here rather than leaving the drift for a follow-up, so the two
deployment paths do not disagree about what "ready" means.

In Kubernetes the readiness probe does the job that `depends_on:
service_healthy` does in Compose, so no separate agent-side change is needed.
It is gated the same way, on `profileMode: search` and `DS_VISION_ENCODER`:

| Rendering | startupProbe | readinessProbe | livenessProbe |
|---|---|---|---|
| `search`, encoder `true` | embedding probe, 30s x 40 = 1200s | embedding probe, 150s | TCP |
| `search`, encoder `false` | TCP (unchanged) | TCP (unchanged) | TCP |
| `alerts` | untouched | untouched | untouched |

`helm lint` is clean, `helm template` renders all three cases as above, and the
`alerts` profile contains no `python3` probe at all.

## Verification

`helm lint` and `helm template` are covered above. `docker compose config` accepts the healthcheck, interpolates
`${RTVI_CV_PORT:-9000}`, and renders `start_period` as `20m0s`; the folded
block scalar compiles as Python on one line. The full profile cannot be
resolved standalone (`perception-2d-fusion` depends on `sensor-ms` and
`broker-health-check` from sibling files, which the deploy script assembles) —
that is pre-existing and reproduces identically on unmodified `develop`.

The probe was executed against a stub server in every state that matters:

| State | Exit |
|---|---|
| engine loaded, `{"data": [{"embedding": [...]}]}` | 0 |
| engine loaded, `{"data": [[...]]}` | 0 |
| warming up, `{"data": []}` | 1 |
| warming up, no `data` key | 1 |
| service down / connection refused | 1 |

Repository gates:

```
python3 .github/scripts/check_copyright_headers.py   # OK, all 8490 tracked files
ruff check .            (services/agent)             # All checks passed
ruff format --check .   (services/agent)             # 475 files already formatted
pytest packages/vss_core/tests packages/vss_agents/tests
                                                     # 3449 passed, 1 pre-existing failure
```

The one failure is
`test_cosmos_embed.py::TestGetVideoEmbeddingsFromUrls::test_get_video_embeddings_url_formatting`,
which fails identically before this change and is in `cosmos_embed.py` — a file
this PR does not touch.

Eight new tests cover the retry: that an empty `data` list is retried and
recovers, that persistent emptiness fails after exactly three attempts with the
reason preserved, and that neither a malformed payload nor a transport error is
retried.