### PR TITLE
fix(search): resolve RTSP video_sources to the VST sensor UUID

### DIFF
--- a/services/agent/packages/vss_agents/src/vss_agents/tools/search.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/search.py
@@ -376,37 +376,25 @@ def _resolve_video_sources_for_search(
     name_to_uuid: dict[str, str],
     source_type: str | None,
 ) -> list[str]:
-    """Resolve source names to the IDs expected by each ES source index."""
+    """Resolve source names to the VST sensor UUID stored in ES ``sensor.id``.
+
+    Every ES source index — RTSP included — stores the VST-assigned sensor UUID
+    under ``sensor.id`` and the human-readable stream name under
+    ``sensor.description``. Since the filter builder only ever matches
+    ``sensor.id`` (plus the url/path keyword fields), a name must become a UUID
+    for any ``source_type``; the previous ``rtsp`` branch kept names as-is (and
+    even mapped a caller-supplied UUID back to its name), so every filtered RTSP
+    search matched nothing.
+    """
     if not video_sources or not name_to_uuid:
         return video_sources
-
-    if source_type == "rtsp":
-        uuid_to_name = {stream_id: name for name, stream_id in name_to_uuid.items()}
-        resolved_sources = []
-        for video_source in video_sources:
-            stream_id = name_to_uuid.get(video_source)
-            if stream_id:
-                resolved_sources.append(video_source)
-                logger.debug(
-                    "Keeping RTSP video source '%s' as sensor name; VST stream UUID is '%s'",
-                    video_source,
-                    stream_id,
-                )
-            elif video_source in uuid_to_name:
-                sensor_name = uuid_to_name[video_source]
-                resolved_sources.append(sensor_name)
-                logger.debug("Resolved RTSP stream UUID '%s' to sensor name '%s'", video_source, sensor_name)
-            else:
-                resolved_sources.append(video_source)
-                logger.debug("RTSP video source '%s' not resolved in VST map; keeping original name", video_source)
-        return resolved_sources
 
     resolved_sources = []
     for video_source in video_sources:
         stream_id = name_to_uuid.get(video_source)
         if stream_id:
             resolved_sources.append(stream_id)
-            logger.debug("Resolved video source '%s' to UUID '%s'", video_source, stream_id)
+            logger.debug("Resolved %s video source '%s' to sensor UUID '%s'", source_type, video_source, stream_id)
         else:
             resolved_sources.append(video_source)
             logger.debug("Video source '%s' not resolved; will use wildcard filter", video_source)
