### PR TITLE
fix(rtvi-vlm): handle expected teardown cancellation

### DIFF
--- a/services/rtvi/rt-vlm/src/vlm_pipeline/process_base.py
+++ b/services/rtvi/rt-vlm/src/vlm_pipeline/process_base.py
@@ -265,12 +265,16 @@ class ProcessBase(mp_ctx.Process):
         num_items = len(kwargs["chunk"]) if self._supports_batching() else 1
 
         if isinstance(result, concurrent.futures.Future):
-            if result.exception():
+            if result.cancelled():
+                result = {}
+            elif result.exception():
                 result = result.exception()
             else:
                 result = result.result()
 
-        if isinstance(result, BaseException):
+        if isinstance(result, concurrent.futures.CancelledError):
+            result = {}
+        elif isinstance(result, BaseException):
             logger.error("".join(traceback.format_exception(result)))
             # Preserve ServiceException message and status code if available
             try:
@@ -373,18 +377,22 @@ class ProcessBase(mp_ctx.Process):
         elif isinstance(result, dict):
             # Empty dict returned by process method, send the chunk to final output queue
             for idx in range(num_items):
-                self._final_output_queue.put(
-                    {
-                        "chunk": (
-                            kwargs["chunk"][idx] if self._supports_batching() else kwargs["chunk"]
-                        ),
-                        "chunk_id": (
-                            kwargs["chunk_id"][idx]
-                            if self._supports_batching()
-                            else kwargs["chunk_id"]
-                        ),
-                    }
-                )
+                ret_item = {
+                    "chunk": (
+                        kwargs["chunk"][idx] if self._supports_batching() else kwargs["chunk"]
+                    ),
+                    "chunk_id": (
+                        kwargs["chunk_id"][idx]
+                        if self._supports_batching()
+                        else kwargs["chunk_id"]
+                    ),
+                }
+                for key in ("is_live_stream", "request_id"):
+                    if key in kwargs:
+                        ret_item[key] = (
+                            kwargs[key][idx] if self._supports_batching() else kwargs[key]
+                        )
+                self._final_output_queue.put(ret_item)
         _safe_cuda_empty_cache()
         # Force Garbage Collect
         if os.environ.get("FORCE_PYTHON_GC"):

--- a/services/rtvi/rt-vlm/tests/rtvi_vlm/test_process_base.py
+++ b/services/rtvi/rt-vlm/tests/rtvi_vlm/test_process_base.py
@@ -157,9 +157,11 @@ def test_cancelled_live_future_preserves_stream_routing(monkeypatch):
     proc._output_queue = _RecordingQueue()
     proc._final_output_queue = _RecordingQueue()
     monkeypatch.setattr(process_base_module, "_safe_cuda_empty_cache", lambda **kwargs: None)
+    error_logs = []
+    monkeypatch.setattr(process_base_module.logger, "error", error_logs.append)
 
     cancelled_future = concurrent.futures.Future()
-    cancelled_future.set_exception(concurrent.futures.CancelledError())
+    cancelled_future.cancel()
     chunk = object()
 
     proc._handle_result(
@@ -176,6 +178,8 @@ def test_cancelled_live_future_preserves_stream_routing(monkeypatch):
     assert error_item["chunk"] is chunk
     assert error_item["is_live_stream"] is True
     assert error_item["request_id"] == "request-1"
+    assert "error" not in error_item
+    assert error_logs == []
 
 
 def test_async_callback_preserves_live_stream_routing(monkeypatch):
@@ -183,6 +187,8 @@ def test_async_callback_preserves_live_stream_routing(monkeypatch):
     proc._output_queue = _RecordingQueue()
     proc._final_output_queue = _RecordingQueue()
     monkeypatch.setattr(process_base_module, "_safe_cuda_empty_cache", lambda **kwargs: None)
+    error_logs = []
+    monkeypatch.setattr(process_base_module.logger, "error", error_logs.append)
 
     future = concurrent.futures.Future()
     proc._process = lambda **kwargs: future
@@ -202,6 +208,8 @@ def test_async_callback_preserves_live_stream_routing(monkeypatch):
     assert error_item["chunk"] is chunk
     assert error_item["is_live_stream"] is True
     assert error_item["request_id"] == "request-1"
+    assert "error" not in error_item
+    assert error_logs == []
 
 
 def test_move_cuda_frames_to_cpu_keeps_tensor_type_with_gpu_queue(monkeypatch):


### PR DESCRIPTION
## Summary
- treat `concurrent.futures.CancelledError` as expected during RTVI-VLM live-stream teardown
- preserve live-stream routing metadata so cancellation still completes drain accounting
- cover directly cancelled futures and callback-delivered cancellation

## Validation
- regression before fix: 2 focused tests failed (`CancelledError` escaped; callback cancellation became HTTP 500)
- focused unit tests in `vss-rt-vlm:nightly-20260907`: 5 passed, 1 skipped
- `git diff --check` and Python compilation passed
- RTX PRO 4500, 128-stream teardown: 128 deleted, HTTP 200, zero cancellation tracebacks, zero unknown errors, service remained ready

NVBug 6759833