@@ -919,8 +907,8 @@ async def execute_core_search(
                 search_input.query = decomposed.query
             if decomposed.video_sources:
                 search_input.video_sources = decomposed.video_sources
-            # Resolve video sources to the identifier expected by the selected source index.
-            # Video files filter by UUID; RTSP indices filter by camera/sensor name.
+            # Resolve video sources to the identifier expected by the selected source index:
+            # every index filters on the VST sensor UUID stored in ``sensor.id``.
             if search_input.video_sources and name_to_uuid:
                 search_input.video_sources = _resolve_video_sources_for_search(
                     video_sources=search_input.video_sources,

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_search.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_search.py
@@ -39,7 +39,11 @@ from vss_agents.tools.search import decompose_query
 class TestResolveVideoSourcesForSearch:
     """Test source-name resolution for search filters."""
 
-    def test_rtsp_keeps_sensor_name_when_uuid_known(self):
+    def test_rtsp_resolves_sensor_name_to_uuid(self):
+        # RTSP ES documents store the VST sensor UUID under ``sensor.id`` (the
+        # stream name lives in ``sensor.description``), so the name must be
+        # resolved to the UUID just like the video_file path. Keeping the name
+        # here made every filtered RTSP search match zero documents.
         stream_id = "7f8fcbf4-9e1b-41b9-bf52-1e6ce1ca9f6c"
 
         result = _resolve_video_sources_for_search(
@@ -48,9 +52,9 @@ class TestResolveVideoSourcesForSearch:
             source_type="rtsp",
         )
 
-        assert result == ["video1"]
+        assert result == [stream_id]
 
-    def test_rtsp_resolves_uuid_back_to_sensor_name(self):
+    def test_rtsp_keeps_uuid_already_supplied_by_caller(self):
         stream_id = "7f8fcbf4-9e1b-41b9-bf52-1e6ce1ca9f6c"
 
         result = _resolve_video_sources_for_search(
@@ -59,7 +63,7 @@ class TestResolveVideoSourcesForSearch:
             source_type="rtsp",
         )
 
-        assert result == ["video1"]
+        assert result == [stream_id]
 
     def test_video_file_resolves_name_to_uuid(self):
         stream_id = "7f8fcbf4-9e1b-41b9-bf52-1e6ce1ca9f6c"

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_search_inner.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_search_inner.py
@@ -288,8 +288,13 @@ class TestSearchInner:
         assert isinstance(result, SearchOutput)
 
     @pytest.mark.asyncio
-    async def test_search_agent_mode_rtsp_keeps_video_source_name_for_attribute_search(self, mock_builder, monkeypatch):
-        """RTSP agent-mode search must preserve camera names for attribute_search filters."""
+    async def test_search_agent_mode_rtsp_resolves_video_source_to_sensor_uuid(self, mock_builder, monkeypatch):
+        """RTSP agent-mode search must resolve camera names to the VST sensor UUID.
+
+        RTSP documents store the sensor UUID under ``sensor.id`` (the name lives
+        in ``sensor.description``), and the ES filter builder only matches
+        ``sensor.id``, so forwarding the bare name matched zero documents.
+        """
         from vss_agents.tools import search as search_module
 
         config = SearchConfig(
@@ -350,7 +355,9 @@ class TestSearchInner:
 
         assert isinstance(result, SearchOutput)
         mock_attribute_search.ainvoke.assert_awaited_once()
-        assert mock_attribute_search.ainvoke.await_args.args[0]["video_sources"] == ["video1"]
+        assert mock_attribute_search.ainvoke.await_args.args[0]["video_sources"] == [
+            "7f8fcbf4-9e1b-41b9-bf52-1e6ce1ca9f6c"
+        ]
 
     @pytest.mark.asyncio
     async def test_object_id_search_passes_external_vst_url_to_enrichment(self, mock_builder, monkeypatch):

--- a/services/agent/packages/vss_core/src/vss_core/search_core/primitives/_search_helpers.py
+++ b/services/agent/packages/vss_core/src/vss_core/search_core/primitives/_search_helpers.py
@@ -240,30 +240,23 @@ def _resolve_video_sources_for_search(
     name_to_uuid: dict[str, str],
     source_type: str | None,
 ) -> list[str]:
-    """Resolve source names to the IDs expected by each ES source index."""
+    """Resolve source names to the VST sensor UUID stored in ES ``sensor.id``.
+
+    Every ES source index — RTSP included — stores the VST-assigned sensor UUID
+    under ``sensor.id``, so a name must become a UUID for any ``source_type``;
+    the parameter is kept only for logging and caller compatibility.
+    """
+    resolved_sources: list[str] = []
     if not video_sources or not name_to_uuid:
         return video_sources
 
-    if source_type == "rtsp":
-        uuid_to_name = {stream_id: name for name, stream_id in name_to_uuid.items()}
-        resolved_sources: list[str] = []
-        for video_source in video_sources:
-            stream_id = name_to_uuid.get(video_source)
-            if stream_id:
-                resolved_sources.append(video_source)
-            elif video_source in uuid_to_name:
-                resolved_sources.append(uuid_to_name[video_source])
-            else:
-                resolved_sources.append(video_source)
-        return resolved_sources
-
-    resolved_sources = []
     for video_source in video_sources:
         stream_id = name_to_uuid.get(video_source)
         if stream_id:
             resolved_sources.append(stream_id)
         else:
             resolved_sources.append(video_source)
+    logger.debug("Resolved %s video_sources to sensor ids: %s", source_type, resolved_sources)
     return resolved_sources
 
 

--- a/services/agent/packages/vss_core/tests/unit_test/lib/search_core/test_search_helpers.py
+++ b/services/agent/packages/vss_core/tests/unit_test/lib/search_core/test_search_helpers.py
@@ -29,11 +29,13 @@ def test_resolve_sources_video_file_maps_names_to_uuids():
     assert resolved == ["uuid-1", "unknown"]
 
 
-def test_resolve_sources_rtsp_keeps_names_and_maps_uuid_back():
+def test_resolve_sources_rtsp_maps_names_to_uuids_like_video_file():
     name_to_uuid = {"warehouse": "uuid-1"}
-    # A known name stays a name; a known uuid is converted back to its name.
+    # RTSP documents are keyed by the VST sensor UUID under ``sensor.id``, so a
+    # known name resolves to its uuid, an already-resolved uuid is left alone,
+    # and an unknown source falls through to wildcard matching.
     resolved = sh._resolve_video_sources_for_search(["warehouse", "uuid-1", "other"], name_to_uuid, "rtsp")
-    assert resolved == ["warehouse", "warehouse", "other"]
+    assert resolved == ["uuid-1", "uuid-1", "other"]
 
 
 # ----------------------------------------------- attribute_result_to_search_result


### PR DESCRIPTION
## Summary

Filtered search for `source_type=rtsp` returns **zero results for every query**. `_resolve_video_sources_for_search` special-cased `rtsp` to keep the stream *name* as-is — and its `elif` branch even mapped a caller-supplied UUID *back* to a name — but the Elasticsearch filter builder only ever matches `sensor.id` (plus the url/path keyword fields), and RTSP documents store the VST-assigned **sensor UUID** under `sensor.id`. The human-readable stream name lives in `sensor.description`, which nothing filters on. The filter therefore compared a name against a field holding a UUID and matched nothing.

This drops the `rtsp` branch so names resolve to the sensor UUID for every `source_type`, matching what the index actually stores.

Because the special-case looks deliberate and shipped with its own tests, the evidence that it is wrong is laid out below.

## Why the special-case is wrong

**1. Direct proof of what RTSP documents store.** A downstream integration test polls Elasticsearch for RTSP embeddings and matched a real document with an exact term query on the UUID:

```
Waiting for embeddings in ES (index=mdx-embed-filtered-*,-mdx-embed-filtered-2025-01-01,
                              sensor.id=57412d75-e93c-4e91-8925-e436016ecf3f) ...
✓ ES index ... ready with 1 doc(s) for 57412d75-e93c-4e91-8925-e436016ecf3f
```

The query is `{"term": {"sensor.id.keyword": "57412d75-…"}}`. A `term` query returning a document is only possible if `sensor.id` *is* the UUID. The same run deleted that sensor as `warehouse_sample_rtsp`, confirming the UUID and the name refer to one stream.

**2. The readiness gate was already moved for exactly this reason.** Commit `701afdd` flipped that gate from `stream_name` to `sensor_id`, with the accompanying comment:

> Indexed docs store the VST-assigned sensor UUID under `sensor.id` and the human-readable stream name under `sensor.description` — filtering by `stream_name` here always returns 0 and times out the wait even when embeddings are flowing normally.

**3. Measured impact.** Filtered `/api/v1/search` returned results in **0 of 14** downstream traces that reached it. In the same run, at the same instant and against the same index, *unfiltered* `embed_search` returned **100** results — so the index was healthy and populated; only the filtered path was empty. This is deterministic, not a flake or an indexing race.

**4. The documented contract puts the obligation on the resolution layer.** `SearchInput` accepts either form — `"video_sources must contain only non-empty source names or IDs"` (`models/search.py:86`). Accepting a name therefore obliges resolution to hand Elasticsearch the identifier it actually stores, which is the UUID for every source type.

**5. Callers could not work around it.** Passing the UUID explicitly did not help: the `elif video_source in uuid_to_name` branch converted it straight back to the name. Both inputs led to the same empty result, so the fix has to be here.

## Why `video_file` was unaffected

Two independent reasons, which is why this never showed up as a general search regression:

- `/api/v1/search` for `video_file` already resolved name → UUID, hitting the exact `term` on `sensor.id.keyword`.
- Filtered `embed_search` performs no name resolution at all, yet still matched a bare filename via the `*name*` wildcard on `sensor.info.path.keyword`, because an uploaded file carries its filename in its path. An RTSP sensor has no equivalent path, and its name is not matched by any clause the builder emits.

## Changes

- `vss_agents/tools/search.py` — remove the `rtsp` branch from `_resolve_video_sources_for_search`; names now resolve to the sensor UUID uniformly. Docstring records why, and the call-site comment no longer claims RTSP filters by name.
- `vss_core/search_core/primitives/_search_helpers.py` — same change to the duplicated copy, keeping the two in sync.
- Four tests updated to **assert the corrected behavior** rather than being deleted, pinning the fix against regression:
  - `test_rtsp_resolves_sensor_name_to_uuid` (was `test_rtsp_keeps_sensor_name_when_uuid_known`)
  - `test_rtsp_keeps_uuid_already_supplied_by_caller` (was `test_rtsp_resolves_uuid_back_to_sensor_name`)
  - `test_resolve_sources_rtsp_maps_names_to_uuids_like_video_file` (was `test_resolve_sources_rtsp_keeps_names_and_maps_uuid_back`)
  - the end-to-end `test_search_agent_mode_rtsp_resolves_video_source_to_sensor_uuid` (was `…_keeps_video_source_name_for_attribute_search`), which asserts the identifier `attribute_search` actually receives.

## Deliberately left out

Noting these so a reviewer does not think they were missed:

- **`es_filters.py` docstring is factually wrong.** `build_video_sources_filter` states that for `rtsp` "UUIDs live in the path, not `sensor.id`", which is the inverse of what the index holds. The fix does not depend on it: the resolved UUID already reaches an exact `term` clause via the existing name path. Correcting it means dropping the now-inert `source_type` parameter, which cascades into unused-argument (`ARG`) churn in `_attribute_helpers` and its callers. Left as a focused follow-up.
- **A stale downstream call-site comment** in the internal CI wrapper's `test_search_critic_disabled.py` still claims RTSP documents are indexed by name and skips the `agent_mode=True` + `video_sources` RTSP path. It should be updated after this lands.

## Verification

Run locally against the touched packages (Python 3.13, `uv run`):

- `pytest packages/vss_core/tests/unit_test/ packages/vss_agents/tests/unit_test/` — **3442 passed**, no failures.
- `uv run ruff check` on all touched files — clean.
- `.github/scripts/check_copyright_headers.py` — `OK: All 8489 tracked files checked`.

The resolver change is also confirmed at the filter level: with the name, the clause is `term sensor.id.keyword == "warehouse_sample_rtsp"` (no match); after resolution it is `term sensor.id.keyword == "57412d75-…"`, the exact document the readiness gate found.

## Note for CI triage

`test-search` on this head is still expected to show the **RTVI-CV empty-`data` embedder fault** on `generate_text_embeddings` (HTTP 200 with an empty `data` array). That is a separate defect with its own fix in flight and is unrelated to this change.
